### PR TITLE
feat!: Include quorum certificates in Decide

### DIFF
--- a/examples/dentry-simulator.rs
+++ b/examples/dentry-simulator.rs
@@ -164,7 +164,7 @@ async fn main() {
             }
             println!("    - Node {} reached decision", node_id);
             debug!(?node_id, "Decision emitted");
-            if let EventType::Decide { block, state } = event.event {
+            if let EventType::Decide { block, state, .. } = event.event {
                 blocks.push(block);
                 states.push(state);
             } else {
@@ -230,7 +230,7 @@ async fn main() {
             }
             println!("    - Node {} reached decision", node_id);
             debug!(?node_id, "Decision emitted");
-            if let EventType::Decide { block, state } = event.event {
+            if let EventType::Decide { block, state, .. } = event.event {
                 blocks.push(block);
                 states.push(state);
             } else {

--- a/examples/multi-machine.rs
+++ b/examples/multi-machine.rs
@@ -268,7 +268,7 @@ async fn main() {
         }
         println!("Node {} reached decision", own_id);
         debug!(?own_id, "Decision emitted");
-        if let EventType::Decide { block: _, state } = event.event {
+        if let EventType::Decide { state, .. } = event.event {
             println!("  - Balances:");
             for (account, balance) in &state[0].balances {
                 println!("    - {}: {}", account, balance);

--- a/phaselock-hotstuff/src/traits.rs
+++ b/phaselock-hotstuff/src/traits.rs
@@ -2,7 +2,7 @@
 
 use async_trait::async_trait;
 use phaselock_types::{
-    data::{Stage, ViewNumber},
+    data::{Stage, VecQuorumCertificate, ViewNumber},
     event::{Event, EventType},
     traits::{
         network::NetworkError,
@@ -98,6 +98,7 @@ pub trait ConsensusApi<I: NodeImplementation<N>, const N: usize>: Send + Sync {
         view_number: ViewNumber,
         blocks: Vec<I::Block>,
         states: Vec<I::State>,
+        qcs: Vec<VecQuorumCertificate>,
     ) {
         self.send_event(Event {
             view_number,
@@ -105,6 +106,7 @@ pub trait ConsensusApi<I: NodeImplementation<N>, const N: usize>: Send + Sync {
             event: EventType::Decide {
                 block: Arc::new(blocks),
                 state: Arc::new(states),
+                qcs: Arc::new(qcs),
             },
         })
         .await;

--- a/phaselock-testing/src/lib.rs
+++ b/phaselock-testing/src/lib.rs
@@ -268,7 +268,7 @@ impl<
                         return Err(PhaseLockError::ViewTimeoutError { view_number });
                     }
                 }
-                EventType::Decide { block, state } => {
+                EventType::Decide { block, state, .. } => {
                     return Ok((
                         state.iter().cloned().collect(),
                         block.iter().cloned().collect(),

--- a/phaselock-types/src/data.rs
+++ b/phaselock-types/src/data.rs
@@ -278,7 +278,7 @@ impl<const N: usize> QuorumCertificate<N> {
     /// directly consensus relevant.
     pub fn to_vec_cert(&self) -> VecQuorumCertificate {
         VecQuorumCertificate {
-            hash: self.block_hash.as_ref().to_vec(),
+            block_hash: self.block_hash.as_ref().to_vec(),
             view_number: self.view_number,
             stage: self.stage,
             signature: self.signature.clone(),
@@ -298,7 +298,7 @@ impl<const N: usize> QuorumCertificate<N> {
 pub struct VecQuorumCertificate {
     /// Block this QC refers to
     #[debug(with = "fmt_vec")]
-    pub hash: Vec<u8>,
+    pub block_hash: Vec<u8>,
     /// The view we were on when we made this certificate
     pub view_number: ViewNumber,
     /// The stage of consensus we were on when we made this certificate

--- a/phaselock-types/src/event.rs
+++ b/phaselock-types/src/event.rs
@@ -1,7 +1,7 @@
 //! Events that a `PhaseLock` instance can emit
 
 use crate::{
-    data::{Stage, ViewNumber},
+    data::{Stage, VecQuorumCertificate, ViewNumber},
     error::PhaseLockError,
 };
 use std::sync::Arc;
@@ -53,6 +53,8 @@ pub enum EventType<B: Send + Sync, S: Send + Sync> {
         ///
         /// This list may be incomplete if the node is currently performing catchup.
         state: Arc<Vec<S>>,
+        /// The quorum certificates that accompy this Decide
+        qcs: Arc<Vec<VecQuorumCertificate>>,
     },
     /// A new view was started by this node
     NewView {


### PR DESCRIPTION
Include the quorum certificates in the event stream's Decide message.

Closes https://github.com/EspressoSystems/espresso/issues/103

BREAKING CHANGE: Adds the qcs field to EventType::Decide