### PR TITLE
Improved `consensus::can_insert_view`

### DIFF
--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -310,15 +310,8 @@ impl<I: NodeImplementation<N>, const N: usize> Consensus<I, N> {
         if let Some(highest) = self.active_phases.back() {
             view_number > *highest
         } else {
-            // if we have no phases, always return true
-            if self.inactive_phases.iter().any(|p| p >= &view_number) {
-                tracing::error!(
-                    "Trying to insert view number {:?} but our inactive_phases is {:?}",
-                    view_number,
-                    self.inactive_phases
-                );
-            }
-            true
+            // if we have no active phases, check if all `inactive_phases` are less than `view_number`
+            self.inactive_phases.iter().all(|p| p < &view_number)
         }
     }
 }


### PR DESCRIPTION
If the consensus algorithm was in a state where a round (1) just ended, before a new round (2) was started, but a message of round 1 would trigger this branch in this function.

It would print an error and then insret `true`, indicating that the view could be inserted.

The new functionality is that the function will check if all views in `inactive_phases` are less than the incoming view. In this example, `1` is not less than the just-closed round `1`, so it would return false.