### PR TITLE
Ahead of time address lookup

### DIFF
--- a/src/traits/networking/libp2p_network.rs
+++ b/src/traits/networking/libp2p_network.rs
@@ -694,4 +694,8 @@ impl<
             .await
             .map_err(Into::<NetworkError>::into)
     }
+
+    async fn lookup_pks(&self, _pk: Vec<P>) {
+        todo!()
+    }
 }

--- a/src/traits/networking/memory_network.rs
+++ b/src/traits/networking/memory_network.rs
@@ -480,6 +480,10 @@ impl<
     ) -> Result<V, NetworkError> {
         unimplemented!()
     }
+
+    async fn lookup_pks(&self, _pk: Vec<P>) {
+        // NOTE: already have metadata so this is a noop
+    }
 }
 
 #[cfg(test)]

--- a/src/traits/networking/w_network.rs
+++ b/src/traits/networking/w_network.rs
@@ -1004,6 +1004,10 @@ impl<
     ) -> Result<V, NetworkError> {
         todo!()
     }
+
+    async fn lookup_pks(&self, _pk: Vec<P>) {
+        // NOTE: already have metadata so this is a noop
+    }
 }
 
 /// Tries to get a networking implementation with the given id

--- a/types/src/traits/network.rs
+++ b/types/src/traits/network.rs
@@ -144,6 +144,10 @@ where
         &self,
         key: impl Serialize + Send + Sync + 'static,
     ) -> Result<V, NetworkError>;
+
+    /// Lookup leader metadata so we are prepared to DM in
+    /// a subsequent view.
+    async fn lookup_pks(&self, pk: Vec<P>);
 }
 
 /// Describes additional functionality needed by the test network implementation


### PR DESCRIPTION
Right now, address location and pubkeys are looked up on demand (e.g. when needed). It would be better to do this ahead of time, and that's what this PR is doing.

Note: I had hoped to implement this as a background task. However, this involves adding another channel to the `HotStuff` struct just for new view notifications. It seemed simpler just to call the networking implementation directly from the RoundRunner implementation.

Closes #286 