### PR TITLE
Applying cargo sort to reduce impending merge conflicts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,41 +25,38 @@ async-std = { version = "1.12.0", features = [] }
 async-trait = "0.1.57"
 async-tungstenite = { version = "0.17.2", features = ["async-std-runtime"] }
 atomic_store = { git = "https://github.com/EspressoSystems/atomicstore", tag = "0.1.3" }
+bimap = "0.6.2"
 bincode = "1.3.3"
 blake3 = { version = "1.1.0", optional = true }
+commit = { git = "https://github.com/EspressoSystems/commit", tag = "0.1.0" }
 custom_debug = "0.5"
 dashmap = "5.3.4"
+embed-doc-image = "0.1.4"
 flume = "0.10.14"
 futures = "0.3.24"
+hotshot-centralized-server = { version = "0.1.1", path = "centralized_server" }
 hotshot-consensus = { path = "./consensus", version = "0.1.0" }
 hotshot-types = { path = "./types", version = "0.1.0", default-features = false }
 hotshot-utils = { path = "./utils", version = "0.1.0" }
-libp2p-networking = { path = "./libp2p-networking", version = "0.1.0" }
 libp2p = { version = "0.47.0", features = ["serde"] }
-bimap = "0.6.2"
+libp2p-networking = { path = "./libp2p-networking", version = "0.1.0" }
 rand = "0.8.5"
+rand_chacha = "0.3.1"
 serde = { version = "1.0.144", features = ["derive", "rc"] }
 snafu = { version = "0.7.0", features = ["backtraces"] }
+tempfile = "3.3.0"
 tracing = "0.1.36"
 tracing-unwrap = "0.9.2"
-tempfile = "3.3.0"
-embed-doc-image = "0.1.4"
-rand_chacha = "0.3.1"
-commit = { git = "https://github.com/EspressoSystems/commit", tag = "0.1.0" }
-hotshot-centralized-server = { version = "0.1.1", path = "centralized_server" }
 
 [dev-dependencies]
 async-std = { version = "1.12.0", features = ["attributes"] }
+clap = { version = "3.2.20", features = ["derive", "env"] }
 hotshot-utils = { path = "./utils", version = "0.1.0", features = [
         "logging-utils",
 ] }
 rand_xoshiro = "0.6.0"
-clap = { version = "3.2.20", features = ["derive", "env"] }
 toml = "0.5.8"
-
-### Profiles
-###
-### Note: these only apply to example executables or tests built from within this crate. They have
+### Profiles###### Note: these only apply to example executables or tests built from within this crate. They have
 ### no effect on crates that depend on this crate.
 
 ## Apply some optimizations to test dependencies in debug/test builds
@@ -85,11 +82,11 @@ incremental = true
 [workspace]
 
 members = [
-        "libp2p-networking",
+        "centralized_server",
+        "centralized_server/bin",
         "consensus",
+        "libp2p-networking",
         "testing",
         "types",
         "utils",
-        "centralized_server",
-        "centralized_server/bin",
 ]

--- a/centralized_server/Cargo.toml
+++ b/centralized_server/Cargo.toml
@@ -6,11 +6,11 @@ edition = "2021"
 [dependencies]
 async-std = "1.12.0"
 bincode = "1.3.3"
-hotshot-types = { version = "0.1.0", path = "../types" }
-serde = { version = "1.0.143", features = ["derive"] }
-snafu = "0.7.1"
+commit = { git = "https://github.com/EspressoSystems/commit", tag = "0.1.0" }
 flume = "0.10.14"
 futures = "0.3.24"
+hotshot-types = { version = "0.1.0", path = "../types" }
 hotshot-utils = { path = "../utils" }
-commit = { git = "https://github.com/EspressoSystems/commit", tag = "0.1.0" }
+serde = { version = "1.0.143", features = ["derive"] }
+snafu = "0.7.1"
 tracing = "0.1.36"

--- a/centralized_server/bin/Cargo.toml
+++ b/centralized_server/bin/Cargo.toml
@@ -6,11 +6,11 @@ edition = "2021"
 [dependencies]
 async-std = { version = "1.12.0", features = ["attributes"] }
 clap = { version = "3.2.20", features = ["derive", "env"] }
-hotshot-types = { path = "../../types" }
+commit = { git = "https://github.com/EspressoSystems/commit", tag = "0.1.0" }
 hotshot = { path = "../../" }
 hotshot-centralized-server = { path = "../" }
+hotshot-types = { path = "../../types" }
 hotshot-utils = { path = "../../utils" }
-commit = { git = "https://github.com/EspressoSystems/commit", tag = "0.1.0" }
 toml = "0.5.9"
 tracing = "0.1.36"
 

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -5,13 +5,13 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+async-std = "1.12.0"
 async-trait = "0.1.57"
+commit = { git = "https://github.com/EspressoSystems/commit", tag = "0.1.0" }
 custom_debug = "0.5"
+flume = "0.10.14"
 futures = "0.3.24"
 hotshot-types = { path = "../types" }
-snafu = "0.7.0"
-async-std = "1.12.0"
-tracing = "0.1.36"
-flume = "0.10.14"
 hotshot-utils = { path = "../utils", features = ["logging-utils"] }
-commit = { git = "https://github.com/EspressoSystems/commit", tag = "0.1.0" }
+snafu = "0.7.0"
+tracing = "0.1.36"

--- a/libp2p-networking/Cargo.toml
+++ b/libp2p-networking/Cargo.toml
@@ -4,30 +4,28 @@ name = "libp2p-networking"
 version = "0.1.0"
 edition = "2021"
 authors = ["Nathan McCarty <nathan.mccarty@translucence.net>", "Victor Koenders <vkoenders@espressosys.com>", "Justin Restivo <justin@espressosys.com"]
-
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 async-std = { version = "1.12.0", features = ["attributes" ] }
+async-trait = "0.1.57"
 bincode = "1.3.3"
 blake3 = "1.3.1"
 color-eyre = "0.6.2"
+custom_debug = "0.5"
+derive_builder = "0.11.1"
+either = { version = "1.8.0" }
 flume = "0.10.14"
 futures = "0.3.24"
+hotshot-types = { path = "../types", version = "0.1.0" }
+hotshot-utils = { path = "../utils", version = "0.1.0", features = ["logging-utils"] }
 libp2p = { version = "0.47.0", features = ["serde"] }
 parking_lot = "0.12.0"
+rand = "0.8.5"
 serde = { version = "1.0.144", features = ["derive"] }
 serde_json = "1.0.85"
 snafu = "0.7.0"
 tracing = "0.1.36"
-rand = "0.8.5"
-async-trait = "0.1.57"
-derive_builder = "0.11.1"
-custom_debug = "0.5"
-hotshot-utils = { path = "../utils", version = "0.1.0", features = ["logging-utils"] }
-hotshot-types = { path = "../types", version = "0.1.0"}
-either = { version = "1.8.0" }
-
 # Feature dependencies
 
 ## webui
@@ -36,13 +34,13 @@ tide = { version = "0.16", optional = true, default-features = false, features =
 [target.'cfg(target_os = "linux")'.dependencies]
 ## lossy_network dependencies
 nix = { version = "0.25.0", optional = true }
-rtnetlink = { git = "ssh://git@github.com/EspressoSystems/netlink.git", version = "0.9.1", features = ["smol_socket"], default-features = false, optional = true}
-netlink-packet-route = { git = "ssh://git@github.com/EspressoSystems/netlink.git", version = "0.11.0", optional = true}
-netlink-packet-utils = { git = "ssh://git@github.com/EspressoSystems/netlink.git", version = "0.5.1", optional = true}
-netlink-packet-core = { git = "ssh://git@github.com/EspressoSystems/netlink.git", version = "0.4.2", optional = true}
-netlink-proto = { git = "ssh://git@github.com/EspressoSystems/netlink.git", version = "0.9.2", optional = true}
+rtnetlink = { git = "ssh://git@github.com/EspressoSystems/netlink.git", version = "0.9.1", features = ["smol_socket"], default-features = false, optional = true }
+netlink-packet-route = { git = "ssh://git@github.com/EspressoSystems/netlink.git", version = "0.11.0", optional = true }
+netlink-packet-utils = { git = "ssh://git@github.com/EspressoSystems/netlink.git", version = "0.5.1", optional = true }
+netlink-packet-core = { git = "ssh://git@github.com/EspressoSystems/netlink.git", version = "0.4.2", optional = true }
+netlink-proto = { git = "ssh://git@github.com/EspressoSystems/netlink.git", version = "0.9.2", optional = true }
 netlink-sys = { git = "ssh://git@github.com/EspressoSystems/netlink.git", version = "0.8.2", features = [ "smol_socket" ], optional = true }
-netlink-packet-generic = { git = "ssh://git@github.com/EspressoSystems/netlink.git", version = "0.2.0", optional = true}
+netlink-packet-generic = { git = "ssh://git@github.com/EspressoSystems/netlink.git", version = "0.2.0", optional = true }
 
 [features]
 webui = ["tide"]

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -4,26 +4,25 @@ version = "0.1.0"
 edition = "2021"
 description = "Types and traits for the HotShot consesus module"
 authors = ["Victor Koenders <vkoenders@espressosys.com>"]
-
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-hotshot = { path = "../", features = ["hotshot-testing"] }
-hotshot-types = { path = "../types" }
-hotshot-utils = { path = "../utils", features = ["logging-utils"] }
-hotshot-consensus = { path = "../consensus" }
 async-std = "1.12.0"
 async-trait = "0.1.57"
-tracing = "0.1.36"
+commit = { git = "https://github.com/EspressoSystems/commit", tag = "0.1.0" }
+either = { version = "1.8.0" }
+futures = "0.3.24"
+hotshot = { path = "../", features = ["hotshot-testing"] }
+hotshot-consensus = { path = "../consensus" }
+hotshot-types = { path = "../types" }
+hotshot-utils = { path = "../utils", features = ["logging-utils"] }
 rand = "0.8.5"
 snafu = { version = "0.7.0", features = ["backtraces"] }
-futures = "0.3.24"
-either = { version = "1.8.0" }
-commit = { git = "https://github.com/EspressoSystems/commit", tag = "0.1.0" }
+tracing = "0.1.36"
 
 [dev-dependencies]
-tempfile = "3.3.0"
 proptest = "1.0.0"
+tempfile = "3.3.0"
 
 [features]
 slow-tests = []

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -12,27 +12,26 @@ default = ["demo"]
 demo = ["ed25519-compact"]
 
 [dependencies]
+arbitrary = { version = "1.0", features = ["derive"] }
 async-std = "1.12.0"
 async-trait = "0.1.57"
 async-tungstenite = "0.17.2"
 atomic_store = { git = "https://github.com/EspressoSystems/atomicstore", tag = "0.1.3" }
-commit = { git = "https://github.com/EspressoSystems/commit", tag = "0.1.0" }
 bincode = "1.3.3"
 blake3 = "1.3.1"
+commit = { git = "https://github.com/EspressoSystems/commit", tag = "0.1.0" }
 custom_debug = "0.5"
 ed25519-compact = { version = "1.0.11", optional = true }
+espresso-systems-common = { git = "https://github.com/espressosystems/espresso-systems-common", tag = "0.2.0" }
 futures = "0.3.24"
 hex_fmt = "0.3.0"
+hotshot-utils = { path = "../utils", features = ["logging-utils"] }
 rand = "0.8.5"
 serde = { version = "1.0.144", features = ["derive"] }
 serde_bytes = "0.11.7"
 snafu = "0.7.0"
 tagged-base64 = { git = "https://github.com/EspressoSystems/tagged-base64", tag = "0.2.0" }
 tracing = "0.1.36"
-espresso-systems-common = { git = "https://github.com/espressosystems/espresso-systems-common", tag = "0.2.0" }
-hotshot-utils = { path = "../utils", features = ["logging-utils"] }
-arbitrary = { version="1.0", features=["derive"] }
-
 
 [dev-dependencies]
 serde_json = "1.0.85"

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -7,15 +7,15 @@ readme = "../README.md"
 version = "0.1.0"
 
 [dependencies]
-flume = "0.10.14"
-tracing = "0.1.36"
-bincode = "1.3.3"
 async-std = "1.12.0"
-tracing-error = "0.2.0"
-tracing-subscriber = { version = "0.3.15", features = ["env-filter", "json"], optional = true}
-futures = "0.3.24"
 async-trait = "0.1.57"
+bincode = "1.3.3"
 color-eyre = "0.6.2"
+flume = "0.10.14"
+futures = "0.3.24"
+tracing = "0.1.36"
+tracing-error = "0.2.0"
+tracing-subscriber = { version = "0.3.15", features = ["env-filter", "json"], optional = true }
 
 [dev-dependencies]
 # need async-std test attribute for subscriber mutex tests


### PR DESCRIPTION
`cargo sort -g -w` should be part of pre-commit, and `cargo sort -g -w -c` part of CI.