### PR TITLE
Added information on why a round timed out

### DIFF
--- a/phaselock-hotstuff/src/phase/commit/mod.rs
+++ b/phaselock-hotstuff/src/phase/commit/mod.rs
@@ -6,7 +6,7 @@ mod leader;
 mod replica;
 
 use super::{decide::DecidePhase, Progress, UpdateCtx};
-use crate::{utils, ConsensusApi, Result};
+use crate::{utils, ConsensusApi, Result, RoundTimedoutState};
 use leader::CommitLeader;
 use phaselock_types::{
     data::{QuorumCertificate, Stage},
@@ -68,6 +68,14 @@ impl<const N: usize> CommitPhase<N> {
             Ok(Progress::Next(decide))
         } else {
             Ok(Progress::NotReady)
+        }
+    }
+
+    /// We're timing out, get the state of this phase
+    pub fn timeout_reason(&self) -> RoundTimedoutState {
+        match self {
+            Self::Leader(_) => RoundTimedoutState::LeaderWaitingForPreCommitVotes,
+            Self::Replica(_) => RoundTimedoutState::ReplicaWaitingForCommit,
         }
     }
 }

--- a/phaselock-hotstuff/src/phase/decide/mod.rs
+++ b/phaselock-hotstuff/src/phase/decide/mod.rs
@@ -6,7 +6,7 @@ mod leader;
 mod replica;
 
 use super::{Progress, UpdateCtx};
-use crate::{utils, ConsensusApi, Result};
+use crate::{utils, ConsensusApi, Result, RoundTimedoutState};
 use leader::DecideLeader;
 use phaselock_types::{
     data::{QuorumCertificate, Stage},
@@ -68,6 +68,14 @@ impl<const N: usize> DecidePhase<N> {
             Ok(Progress::Next(()))
         } else {
             Ok(Progress::NotReady)
+        }
+    }
+
+    /// We're timing out, get the state of this phase
+    pub fn timeout_reason(&self) -> RoundTimedoutState {
+        match self {
+            Self::Leader(_) => RoundTimedoutState::LeaderWaitingForCommitVotes,
+            Self::Replica(_) => RoundTimedoutState::ReplicaWaitingForDecide,
         }
     }
 }

--- a/phaselock-hotstuff/src/phase/precommit/mod.rs
+++ b/phaselock-hotstuff/src/phase/precommit/mod.rs
@@ -6,7 +6,7 @@ mod leader;
 mod replica;
 
 use super::{commit::CommitPhase, Progress, UpdateCtx};
-use crate::{utils, ConsensusApi, Result};
+use crate::{utils, ConsensusApi, Result, RoundTimedoutState};
 use leader::PreCommitLeader;
 use phaselock_types::{
     data::{QuorumCertificate, Stage},
@@ -67,6 +67,14 @@ impl<I: NodeImplementation<N>, const N: usize> PreCommitPhase<I, N> {
             Ok(Progress::Next(commit))
         } else {
             Ok(Progress::NotReady)
+        }
+    }
+
+    /// We're timing out, get the state of this phase
+    pub fn timeout_reason(&self) -> RoundTimedoutState {
+        match self {
+            Self::Leader(_) => RoundTimedoutState::LeaderWaitingForPrepareVotes,
+            Self::Replica(_) => RoundTimedoutState::ReplicaWaitingForPreCommit,
         }
     }
 }

--- a/phaselock-hotstuff/src/phase/prepare/leader.rs
+++ b/phaselock-hotstuff/src/phase/prepare/leader.rs
@@ -15,9 +15,9 @@ use tracing::{debug, error, instrument, trace, warn};
 #[derive(Debug)]
 pub(crate) struct PrepareLeader<const N: usize> {
     /// The `high_qc` that was calculated
-    high_qc: Option<QuorumCertificate<N>>,
+    pub(super) high_qc: Option<QuorumCertificate<N>>,
     /// The timestamp at which this round started. This will be after enough `NewView` messages have been received
-    round_start: Option<Instant>,
+    pub(super) round_start: Option<Instant>,
 }
 
 impl<const N: usize> PrepareLeader<N> {

--- a/phaselock-testing/src/lib.rs
+++ b/phaselock-testing/src/lib.rs
@@ -25,7 +25,7 @@ use phaselock::{
     PhaseLock, PhaseLockConfig, PhaseLockError, H_256,
 };
 use phaselock_types::{
-    error::TimeoutSnafu,
+    error::{RoundTimedoutState, TimeoutSnafu},
     traits::{
         network::TestableNetworkingImplementation,
         signature_key::{
@@ -298,7 +298,10 @@ impl<
                 EventType::ViewTimeout { view_number } => {
                     if view_number >= cur_view {
                         error!(?event, "Round timed out!");
-                        return Err(PhaseLockError::ViewTimeoutError { view_number });
+                        return Err(PhaseLockError::ViewTimeoutError {
+                            view_number,
+                            state: RoundTimedoutState::TestCollectRoundEventsTimedOut,
+                        });
                     }
                 }
                 EventType::Decide { block, state, .. } => {

--- a/phaselock-types/src/error.rs
+++ b/phaselock-types/src/error.rs
@@ -82,6 +82,8 @@ pub enum PhaseLockError {
     ViewTimeoutError {
         /// view number
         view_number: ViewNumber,
+        /// The state that the round was in when it timed out
+        state: RoundTimedoutState,
     },
     /// Internal value used to drive the state machine
     Continue,
@@ -99,4 +101,32 @@ impl PhaseLockError {
             _ => None,
         }
     }
+}
+
+/// Contains information about what the state of the phaselock-hotstuff was when a round timed out
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub enum RoundTimedoutState {
+    /// Leader is in a Prepare phase and is waiting for a HighQC
+    LeaderWaitingForHighQC,
+    /// Leader is in a Prepare phase and timed out before the round min time is reached
+    LeaderMinRoundTimeNotReached,
+    /// Leader is waiting for prepare votes
+    LeaderWaitingForPrepareVotes,
+    /// Leader is waiting for precommit votes
+    LeaderWaitingForPreCommitVotes,
+    /// Leader is waiting for commit votes
+    LeaderWaitingForCommitVotes,
+
+    /// Replica is waiting for a prepare message
+    ReplicaWaitingForPrepare,
+    /// Replica is waiting for a pre-commit message
+    ReplicaWaitingForPreCommit,
+    /// Replica is waiting for a commit message
+    ReplicaWaitingForCommit,
+    /// Replica is waiting for a decide message
+    ReplicaWaitingForDecide,
+
+    /// Phaselock-testing tried to collect round events, but it timed out
+    TestCollectRoundEventsTimedOut,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -338,8 +338,12 @@ impl<I: NodeImplementation<N> + Sync + Send + 'static, const N: usize> PhaseLock
         };
         match result.state {
             RoundFinishedEventState::Success => Ok(result.view_number),
-            _ => Err(PhaseLockError::ViewTimeoutError {
+            RoundFinishedEventState::Interrupted(state) => Err(PhaseLockError::ViewTimeoutError {
                 view_number: result.view_number,
+                state,
+            }),
+            x => Err(PhaseLockError::InvalidState {
+                context: format!("Round finished in an unknown state: {:?}", x),
             }),
         }
     }


### PR DESCRIPTION
The message "Round timed out" was a warning and did not contain any information. It is fine for the network to occasionally time out a round.

As discussed on Zulip it makes more sense to make this an increasingly urgent message, as well as add more information to the message so we know what state the hotstuff implementation was in.

Closes #245 