### PR TITLE
Added a panic hook whenever we set up logging

### DIFF
--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -146,6 +146,10 @@ pub mod test_util {
                         .init();
                 },
             };
+
+            std::panic::set_hook(Box::new(|info| {
+                tracing::error!(?info, "Thread panicked!");
+            }));
         });
     }
 }


### PR DESCRIPTION
Tested with a test `panic!("foo");`

![image](https://user-images.githubusercontent.com/2743142/188697278-3996171a-fb54-4049-be21-cbe5b9cbbb18.png)
