### PR TITLE
Fixed new clippy warnings

### DIFF
--- a/libp2p-networking/tests/common/mod.rs
+++ b/libp2p-networking/tests/common/mod.rs
@@ -8,7 +8,13 @@ use libp2p_networking::network::{
 };
 use phaselock_utils::test_util::{setup_backtrace, setup_logging};
 use snafu::{ResultExt, Snafu};
-use std::{collections::HashMap, fmt::Debug, num::NonZeroUsize, sync::Arc, time::Duration};
+use std::{
+    collections::HashMap,
+    fmt::{Debug, Write},
+    num::NonZeroUsize,
+    sync::Arc,
+    time::Duration,
+};
 use tracing::{info, instrument, warn};
 
 /// General function to spin up testing infra
@@ -98,18 +104,20 @@ pub async fn check_connection_state<S>(handles: &[Arc<NetworkNodeHandle<S>>]) {
         if state.known_peers.len() < handle.config().min_num_peers
             && handle.config().node_type != NetworkNodeType::Bootstrap
         {
-            err_msg.push_str(&format!(
+            let _ = write!(
+                &mut err_msg,
                 "\nhad {} known peers for {}-th handle",
                 state.known_peers.len(),
                 i
-            ));
+            );
         }
         if state.connected_peers.len() < handle.config().min_num_peers {
-            err_msg.push_str(&format!(
+            let _ = write!(
+                &mut err_msg,
                 "\nhad {} connected peers for {}-th handle",
                 state.connected_peers.len(),
                 i
-            ));
+            );
         }
     }
     if !err_msg.is_empty() {

--- a/phaselock-testing/tests/common/mod.rs
+++ b/phaselock-testing/tests/common/mod.rs
@@ -542,7 +542,7 @@ macro_rules! cross_tests {
         #[ macro_use ]
         #[ allow(non_snake_case) ]
         mod $NETWORK {
-            use crate::*;
+            use $crate::*;
             cross_tests!($NETWORK, [ $($STORAGES)+ ], [ $($BLOCKS)+ ], [ $($STATES)+ ], $fn_name, $e, keep: $keep, args: $($args)*);
         }
         cross_tests!([ $($NETWORKS)*  ], [ $($STORAGES)+ ], [ $($BLOCKS)+ ], [ $($STATES)+ ], $fn_name, $e, keep: $keep, args: $($args)* );
@@ -555,7 +555,7 @@ macro_rules! cross_tests {
         #[ macro_use ]
         #[ allow(non_snake_case) ]
         mod $STORAGE {
-            use crate::*;
+            use $crate::*;
             cross_tests!($NETWORK, $STORAGE, [ $($BLOCKS)+ ], [ $($STATES)+ ], $fn_name, $e, keep: $keep, args: $($args)*);
         }
         cross_tests!($NETWORK, [ $($STORAGES),* ], [ $($BLOCKS),+ ], [ $($STATES),+ ], $fn_name, $e, keep: $keep, args: $($args)*);
@@ -568,7 +568,7 @@ macro_rules! cross_tests {
         #[ macro_use ]
         #[ allow(non_snake_case) ]
         mod $BLOCK {
-            use crate::*;
+            use $crate::*;
             cross_tests!($NETWORK, $STORAGE, $BLOCK, [ $($STATES)+ ], $fn_name, $e, keep: $keep, args: $($args)*);
         }
         cross_tests!($NETWORK, $STORAGE, [ $($BLOCKS),* ], [ $($STATES),+ ], $fn_name, $e, keep: $keep, args: $($args)*);
@@ -581,7 +581,7 @@ macro_rules! cross_tests {
         #[ macro_use ]
         #[ allow(non_snake_case) ]
         mod $STATE {
-            use crate::*;
+            use $crate::*;
             cross_tests!($NETWORK, $STORAGE, $BLOCK, $STATE, $fn_name, $e, keep: $keep, args: $($args)*);
         }
         cross_tests!($NETWORK, $STORAGE, $BLOCK, [ $($STATES)* ], $fn_name, $e, keep: $keep, args: $($args)*);
@@ -614,7 +614,7 @@ macro_rules! cross_all_types {
         #[cfg(test)]
         #[macro_use]
         pub mod $fn_name {
-            use crate::*;
+            use $crate::*;
 
             cross_tests!(
                 [ MemoryNetwork ],
@@ -647,7 +647,7 @@ macro_rules! cross_all_types_proptest {
         #[cfg(test)]
         #[macro_use]
         pub mod $fn_name {
-            use crate::*;
+            use $crate::*;
 
             cross_tests!(
                 [ MemoryNetwork Libp2pNetwork ],


### PR DESCRIPTION
Rust 1.62.0 introduced new clippy lints. This PR fixes the new warnings.