### PR TITLE
Optimize sortition

### DIFF
--- a/src/traits/election/vrf.rs
+++ b/src/traits/election/vrf.rs
@@ -557,12 +557,11 @@ impl BinomialQuery {
 #[instrument]
 fn calculate_threshold_from_cache(previous_calculation: Option<(BinomialQuery, Ratio<BigUint>)>, query: BinomialQuery) -> Option<Ratio<BigUint>>{
     if let Some((previous_query, previous_result)) = previous_calculation {
-        if previous_query.sortition_parameter == query.sortition_parameter
-           && previous_query.replicas_stake == query.replicas_stake
-           && previous_query.total_stake == query.total_stake
-           && previous_query.stake_attempt == query.stake_attempt - 1
-           {
-
+        let expected_previous_query = BinomialQuery {
+            stake_attempt: query.stake_attempt - 1,
+            ..query
+        };
+        if previous_query == expected_previous_query {
                let permutation = Ratio::new(BigUint::from(query.replicas_stake - u64::from(query.stake_attempt) + 1),  BigUint::from(query.stake_attempt));
                let p = query.get_p();
                assert!(p.numer() < p.denom());


### PR DESCRIPTION
This PR introduces a cache for all binomial pdf calculations used for vrf sortition. This allows us to reuse previous results in current calculations within a view as well as cache binomial distribution calculations between views. Practically speaking, this allows us to be much less naive from a performance perspective as we are no longer recalculating ${n \choose k}$ from scratch every time we check a bin.

The (hopefully straightforward) tricks being applied are described [here](https://github.com/EspressoSystems/HotShot/issues/644). This should JustWorkTM with dynamic stake when we start doing that.

Closes #644 