### PR TITLE
Fixed the multi-machine-centralized demo with the new storage API

### DIFF
--- a/examples/multi-machine-centralized.rs
+++ b/examples/multi-machine-centralized.rs
@@ -106,15 +106,13 @@ async fn init_state_and_hotshot(
     let pub_key = Ed25519Pub::from_private(&priv_key);
     let genesis = DEntryBlock::default();
     let hotshot = HotShot::init(
-        genesis,
         known_nodes.clone(),
         pub_key,
         priv_key,
         node_id,
         config,
-        state.clone(),
         networking,
-        MemoryStorage::default(),
+        MemoryStorage::new(genesis, state.clone()),
         Stateless::default(),
         StaticCommittee::new(known_nodes),
     )


### PR DESCRIPTION
Merging both #437 and #401 at the same time resulted in the main branch being unbuildable. This PR fixes this