### PR TITLE
Updated build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
           sharedKey: HotShot163
 
       - name: Audit
-        run: cargo audit --deny warnings  --ignore RUSTSEC-2022-0040
+        run: cargo audit --deny warnings  --ignore RUSTSEC-2022-0040 --ignore RUSTSEC-2021-0139
 
       - name: Check
         run: cargo check


### PR DESCRIPTION
Updated the build.yml to pick rust 1.63.0.

Additionally it looks like `ansi-term` is unmaintained. Even though there are not immediate issues, they've decided to emit it as a warning anyway. More info here: [RUSTSEC-2021-0139](https://rustsec.org/advisories/RUSTSEC-2021-0139.html)