### PR TITLE
Reduce strictness

### DIFF
--- a/phaselock-testing/tests/atomic_storage.rs
+++ b/phaselock-testing/tests/atomic_storage.rs
@@ -8,7 +8,7 @@ use common::{
     TestRoundResult, TestTransaction,
 };
 use either::Either::Right;
-use phaselock_testing::{ConsensusRoundError, Round, TestRunner};
+use phaselock_testing::{ConsensusRoundError, Round, TestRunner, ValidateStrictness};
 
 use phaselock::{
     data::{Leaf, QuorumCertificate, StateHash},
@@ -245,7 +245,9 @@ async fn restart() {
     >|
      -> Result<(), ConsensusRoundError> {
         block_on(async move {
-            runner.validate_node_states().await;
+            runner
+                .validate_node_states(ValidateStrictness::Strict)
+                .await;
             // nodes should start at view_number 0
             for node in runner.nodes() {
                 assert_eq!(
@@ -277,7 +279,9 @@ async fn restart() {
          _results: TestRoundResult|
          -> Result<(), ConsensusRoundError> {
             block_on(async move {
-                runner.validate_node_states().await;
+                runner
+                    .validate_node_states(ValidateStrictness::Strict)
+                    .await;
 
                 // nodes should now be at view_number 1
                 for node in runner.nodes() {
@@ -355,7 +359,9 @@ async fn restart() {
     >|
      -> Result<(), ConsensusRoundError> {
         block_on(async move {
-            runner.validate_node_states().await;
+            runner
+                .validate_node_states(ValidateStrictness::Strict)
+                .await;
             // nodes should start at view_number 1
             for node in runner.nodes() {
                 assert_eq!(
@@ -387,7 +393,9 @@ async fn restart() {
          _results: TestRoundResult|
          -> Result<(), ConsensusRoundError> {
             block_on(async move {
-                runner.validate_node_states().await;
+                runner
+                    .validate_node_states(ValidateStrictness::Strict)
+                    .await;
 
                 // nodes should now be at view_number 2
                 for node in runner.nodes() {

--- a/phaselock-testing/tests/common/mod.rs
+++ b/phaselock-testing/tests/common/mod.rs
@@ -11,7 +11,9 @@ use phaselock::{
     types::Message,
     PhaseLockConfig,
 };
-use phaselock_testing::{ConsensusRoundError, Round, RoundResult, TestLauncher, TestRunner};
+use phaselock_testing::{
+    ConsensusRoundError, Round, RoundResult, TestLauncher, TestRunner, ValidateStrictness,
+};
 use phaselock_types::traits::{
     network::TestableNetworkingImplementation, signature_key::ed25519::Ed25519Pub,
     state::TestableState, storage::TestableStorage,
@@ -408,7 +410,7 @@ impl<
             // this check is rather strict:
             // 1) all nodes have the SAME state
             // 2) no nodes failed
-            async_std::task::block_on(runner.validate_node_states());
+            async_std::task::block_on(runner.validate_node_states(ValidateStrictness::Relaxed));
             assert!(
                 results.failures.is_empty(),
                 "Failing nodes: {:?}",


### PR DESCRIPTION
By default, the validation function is quite strict, as it asserts that all blocks and leafs match amongst all replicas. In some rounds not all blocks/leafs match. This PR introduces a strictness enum to specify when to error upon storage state mismatch.