### PR TITLE
feat: check states match

### DIFF
--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -661,6 +661,7 @@ impl<I: NodeImplementation<N>, const N: usize> Consensus<I, N> {
             .for_each(|(_view_number, leaf)| {
                 let _removed = self.undecided_leaves.remove(leaf);
             });
+        self.state_map = self.state_map.split_off(&new_anchor_view);
     }
 }
 

--- a/consensus/src/traits.rs
+++ b/consensus/src/traits.rs
@@ -137,10 +137,8 @@ pub trait ConsensusApi<I: NodeImplementation<N>, const N: usize>: Send + Sync {
     /// Sends a `ViewFinished` event
     async fn send_view_finished(&self, view_number: ViewNumber) {
         self.send_event(Event {
-            view_number: view_number,
-            event: EventType::ViewFinished {
-                view_number
-            },
+            view_number,
+            event: EventType::ViewFinished { view_number },
         })
         .await;
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -379,6 +379,13 @@ impl<I: NodeImplementation<N> + Sync + Send + 'static, const N: usize> HotShot<I
         self.hotstuff.read().await.get_decided_leaf().state
     }
 
+    /// Returns a copy of the last decided leaf
+    /// # Panics
+    /// Panics if internal state for consensus is inconsistent
+    pub async fn get_decided_leaf(&self) -> Leaf<I::Block, I::State, N> {
+        self.hotstuff.read().await.get_decided_leaf()
+    }
+
     /// Initializes a new hotshot and does the work of setting up all the background tasks
     ///
     /// Assumes networking implementation is already primed.

--- a/src/types/handle.rs
+++ b/src/types/handle.rs
@@ -7,6 +7,7 @@ use crate::{
 };
 use async_std::task::block_on;
 use hotshot_types::{
+    data::Leaf,
     error::{HotShotError, RoundTimedoutState},
     event::EventType,
     traits::network::NetworkingImplementation,
@@ -111,6 +112,14 @@ impl<I: NodeImplementation<N> + 'static, const N: usize> HotShotHandle<I, N> {
     /// Returns an error if the underlying `Storage` returns an error
     pub async fn get_state(&self) -> I::State {
         self.hotshot.get_state().await
+    }
+
+    /// Gets most recent decided leaf
+    /// # Panics
+    ///
+    /// Panics if internal consensus is in an inconsistent state.
+    pub async fn get_decided_leaf(&self) -> Leaf<I::Block, I::State, N> {
+        self.hotshot.get_decided_leaf().await
     }
 
     /// Submits a transaction to the backing [`HotShot`] instance.

--- a/testing/tests/atomic_storage.rs
+++ b/testing/tests/atomic_storage.rs
@@ -8,7 +8,7 @@ use common::{
     TestRoundResult, TestTransaction,
 };
 use either::Either::Right;
-use hotshot_testing::{ConsensusRoundError, Round, TestRunner, ValidateStrictness};
+use hotshot_testing::{ConsensusRoundError, Round, TestRunner};
 
 use hotshot::{
     data::{Leaf, QuorumCertificate, StateHash},
@@ -244,9 +244,7 @@ async fn restart() {
     >|
      -> Result<(), ConsensusRoundError> {
         block_on(async move {
-            runner
-                .validate_node_states(ValidateStrictness::Strict)
-                .await;
+            runner.validate_node_states().await;
             // nodes should start at view_number 0
             for node in runner.nodes() {
                 assert_eq!(
@@ -278,9 +276,7 @@ async fn restart() {
          _results: TestRoundResult|
          -> Result<(), ConsensusRoundError> {
             block_on(async move {
-                runner
-                    .validate_node_states(ValidateStrictness::Strict)
-                    .await;
+                runner.validate_node_states().await;
 
                 // nodes should now be at view_number 1
                 for node in runner.nodes() {
@@ -360,9 +356,7 @@ async fn restart() {
     >|
      -> Result<(), ConsensusRoundError> {
         block_on(async move {
-            runner
-                .validate_node_states(ValidateStrictness::Strict)
-                .await;
+            runner.validate_node_states().await;
             // nodes should start at view_number 1
             for node in runner.nodes() {
                 assert_eq!(
@@ -394,9 +388,7 @@ async fn restart() {
          _results: TestRoundResult|
          -> Result<(), ConsensusRoundError> {
             block_on(async move {
-                runner
-                    .validate_node_states(ValidateStrictness::Strict)
-                    .await;
+                runner.validate_node_states().await;
 
                 // nodes should now be at view_number 2
                 for node in runner.nodes() {

--- a/testing/tests/common/mod.rs
+++ b/testing/tests/common/mod.rs
@@ -11,9 +11,7 @@ use hotshot::{
     types::Message,
     HotShotConfig,
 };
-use hotshot_testing::{
-    ConsensusRoundError, Round, RoundResult, TestLauncher, TestRunner, ValidateStrictness,
-};
+use hotshot_testing::{ConsensusRoundError, Round, RoundResult, TestLauncher, TestRunner};
 use hotshot_types::traits::{
     network::TestableNetworkingImplementation, signature_key::ed25519::Ed25519Pub,
     state::TestableState, storage::TestableStorage,
@@ -412,16 +410,15 @@ impl<
             // this check is rather strict:
             // 1) all nodes have the SAME state
             // 2) no nodes failed
-            async_std::task::block_on(runner.validate_node_states(ValidateStrictness::Relaxed));
-
-            error!(
-                "post safety check failed. Failing nodes {:?}",
-                results.failures
-            );
+            async_std::task::block_on(runner.validate_node_states());
 
             if results.failures.is_empty() {
                 Ok(())
             } else {
+                error!(
+                    "post safety check failed. Failing nodes {:?}",
+                    results.failures
+                );
                 Err(ConsensusRoundError::ReplicasTimedOut {})
             }
         };


### PR DESCRIPTION
This PR:

- Upstreams @nyospe 's prune `state_map` in `collect_garbage`
- Introduces strict state checking (this should only be used for happy paths). State checking was not being done before since we were checking storage (which, of course, is empty and therefore trivially matches)