### PR TITLE
Add nix repl

### DIFF
--- a/repl.nix
+++ b/repl.nix
@@ -1,0 +1,9 @@
+# usage: nix repl repl.nix
+let
+  flake = builtins.getFlake (toString ./.);
+in
+  {
+    inherit flake;
+    self = flake.inputs.self;
+    pkgs = flake.inputs.nixpkgs.legacyPackages;
+  }


### PR DESCRIPTION
This is a tiny quality of life improvement. Saves the 5 seconds to import the flake every time one uses the repl. Usage: `nix repl repl.nix`.