### PR TITLE
Moved cargo fmt and clippy to their own step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,12 +25,6 @@ jobs:
       - uses: Swatinem/rust-cache@v1
         name: Enable Rust Caching
 
-      - name: Format Check
-        run: cargo fmt -- --check
-
-      - name: Clippy
-        run: cargo clippy --workspace --all-targets --all-features -- -D warnings
-
       - name: Audit
         run: cargo audit --deny warnings
 

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -1,0 +1,28 @@
+name: Lints
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  lints:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v3
+        name: Checkout Repository
+
+      - name: Configure Git
+        run: |
+          git config --global url."https://ancient123:${{ secrets.ORG_GITHUB_PAT }}@github.com/".insteadOf git://github.com/
+          git config --global url."https://ancient123:${{ secrets.ORG_GITHUB_PAT }}@github.com/".insteadOf ssh://git@github.com/
+
+      - uses: Swatinem/rust-cache@v1
+        name: Enable Rust Caching
+
+      - name: Format Check
+        run: cargo fmt -- --check
+
+      - name: Clippy
+        run: cargo clippy --workspace --all-targets --all-features -- -D warnings


### PR DESCRIPTION
This moves `cargo fmt` and `cargo clippy` to their own workflow step.

This will improve 2 things:
- The build won't skip `cargo test` if you forget to run `cargo fmt`, so we get to see both at the same time
- The build will be faster as `cargo clippy` is relatively slow. 

Closes #123 