### PR TITLE
Fix code coverage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -42,4 +42,3 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: lcov.info
-          fail_ci_if_error: true


### PR DESCRIPTION
I re-enabled the workflow, and dropped the deprecated attribute. Seems to work.