### PR TITLE
Two unrelated fixes

### DIFF
--- a/consensus/src/replica.rs
+++ b/consensus/src/replica.rs
@@ -395,6 +395,10 @@ impl<A: ConsensusApi<TYPES>, TYPES: NodeTypes> Replica<A, TYPES> {
             }) as i64;
             consensus
                 .metrics
+                .outstanding_transactions
+                .update(-(included_txns_set.len() as i64));
+            consensus
+                .metrics
                 .outstanding_transactions_memory_size
                 .update(-included_txn_size);
             consensus

--- a/consensus/src/replica.rs
+++ b/consensus/src/replica.rs
@@ -389,10 +389,26 @@ impl<A: ConsensusApi<TYPES>, TYPES: NodeTypes> Replica<A, TYPES> {
                 .metrics
                 .invalid_qc_views
                 .add_point(consensus.invalid_qc as f64);
-            #[allow(clippy::cast_possible_wrap)]
-            let included_txn_size = included_txns_set.iter().fold(0, |total, txn| {
-                total + bincode_opts().serialized_size(&txn).unwrap_or(0)
-            }) as i64;
+
+            let mut included_txn_size = 0;
+            consensus
+                .transactions
+                .modify(|txns| {
+                    *txns = txns
+                        .drain()
+                        .filter(|(txn_hash, txn)| {
+                            #[allow(clippy::cast_possible_wrap)]
+                            if included_txns_set.contains(txn_hash) {
+                                included_txn_size +=
+                                    bincode_opts().serialized_size(txn).unwrap_or_default() as i64;
+                                false
+                            } else {
+                                true
+                            }
+                        })
+                        .collect();
+                })
+                .await;
             consensus
                 .metrics
                 .outstanding_transactions
@@ -401,15 +417,6 @@ impl<A: ConsensusApi<TYPES>, TYPES: NodeTypes> Replica<A, TYPES> {
                 .metrics
                 .outstanding_transactions_memory_size
                 .update(-included_txn_size);
-            consensus
-                .transactions
-                .modify(|txns| {
-                    *txns = txns
-                        .drain()
-                        .filter(|(txn_hash, _txn)| !included_txns_set.contains(txn_hash))
-                        .collect();
-                })
-                .await;
 
             consensus
                 .metrics

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -3,7 +3,7 @@
 use crate::{create_or_obtain_chan_from_write, types::HotShotHandle, HotShot, HotShotConsensusApi};
 use async_compatibility_layer::{
     art::{async_sleep, async_spawn, async_spawn_local, async_timeout},
-    async_primitives::{broadcast::channel, subscribable_rwlock::ReadView},
+    async_primitives::broadcast::channel,
     channel::{unbounded, UnboundedReceiver, UnboundedSender},
 };
 use async_lock::RwLock;
@@ -348,10 +348,6 @@ pub async fn run_view<TYPES: NodeTypes, I: NodeImplementation<TYPES>>(
         .metrics
         .view_duration
         .add_point(start.elapsed().as_secs_f64());
-    consensus
-        .metrics
-        .outstanding_transactions
-        .set(txns.cloned().await.len());
     c_api.send_view_finished(consensus.cur_view).await;
 
     info!("Returning from view {:?}!", cur_view);


### PR DESCRIPTION
commit 4a804e5be42d7940f71637ed99d703d3269a400e
Author: Jeb Bearer <jeb@espressosys.com>
Date:   Fri Dec 2 12:48:24 2022 -0800

    Ensure QC for genesis Decide refers to genesis leaf/block

commit d84bc2ab870f0a757b8c7bef052d0225c0c0405a
Author: Jeb Bearer <jeb@espressosys.com>
Date:   Fri Dec 2 12:43:05 2022 -0800

    Update `oustanding_transactions` together with `outstanding_tranactions_memory_size`.
    
    The lock order (first `hotstuff`, then `transactions`) is
    consistent with the previous ordering (where `hotstuff` was locked
    at the start of the view and then `transactions` was locked
    (via `cloned`) within the view.

