### PR TITLE
Added dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Added dependabot.yml

This will try to open PRs to update `rand`, `rand_chacha` and `rand_xoshiro`, which won't be updateable because of a dependency on `threshold_crypto`. 

We can either wait for `treshold_crypto` to be updated + released, or accept that we'll get PRs on `rand*` and leave those open for now