### PR TITLE
Increase coveralls code coverage

### DIFF
--- a/.github/workflows/coverage_libp2p_networking.yml
+++ b/.github/workflows/coverage_libp2p_networking.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   code-coverage:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3


### PR DESCRIPTION
Add workspace flag to get coverage tests run. Bumps toolchain as well for coverage workflow.

Closes #125 