### PR TITLE
Made build, build_nix and coverage not trigger on dependabot PR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,7 @@ on:
     branches:
       - 'main'
       - '*/*'
+      - '!dependabot/*'
   schedule:
     - cron: '0 0 * * 1'
   workflow_dispatch:

--- a/.github/workflows/build_nix.yml
+++ b/.github/workflows/build_nix.yml
@@ -9,6 +9,7 @@ on:
       - 'main'
       - '*/*'
       - 'update_flake_lock_action'
+      - '!dependabot/*'
   schedule:
     - cron: '0 0 * * 1'
   workflow_dispatch:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -8,6 +8,7 @@ on:
     branches:
       - 'main'
       - '*/*'
+      - '!dependabot/*'
   schedule:
     - cron: '0 0 * * 1'
   workflow_dispatch:


### PR DESCRIPTION
This should ignore all `dependabot/*` branches as per the [github documentation](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-including-and-excluding-branches)