### PR TITLE
Pass nix tests

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -50,6 +50,9 @@
           })
           {
             inherit pkgs;
+            # need to force threshold_crypto/use-insuecure-test-only-mock-crypto
+            # otherwise a subset of tests hang
+            rootFeatures = [ "demo" "docs" "blake3" "threshold_crypto/use-insecure-test-only-mock-crypto" ] ;
             defaultCrateOverrides = pkgs.defaultCrateOverrides // {
               # Crate dependency overrides go here
             };
@@ -58,7 +61,7 @@
       in
       {
         packages.${crateName} = project.rootCrate.build;
-        packages.tests.${crateName} = project.rootCrate.build.override {
+        checks.${crateName} = project.rootCrate.build.override {
           runTests = true;
         };
 


### PR DESCRIPTION
The `nix` tests seem to be running into the same issue as Kaley was last Friday. The crate does not have the `threshold_crypto/use-insecure-test-only-mock-crypto` feature enabled, and as a result hangs during some of its tests. This PR explicitly lists features to build, and now the tests pass. 

It also moves `packages.tests` to `check`. The idea with this is to get slightly nicer cli integration. Running `nix flake check --keep-going` would run all tests for a specific architecture. `--keep-going` is needed for `aarch64-darwin` as nix is unable to build/evaluate for other architectures on `aarch64-darwin`. 

Note: I've only tested on `aarch64-darwin`.