### PR TITLE
Bump dashmap dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1101,13 +1101,14 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "5.3.3"
+version = "5.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "391b56fbd302e585b7a9494fb70e40949567b1cf9003a8e4a6041a1687c26573"
+checksum = "3495912c9c1ccf2e18976439f4443f3fee0fd61f424ff99fde6a66b15ecb448f"
 dependencies = [
  "cfg-if",
  "hashbrown 0.12.1",
  "lock_api",
+ "parking_lot_core 0.9.3",
 ]
 
 [[package]]
@@ -3113,7 +3114,7 @@ dependencies = [
  "blake3",
  "byteorder",
  "custom_debug",
- "dashmap 5.3.3",
+ "dashmap 5.3.4",
  "flume",
  "futures",
  "hex_fmt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ bincode = "1.3.3"
 blake3 = { version = "1.1.0", optional = true }
 byteorder = "1.4.3"
 custom_debug = "0.5"
-dashmap = "5.3.3"
+dashmap = "5.3.4"
 flume = "0.10.12"
 futures = "0.3.21"
 hex_fmt = "0.3.0"


### PR DESCRIPTION
[diff](https://github.com/xacrimon/dashmap/compare/v5.3.3..v5.3.4)

- Pins MSRV to 1.59
- Adds a dependency to `parking_lot_core 0.9.3` 
- Adds a `src/table.rs` file but it does not seem to be used. I've [asked if this is intentional](https://github.com/xacrimon/dashmap/pull/214)
  - The developer confirmed that should not be there and will be removing it shortly