### PR TITLE
Bump nix dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2210,7 +2210,7 @@ dependencies = [
  "netlink-packet-utils 0.5.1 (git+ssh://git@github.com/EspressoSystems/netlink.git)",
  "netlink-proto 0.9.2 (git+ssh://git@github.com/EspressoSystems/netlink.git)",
  "netlink-sys 0.8.2 (git+ssh://git@github.com/EspressoSystems/netlink.git)",
- "nix 0.23.1",
+ "nix 0.24.1",
  "parking_lot 0.12.0",
  "phaselock-types",
  "phaselock-utils",
@@ -2883,12 +2883,11 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.23.1"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f866317acbd3a240710c63f065ffb1e4fd466259045ccb504130b7f668f35c6"
+checksum = "8f17df307904acd05aa8e32e97bb20f2a0df1728bbc2d771ae8f9a90463441e9"
 dependencies = [
  "bitflags",
- "cc",
  "cfg-if",
  "libc",
  "memoffset",

--- a/libp2p-networking/Cargo.toml
+++ b/libp2p-networking/Cargo.toml
@@ -41,7 +41,7 @@ tide = { version = "0.16", optional = true, default-features = false, features =
 
 [target.'cfg(target_os = "linux")'.dependencies]
 ## lossy_network dependencies
-nix = { version = "0.23.1", optional = true }
+nix = { version = "0.24.1", optional = true }
 rtnetlink = { git = "ssh://git@github.com/EspressoSystems/netlink.git", version = "0.9.1", features = ["smol_socket"], default-features = false, optional = true}
 netlink-packet-route = { git = "ssh://git@github.com/EspressoSystems/netlink.git", version = "0.11.0", optional = true}
 netlink-packet-utils = { git = "ssh://git@github.com/EspressoSystems/netlink.git", version = "0.5.1", optional = true}


### PR DESCRIPTION
[diff](https://github.com/nix-rust/nix/compare/v0.23.1..v0.24.1)
[changelog](https://github.com/nix-rust/nix/blob/master/CHANGELOG.md#0241---2022-04-22)

- Bumps `libc` dependency
- Made the `memoffset` dependency optional
- Removed the `cc` dependency on dragonfly targets
- Adds a whole bunch of features, all seem to be enabled by default.
  - <https://docs.rs/nix/latest/nix/#features>
  - Maybe we can fine tune which features we need? It might reduce in a faster compile time
