### PR TITLE
Introduced `Storage::update` that bundles all `.insert_*` calls in a single transaction

### DIFF
--- a/phaselock-types/src/traits/storage.rs
+++ b/phaselock-types/src/traits/storage.rs
@@ -1,11 +1,10 @@
 //! Abstraction over on-disk storage of node state
 
-use futures::future::BoxFuture;
-
 use crate::{
     data::{BlockHash, Leaf, LeafHash, QuorumCertificate},
     traits::{BlockContents, State},
 };
+use futures::{future::BoxFuture, Future};
 
 /// Result for a storage type
 pub type StorageResult<T = ()> =
@@ -25,8 +24,6 @@ pub trait Storage<B: BlockContents<N> + 'static, S: State<N, Block = B> + 'stati
         &'a self,
         hash: &'b BlockHash<N>,
     ) -> BoxFuture<'b, StorageResult<Option<B>>>;
-    /// Inserts a block into storage. Make sure to call [`commit`] after all data is inserted.
-    fn insert_block(&self, hash: BlockHash<N>, block: B) -> BoxFuture<'_, StorageResult>;
     /// Retrieves a Quorum Certificate from storage, by the hash of the block it refers to
     fn get_qc<'b, 'a: 'b>(
         &'a self,
@@ -37,9 +34,6 @@ pub trait Storage<B: BlockContents<N> + 'static, S: State<N, Block = B> + 'stati
         &self,
         view: u64,
     ) -> BoxFuture<'_, StorageResult<Option<QuorumCertificate<N>>>>;
-    /// Inserts a Quorum Certificate into the storage. Should reject the QC if it is malformed or
-    /// not from a decide stage. Make sure to call [`commit`] after all data is inserted.
-    fn insert_qc(&self, qc: QuorumCertificate<N>) -> BoxFuture<'_, StorageResult>;
     /// Retrieves a leaf by its hash
     fn get_leaf<'b, 'a: 'b>(
         &'a self,
@@ -50,20 +44,36 @@ pub trait Storage<B: BlockContents<N> + 'static, S: State<N, Block = B> + 'stati
         &'a self,
         hash: &'b BlockHash<N>,
     ) -> BoxFuture<'b, StorageResult<Option<Leaf<B, N>>>>;
-    /// Inserts a leaf. Make sure to call [`commit`] after all data is inserted.
-    fn insert_leaf(&self, leaf: Leaf<B, N>) -> BoxFuture<'_, StorageResult>;
-    /// Inserts a `State`, indexed by the hash of the `Leaf` that created it. Make sure to call [`commit`] after all data is inserted.
-    fn insert_state(&self, state: S, hash: LeafHash<N>) -> BoxFuture<'_, StorageResult>;
     /// Retrieves a `State`, indexed by the hash of the `Leaf` that created it
     fn get_state<'b, 'a: 'b>(
         &'a self,
         hash: &'b LeafHash<N>,
     ) -> BoxFuture<'b, StorageResult<Option<S>>>;
 
-    /// Commit the changes in the Storage. This should be called every time one or multiple of the following functions are called:
-    /// - `insert_block`
-    /// - `insert_qc`
-    /// - `insert_leaf`
-    /// - `insert_state`
-    fn commit(&self) -> BoxFuture<'_, StorageResult>;
+    /// Calls the given `update_fn` for a list of modifications, then stores these.
+    ///
+    /// If an error occurs somewhere, the caller can assume that no data is stored at all.
+    fn update<'a, F, FUT>(&'a self, update_fn: F) -> BoxFuture<'_, StorageResult>
+    where
+        F: FnOnce(Box<dyn StorageUpdater<'a, B, S, N> + 'a>) -> FUT + Send + 'a,
+        FUT: Future<Output = StorageResult> + Send + 'a;
+}
+
+/// Trait to be used with [`Storage`]'s `update` function.
+pub trait StorageUpdater<
+    'a,
+    B: BlockContents<N> + 'static,
+    S: State<N, Block = B> + 'static,
+    const N: usize,
+>: Send
+{
+    /// Inserts a block into storage. Make sure to call [`commit`] after all data is inserted.
+    fn insert_block(&mut self, hash: BlockHash<N>, block: B) -> BoxFuture<'_, StorageResult>;
+    /// Inserts a Quorum Certificate into the storage. Should reject the QC if it is malformed or
+    /// not from a decide stage. Make sure to call [`commit`] after all data is inserted.
+    fn insert_qc(&mut self, qc: QuorumCertificate<N>) -> BoxFuture<'_, StorageResult>;
+    /// Inserts a leaf. Make sure to call [`commit`] after all data is inserted.
+    fn insert_leaf(&mut self, leaf: Leaf<B, N>) -> BoxFuture<'_, StorageResult>;
+    /// Inserts a `State`, indexed by the hash of the `Leaf` that created it. Make sure to call [`commit`] after all data is inserted.
+    fn insert_state(&mut self, state: S, hash: LeafHash<N>) -> BoxFuture<'_, StorageResult>;
 }

--- a/src/types/handle.rs
+++ b/src/types/handle.rs
@@ -1,15 +1,13 @@
 //! Provides an event-streaming handle for a [`PhaseLock`] running in the background
 
-use async_std::{sync::RwLock, task::block_on};
-use std::sync::Arc;
-
 use crate::{
     traits::{BlockContents, NetworkError::ShutDown, NodeImplementation},
     types::{Event, PhaseLockError, PhaseLockError::NetworkFault},
     PhaseLock,
 };
-
+use async_std::{sync::RwLock, task::block_on};
 use phaselock_utils::broadcast::{BroadcastReceiver, BroadcastSender};
+use std::sync::Arc;
 
 /// Event streaming handle for a [`PhaseLock`] instance running in the background
 ///


### PR DESCRIPTION
This PR removes the old `Storage::commit` and makes each storage implementation responsible for calling this automatically after records have been changed.

I couldn't get the lifetimes perfectly right  for the `Storage::update` call, so unfortunately I had to `Box` the `StorageUpdater` and have the callback `async move` all values it requires.