### PR TITLE
Timeout Fix

### DIFF
--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -194,7 +194,7 @@ impl<I: NodeImplementation<N>, const N: usize> Consensus<I, N> {
     /// If the given round is done, this function will not have any effect
     #[instrument]
     pub fn round_timeout(&mut self, view_number: ViewNumber) {
-        if self.active_phases.iter().any(|v| v == &view_number) {
+        if self.inactive_phases.iter().any(|v| v == &view_number) {
             return; // round is not running
         }
 


### PR DESCRIPTION
This check should be over inactive phases. The `timeout_round` function needs to time out the currently running round. So one would expect the round to be currently active, then have `after_update` mark the round as tiemd out. Otherwise (in the case of inactive phases), `timeout_round` should be a noop.

This prevents round timeouts from originating from being generated by the current replica.