### PR TITLE
Bump tui and crossterm dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -893,22 +893,6 @@ dependencies = [
 
 [[package]]
 name = "crossterm"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c85525306c4291d1b73ce93c8acf9c339f9b213aef6c1d85c3830cbf1c16325c"
-dependencies = [
- "bitflags",
- "crossterm_winapi",
- "libc",
- "mio 0.7.14",
- "parking_lot 0.11.2",
- "signal-hook",
- "signal-hook-mio",
- "winapi",
-]
-
-[[package]]
-name = "crossterm"
 version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2102ea4f781910f8a5b98dd061f4c2023f479ce7bb1236330099ceb5a93cf17"
@@ -917,7 +901,7 @@ dependencies = [
  "crossterm_winapi",
  "futures-core",
  "libc",
- "mio 0.8.2",
+ "mio",
  "parking_lot 0.12.0",
  "signal-hook",
  "signal-hook-mio",
@@ -2197,7 +2181,7 @@ dependencies = [
  "bincode",
  "blake3",
  "color-eyre",
- "crossterm 0.23.2",
+ "crossterm",
  "custom_debug",
  "derive_builder",
  "either",
@@ -2614,19 +2598,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2b29bd4bc3f33391105ebee3589c19197c4271e3e5a9ec9bfe8127eeff8f082"
 dependencies = [
  "adler",
-]
-
-[[package]]
-name = "mio"
-version = "0.7.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8067b404fe97c70829f082dec8bcf4f71225d7eaea1d8645349cb76fa06205cc"
-dependencies = [
- "libc",
- "log",
- "miow",
- "ntapi",
- "winapi",
 ]
 
 [[package]]
@@ -4100,8 +4071,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29ad2e15f37ec9a6cc544097b78a1ec90001e9f71b81338ca39f430adaca99af"
 dependencies = [
  "libc",
- "mio 0.7.14",
- "mio 0.8.2",
+ "mio",
  "signal-hook",
 ]
 
@@ -4548,7 +4518,7 @@ dependencies = [
  "bytes",
  "libc",
  "memchr",
- "mio 0.8.2",
+ "mio",
  "pin-project-lite 0.2.9",
  "socket2",
  "winapi",
@@ -4712,13 +4682,13 @@ dependencies = [
 
 [[package]]
 name = "tui"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23ed0a32c88b039b73f1b6c5acbd0554bfa5b6be94467375fd947c4de3a02271"
+checksum = "96fe69244ec2af261bced1d9046a6fee6c8c2a6b0228e59e5ba39bc8ba4ed729"
 dependencies = [
  "bitflags",
  "cassowary",
- "crossterm 0.22.1",
+ "crossterm",
  "unicode-segmentation",
  "unicode-width",
 ]

--- a/libp2p-networking/Cargo.toml
+++ b/libp2p-networking/Cargo.toml
@@ -24,7 +24,7 @@ structopt = "0.3.26"
 tracing = "0.1.32"
 tracing-error = "0.2.0"
 tracing-subscriber = { version = "0.3.10", features = ["env-filter", "json"] }
-tui = { version = "0.17.0", features = ["crossterm"], default-features = false }
+tui = { version = "0.18.0", features = ["crossterm"], default-features = false }
 rand = "0.8.5"
 async-trait = "0.1.53"
 derive_builder = "0.11.1"


### PR DESCRIPTION
tui
- [diff](https://github.com/fdehau/tui-rs/compare/v0.17.0..v0.18.0)
- Bumps crossterm dependency to 0.23

crossterm
- [diff](https://github.com/crossterm-rs/crossterm/compare/0.22..0.23)
- Bumped edition to 2021
- Bumped bitflags and parking_lot dependency
- Bumped crossterm_winapi dependency on windows
- Bumped signal-hook dependency on unix
