### PR TITLE
Remove old security advisory for clap

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -43,12 +43,4 @@ ignore = [
     # https://rustsec.org/advisories/RUSTSEC-2022-0008
     "RUSTSEC-2022-0008",
 
-    # atty 0.2.14
-    # Dependency of clap -> atty
-    # Dependency of tagged-base64 -> structopt -> clap -> atty
-    # Potential unsound behaviour
-    # Waiting on new release of clap
-    # https://github.com/clap-rs/clap/pull/4249
-    # https://rustsec.org/advisories/RUSTSEC-2021-0145
-    "RUSTSEC-2021-0145",
 ]


### PR DESCRIPTION
Clap has been upgraded, so we can drop the security advisory. Closes #767 