### PR TITLE
Updated atomicstore to remove the chrono dependency

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -17,11 +17,6 @@ ignore = [
     # https://rustsec.org/advisories/RUSTSEC-2020-0056
     "RUSTSEC-2020-0056",
 
-    # chrono 0.4.19, potential segfault
-    # No safe upgrade is available
-    # https://rustsec.org/advisories/RUSTSEC-2020-0159
-    "RUSTSEC-2020-0159",
-
     # aesni 0.10.0 unmaintained
     # Dependency of tide -> http-types -> cookie -> aes-gcm -> aesni
     # Fixed in cookie 0.16.0, waiting on http-types 3.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -512,12 +512,11 @@ checksum = "065374052e7df7ee4047b1160cca5e1467a12351a40b3da123c870ba0b8eda2a"
 
 [[package]]
 name = "atomic_store"
-version = "0.1.1"
-source = "git+https://github.com/EspressoSystems/atomicstore?tag=0.1.1#e116cea2de934fd315f690d07d45b3bb7a213654"
+version = "0.1.2"
+source = "git+https://github.com/EspressoSystems/atomicstore?tag=0.1.2#55d9753e1fcb35c61566b8e056426e85e9e7eeeb"
 dependencies = [
  "ark-serialize",
  "bincode",
- "chrono",
  "glob",
  "serde",
  "snafu",
@@ -542,15 +541,15 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "backtrace"
-version = "0.3.64"
+version = "0.3.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e121dee8023ce33ab248d9ce1493df03c3b38a659b240096fcbd7048ff9c31f"
+checksum = "11a17d453482a265fd5f8479f2a3f405566e6ca627837aaddb85af8b1ab8ef61"
 dependencies = [
  "addr2line",
  "cc",
  "cfg-if",
  "libc",
- "miniz_oxide 0.4.4",
+ "miniz_oxide",
  "object",
  "rustc-demangle",
 ]
@@ -739,18 +738,6 @@ dependencies = [
  "cipher 0.3.0",
  "poly1305",
  "zeroize",
-]
-
-[[package]]
-name = "chrono"
-version = "0.4.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
-dependencies = [
- "libc",
- "num-integer",
- "num-traits",
- "winapi",
 ]
 
 [[package]]
@@ -1354,7 +1341,7 @@ dependencies = [
  "crc32fast",
  "libc",
  "libz-sys",
- "miniz_oxide 0.5.1",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -1367,7 +1354,7 @@ dependencies = [
  "futures-sink",
  "nanorand",
  "pin-project 1.0.10",
- "spin 0.9.2",
+ "spin 0.9.3",
 ]
 
 [[package]]
@@ -1836,9 +1823,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35e70ee094dc02fd9c13fdad4940090f22dbd6ac7c9e7094a46cf0232a50bc7c"
+checksum = "879d54834c8c76457ef4293a689b2a8c59b076067ad77b15efafbb05f92a592b"
 
 [[package]]
 name = "itertools"
@@ -2545,16 +2532,6 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
-dependencies = [
- "adler",
- "autocfg",
-]
-
-[[package]]
-name = "miniz_oxide"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2b29bd4bc3f33391105ebee3589c19197c4271e3e5a9ec9bfe8127eeff8f082"
@@ -2946,9 +2923,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.27.1"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67ac1d3f9a1d3616fd9a60c8d74296f22406a238b6a72f5cc1e6f314df4ffbf9"
+checksum = "40bec70ba014595f99f7aa110b84331ffe1ee9aece7fe6f387cc7e3ecda4d456"
 dependencies = [
  "memchr",
 ]
@@ -4099,9 +4076,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "511254be0c5bcf062b019a6c89c01a664aa359ded62f78aa72c6fc137c0590e5"
+checksum = "c530c2b0d0bf8b69304b39fe2001993e267461948b890cd037d8ad4293fa1a0d"
 dependencies = [
  "lock_api",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ ark-ec = { version = "0.3.0", default-features = false }
 ark-ed-on-bls12-381 = { version = "0.3.0", default-features = false }
 async-std = { version = "1.11.0", features = ["unstable"] }
 async-tungstenite = { version = "0.17.2", features = ["async-std-runtime"] }
-atomic_store = { git = "https://github.com/EspressoSystems/atomicstore", tag = "0.1.1" }
+atomic_store = { git = "https://github.com/EspressoSystems/atomicstore", tag = "0.1.2" }
 bincode = "1.3.3"
 blake3 = { version = "1.1.0", optional = true }
 byteorder = "1.4.3"

--- a/phaselock-types/Cargo.toml
+++ b/phaselock-types/Cargo.toml
@@ -13,7 +13,7 @@ test_crypto = ["threshold_crypto/use-insecure-test-only-mock-crypto"]
 [dependencies]
 async-std = "1.11.0"
 async-tungstenite = "0.17.2"
-atomic_store = { git = "https://github.com/EspressoSystems/atomicstore", tag = "0.1.1" }
+atomic_store = { git = "https://github.com/EspressoSystems/atomicstore", tag = "0.1.2" }
 bincode = "1.3.3"
 blake3 = "1.3.1"
 futures = "0.3.21"


### PR DESCRIPTION
`atomic_store` was only using `chrono` to get the unix timestamp, so I [removed it](https://github.com/EspressoSystems/atomicstore/pull/34).

This also removes the `chrono` CVE that we are ignoring, so I removed that CVE from the ignore list