### PR TITLE
Check for UB

### DIFF
--- a/.github/workflows/careful.yml
+++ b/.github/workflows/careful.yml
@@ -1,0 +1,33 @@
+name: Careful Workflow
+
+on:
+  schedule:
+    # run at midnight on monday
+    - cron: '0 0 * * 1'
+  workflow_dispatch:
+
+jobs:
+  careful:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - name: Install Nix
+        uses: cachix/install-nix-action@v17
+
+      - uses: cachix/cachix-action@v10
+        with:
+          name: espresso-systems-private
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+
+      - name: Configure Git
+        run: |
+          git config --global url."https://ancient123:${{ secrets.ORG_GITHUB_PATH }}@github.com/".insteadOf git://github.com/
+          git config --global url."https://ancient123:${{ secrets.ORG_GITHUB_PAT }}@github.com/".insteadOf ssh://git@github.com/
+
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: Run careful tests
+        run: |
+          nix develop .#correctnessShell -c just careful
+        timeout-minutes: 90

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,6 +137,14 @@ debug = 1
 lto = "thin"
 incremental = true
 
+## LTO doesn't work with careful
+## explicitly specifying features in case releases features change
+[profile.careful]
+debug = 1
+inherits = "release"
+lto = "off"
+incremental = true
+
 ### Workspace
 
 # The hotshot-types crate needs to be a seperate crate, as to not create a circular dependency

--- a/README.md
+++ b/README.md
@@ -83,6 +83,15 @@ To stress test, run the ignored tests prefixed with `test_stress`:
 RUST_LOG=$ERROR_LOG_LEVEL RUST_LOG_FORMAT=$ERROR_LOG_FORMAT cargo test --verbose --release --lib --bins --tests --benches --features=full-ci --workspace test_stress -- --nocapture --test-threads=1 --ignored
 ```
 
+## Careful
+
+To double check for UB:
+
+```bash
+nix develop .#correctnessShell
+just careful
+```
+
 ## Testing on CI
 
 To test as if running on CI, one must limit the number of cores and ram to match github runners (2 core, 7 gig ram). To limit the ram, spin up a virtual machine or container with 7 gigs ram. To limit the core count when running tests:

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,21 @@
 {
   "nodes": {
+    "cargo-careful": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1664434223,
+        "narHash": "sha256-kKF/Fp6RCF9PUdgqeo2e4vLVhl8+5M4oa0Q18ZdXJRc=",
+        "owner": "RalfJung",
+        "repo": "cargo-careful",
+        "rev": "b0cbd3384a84d412f13f45a50051d0fbad733b57",
+        "type": "github"
+      },
+      "original": {
+        "owner": "RalfJung",
+        "repo": "cargo-careful",
+        "type": "github"
+      }
+    },
     "crate2nix": {
       "flake": false,
       "locked": {
@@ -72,6 +88,7 @@
     },
     "root": {
       "inputs": {
+        "cargo-careful": "cargo-careful",
         "crate2nix": "crate2nix",
         "fenix": "fenix",
         "flake-compat": "flake-compat",

--- a/justfile
+++ b/justfile
@@ -35,3 +35,13 @@ lint_tokio:
 lint_async_std:
   echo Linting with async std executor
   cargo clippy --workspace --all-targets --no-default-features --features=tokio-ci --bins --tests --examples -- -D warnings
+
+careful: careful_tokio careful_async_std
+
+careful_tokio:
+  echo Careful-ing with tokio executor
+  cargo careful test --verbose --profile careful --features=full-ci --lib --bins --tests --benches --workspace --no-fail-fast -- --test-threads=1 --nocapture
+
+careful_async_std:
+  echo Careful-ing with async std executor
+  cargo careful test --verbose --profile careful --features=full-ci --lib --bins --tests --benches --workspace --no-fail-fast -- --test-threads=1 --nocapture


### PR DESCRIPTION
Add a weekly workflow to check for UB using cargo careful. Notably:

- Adds cargo careful profile
- Adds `careful` target to justfile
- Adds a new `correctnessShell` for running cargo careful, as careful requires nightly rust.
- Adds documentation to our README

Closes #553 