### PR TITLE
refactor out HandleError type

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,15 +54,16 @@ use crate::{
     data::{BlockHash, Leaf, QuorumCertificate, Stage},
     traits::{BlockContents, NetworkingImplementation, NodeImplementation, Storage, StorageResult},
     types::{
-        error::{NetworkFault, PhaseLockError},
-        Commit, Decide, Event, EventType, Message, NewView, PhaseLockHandle, PreCommit, Prepare,
-        Vote,
+        error::NetworkFault, Commit, Decide, Event, EventType, Message, NewView, PhaseLockHandle,
+        PreCommit, Prepare, Vote,
     },
     utility::{
         broadcast::BroadcastSender,
         waitqueue::{WaitOnce, WaitQueue},
     },
 };
+
+pub use crate::types::error::PhaseLockError;
 
 /// Reexport rand crate
 pub use rand;

--- a/src/types.rs
+++ b/src/types.rs
@@ -8,6 +8,6 @@ pub use error::PhaseLockError;
 pub use event::Event;
 pub use event::EventType;
 
-pub use handle::{HandleError, PhaseLockHandle};
+pub use handle::PhaseLockHandle;
 
 pub use message::{Commit, Decide, Message, NewView, PreCommit, Prepare, Vote};

--- a/tests/random_tests.rs
+++ b/tests/random_tests.rs
@@ -6,8 +6,8 @@ use phaselock::{
     demos::dentry::*,
     tc,
     traits::implementations::{MasterMap, MemoryNetwork, MemoryStorage, Stateless},
-    types::{Event, EventType, HandleError, Message, PhaseLockHandle},
-    PhaseLock, PhaseLockConfig, PubKey, H_256,
+    types::{Event, EventType, Message, PhaseLockHandle},
+    PhaseLock, PhaseLockConfig, PhaseLockError, PubKey, H_256,
 };
 use proptest::prelude::*;
 use rand_xoshiro::{rand_core::SeedableRng, Xoshiro256StarStar};
@@ -31,7 +31,7 @@ pub enum ConsensusError {
 
     FailedToProposeTxn,
 
-    PhaselockClosed(HandleError),
+    PhaselockClosed(PhaseLockError),
 
     /// States after a round of consensus is inconsistent.
     InconsistentAfterTxn,


### PR DESCRIPTION
Removes the HandleError type and replaces it with PhaseLockError. Closes #12 .

`next_event`, `next_event_sync`, and `try_next_event` all return `PhaseLockError`, but they're all restricted to returning `PhaseLockError::NetworkFault { source: NetworkError::ShutDown }`. I left these functions returning `PhaseLockError`, but they could also potentially all return `NetworkFault` since that's the only way to fail. Not sure what's best here.