### PR TITLE
Nested Message under ConsensusMessage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1184,18 +1184,18 @@ dependencies = [
 
 [[package]]
 name = "derive_builder"
-version = "0.10.2"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d13202debe11181040ae9063d739fa32cfcaaebe2275fe387703460ae2365b30"
+checksum = "11d918e7dabe374a51dae0f29d818fece3b218b8b4eabec3bc4d42c537e7ed8f"
 dependencies = [
  "derive_builder_macro",
 ]
 
 [[package]]
 name = "derive_builder_core"
-version = "0.10.2"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66e616858f6187ed828df7c64a6d71720d83767a7f19740b2d1b6fe6327b36e5"
+checksum = "f712c2d4e52d5fcae53584e461dcb92fb2202e144ebf83ab0ba4360d18b767c7"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1205,9 +1205,9 @@ dependencies = [
 
 [[package]]
 name = "derive_builder_macro"
-version = "0.10.2"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58a94ace95092c5acb1e97a7e846b310cfbd499652f72297da7493f618a98d73"
+checksum = "a8a2ac71b4a9a590dde6cee3ca4687aca5e7ce06f4ee297c5a959de5f1e42b2e"
 dependencies = [
  "derive_builder_core",
  "syn",

--- a/phaselock-types/src/message.rs
+++ b/phaselock-types/src/message.rs
@@ -4,17 +4,28 @@
 //! `PhaseLock` nodes can send among themselves.
 
 use crate::data::Stage;
+use crate::data::{Leaf, LeafHash, QuorumCertificate};
 use hex_fmt::HexFmt;
 use serde::{Deserialize, Serialize};
-use threshold_crypto::SignatureShare;
-
 use std::fmt::Debug;
-
-use crate::data::{Leaf, LeafHash, QuorumCertificate};
+use threshold_crypto::SignatureShare;
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 /// Enum representation of any message type
 pub enum Message<B, T, S, const N: usize> {
+    /// Messages related to the consensus protocol
+    Consensus(ConsensusMessage<B, T, S, N>),
+}
+
+impl<B, T, S, const N: usize> From<ConsensusMessage<B, T, S, N>> for Message<B, T, S, N> {
+    fn from(m: ConsensusMessage<B, T, S, N>) -> Self {
+        Self::Consensus(m)
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+/// Messages related to the consensus protocol
+pub enum ConsensusMessage<B, T, S, const N: usize> {
     /// Signals start of a new view
     NewView(NewView<N>),
     /// Contains the prepare qc from the leader

--- a/phaselock-types/src/traits/node_implementation.rs
+++ b/phaselock-types/src/traits/node_implementation.rs
@@ -3,15 +3,14 @@
 //! This module defines the [`NodeImplementation`] trait, which is a composite trait used for
 //! describing the overall behavior of a node, as a composition of implementations of the node trait.
 
-use std::fmt::Debug;
-
 use crate::{
-    message::Message,
+    message::{ConsensusMessage, Message},
     traits::{
         network::NetworkingImplementation, stateful_handler::StatefulHandler, storage::Storage,
         BlockContents,
     },
 };
+use std::fmt::Debug;
 
 /// Node implementation aggregate trait
 ///
@@ -38,4 +37,38 @@ pub trait NodeImplementation<const N: usize>: Send + Sync + Debug + Clone + 'sta
         > + Clone;
     /// Stateful call back handler for this consensus implementation
     type StatefulHandler: StatefulHandler<N, Block = Self::Block, State = Self::State>;
+}
+
+/// Helper trait to make aliases.
+///
+/// This allows you to replace
+///
+/// ```ignore
+/// Message<
+///     I::Block,
+///     <I::Block as BlockContents<N>>::Transaction,
+///     I::State,
+///     N,
+/// >
+/// ```
+///
+/// with
+///
+/// ```ignore
+/// <I as TypeMap<N>>::Message
+/// ```
+pub trait TypeMap<const N: usize> {
+    /// Type alias for the [`Message`] enum.
+    type Message;
+    /// Type alias for the [`ConsensusMessage`] enum.
+    type ConsensusMessage;
+}
+
+impl<I, const N: usize> TypeMap<N> for I
+where
+    I: NodeImplementation<N>,
+{
+    type Message = Message<I::Block, <I::Block as BlockContents<N>>::Transaction, I::State, N>;
+    type ConsensusMessage =
+        ConsensusMessage<I::Block, <I::Block as BlockContents<N>>::Transaction, I::State, N>;
 }


### PR DESCRIPTION
This PR prepares the codebase for #9 and other issues. It moves the `Message` enum under a `Consensus` variant so we can easily add more variants.

All `*Message` variants should have an `impl From<...> for Message` implementation, so you can call `phaselock.send_broadcast_message` or `phaselock.send_direct_message`. These will automatically do the `Into` conversion.

Also added some helper functions which will make it easier to split up the logic of the different types of messages.

`TypeMap` is some trait magic to make it easier to use the `Message` alias. It was getting quite annoying typing `Message<I::Block, <I::Block as BlockContents<N>>::Transaction, I::State, N>` all over the place. Using `<I as TypeMap<N>>::Message` is a lot easier to parse.