### PR TITLE
Simulate lossy network

### DIFF
--- a/examples/dentry-simulator.rs
+++ b/examples/dentry-simulator.rs
@@ -364,22 +364,3 @@ async fn get_phaselock(
     debug!("phaselock launched");
     h
 }
-
-/// Provides a random valid transaction from the current state
-fn random_transaction<R: rand::Rng>(state: &State, mut rng: &mut R) -> Transaction {
-    use rand::seq::IteratorRandom;
-    let input_account = state.balances.keys().choose(&mut rng).unwrap();
-    let output_account = state.balances.keys().choose(&mut rng).unwrap();
-    let amount = rng.gen_range(0, state.balances[input_account]);
-    Transaction {
-        add: Addition {
-            account: output_account.to_string(),
-            amount,
-        },
-        sub: Subtraction {
-            account: input_account.to_string(),
-            amount,
-        },
-        nonce: rng.gen(),
-    }
-}

--- a/examples/multi-machine.rs
+++ b/examples/multi-machine.rs
@@ -139,25 +139,6 @@ async fn init_state_and_phaselock(
     (state, phaselock)
 }
 
-/// Provides a random valid transaction from the current state.
-fn random_transaction<R: rand::Rng>(state: &State, mut rng: &mut R) -> Transaction {
-    use rand::seq::IteratorRandom;
-    let input_account = state.balances.keys().choose(&mut rng).unwrap();
-    let output_account = state.balances.keys().choose(&mut rng).unwrap();
-    let amount = rng.gen_range(0, state.balances[input_account]);
-    Transaction {
-        add: Addition {
-            account: output_account.to_string(),
-            amount,
-        },
-        sub: Subtraction {
-            account: input_account.to_string(),
-            amount,
-        },
-        nonce: rng.gen(),
-    }
-}
-
 #[async_std::main]
 async fn main() {
     // Setup tracing listener

--- a/src/data.rs
+++ b/src/data.rs
@@ -13,7 +13,7 @@ use threshold_crypto as tc;
 
 use crate::traits::BlockContents;
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, Eq, PartialEq, Hash)]
 /// A node in [`PhaseLock`](crate::PhaseLock)'s consensus-internal merkle tree.
 ///
 /// This is the consensus-internal analogous concept to a block, and it contains the block proper,

--- a/src/demos/dentry.rs
+++ b/src/demos/dentry.rs
@@ -362,3 +362,24 @@ where
 
     type StatefulHandler = crate::traits::implementations::Stateless<DEntryBlock, State, H_256>;
 }
+
+/// Provides a random valid transaction from the current state
+/// # Panics
+/// panics if state has no balances
+pub fn random_transaction<R: rand::Rng>(state: &State, mut rng: &mut R) -> Transaction {
+    use rand::seq::IteratorRandom;
+    let input_account = state.balances.keys().choose(&mut rng).unwrap();
+    let output_account = state.balances.keys().choose(&mut rng).unwrap();
+    let amount = rng.gen_range(0, state.balances[input_account]);
+    Transaction {
+        add: Addition {
+            account: output_account.to_string(),
+            amount,
+        },
+        sub: Subtraction {
+            account: input_account.to_string(),
+            amount,
+        },
+        nonce: rng.gen(),
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -367,7 +367,7 @@ impl<I: NodeImplementation<N> + Sync + Send + 'static, const N: usize> PhaseLock
             let view_number = qc.view_number > locked_qc.view_number;
             let result = extends_from || view_number;
             if !result {
-                error!("Safe node check failed");
+                error!(?locked_qc, ?leaf, ?qc, "Safe node check failed");
             }
             result
         } else {
@@ -479,7 +479,7 @@ impl<I: NodeImplementation<N> + Sync + Send + 'static, const N: usize> PhaseLock
                 while let Ok(queue) = networking.broadcast_queue().await {
                     debug!(?queue, "Processing messages");
                     if queue.is_empty() {
-                        trace!("No message, yeilding");
+                        trace!("No message, yielding");
                         yield_now().await;
                     } else {
                         for item in queue {

--- a/src/state_machine.rs
+++ b/src/state_machine.rs
@@ -1207,7 +1207,7 @@ impl<I: NodeImplementation<N> + 'static + Send + Sync, const N: usize> Sequentia
                             debug!("Waiting for prepare");
                             futures::select_biased! {
                                 x = decide_fut =>
-                                    Ok(WaitResult::ShortCircutDecide(x)),
+                                    Ok(WaitResult::ShortCircuitDecide(x)),
                                 x = prepare_fut => Ok(WaitResult::Prepare(x)),
                             }
                         }
@@ -1216,7 +1216,7 @@ impl<I: NodeImplementation<N> + 'static + Send + Sync, const N: usize> Sequentia
                             let leaf = leaf.expect("No leaf in precommit");
                             futures::select_biased! {
                                 x = decide_fut =>
-                                    Ok(WaitResult::ShortCircutDecide(x)),
+                                    Ok(WaitResult::ShortCircuitDecide(x)),
                                 x = precommit_fut => Ok(WaitResult::PreCommit(leaf, x)),
                             }
                         }
@@ -1225,7 +1225,7 @@ impl<I: NodeImplementation<N> + 'static + Send + Sync, const N: usize> Sequentia
                             let leaf = leaf.expect("No leaf in commit");
                             futures::select_biased! {
                                 x = decide_fut =>
-                                    Ok(WaitResult::ShortCircutDecide(x)),
+                                    Ok(WaitResult::ShortCircuitDecide(x)),
                                 x = commit_fut => Ok(WaitResult::Commit(leaf, x)),
                             }
                         }
@@ -1234,7 +1234,7 @@ impl<I: NodeImplementation<N> + 'static + Send + Sync, const N: usize> Sequentia
                             let leaf = leaf.expect("No leaf in decide");
                             let x = decide_fut.await;
                             if x.current_view > current_view {
-                                Ok(WaitResult::ShortCircutDecide(x))
+                                Ok(WaitResult::ShortCircuitDecide(x))
                             } else {
                                 Ok(WaitResult::Decide(leaf, x))
                             }
@@ -1255,7 +1255,7 @@ impl<I: NodeImplementation<N> + 'static + Send + Sync, const N: usize> Sequentia
                         }
                         WaitResult::Commit(leaf, message) => *self = BeforeCommit { leaf, message },
                         WaitResult::Decide(leaf, message) => *self = BeforeDecide { leaf, message },
-                        WaitResult::ShortCircutDecide(message) => {
+                        WaitResult::ShortCircuitDecide(message) => {
                             *self = BeforeDecideShort { message }
                         }
                     }
@@ -1278,5 +1278,5 @@ enum WaitResult<B, S, const N: usize> {
     /// Goto Decide stage
     Decide(Leaf<B, N>, Decide<N>),
     /// Goto Decide stage
-    ShortCircutDecide(Decide<N>),
+    ShortCircuitDecide(Decide<N>),
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -9,7 +9,7 @@ mod storage;
 
 pub use block_contents::BlockContents;
 pub use election::Election;
-pub use networking::{BoxedFuture, NetworkError, NetworkingImplementation};
+pub use networking::{BoxedFuture, NetworkError, NetworkReliability, NetworkingImplementation};
 pub use node_implementation::NodeImplementation;
 pub use state::State;
 pub use stateful_handler::StatefulHandler;
@@ -17,7 +17,7 @@ pub use storage::{Storage, StorageResult};
 
 /// Module for publicly usable implementations of the traits
 pub mod implementations {
-    pub use super::networking::memory_network::{MasterMap, MemoryNetwork};
+    pub use super::networking::memory_network::{DummyReliability, MasterMap, MemoryNetwork};
     pub use super::networking::w_network::WNetwork;
     pub use super::stateful_handler::Stateless;
     pub use super::storage::memory_storage::MemoryStorage;

--- a/src/traits/networking.rs
+++ b/src/traits/networking.rs
@@ -14,6 +14,7 @@ use async_tungstenite::tungstenite::error as werror;
 use futures::future::BoxFuture;
 use serde::{de::DeserializeOwned, Serialize};
 use snafu::Snafu;
+use std::time::Duration;
 
 pub mod memory_network;
 pub mod w_network;
@@ -116,4 +117,18 @@ where
     fn known_nodes(&self) -> BoxFuture<'_, Vec<PubKey>>;
     /// Object safe clone
     fn obj_clone(&self) -> Box<dyn NetworkingImplementation<M> + 'static>;
+}
+
+/// interface describing how reliable the network is
+pub trait NetworkReliability: std::fmt::Debug + Sync + std::marker::Send + Copy {
+    /// Sample from bernoulli distribution to decide whether
+    /// or not to keep a packet
+    /// # Panics
+    ///
+    /// Panics if `self.keep_numerator > self.keep_denominator`
+    ///
+    fn sample_keep(&self) -> bool;
+    /// sample from uniform distribution to decide whether
+    /// or not to keep a packet
+    fn sample_delay(&self) -> Duration;
 }

--- a/src/traits/storage.rs
+++ b/src/traits/storage.rs
@@ -13,6 +13,7 @@ use super::state::State;
 pub mod memory_storage;
 
 /// Result for a storage type
+#[derive(Debug)]
 pub enum StorageResult<T> {
     /// The item was located in storage
     Some(T),

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -30,6 +30,34 @@ pub fn get_starting_state() -> State {
     }
 }
 
+/// generates random transactions with no regard for going negative
+/// # Panics when accounts is empty
+pub fn random_transactions<R: rand::Rng>(
+    mut rng: &mut R,
+    num_txns: usize,
+    accounts: Vec<String>,
+) -> Vec<Transaction> {
+    use rand::seq::IteratorRandom;
+    let mut txns = Vec::new();
+    for _ in 0..num_txns {
+        let input_account = accounts.iter().choose(&mut rng).unwrap();
+        let output_account = accounts.iter().choose(&mut rng).unwrap();
+        let amount = rng.gen_range(0, 100);
+        txns.push(Transaction {
+            add: Addition {
+                account: input_account.to_string(),
+                amount,
+            },
+            sub: Subtraction {
+                account: output_account.to_string(),
+                amount,
+            },
+            nonce: rng.gen(),
+        })
+    }
+    txns
+}
+
 /// Provides a common list of transactions
 pub fn get_ten_prebaked_trasnactions() -> Vec<Transaction> {
     vec![

--- a/tests/failures.rs
+++ b/tests/failures.rs
@@ -11,7 +11,9 @@ use std::collections::VecDeque;
 use phaselock::{
     demos::dentry::*,
     tc,
-    traits::implementations::{MasterMap, MemoryNetwork, MemoryStorage, Stateless},
+    traits::implementations::{
+        DummyReliability, MasterMap, MemoryNetwork, MemoryStorage, Stateless,
+    },
     types::{Event, EventType, Message, PhaseLockHandle},
     PhaseLock, PhaseLockConfig, PubKey, H_256,
 };
@@ -41,7 +43,11 @@ async fn single_permanent_failure() {
     )> = Vec::new();
     for node_id in 0..nodes {
         let pub_key = PubKey::from_secret_key_set_escape_hatch(&sks, node_id);
-        let mn = MemoryNetwork::new(pub_key.clone(), master.clone());
+        let mn = MemoryNetwork::new(
+            pub_key.clone(),
+            master.clone(),
+            Option::<DummyReliability>::None,
+        );
         networkings.push((mn, pub_key));
     }
     info!("Created networking");
@@ -185,7 +191,11 @@ async fn double_permanent_failure() {
     )> = Vec::new();
     for node_id in 0..nodes {
         let pub_key = PubKey::from_secret_key_set_escape_hatch(&sks, node_id);
-        let mn = MemoryNetwork::new(pub_key.clone(), master.clone());
+        let mn = MemoryNetwork::new(
+            pub_key.clone(),
+            master.clone(),
+            Option::<DummyReliability>::None,
+        );
         networkings.push((mn, pub_key));
     }
     info!("Created networking");

--- a/tests/lossy.rs
+++ b/tests/lossy.rs
@@ -1,0 +1,512 @@
+#![cfg(feature = "demo")]
+#![allow(clippy::type_complexity)]
+mod common;
+use common::*;
+use rand_xoshiro::{rand_core::SeedableRng, Xoshiro256StarStar};
+use tracing::{debug, error, info, instrument, trace, warn};
+
+use rand::distributions::{Bernoulli, Distribution, Uniform};
+use rand::seq::IteratorRandom;
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use std::ops::Sub;
+use std::time::Duration;
+
+use phaselock::{
+    demos::dentry::*,
+    tc,
+    traits::{
+        implementations::{MasterMap, MemoryNetwork, MemoryStorage, Stateless},
+        NetworkReliability,
+    },
+    types::{Event, EventType, Message, PhaseLockHandle},
+    PhaseLock, PhaseLockConfig, PubKey, H_256,
+};
+
+#[allow(clippy::upper_case_acronyms)]
+type NODE = DEntryNode<MemoryNetwork<Message<DEntryBlock, Transaction, State, H_256>>>;
+
+/// A synchronous network. Packets may be delayed, but are guaranteed
+/// to arrive within `timeout` ns
+#[derive(Clone, Copy, Debug)]
+pub struct SynchronousNetwork {
+    /// max delay of packet before arrival
+    timeout_ms: u64,
+    /// lowest value in milliseconds that a packet may be delayed
+    delay_low_ms: u64,
+}
+
+impl NetworkReliability for SynchronousNetwork {
+    /// never drop a packet
+    fn sample_keep(&self) -> bool {
+        true
+    }
+    fn sample_delay(&self) -> Duration {
+        Duration::from_millis(
+            Uniform::new_inclusive(self.delay_low_ms, self.timeout_ms)
+                .sample(&mut rand::thread_rng()),
+        )
+    }
+}
+
+/// An asynchronous network. Packets may be dropped entirely
+/// or delayed for arbitrarily long periods
+/// probability that packet is kept = `keep_numerator` / `keep_denominator`
+/// packet delay is obtained by sampling from a uniform distribution
+/// between `delay_low_ms` and `delay_high_ms`, inclusive
+#[derive(Debug, Clone, Copy)]
+pub struct AsynchronousNetwork {
+    /// numerator for probability of keeping packets
+    keep_numerator: u32,
+    /// denominator for probability of keeping packets
+    keep_denominator: u32,
+    /// lowest value in milliseconds that a packet may be delayed
+    delay_low_ms: u64,
+    /// highest value in milliseconds that a packet may be delayed
+    delay_high_ms: u64,
+}
+
+impl NetworkReliability for AsynchronousNetwork {
+    fn sample_keep(&self) -> bool {
+        Bernoulli::from_ratio(self.keep_numerator, self.keep_denominator)
+            .unwrap()
+            .sample(&mut rand::thread_rng())
+    }
+    fn sample_delay(&self) -> Duration {
+        Duration::from_millis(
+            Uniform::new_inclusive(self.delay_low_ms, self.delay_high_ms)
+                .sample(&mut rand::thread_rng()),
+        )
+    }
+}
+
+/// An partially synchronous network. Behaves asynchronously
+/// until some arbitrary time bound, GST,
+/// then synchronously after GST
+#[derive(Debug, Clone, Copy)]
+pub struct PartiallySynchronousNetwork {
+    /// asynchronous portion of network
+    asynchronous: AsynchronousNetwork,
+    /// synchronous portion of network
+    synchronous: SynchronousNetwork,
+    /// time when GST occurs
+    gst: std::time::Duration,
+    /// when the network was started
+    start: std::time::Instant,
+}
+
+impl NetworkReliability for PartiallySynchronousNetwork {
+    /// never drop a packet
+    fn sample_keep(&self) -> bool {
+        true
+    }
+    fn sample_delay(&self) -> Duration {
+        // act asyncronous before gst
+        if self.start.elapsed() < self.gst {
+            if self.asynchronous.sample_keep() {
+                self.asynchronous.sample_delay()
+            } else {
+                // assume packet was "dropped" and will arrive after gst
+                self.synchronous.sample_delay() + self.gst
+            }
+        } else {
+            // act syncronous after gst
+            self.synchronous.sample_delay()
+        }
+    }
+}
+
+impl Default for SynchronousNetwork {
+    // disable all chance of failure
+    fn default() -> Self {
+        SynchronousNetwork {
+            delay_low_ms: 0,
+            timeout_ms: 0,
+        }
+    }
+}
+
+impl Default for AsynchronousNetwork {
+    // disable all chance of failure
+    fn default() -> Self {
+        AsynchronousNetwork {
+            keep_numerator: 1,
+            keep_denominator: 1,
+            delay_low_ms: 0,
+            delay_high_ms: 0,
+        }
+    }
+}
+
+impl Default for PartiallySynchronousNetwork {
+    fn default() -> Self {
+        PartiallySynchronousNetwork {
+            synchronous: SynchronousNetwork::default(),
+            asynchronous: AsynchronousNetwork::default(),
+            gst: std::time::Duration::new(0, 0),
+            start: std::time::Instant::now(),
+        }
+    }
+}
+
+impl SynchronousNetwork {
+    /// create new `SynchronousNetwork`
+    pub fn new(timeout: u64, delay_low_ms: u64) -> Self {
+        SynchronousNetwork {
+            timeout_ms: timeout,
+            delay_low_ms,
+        }
+    }
+}
+
+impl AsynchronousNetwork {
+    /// create new `AsynchronousNetwork`
+    pub fn new(
+        keep_numerator: u32,
+        keep_denominator: u32,
+        delay_low_ms: u64,
+        delay_high_ms: u64,
+    ) -> Self {
+        AsynchronousNetwork {
+            keep_numerator,
+            keep_denominator,
+            delay_low_ms,
+            delay_high_ms,
+        }
+    }
+}
+
+impl PartiallySynchronousNetwork {
+    /// create new `PartiallySynchronousNetwork`
+    pub fn new(
+        asynchronous: AsynchronousNetwork,
+        synchronous: SynchronousNetwork,
+        gst: std::time::Duration,
+    ) -> Self {
+        PartiallySynchronousNetwork {
+            asynchronous,
+            synchronous,
+            gst,
+            start: std::time::Instant::now(),
+        }
+    }
+}
+
+/// This runs multiple rounds rounds of consensus
+/// with all networks treated with `network_reliability`.
+/// ensuring 'num_txns` randomly generated transactions
+/// become committed between 3 * `num_byzantine` + 1 nodes.
+/// safety check: at the end of each view, any nodes
+///   that commit should commit the same final block and state
+/// terminiation check: once all nodes have completed view i,
+///   at least one node must have each of the generated `important_txns`
+///   in storage, and all nodes must have produced a Decide event
+///   in a more recent view than all of the `important_txns`
+#[instrument]
+async fn lossy_network(
+    network_reliability: impl NetworkReliability + 'static,
+    num_txns: usize,
+    num_byzantine: usize,
+) {
+    setup_logging();
+
+    // Calculate the threshold
+    let threshold = 2 * num_byzantine + 1;
+    let num_nodes = 3 * num_byzantine + 1;
+    info!(?num_nodes, ?threshold);
+    // Generate the private key set
+    // Generated using xoshiro for reproduceability
+    let mut rng = Xoshiro256StarStar::seed_from_u64(0);
+    let sks = tc::SecretKeySet::random(threshold as usize - 1, &mut rng);
+    // Generate the networking backends
+    let master = MasterMap::<Message<DEntryBlock, Transaction, State, H_256>>::new();
+    let mut networkings: Vec<(
+        MemoryNetwork<Message<DEntryBlock, Transaction, State, H_256>>,
+        PubKey,
+    )> = Vec::new();
+    for node_id in 0..num_nodes {
+        let pub_key = PubKey::from_secret_key_set_escape_hatch(&sks, node_id.try_into().unwrap());
+        let mn = MemoryNetwork::new(pub_key.clone(), master.clone(), Some(network_reliability));
+        networkings.push((mn, pub_key));
+    }
+    info!("Created networking");
+    // Create the phaselocks
+    let known_nodes: Vec<PubKey> = networkings.iter().map(|(_, x)| x.clone()).collect();
+    let config = PhaseLockConfig {
+        total_nodes: num_nodes as u32,
+        threshold: threshold as u32,
+        max_transactions: 100,
+        known_nodes,
+        next_view_timeout: 100,
+        timeout_ratio: (11, 10),
+        round_start_delay: 1,
+        start_delay: 1,
+    };
+    debug!(?config);
+    let gensis = DEntryBlock::default();
+    let accounts = (b'a'..=b'g')
+        .map(|c| c as char) // Convert all to chars
+        .filter(|c| c.is_alphabetic()) // Filter only alphabetic chars
+        .map(|c| char::to_string(&c))
+        .collect::<Vec<String>>();
+    let state = State {
+        balances: accounts
+            .clone()
+            .iter()
+            .map(|name| (name.clone(), 500_000_000))
+            .collect::<BTreeMap<Account, Balance>>(),
+        nonces: BTreeSet::default(),
+    };
+    let mut phaselocks: Vec<PhaseLockHandle<NODE, H_256>> = Vec::new();
+    for node_id in 0..num_nodes {
+        let (_, h) = PhaseLock::init(
+            gensis.clone(),
+            sks.public_keys(),
+            sks.secret_key_share(node_id),
+            node_id.try_into().unwrap(),
+            config.clone(),
+            state.clone(),
+            networkings[node_id as usize].0.clone(),
+            MemoryStorage::default(),
+            Stateless::default(),
+        )
+        .await;
+        phaselocks.push(h);
+    }
+
+    let important_txns: Vec<_> =
+        random_transactions(&mut rand::thread_rng(), num_txns, accounts.clone())
+            .into_iter()
+            .collect();
+
+    info!("PhaseLocks prepared, running prebaked transactions");
+    let mut round = 1;
+    let mut txns = important_txns.clone();
+    let mut mrc = vec![0; num_nodes];
+    let mut txns_to_view = HashMap::new();
+    while !check_if_finished(&important_txns, &txns_to_view, &mrc) {
+        let txn = match txns.pop() {
+            Some(t) => t,
+            None => {
+                // accounts nonempty, so unwrap is fine
+                random_transactions(&mut rand::thread_rng(), 1, accounts.clone())
+                    .into_iter()
+                    .next()
+                    .unwrap()
+            }
+        };
+
+        phaselocks
+            .iter()
+            .choose(&mut rand::thread_rng())
+            .unwrap()
+            .submit_transaction(txn.clone())
+            .await
+            .expect("Failed to submit transaction");
+
+        // add second random transaction to prevent round from spinning
+        // this txn is not tracked and is only used for liveness
+        phaselocks
+            .iter()
+            .choose(&mut rand::thread_rng())
+            .unwrap()
+            // phaselocks nonempty, so unwrap is fine
+            .submit_transaction(
+                random_transactions(&mut rand::thread_rng(), 1, accounts.clone())
+                    .into_iter()
+                    .next()
+                    .unwrap(),
+            )
+            .await
+            .expect("Failed to submit transaction");
+
+        for (_i, phaselock) in phaselocks.iter().enumerate() {
+            phaselock.run_one_round().await;
+        }
+        debug!("Waiting for consensus to occur");
+        let mut num_failed = 0;
+        let mut states = HashMap::<usize, Vec<State>>::new();
+        let mut blocks = HashMap::<usize, Vec<DEntryBlock>>::new();
+        let mut successful_nodes = HashSet::new();
+        for (node_id, phaselock) in phaselocks.iter_mut().enumerate() {
+            debug!(?node_id, "Waiting on node to emit decision");
+            let mut event: Event<DEntryBlock, State> = phaselock
+                .next_event()
+                .await
+                .expect("PhaseLock unexpectedly closed");
+            // Actually wait for decision
+            while !matches!(event.event, EventType::Decide { .. } if event.view_number == round ) {
+                info!("lossy: next event for node id {:?}", node_id);
+                // timeout -> exist
+                if let EventType::ViewTimeout { view_number } = event.event {
+                    if view_number < round {
+                        continue;
+                    }
+
+                    warn!(?event, "\nRound timed out for replica {:?}\n", node_id,);
+                    num_failed += 1;
+                    break;
+                }
+                // error -> continue
+                else if matches!(event.event, EventType::Error { .. }) {
+                    warn!(?event, "\nRound encountered error {:?}\n", event.event);
+                    num_failed += 1;
+                    break;
+                }
+                // decide from prior view shouldn't be possible
+                else if let EventType::Decide { .. } = event.event {
+                    error!(
+                        "decision event from previous round {:?} encountered in round {:?}",
+                        event.view_number, round
+                    );
+                }
+
+                trace!(?node_id, ?event);
+                event = phaselock
+                    .next_event()
+                    .await
+                    .expect("PhaseLock unexpectedly closed");
+            }
+            if let EventType::Decide { block, state } = event.event {
+                warn!("\nRound finished for replica {:?}\n", node_id);
+                debug!(?node_id, "Node reached decision");
+                // commit for round
+                successful_nodes.insert(node_id);
+                states.insert(node_id, (*state).clone());
+                blocks.insert(node_id, (*block).clone());
+                mrc[node_id] = round as usize;
+            } else {
+                error!(
+                    "round failed for replica {} with error {:?}",
+                    node_id, event,
+                );
+            }
+        }
+        error!(
+            "Round finished. {:?} failures occurred on nodes: {:?}",
+            num_failed,
+            (0..num_nodes)
+                .into_iter()
+                .collect::<HashSet<_>>()
+                .sub(&successful_nodes)
+        );
+        // update when/if transaction was committed
+        if contains_txn(&txn, &blocks) {
+            // transaction was committed by at least one replice
+            txns_to_view.insert(txn, round as usize);
+        } else {
+            // transaction failed. Resubmit, and try again
+            txns.push(txn);
+        }
+        check_safety(&successful_nodes, &states, &blocks).await;
+
+        // Finally, increment the round counter
+        round += 1;
+    }
+}
+
+/// checks safety requirement. In particular, checks that the most recent
+/// block and state for a view match across all nodes that committed
+/// `nodes_to_check`: set of node ids that committed this view
+/// `node_states`: map node_id -> commited Vec<State> for this view
+/// `node_blocks`: map node_id -> commited Vec<DEntryBlock> for this view
+/// # Panics
+/// Panics if node has no state or blocks included
+pub async fn check_safety(
+    nodes_to_check: &HashSet<usize>,
+    node_states: &HashMap<usize, Vec<State>>,
+    node_blocks: &HashMap<usize, Vec<DEntryBlock>>,
+) {
+    if nodes_to_check.len() <= 1 {
+        return;
+    }
+
+    let first_node_idx = nodes_to_check.iter().next().unwrap();
+
+    let first_blocks = node_blocks[first_node_idx].clone();
+    let first_states = node_states[first_node_idx].clone();
+
+    for &i in nodes_to_check {
+        let i_blocks = node_blocks[&i].clone();
+        let i_states = node_states[&i].clone();
+        // first block/state most recent
+        if first_blocks.get(0) != i_blocks.get(0) || first_states.get(0) != i_states.get(0) {
+            error!(
+                ?first_blocks,
+                ?i_blocks,
+                ?first_states,
+                ?i_states,
+                ?first_node_idx,
+                ?i,
+                "SAFETY ERROR: most recent block or state does not match"
+            );
+            panic!("safety check failed");
+        }
+    }
+}
+
+/// checks that `txn` is committed in at least one node within the map
+/// `blocks` (from `node_id` -> blocks) generated during a view
+pub fn contains_txn(txn: &Transaction, blocks: &HashMap<usize, Vec<DEntryBlock>>) -> bool {
+    for (_k, node_blocks) in blocks.iter() {
+        for node_block in node_blocks {
+            if node_block.transactions.contains(txn) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// `txn_to_view` is a map from Transaction to the view it was committed
+/// `mrc` is a map from node id to the most recent view that committed
+/// this function checks the termination condition that all txns
+/// have been committed by all nodes
+pub fn check_if_finished(
+    txns: &[Transaction],
+    txn_to_view: &HashMap<Transaction, usize>,
+    mrc: &[usize],
+) -> bool {
+    let mut most_recent_view = 0;
+    // check that all txns have been committed
+    // find the txn with the highest view
+    for txn in txns {
+        match txn_to_view.get(txn) {
+            None => return false,
+            Some(view) => most_recent_view = most_recent_view.max(*view),
+        }
+    }
+
+    // check that all nodes have committed a view more recent than any of the submitted txns last committed view
+    mrc.iter().all(|&view| view > most_recent_view)
+}
+
+#[async_std::test]
+#[instrument]
+async fn test_no_loss_network() {
+    // tests base level of working synchronous network
+    lossy_network(SynchronousNetwork::default(), 1, 10).await
+}
+
+#[async_std::test]
+#[instrument]
+async fn test_synchronous_network() {
+    // tests network with forced packet delay
+    lossy_network(SynchronousNetwork::new(10, 5), 2, 4).await
+}
+
+#[async_std::test]
+#[instrument]
+async fn test_asynchronous_network() {
+    // tests network with small packet delay and dropped packets
+    lossy_network(AsynchronousNetwork::new(97, 100, 0, 5), 2, 4).await
+}
+
+/// tests network with asynchronous patch that eventually becomes synchronous
+#[async_std::test]
+#[instrument]
+async fn test_partially_synchronous_network() {
+    let asn = AsynchronousNetwork::new(90, 100, 0, 0);
+    let sn = SynchronousNetwork::new(10, 0);
+    let gst = std::time::Duration::new(10, 0);
+    lossy_network(PartiallySynchronousNetwork::new(asn, sn, gst), 2, 4).await
+}

--- a/tests/random_tests.rs
+++ b/tests/random_tests.rs
@@ -5,7 +5,9 @@ mod common;
 use phaselock::{
     demos::dentry::*,
     tc,
-    traits::implementations::{MasterMap, MemoryNetwork, MemoryStorage, Stateless},
+    traits::implementations::{
+        DummyReliability, MasterMap, MemoryNetwork, MemoryStorage, Stateless,
+    },
     types::{Event, EventType, Message, PhaseLockHandle},
     PhaseLock, PhaseLockConfig, PhaseLockError, PubKey, H_256,
 };
@@ -56,7 +58,11 @@ async fn get_networkings<
     let mut networkings: Vec<(MemoryNetwork<T>, PubKey)> = Vec::new();
     for node_id in 0..num_nodes {
         let pub_key = PubKey::from_secret_key_set_escape_hatch(sks, node_id);
-        let network = MemoryNetwork::new(pub_key.clone(), master.clone());
+        let network = MemoryNetwork::new(
+            pub_key.clone(),
+            master.clone(),
+            Option::<DummyReliability>::None,
+        );
         networkings.push((network, pub_key));
     }
     networkings

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -9,7 +9,9 @@ use tracing::{debug, error, info, instrument, trace};
 use phaselock::{
     demos::dentry::*,
     tc,
-    traits::implementations::{MasterMap, MemoryNetwork, MemoryStorage, Stateless},
+    traits::implementations::{
+        DummyReliability, MasterMap, MemoryNetwork, MemoryStorage, Stateless,
+    },
     types::{Event, EventType, Message, PhaseLockHandle},
     PhaseLock, PhaseLockConfig, PubKey, H_256,
 };
@@ -38,7 +40,11 @@ async fn ten_tx_seven_nodes() {
     )> = Vec::new();
     for node_id in 0..nodes {
         let pub_key = PubKey::from_secret_key_set_escape_hatch(&sks, node_id);
-        let mn = MemoryNetwork::new(pub_key.clone(), master.clone());
+        let mn = MemoryNetwork::new(
+            pub_key.clone(),
+            master.clone(),
+            Option::<DummyReliability>::None,
+        );
         networkings.push((mn, pub_key));
     }
     info!("Created networking");
@@ -154,7 +160,11 @@ async fn ten_tx_five_nodes() {
     )> = Vec::new();
     for node_id in 0..nodes {
         let pub_key = PubKey::from_secret_key_set_escape_hatch(&sks, node_id);
-        let mn = MemoryNetwork::new(pub_key.clone(), master.clone());
+        let mn = MemoryNetwork::new(
+            pub_key.clone(),
+            master.clone(),
+            Option::<DummyReliability>::None,
+        );
         networkings.push((mn, pub_key));
     }
     info!("Created networking");


### PR DESCRIPTION
# Description

This PR introduces a `NetworkReliability` trait (is `networking.rs` the right spot for this?) that describes packet loss and delay. It includes implementations for a synchronous, asynchronous, and partially synchronous network and adds `NetworkReliability` to the `memory_network` implementation. Closes #17 

As context, a synchronous network guarantees no packet loss, but allows for packet delay. An asynchronous network allows for packet loss and delay. A partially synchronous network acts asynchronously up until some time, GST, and then acts synchronously. The useful part of a partially synchronous network is the provided liveness guarantee that does not exist for asynchronous networks.

When a packet is sent, an async task is spawned. The task decides whether or not to keep the packet. If the packet is to be kept, the task sleeps for some (sampled) time then delivers the packet.

Finally this PR adds tests (tweaked from `random_tests:mul_txns`) in `lossy.rs` to test consensus on a network with some packet loss and/or delay.

## Conditions for termination

Let me preface this with: I think this makes sense, but I'm not 100% sure it's a strong enough check.

`lossy.rs:lossy_network` runs until "consensus" is reached for a list of `num_txns` randomly generated  transactions (denoted `important_txns`) are "agreed upon" across all replicas (denote the set of repliacs R). Each round adds at most one transaction from `important_txns` , so at least `num_txns` rounds shall run. I implemented "agreed upon" as to terminate when the following predicate is true: for all transactions `t` in `important_txns`, `t` must be committed within a block on some replica. Assume this happens on view `v`. Then for all `r` in `R` (set of replicas), `r` must have committed a transaction on a view greater than `v`.

First I had tried `t must be committed in some block on all replicas` instead of `on some replica`. But then, the transaction did not show up on all replicas after a bunch of rounds (>20) in the asynchronous case, though further transactions were committed to the nodes missing the txns. I'm not sure if this is expected behavior.

Another idea I tried was to wait for the transaction to be committed, and then for all replicas to commit in the same view/round. This works in the case of partial synchrony, but in an asynchronous network, most of the time there will be at least one node that did not commit. So the asynchronous network would not necessarily terminate.

It's worth noting that I had to keep submitting txns. Otherwise after submitting transactions and getting a decision on the majority of nodes, the next view's leader would spin waiting for a transaction to be submitted, and the follower replicas that did not receive the transaction would not be updated.

## Conditions for safety

Any time a view results in replica commits, the replicas that committed must have matching most recent (state,block) within that decision. I believe other previous state can be committed as part of the catchup mechanism, resulting in different `(state, block)` pairs on commit.

# Testing

I ran the entire suite 100 times without encountering failure or livelock.