### PR TITLE
Include Stage and View number in Signature

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,7 @@ use std::time::{Duration, Instant};
 
 use async_std::sync::{Mutex, RwLock};
 use async_std::task::{spawn, yield_now, JoinHandle};
+use data::create_hash;
 use serde::{Deserialize, Serialize};
 use snafu::ResultExt;
 use tracing::{debug, error, info, info_span, instrument, trace, warn, Instrument};
@@ -146,10 +147,11 @@ impl PrivKey {
     pub fn partial_sign<const N: usize>(
         &self,
         hash: &BlockHash<N>,
-        _stage: Stage,
-        _view: u64,
+        stage: Stage,
+        view: u64,
     ) -> tc::SignatureShare {
-        self.node.sign(hash)
+        let blockhash = create_hash(hash, view, stage);
+        self.node.sign(blockhash)
     }
 }
 

--- a/src/types/message.rs
+++ b/src/types/message.rs
@@ -3,6 +3,7 @@
 //! This module contains types used to represent the various types of messages that
 //! [`PhaseLock`](crate::PhaseLock) nodes can send among themselves.
 
+use crate::data::Stage;
 use hex_fmt::HexFmt;
 use serde::{Deserialize, Serialize};
 use threshold_crypto::SignatureShare;
@@ -67,6 +68,8 @@ pub struct Vote<const N: usize> {
     pub leaf_hash: BlockHash<N>,
     /// The view this vote was cast for
     pub current_view: u64,
+    /// The current stage
+    pub stage: Stage,
 }
 
 impl<const N: usize> Debug for Vote<N> {


### PR DESCRIPTION
This PR:

- Adds `Stage` to the `Vote` struct.
- Hashes `view_number`,`stage`, and blockhash, and signs the result in `partial_sign`. I added the hash in order to return a known size vector.
- Includes the `view` and `stage` when checking the `signature` in the `verify` function.
- Closes #3 .

The changes don't *seem* to break tests.