### PR TITLE
Correct dht quirks

### DIFF
--- a/libp2p-networking/src/network/behaviours/exponential_backoff.rs
+++ b/libp2p-networking/src/network/behaviours/exponential_backoff.rs
@@ -64,9 +64,9 @@ impl ExponentialBackoff {
 impl Default for ExponentialBackoff {
     fn default() -> Self {
         Self {
-            reset_val: Duration::from_millis(1000),
+            reset_val: Duration::from_millis(500),
             backoff_factor: 2,
-            timeout: Duration::from_millis(1000) * 2,
+            timeout: Duration::from_millis(500),
             started: None,
         }
     }

--- a/libp2p-networking/src/network/mod.rs
+++ b/libp2p-networking/src/network/mod.rs
@@ -94,6 +94,8 @@ impl Default for NetworkNodeType {
 /// Actions to send from the client to the swarm
 #[derive(Debug)]
 pub enum ClientRequest {
+    /// Start the bootstrap process to kademlia
+    BeginBootstrap,
     /// kill the swarm
     Shutdown,
     /// broadcast a serialized message

--- a/libp2p-networking/tests/common/mod.rs
+++ b/libp2p-networking/tests/common/mod.rs
@@ -100,7 +100,7 @@ pub async fn spin_up_swarms<S: std::fmt::Debug + Default>(
     let mut bootstrap_addrs = Vec::<(PeerId, Multiaddr)>::new();
     let mut connecting_futs = Vec::new();
     // should never panic unless num_nodes is 0
-    let replication_factor = NonZeroUsize::new(num_of_nodes).unwrap();
+    let replication_factor = NonZeroUsize::new(num_of_nodes - 1).unwrap();
 
     for i in 0..num_bootstrap {
         let mut config = NetworkNodeConfigBuilder::default();

--- a/src/tasks/round_runner.rs
+++ b/src/tasks/round_runner.rs
@@ -286,6 +286,7 @@ pub struct RoundRunnerState {
 }
 
 /// Events going to the round runner.
+#[derive(Debug)]
 pub enum ToRoundRunner {
     /// Notify the round runner that there is a new view number inserted externally that it should use from now on.
     NewViewNumber(ViewNumber),

--- a/src/traits/networking/libp2p_network.rs
+++ b/src/traits/networking/libp2p_network.rs
@@ -326,17 +326,12 @@ impl<
                 .await
                 .unwrap()
                 .unwrap();
-                handle.subscribe(QC_TOPIC.to_string()).await.unwrap();
-
-                error!(
-                    "peer {:?} waiting for bootstrap, type: {:?}",
-                    handle.peer_id(),
-                    node_type
-                );
 
                 while !is_bootstrapped.load(std::sync::atomic::Ordering::Relaxed) {
                     sleep(Duration::from_secs(1)).await;
                 }
+
+                handle.subscribe(QC_TOPIC.to_string()).await.unwrap();
 
                 error!(
                     "peer {:?} waiting for publishing, type: {:?}",


### PR DESCRIPTION
This PR contains a couple of logic fixes:

- The bootstrap node's DHT was not bootstrapping if it did not contain any other bootstrap nodes. This is corrected by causing the caller to trigger bootstrapping into kademlia in `wait_to_connect`.
- Generally decrease the timeouts (default ExponentialBackoff implementation). Unclear if this is too aggressive, but backoff *is* exponential so things ought to stabilize over time. This is mostly to speed up the network initialization process.
- DHT now publishes to `replication_factor` nodes, not the quorum majority.