### PR TITLE
Removed `State::new_transaction_ids` and `Transaction::id`

### DIFF
--- a/phaselock-hotstuff/src/phase/prepare/replica.rs
+++ b/phaselock-hotstuff/src/phase/prepare/replica.rs
@@ -6,9 +6,9 @@ use phaselock_types::{
     data::{LeafHash, Stage},
     error::PhaseLockError,
     message::{Prepare, PrepareVote, Vote},
-    traits::{node_implementation::NodeImplementation, State, Transaction as _},
+    traits::{node_implementation::NodeImplementation, State},
 };
-use tracing::{error, info};
+use tracing::error;
 
 /// A prepare replica
 #[derive(Debug)]
@@ -99,20 +99,23 @@ impl PrepareReplica {
             });
         }
 
-        let mut added_transactions = Vec::new();
-        for id in prepare.state.new_transaction_ids(&state) {
-            if let Some(transaction_state) =
-                ctx.transactions.iter().find(|t| t.transaction.id() == id)
-            {
-                added_transactions.push(transaction_state.clone());
-            } else {
-                info!(
-                    ?id,
-                    "Could not find transaction to mark, will sit out until we receive it"
-                );
-                return Ok(None);
-            }
-        }
+        let added_transactions = Vec::new();
+        // TODO: rework how transactions are stored and processed
+        // https://github.com/EspressoSystems/phaselock/issues/136
+        //
+        // for id in prepare.state.new_transaction_ids(&state) {
+        //     if let Some(transaction_state) =
+        //         ctx.transactions.iter().find(|t| t.transaction.id() == id)
+        //     {
+        //         added_transactions.push(transaction_state.clone());
+        //     } else {
+        //         info!(
+        //             ?id,
+        //             "Could not find transaction to mark, will sit out until we receive it"
+        //         );
+        //         return Ok(None);
+        //     }
+        // }
 
         Ok(Some(ValidationResult {
             added_transactions,

--- a/phaselock-types/src/traits/block_contents.rs
+++ b/phaselock-types/src/traits/block_contents.rs
@@ -53,17 +53,9 @@ pub trait BlockContents<const N: usize>:
 pub trait Transaction<const N: usize>:
     Clone + Serialize + DeserializeOwned + Debug + Hash + PartialEq + Eq + Sync + Send
 {
-    /// The unique identifier type that this transaction uses. Will most likely be [`TransactionHash`]
-    type Id: PartialEq + Eq + Debug;
-    /// Get this `Transaction`'s ID.
-    fn id(&self) -> Self::Id;
 }
 
-impl<const N: usize> Transaction<N> for () {
-    type Id = ();
-
-    fn id(&self) {}
-}
+impl<const N: usize> Transaction<N> for () {}
 
 /// Dummy implementation of `BlockContents` for unit tests
 pub mod dummy {

--- a/phaselock-types/src/traits/state.rs
+++ b/phaselock-types/src/traits/state.rs
@@ -3,7 +3,6 @@
 //! This module provides the [`State`] trait, which serves as an abstraction over the current
 //! network state, which is modified by the transactions contained within blocks.
 
-use super::Transaction;
 use crate::traits::BlockContents;
 use serde::{de::DeserializeOwned, Serialize};
 use std::{error::Error, fmt::Debug, hash::Hash};
@@ -39,12 +38,6 @@ pub trait State<const N: usize>:
     fn append(&self, block: &Self::Block) -> Result<Self, Self::Error>;
     /// Gets called to notify the persistence backend that this state has been committed
     fn on_commit(&self);
-
-    /// Return a list of transaction ids that are included in this state but not the previous one
-    fn new_transaction_ids(
-        &self,
-        previous: &Self,
-    ) -> Vec<<<Self::Block as BlockContents<N>>::Transaction as Transaction<N>>::Id>;
 }
 
 /// Dummy implementation of `State` for unit tests
@@ -88,9 +81,5 @@ pub mod dummy {
         }
 
         fn on_commit(&self) {}
-
-        fn new_transaction_ids(&self, _: &DummyState) -> Vec<()> {
-            vec![]
-        }
     }
 }

--- a/src/demos/dentry.rs
+++ b/src/demos/dentry.rs
@@ -84,13 +84,7 @@ pub struct Transaction {
     pub nonce: u64,
 }
 
-impl crate::traits::Transaction<H_256> for Transaction {
-    type Id = u64;
-
-    fn id(&self) -> u64 {
-        self.nonce
-    }
-}
+impl crate::traits::Transaction<H_256> for Transaction {}
 
 impl Transaction {
     /// Ensures that this transaction is at least consistent with itself
@@ -261,10 +255,6 @@ impl crate::traits::State<H_256> for State {
 
     fn on_commit(&self) {
         // Does nothing in this implementation
-    }
-
-    fn new_transaction_ids(&self, old_state: &Self) -> Vec<u64> {
-        self.nonces.difference(&old_state.nonces).copied().collect()
     }
 }
 


### PR DESCRIPTION
This PR removes:
- `State::new_transaction_ids`, as we want to store this information in meta data associated with the QC
  - See #136 for more information
- `Transaction::id` as we can use `BlockContents::hash_transaction` instead

We want to get this API in place for phaselock 0.0.8 so espresso has an easier time updating