### PR TITLE
Added a utility script to make the update_flake_lock_action PR more readable

### DIFF
--- a/scripts/nix_bump_pr_changes.py
+++ b/scripts/nix_bump_pr_changes.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+
+# Utility script to show the github commit diff when a `update_flake_lock_action` PR is made.
+# 
+# To run, pipe the contents of the `Flake lock file updates:` into this file
+#
+# e.g. `cat updates.txt | ./scripts/nix_bump_pr_changes.py`
+#
+# The output of this script should be pasted as a reply to that PR
+
+import sys
+import re
+
+name_commit_regex = re.compile(r"'github:([^\/]+\/[^\/]+)\/([^']+)")
+prev = ''
+
+for line in sys.stdin:
+    line = line.rstrip()
+    if line.startswith("    'github:"):
+        prev = line
+    if line.startswith("  → 'github:"):
+
+        [_, repo, start_commit, _] = name_commit_regex.split(prev)
+        [_, _, end_commit, _] = name_commit_regex.split(line)
+        print("- [ ] " + repo + ": [repo](https://github.com/" + repo + ") | [commits this PR](https://github.com/" + repo + "/compare/" + start_commit + ".." + end_commit + ")")
+
+


### PR DESCRIPTION
I made a python script that makes the `update_flake_lock_action` more readable.

To use this script, take the codeblock from a PR (e.g. #185) and run it as stdin to this script.

```bash
edit pr.txt # add text in here
cat pr.txt | ./scripts/nix_bump_pr_changes.py
# copy the output as a comment in the PR
```

This will allow you to create a comment like [this](https://github.com/EspressoSystems/phaselock/pull/185#issuecomment-1134551960), which gives a nicer overview of what is changed in the repos.

Of course some things are still impossible to figure out what changed for some repos (e.g. `nix-community/fenix`) but it seems useful for the other repos