### PR TITLE
Nvim nix support

### DIFF
--- a/.nvim/example.env.lua
+++ b/.nvim/example.env.lua
@@ -1,0 +1,2 @@
+-- copy this into env.lua
+return "full-ci"

--- a/README.md
+++ b/README.md
@@ -197,6 +197,31 @@ To bring `lldb` into scope with nix, run `nix develop .#debugShell`.
 
 For espresso developers we have written up a description of our workflow [here](./WORKFLOW.md).
 
+# Extra Editor Configuration
+
+## Neovim
+
+Copy `.nvim/example.env.lua` to `.nvim/env.lua`. The purpose of this file is to return to neovim the requisite feature flags.
+
+Then load this file when configuring `rust-tools`:
+
+```lua
+rust_tools.setup(
+  {server =
+    {settings =
+      {
+        ["rust-analyzer"] =
+          {cargo =
+            {features =
+              loadfile(".nvim/env.lua") and { loadfile(".nvim/env.lua")() } or "all"
+            }
+          }
+      }
+    }
+  }
+)
+```
+
 # License
 
 ## Copyright

--- a/flake.nix
+++ b/flake.nix
@@ -57,6 +57,7 @@
           ];
 
         CARGO_TARGET_DIR = "target_dirs/nix_rustc";
+        NVIM_RUST_ENABLED_FEATURE_FLAGS = "full-ci";
 
         rustOverlay = final: prev: {
           rustc = fenixStable;
@@ -186,7 +187,7 @@
           ];
       in {
         devShell = pkgs.mkShell {
-          inherit CARGO_TARGET_DIR;
+          inherit CARGO_TARGET_DIR NVIM_RUST_ENABLED_FEATURE_FLAGS;
           buildInputs = [ fenixStable ] ++ buildDeps;
         };
 

--- a/flake.nix
+++ b/flake.nix
@@ -57,7 +57,6 @@
           ];
 
         CARGO_TARGET_DIR = "target_dirs/nix_rustc";
-        NVIM_RUST_ENABLED_FEATURE_FLAGS = "full-ci";
 
         rustOverlay = final: prev: {
           rustc = fenixStable;
@@ -187,14 +186,14 @@
           ];
       in {
         devShell = pkgs.mkShell {
-          inherit CARGO_TARGET_DIR NVIM_RUST_ENABLED_FEATURE_FLAGS;
+          inherit CARGO_TARGET_DIR;
           buildInputs = [ fenixStable ] ++ buildDeps;
         };
 
         devShells = {
           # usage: check correctness
           correctnessShell = pkgs.mkShell {
-            inherit CARGO_TARGET_DIR NVIM_RUST_ENABLED_FEATURE_FLAGS;
+            inherit CARGO_TARGET_DIR;
             shellHook = ''
               ulimit -n 1024
             '';
@@ -206,7 +205,7 @@
 
           # usage: compile a statically linked musl binary
           staticShell = pkgs.mkShell {
-            inherit CARGO_TARGET_DIR NVIM_RUST_ENABLED_FEATURE_FLAGS;
+            inherit CARGO_TARGET_DIR;
             shellHook = ''
               ulimit -n 1024
               export RUSTFLAGS='-C target-feature=+crt-static'
@@ -217,7 +216,7 @@
 
           # usage: link with mold
           moldShell = pkgs.mkShell {
-            inherit CARGO_TARGET_DIR NVIM_RUST_ENABLED_FEATURE_FLAGS;
+            inherit CARGO_TARGET_DIR;
             LD_LIBRARY_PATH = "${pkgs.zlib.out}/lib";
             buildInputs = with pkgs; [ zlib.out fd fenixStable ] ++ buildDeps;
             shellHook = ''
@@ -228,7 +227,7 @@
           # usage: setup for tokio with console
           #        with support for opentelemetry
           consoleShell = pkgs.mkShell {
-            inherit CARGO_TARGET_DIR NVIM_RUST_ENABLED_FEATURE_FLAGS;
+            inherit CARGO_TARGET_DIR;
             OTEL_BSP_MAX_EXPORT_BATCH_SIZE = 25;
             OTEL_BSP_MAX_QUEUE_SIZE = 32768;
             OTL_ENABLED = "true";
@@ -245,7 +244,7 @@
 
           # usage: evaluate performance (llvm-cov + flamegraph)
           perfShell = pkgs.mkShell {
-            inherit CARGO_TARGET_DIR NVIM_RUST_ENABLED_FEATURE_FLAGS;
+            inherit CARGO_TARGET_DIR;
             buildInputs = with pkgs;
               [ cargo-flamegraph fd cargo-llvm-cov fenixStable ripgrep ]
               ++ buildDeps ++ lib.optionals stdenv.isLinux [
@@ -257,7 +256,7 @@
           # usage: brings in debugging tools including:
           # - lldb: a debugger to be used with vscode
           debugShell = pkgs.mkShell {
-            inherit CARGO_TARGET_DIR NVIM_RUST_ENABLED_FEATURE_FLAGS;
+            inherit CARGO_TARGET_DIR;
             buildInputs = with pkgs; [ fenixStable lldb ] ++ buildDeps;
           };
 

--- a/flake.nix
+++ b/flake.nix
@@ -194,7 +194,7 @@
         devShells = {
           # usage: check correctness
           correctnessShell = pkgs.mkShell {
-            inherit CARGO_TARGET_DIR;
+            inherit CARGO_TARGET_DIR NVIM_RUST_ENABLED_FEATURE_FLAGS;
             shellHook = ''
               ulimit -n 1024
             '';
@@ -206,7 +206,7 @@
 
           # usage: compile a statically linked musl binary
           staticShell = pkgs.mkShell {
-            inherit CARGO_TARGET_DIR;
+            inherit CARGO_TARGET_DIR NVIM_RUST_ENABLED_FEATURE_FLAGS;
             shellHook = ''
               ulimit -n 1024
               export RUSTFLAGS='-C target-feature=+crt-static'
@@ -217,7 +217,7 @@
 
           # usage: link with mold
           moldShell = pkgs.mkShell {
-            inherit CARGO_TARGET_DIR;
+            inherit CARGO_TARGET_DIR NVIM_RUST_ENABLED_FEATURE_FLAGS;
             LD_LIBRARY_PATH = "${pkgs.zlib.out}/lib";
             buildInputs = with pkgs; [ zlib.out fd fenixStable ] ++ buildDeps;
             shellHook = ''
@@ -228,7 +228,7 @@
           # usage: setup for tokio with console
           #        with support for opentelemetry
           consoleShell = pkgs.mkShell {
-            inherit CARGO_TARGET_DIR;
+            inherit CARGO_TARGET_DIR NVIM_RUST_ENABLED_FEATURE_FLAGS;
             OTEL_BSP_MAX_EXPORT_BATCH_SIZE = 25;
             OTEL_BSP_MAX_QUEUE_SIZE = 32768;
             OTL_ENABLED = "true";
@@ -245,7 +245,7 @@
 
           # usage: evaluate performance (llvm-cov + flamegraph)
           perfShell = pkgs.mkShell {
-            inherit CARGO_TARGET_DIR;
+            inherit CARGO_TARGET_DIR NVIM_RUST_ENABLED_FEATURE_FLAGS;
             buildInputs = with pkgs;
               [ cargo-flamegraph fd cargo-llvm-cov fenixStable ripgrep ]
               ++ buildDeps ++ lib.optionals stdenv.isLinux [
@@ -257,7 +257,7 @@
           # usage: brings in debugging tools including:
           # - lldb: a debugger to be used with vscode
           debugShell = pkgs.mkShell {
-            inherit CARGO_TARGET_DIR;
+            inherit CARGO_TARGET_DIR NVIM_RUST_ENABLED_FEATURE_FLAGS;
             buildInputs = with pkgs; [ fenixStable lldb ] ++ buildDeps;
           };
 


### PR DESCRIPTION
It doesn't look like there's an environment variable that can be fed into rust-analyzer to set feature flags. So instead, I set an env variable when entering the nix shell that I've modified my neovim config to feed through to the rust-analzyer setup on start.

Relevant code to stick in the `init.lua` is:

```lua
local rust_tools = require('rust-tools')
rust_tools.setup({server = {settings = {["rust-analyzer"] = {cargo = {features = os.getenv("NVIM_RUST_ENABLED_FEATURE_FLAGS") and { os.getenv("NVIM_RUST_ENABLED_FEATURE_FLAGS") } or "all"}}}}})
```