### PR TITLE
Bump docker image to 1.62

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     runs-on: [self-hosted, X64]
     container:
-      image: ghcr.io/espressosystems/devops-rust:1.59
+      image: ghcr.io/espressosystems/devops-rust:1.62
     timeout-minutes: 60
     steps:
       - uses: styfle/cancel-workflow-action@0.10.0


### PR DESCRIPTION
Closes #271 

It looks like our nix flake automatically uses the latest stable, so that didn't need changing

```bash
[nix-shell:/mnt/c/development/phaselock]$ rustc --version
rustc 1.62.0 (a8314ef7d 2022-06-27)
```