### PR TITLE
Made the consensus algorithm send messages when a transaction is rejected

### DIFF
--- a/consensus/src/traits.rs
+++ b/consensus/src/traits.rs
@@ -59,7 +59,7 @@ pub trait ConsensusApi<I: NodeImplementation<N>, const N: usize>: Send + Sync {
     ) -> std::result::Result<(), NetworkError>;
 
     /// Notify the system of an event within `hotshot-consensus`.
-    async fn send_event(&mut self, event: Event<I::Block, I::State>);
+    async fn send_event(&mut self, event: Event<I::Block, I::State, N>);
 
     /// Get a reference to the public key.
     fn public_key(&self) -> &I::SignatureKey;

--- a/examples/dentry-simulator.rs
+++ b/examples/dentry-simulator.rs
@@ -152,7 +152,7 @@ async fn main() {
         let mut states = Vec::new();
         for (node_id, hotshot) in hotshots.iter_mut().enumerate() {
             debug!(?node_id, "Waiting on node to emit decision");
-            let mut event: Event<DEntryBlock, State> = hotshot
+            let mut event: Event<DEntryBlock, State, H_256> = hotshot
                 .next_event()
                 .await
                 .expect("HotShot unexpectedly closed");
@@ -218,7 +218,7 @@ async fn main() {
         let mut states = Vec::new();
         for (node_id, hotshot) in hotshots.iter_mut().enumerate() {
             debug!(?node_id, "Waiting on node to emit decision");
-            let mut event: Event<DEntryBlock, State> = hotshot
+            let mut event: Event<DEntryBlock, State, H_256> = hotshot
                 .next_event()
                 .await
                 .expect("HotShot unexpectedly closed");

--- a/examples/multi-machine.rs
+++ b/examples/multi-machine.rs
@@ -244,7 +244,7 @@ async fn main() {
         // Start consensus
         println!("  - Waiting for consensus to occur");
         debug!("Waiting for consensus to occur");
-        let mut event: Event<DEntryBlock, State> = hotshot
+        let mut event: Event<DEntryBlock, State, H_256> = hotshot
             .next_event()
             .await
             .expect("HotShot unexpectedly closed");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,7 +143,7 @@ pub struct HotShotInner<I: NodeImplementation<N>, const N: usize> {
     election: HotShotElectionState<I::SignatureKey, I::Election, N>,
 
     /// Sender for [`Event`]s
-    event_sender: RwLock<Option<BroadcastSender<Event<I::Block, I::State>>>>,
+    event_sender: RwLock<Option<BroadcastSender<Event<I::Block, I::State, N>>>>,
 
     /// Senders to the background tasks.
     background_task_handle: tasks::TaskHandle,
@@ -306,7 +306,7 @@ impl<I: NodeImplementation<N> + Sync + Send + 'static, const N: usize> HotShot<I
     /// Sends an event over an event broadcaster if one is registered, does nothing otherwise
     ///
     /// Returns `true` if the event was send, `false` otherwise
-    pub async fn send_event(&self, event: Event<I::Block, I::State>) -> bool {
+    pub async fn send_event(&self, event: Event<I::Block, I::State, N>) -> bool {
         if let Some(c) = self.inner.event_sender.read().await.as_ref() {
             if let Err(e) = c.send_async(event).await {
                 warn!(?e, "Could not send event to the registered broadcaster");
@@ -796,7 +796,7 @@ impl<'a, I: NodeImplementation<N>, const N: usize> hotshot_consensus::ConsensusA
             .await
     }
 
-    async fn send_event(&mut self, event: Event<I::Block, I::State>) {
+    async fn send_event(&mut self, event: Event<I::Block, I::State, N>) {
         debug!(?event, "send_event");
         let mut event_sender = self.inner.event_sender.write().await;
         if let Some(sender) = &*event_sender {

--- a/types/src/event.rs
+++ b/types/src/event.rs
@@ -3,6 +3,7 @@
 use crate::{
     data::{Stage, VecQuorumCertificate, ViewNumber},
     error::HotShotError,
+    traits::BlockContents,
 };
 use std::sync::Arc;
 
@@ -11,13 +12,13 @@ use std::sync::Arc;
 /// This includes some metadata, such as the stage and view number that the event was generated in,
 /// as well as an inner [`EventType`] describing the event proper.
 #[derive(Clone, Debug)]
-pub struct Event<B: Send + Sync, S: Send + Sync> {
+pub struct Event<B: BlockContents<N>, S: Send + Sync, const N: usize> {
     /// The view number that this event originates from
     pub view_number: ViewNumber,
     /// The stage that this event originates from
     pub stage: Stage,
     /// The underlying event
-    pub event: EventType<B, S>,
+    pub event: EventType<B, S, N>,
 }
 
 /// The type and contents of a status event emitted by a `HotShot` instance
@@ -26,7 +27,7 @@ pub struct Event<B: Send + Sync, S: Send + Sync> {
 /// number, and is thus always returned wrapped in an [`Event`].
 #[non_exhaustive]
 #[derive(Clone, Debug)]
-pub enum EventType<B: Send + Sync, S: Send + Sync> {
+pub enum EventType<B: BlockContents<N>, S: Send + Sync, const N: usize> {
     /// A view encountered an error and was interrupted
     Error {
         /// The underlying error
@@ -81,5 +82,12 @@ pub enum EventType<B: Send + Sync, S: Send + Sync> {
     Synced {
         /// The current view number
         view_number: ViewNumber,
+    },
+
+    /// The transaction has been rejected.
+    /// Currently HotShot does not know if a transaction is rejected because it is a duplicate, or because the transaction is invalid.
+    TransactionRejected {
+        /// The transaction that has been rejected.
+        transaction: B::Transaction,
     },
 }


### PR DESCRIPTION
This is a breaking change if `espresso` ever uses the type of the `Event` struct or `EventType` enum directly, because it adds an extra parameter.
