### PR TITLE
Remove arbitrary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1722,7 +1722,6 @@ dependencies = [
 name = "hotshot-types"
 version = "0.1.0"
 dependencies = [
- "arbitrary",
  "async-std",
  "async-trait",
  "async-tungstenite",

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -31,7 +31,6 @@ tagged-base64 = { git = "https://github.com/EspressoSystems/tagged-base64", tag 
 tracing = "0.1.36"
 espresso-systems-common = { git = "https://github.com/espressosystems/espresso-systems-common", tag = "0.2.0" }
 hotshot-utils = { path = "../utils", features = ["logging-utils"] }
-arbitrary = { version="1.0", features=["derive"] }
 
 
 [dev-dependencies]


### PR DESCRIPTION
This was added when trying to "fake" commitments for genesis. It should be removed now because we are not using it.