### PR TITLE
Refactor HotShot with ViewRunnerType

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -336,7 +336,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> HotShot<TYPES::ConsensusType
     /// # Errors
     ///
     /// Will return an error when the storage failed to insert the first `QuorumCertificate`
-    #[allow(clippy::too_many_lines, clippy::too_many_arguments)]
+    #[allow(clippy::too_many_arguments)]
     pub async fn init(
         public_key: TYPES::SignatureKey,
         private_key: <TYPES::SignatureKey as SignatureKey>::PrivateKey,

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -8,25 +8,16 @@ use async_compatibility_layer::{
 };
 use async_lock::RwLock;
 use async_trait::async_trait;
-use hotshot_consensus::{ConsensusApi, NextValidatingLeader, Replica, ValidatingLeader, ViewQueue};
-#[cfg(feature = "async-std-executor")]
-use hotshot_types::certificate::QuorumCertificate;
+use hotshot_consensus::ConsensusApi;
 use hotshot_types::{
     constants::LOOK_AHEAD,
-    data::{ValidatingLeaf, ValidatingProposal},
     message::MessageKind,
     traits::{
-        election::Election,
         network::NetworkingImplementation,
         node_implementation::{NodeImplementation, NodeType},
-        state::{
-            ConsensusType, SequencingConsensus, TestableBlock, TestableState, ValidatingConsensus,
-        },
     },
     ExecutionType,
 };
-#[allow(deprecated)]
-use nll::nll_todo::nll_todo;
 use std::{
     collections::HashMap,
     marker::PhantomData,
@@ -34,9 +25,9 @@ use std::{
         atomic::{AtomicBool, Ordering},
         Arc,
     },
-    time::{Duration, Instant},
+    time::Duration,
 };
-use tracing::{error, info, info_span, instrument, trace, Instrument};
+use tracing::{error, info, info_span, trace, Instrument};
 
 #[cfg(feature = "async-std-executor")]
 use async_std::task::{yield_now, JoinHandle};
@@ -149,10 +140,10 @@ struct TaskHandleInner {
 ///
 /// For a list of which tasks are being spawned, see this module's documentation.
 pub async fn spawn_all<TYPES: NodeType, I: NodeImplementation<TYPES>>(
-    hotshot: &HotShot<TYPES, I>,
+    hotshot: &HotShot<TYPES::ConsensusType, TYPES, I>,
 ) -> HotShotHandle<TYPES, I>
 where
-    ViewRunner<<TYPES as NodeType>::ConsensusType>: ViewRunnerType<TYPES, I>,
+    HotShot<TYPES::ConsensusType, TYPES, I>: ViewRunnerType<TYPES, I>,
 {
     let shut_down = Arc::new(AtomicBool::new(false));
     let started = Arc::new(AtomicBool::new(false));
@@ -218,224 +209,22 @@ where
     handle
 }
 
-// TODO (da) we may be able to get rid of `ViewRunner` and many where clauses by implementing
-// `ViewRunnerType` for `HotShot`.
-#[allow(clippy::missing_docs_in_private_items)]
-#[allow(missing_docs)]
-pub struct ViewRunner<CONSENSUS: ConsensusType> {
-    _pd: PhantomData<CONSENSUS>,
-}
-
 #[allow(clippy::missing_docs_in_private_items)]
 #[allow(missing_docs)]
 #[async_trait]
 pub trait ViewRunnerType<TYPES: NodeType, I: NodeImplementation<TYPES>> {
     /// Executes one view of consensus
-    async fn run_view(hotshot: HotShot<TYPES, I>) -> Result<(), ()>;
-}
-
-#[allow(clippy::too_many_lines)]
-#[async_trait]
-impl<
-        TYPES: NodeType<ConsensusType = ValidatingConsensus>,
-        ELECTION: Election<TYPES, LeafType = ValidatingLeaf<TYPES>>,
-        I: NodeImplementation<
-            TYPES,
-            Leaf = ValidatingLeaf<TYPES>,
-            Proposal = ValidatingProposal<TYPES, ELECTION>,
-        >,
-    > ViewRunnerType<TYPES, I> for ViewRunner<ValidatingConsensus>
-where
-    TYPES::StateType: TestableState,
-    TYPES::BlockType: TestableBlock,
-{
-    #[instrument(skip(hotshot), fields(id = hotshot.id), name = "Validating View Runner Task", level = "error")]
-    async fn run_view(hotshot: HotShot<TYPES, I>) -> Result<(), ()> {
-        let c_api = HotShotConsensusApi {
-            inner: hotshot.inner.clone(),
-        };
-        let start = Instant::now();
-        let metrics = Arc::clone(&hotshot.hotstuff.read().await.metrics);
-
-        // do book keeping on channel map
-        // TODO probably cleaner to separate this into a function
-        // e.g. insert the view and remove the last view
-        let mut send_to_replica = hotshot.replica_channel_map.write().await;
-        let replica_last_view: TYPES::Time = send_to_replica.cur_view;
-        // gc previous view's channel map
-        send_to_replica.channel_map.remove(&replica_last_view);
-        send_to_replica.cur_view += 1;
-        let replica_cur_view = send_to_replica.cur_view;
-        let ViewQueue {
-            sender_chan: send_replica,
-            receiver_chan: recv_replica,
-            has_received_proposal: _,
-        } = HotShot::<TYPES, I>::create_or_obtain_chan_from_write(
-            replica_cur_view,
-            send_to_replica,
-        )
-        .await;
-
-        let mut send_to_next_leader = hotshot.next_leader_channel_map.write().await;
-        let next_leader_last_view = send_to_next_leader.cur_view;
-        // gc previous view's channel map
-        send_to_next_leader
-            .channel_map
-            .remove(&next_leader_last_view);
-        send_to_next_leader.cur_view += 1;
-        let next_leader_cur_view = send_to_next_leader.cur_view;
-        let (send_next_leader, recv_next_leader) =
-            if c_api.is_leader(next_leader_cur_view + 1).await {
-                let vq = HotShot::<TYPES, I>::create_or_obtain_chan_from_write(
-                    next_leader_cur_view,
-                    send_to_next_leader,
-                )
-                .await;
-                (Some(vq.sender_chan), Some(vq.receiver_chan))
-            } else {
-                (None, None)
-            };
-
-        // increment consensus and start tasks
-
-        let (cur_view, high_qc, txns) = {
-            // OBTAIN write lock on consensus
-            let mut consensus = hotshot.hotstuff.write().await;
-            let cur_view = consensus.increment_view();
-            // make sure consistent
-            assert_eq!(cur_view, next_leader_cur_view);
-            assert_eq!(cur_view, replica_cur_view);
-            let high_qc = consensus.high_qc.clone();
-            let txns = consensus.transactions.clone();
-            // DROP write lock on consensus
-            drop(consensus);
-            (cur_view, high_qc, txns)
-        };
-
-        // notify networking to start worrying about the (`cur_view + LOOK_AHEAD`)th leader ahead of the current view
-        if hotshot
-            .send_network_lookup
-            .send(Some(cur_view))
-            .await
-            .is_err()
-        {
-            error!("Failed to initiate network lookup");
-        };
-
-        info!("Starting tasks for View {:?}!", cur_view);
-        metrics.current_view.set(*cur_view as usize);
-
-        let mut task_handles = Vec::new();
-
-        // replica always runs? TODO this will change once vrf integration is added
-        let replica = Replica {
-            id: hotshot.id,
-            consensus: hotshot.hotstuff.clone(),
-            proposal_collection_chan: recv_replica,
-            cur_view,
-            high_qc: high_qc.clone(),
-            api: c_api.clone(),
-        };
-        let replica_handle = async_spawn(async move { replica.run_view().await });
-        task_handles.push(replica_handle);
-
-        if c_api.is_leader(cur_view).await {
-            let leader = ValidatingLeader {
-                id: hotshot.id,
-                consensus: hotshot.hotstuff.clone(),
-                high_qc: high_qc.clone(),
-                cur_view,
-                transactions: txns,
-                api: c_api.clone(),
-                _pd: PhantomData,
-            };
-            let leader_handle = async_spawn(async move { leader.run_view().await });
-            task_handles.push(leader_handle);
-        }
-
-        if c_api.is_leader(cur_view + 1).await {
-            let next_leader = NextValidatingLeader {
-                id: hotshot.id,
-                generic_qc: high_qc,
-                // should be fine to unwrap here since the view numbers must be the same
-                vote_collection_chan: recv_next_leader.unwrap(),
-                cur_view,
-                api: c_api.clone(),
-                metrics,
-            };
-            let next_leader_handle = async_spawn(async move {
-                NextValidatingLeader::<HotShotConsensusApi<TYPES, I>, TYPES, _>::run_view(
-                    next_leader,
-                )
-                .await
-            });
-            task_handles.push(next_leader_handle);
-        }
-
-        let children_finished = futures::future::join_all(task_handles);
-
-        async_spawn({
-            let next_view_timeout = hotshot.inner.config.next_view_timeout;
-            let next_view_timeout = next_view_timeout;
-            let hotshot: HotShot<TYPES, I> = hotshot.clone();
-            async move {
-                async_sleep(Duration::from_millis(next_view_timeout)).await;
-                hotshot
-                    .timeout_view(cur_view, send_replica, send_next_leader)
-                    .await;
-            }
-        });
-
-        let results = children_finished.await;
-
-        // unwrap is fine since results must have >= 1 item(s)
-        #[cfg(feature = "async-std-executor")]
-        let high_qc = results
-            .into_iter()
-            .max_by_key(|qc: &QuorumCertificate<TYPES, I::Leaf>| qc.view_number)
-            .unwrap();
-        #[cfg(feature = "tokio-executor")]
-        let high_qc = results
-            .into_iter()
-            .filter_map(std::result::Result::ok)
-            .max_by_key(|qc| qc.view_number)
-            .unwrap();
-
-        #[cfg(not(any(feature = "async-std-executor", feature = "tokio-executor")))]
-        compile_error! {"Either feature \"async-std-executor\" or feature \"tokio-executor\" must be enabled for this crate."}
-
-        let mut consensus = hotshot.hotstuff.write().await;
-        consensus.high_qc = high_qc;
-        consensus
-            .metrics
-            .view_duration
-            .add_point(start.elapsed().as_secs_f64());
-        c_api.send_view_finished(consensus.cur_view).await;
-
-        info!("Returning from view {:?}!", cur_view);
-        Ok(())
-    }
-}
-
-#[async_trait]
-impl<TYPES: NodeType<ConsensusType = SequencingConsensus>, I: NodeImplementation<TYPES>>
-    ViewRunnerType<TYPES, I> for ViewRunner<SequencingConsensus>
-{
-    // #[instrument]
-    async fn run_view(_hotshot: HotShot<TYPES, I>) -> Result<(), ()> {
-        #[allow(deprecated)]
-        nll_todo()
-    }
+    async fn run_view(hotshot: HotShot<TYPES::ConsensusType, TYPES, I>) -> Result<(), ()>;
 }
 
 /// main thread driving consensus
 pub async fn view_runner<TYPES: NodeType, I: NodeImplementation<TYPES>>(
-    hotshot: HotShot<TYPES, I>,
+    hotshot: HotShot<TYPES::ConsensusType, TYPES, I>,
     started: Arc<AtomicBool>,
     shut_down: Arc<AtomicBool>,
     run_once: Option<UnboundedReceiver<()>>,
 ) where
-    ViewRunner<<TYPES as NodeType>::ConsensusType>: ViewRunnerType<TYPES, I>,
+    HotShot<TYPES::ConsensusType, TYPES, I>: ViewRunnerType<TYPES, I>,
 {
     while !shut_down.load(Ordering::Relaxed) && !started.load(Ordering::Relaxed) {
         yield_now().await;
@@ -445,16 +234,13 @@ pub async fn view_runner<TYPES: NodeType, I: NodeImplementation<TYPES>>(
         if let Some(ref recv) = run_once {
             let _ = recv.recv().await;
         }
-        let _ = <ViewRunner<TYPES::ConsensusType> as ViewRunnerType<TYPES, I>>::run_view(
-            hotshot.clone(),
-        )
-        .await;
+        let _ = HotShot::<TYPES::ConsensusType, TYPES, I>::run_view(hotshot.clone()).await;
     }
 }
 
 /// Task to look up a node in the future as needed
 pub async fn network_lookup_task<TYPES: NodeType, I: NodeImplementation<TYPES>>(
-    hotshot: HotShot<TYPES, I>,
+    hotshot: HotShot<TYPES::ConsensusType, TYPES, I>,
     shut_down: Arc<AtomicBool>,
 ) {
     info!("Launching network lookup task");
@@ -516,11 +302,9 @@ pub async fn network_lookup_task<TYPES: NodeType, I: NodeImplementation<TYPES>>(
 
 /// Continually processes the incoming broadcast messages received on `hotshot.inner.networking`, redirecting them to `hotshot.handle_broadcast_*_message`.
 pub async fn network_broadcast_task<TYPES: NodeType, I: NodeImplementation<TYPES>>(
-    hotshot: HotShot<TYPES, I>,
+    hotshot: HotShot<TYPES::ConsensusType, TYPES, I>,
     shut_down: Arc<AtomicBool>,
-) where
-    ViewRunner<<TYPES as NodeType>::ConsensusType>: ViewRunnerType<TYPES, I>,
-{
+) {
     info!("Launching broadcast processing task");
     let networking = &hotshot.inner.networking;
     let mut incremental_backoff_ms = 10;
@@ -571,11 +355,9 @@ pub async fn network_broadcast_task<TYPES: NodeType, I: NodeImplementation<TYPES
 
 /// Continually processes the incoming direct messages received on `hotshot.inner.networking`, redirecting them to `hotshot.handle_direct_*_message`.
 pub async fn network_direct_task<TYPES: NodeType, I: NodeImplementation<TYPES>>(
-    hotshot: HotShot<TYPES, I>,
+    hotshot: HotShot<TYPES::ConsensusType, TYPES, I>,
     shut_down: Arc<AtomicBool>,
-) where
-    ViewRunner<<TYPES as NodeType>::ConsensusType>: ViewRunnerType<TYPES, I>,
-{
+) {
     info!("Launching direct processing task");
     let networking = &hotshot.inner.networking;
     let mut incremental_backoff_ms = 10;
@@ -618,11 +400,9 @@ pub async fn network_direct_task<TYPES: NodeType, I: NodeImplementation<TYPES>>(
 
 /// Runs a task that will call `hotshot.handle_network_change` whenever a change in the network is detected.
 pub async fn network_change_task<TYPES: NodeType, I: NodeImplementation<TYPES>>(
-    hotshot: HotShot<TYPES, I>,
+    hotshot: HotShot<TYPES::ConsensusType, TYPES, I>,
     shut_down: Arc<AtomicBool>,
-) where
-    ViewRunner<<TYPES as NodeType>::ConsensusType>: ViewRunnerType<TYPES, I>,
-{
+) {
     info!("Launching network change handler task");
     let networking = &hotshot.inner.networking;
     let mut incremental_backoff_ms = 10;

--- a/src/types/handle.rs
+++ b/src/types/handle.rs
@@ -1,7 +1,6 @@
 //! Provides an event-streaming handle for a [`HotShot`] running in the background
 
 use crate::{
-    tasks::{ViewRunner, ViewRunnerType},
     traits::{NetworkError::ShutDown, NodeImplementation},
     types::{Event, HotShotError::NetworkFault},
     HotShot,
@@ -50,7 +49,7 @@ pub struct HotShotHandle<TYPES: NodeType, I: NodeImplementation<TYPES>> {
     /// method is needed to generate new receivers for cloning the handle.
     pub(crate) sender_handle: Arc<BroadcastSender<Event<TYPES, I::Leaf>>>,
     /// Internal reference to the underlying [`HotShot`]
-    pub(crate) hotshot: HotShot<TYPES, I>,
+    pub(crate) hotshot: HotShot<TYPES::ConsensusType, TYPES, I>,
     /// The [`BroadcastReceiver`] we get the events from
     pub(crate) stream_output: BroadcastReceiver<Event<TYPES, I::Leaf>>,
     /// Global to signify the `HotShot` should be closed after completing the next round
@@ -71,10 +70,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static> Clone for HotShotH
     }
 }
 
-impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static> HotShotHandle<TYPES, I>
-where
-    ViewRunner<<TYPES as NodeType>::ConsensusType>: ViewRunnerType<TYPES, I>,
-{
+impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static> HotShotHandle<TYPES, I> {
     /// Will return the next event in the queue
     ///
     /// # Errors

--- a/testing/src/launcher.rs
+++ b/testing/src/launcher.rs
@@ -1,8 +1,5 @@
 use super::{Generator, TestRunner};
-use hotshot::{
-    tasks::{ViewRunner, ViewRunnerType},
-    types::SignatureKey,
-};
+use hotshot::types::SignatureKey;
 use hotshot_types::{
     traits::{
         network::TestableNetworkingImplementation,
@@ -161,7 +158,6 @@ where
     TYPES::SignatureKey: TestableSignatureKey,
     I::Networking: TestableNetworkingImplementation<TYPES, I::Leaf, I::Proposal>,
     I::Storage: TestableStorage<TYPES, I::Leaf>,
-    ViewRunner<TYPES::ConsensusType>: ViewRunnerType<TYPES, I>,
 {
     /// Launch the [`TestRunner`]. This function is only available if the following conditions are met:
     ///

--- a/testing/src/lib.rs
+++ b/testing/src/lib.rs
@@ -17,7 +17,7 @@ pub use self::launcher::TestLauncher;
 
 use futures::future::LocalBoxFuture;
 use hotshot::{
-    tasks::{ViewRunner, ViewRunnerType},
+    tasks::ViewRunnerType,
     traits::{NetworkingImplementation, NodeImplementation, Storage},
     types::{HotShotHandle, SignatureKey},
     HotShot, HotShotError, HotShotInitializer, H_256,
@@ -134,7 +134,6 @@ where
     TYPES::SignatureKey: TestableSignatureKey,
     I::Networking: TestableNetworkingImplementation<TYPES, I::Leaf, I::Proposal>,
     I::Storage: TestableStorage<TYPES, I::Leaf>,
-    ViewRunner<TYPES::ConsensusType>: ViewRunnerType<TYPES, I>,
 {
     pub(self) fn new(launcher: TestLauncher<TYPES, I>) -> Self {
         Self {
@@ -155,7 +154,10 @@ where
     pub fn default_safety_check(_runner: &Self, _results: RoundResult<TYPES, I::Leaf>) {}
 
     /// Add `count` nodes to the network. These will be spawned with the default node config and state
-    pub async fn add_nodes(&mut self, count: usize) -> Vec<u64> {
+    pub async fn add_nodes(&mut self, count: usize) -> Vec<u64>
+    where
+        HotShot<TYPES::ConsensusType, TYPES, I>: ViewRunnerType<TYPES, I>,
+    {
         let mut results = vec![];
         for _i in 0..count {
             let node_id = self.next_node_id;
@@ -196,7 +198,10 @@ where
         storage: I::Storage,
         initializer: HotShotInitializer<TYPES, I::Leaf>,
         config: HotShotConfig<TYPES::SignatureKey, TYPES::ElectionConfigType>,
-    ) -> u64 {
+    ) -> u64
+    where
+        HotShot<TYPES::ConsensusType, TYPES, I>: ViewRunnerType<TYPES, I>,
+    {
         let node_id = self.next_node_id;
         self.next_node_id += 1;
 
@@ -372,7 +377,6 @@ where
     TYPES::SignatureKey: TestableSignatureKey,
     I::Networking: TestableNetworkingImplementation<TYPES, I::Leaf, I::Proposal>,
     I::Storage: TestableStorage<TYPES, I::Leaf>,
-    ViewRunner<TYPES::ConsensusType>: ViewRunnerType<TYPES, I>,
 {
     /// Will validate that all nodes are on exactly the same state.
     pub async fn validate_node_states(&self) {
@@ -443,7 +447,6 @@ where
     TYPES::SignatureKey: TestableSignatureKey,
     I::Networking: TestableNetworkingImplementation<TYPES, I::Leaf, I::Proposal>,
     I::Storage: TestableStorage<TYPES, I::Leaf>,
-    ViewRunner<TYPES::ConsensusType>: ViewRunnerType<TYPES, I>,
 {
     /// Add a random transaction to this runner.
     pub async fn add_random_transaction(

--- a/testing/src/lib.rs
+++ b/testing/src/lib.rs
@@ -17,10 +17,9 @@ pub use self::launcher::TestLauncher;
 
 use futures::future::LocalBoxFuture;
 use hotshot::{
-    tasks::ViewRunnerType,
     traits::{NetworkingImplementation, NodeImplementation, Storage},
     types::{HotShotHandle, SignatureKey},
-    HotShot, HotShotError, HotShotInitializer, H_256,
+    HotShot, HotShotError, HotShotInitializer, ViewRunner, H_256,
 };
 use hotshot_types::{
     data::{LeafType, ProposalType},
@@ -156,7 +155,7 @@ where
     /// Add `count` nodes to the network. These will be spawned with the default node config and state
     pub async fn add_nodes(&mut self, count: usize) -> Vec<u64>
     where
-        HotShot<TYPES::ConsensusType, TYPES, I>: ViewRunnerType<TYPES, I>,
+        HotShot<TYPES::ConsensusType, TYPES, I>: ViewRunner<TYPES, I>,
     {
         let mut results = vec![];
         for _i in 0..count {
@@ -200,7 +199,7 @@ where
         config: HotShotConfig<TYPES::SignatureKey, TYPES::ElectionConfigType>,
     ) -> u64
     where
-        HotShot<TYPES::ConsensusType, TYPES, I>: ViewRunnerType<TYPES, I>,
+        HotShot<TYPES::ConsensusType, TYPES, I>: ViewRunner<TYPES, I>,
     {
         let node_id = self.next_node_id;
         self.next_node_id += 1;

--- a/testing/tests/common/mod.rs
+++ b/testing/tests/common/mod.rs
@@ -6,7 +6,6 @@ use blake3::Hasher;
 use either::Either;
 use futures::{future::LocalBoxFuture, FutureExt};
 use hotshot::{
-    tasks::ViewRunnerType,
     traits::{
         dummy::DummyState,
         election::{
@@ -16,7 +15,7 @@ use hotshot::{
         implementations::{MemoryNetwork, MemoryStorage},
         NetworkReliability, NetworkingImplementation,
     },
-    HotShot, HotShotError,
+    HotShot, HotShotError, ViewRunner,
 };
 use hotshot_testing::{
     ConsensusRoundError, Round, RoundPostSafetyCheck, RoundResult, RoundSetup, TestLauncher,
@@ -165,7 +164,7 @@ where
     /// txn_ids: vec of vec of transaction ids to send each round
     pub async fn execute(self) -> Result<(), ConsensusRoundError>
     where
-        HotShot<TYPES::ConsensusType, TYPES, I>: ViewRunnerType<TYPES, I>,
+        HotShot<TYPES::ConsensusType, TYPES, I>: ViewRunner<TYPES, I>,
     {
         setup_logging();
         setup_backtrace();

--- a/testing/tests/common/mod.rs
+++ b/testing/tests/common/mod.rs
@@ -5,9 +5,8 @@ use async_compatibility_layer::logging::{setup_backtrace, setup_logging};
 use blake3::Hasher;
 use either::Either;
 use futures::{future::LocalBoxFuture, FutureExt};
-use hotshot::tasks::ViewRunner;
-use hotshot::tasks::ViewRunnerType;
 use hotshot::{
+    tasks::ViewRunnerType,
     traits::{
         dummy::DummyState,
         election::{
@@ -17,7 +16,7 @@ use hotshot::{
         implementations::{MemoryNetwork, MemoryStorage},
         NetworkReliability, NetworkingImplementation,
     },
-    HotShotError,
+    HotShot, HotShotError,
 };
 use hotshot_testing::{
     ConsensusRoundError, Round, RoundPostSafetyCheck, RoundResult, RoundSetup, TestLauncher,
@@ -118,7 +117,6 @@ where
     TYPES::SignatureKey: TestableSignatureKey,
     I::Networking: TestableNetworkingImplementation<TYPES, I::Leaf, I::Proposal>,
     I::Storage: TestableStorage<TYPES, I::Leaf>,
-    ViewRunner<<TYPES as NodeType>::ConsensusType>: ViewRunnerType<TYPES, I>,
 {
     pub general_info: GeneralTestDescriptionBuilder,
 
@@ -136,7 +134,6 @@ where
     TYPES::SignatureKey: TestableSignatureKey,
     I::Networking: TestableNetworkingImplementation<TYPES, I::Leaf, I::Proposal>,
     I::Storage: TestableStorage<TYPES, I::Leaf>,
-    ViewRunner<<TYPES as NodeType>::ConsensusType>: ViewRunnerType<TYPES, I>,
 {
     /// default implementation of generate runner
     pub fn gen_runner(&self) -> TestRunner<TYPES, I> {
@@ -166,7 +163,10 @@ where
     /// execute a consensus test based on `Self`
     /// total_nodes: num nodes to run with
     /// txn_ids: vec of vec of transaction ids to send each round
-    pub async fn execute(self) -> Result<(), ConsensusRoundError> {
+    pub async fn execute(self) -> Result<(), ConsensusRoundError>
+    where
+        HotShot<TYPES::ConsensusType, TYPES, I>: ViewRunnerType<TYPES, I>,
+    {
         setup_logging();
         setup_backtrace();
 
@@ -206,7 +206,6 @@ impl GeneralTestDescriptionBuilder {
         TYPES::SignatureKey: TestableSignatureKey,
         I::Networking: TestableNetworkingImplementation<TYPES, I::Leaf, I::Proposal>,
         I::Storage: TestableStorage<TYPES, I::Leaf>,
-        ViewRunner<<TYPES as NodeType>::ConsensusType>: ViewRunnerType<TYPES, I>,
     {
         DetailedTestDescriptionBuilder {
             general_info: self,
@@ -224,7 +223,6 @@ where
     TYPES::SignatureKey: TestableSignatureKey,
     I::Networking: TestableNetworkingImplementation<TYPES, I::Leaf, I::Proposal>,
     I::Storage: TestableStorage<TYPES, I::Leaf>,
-    ViewRunner<<TYPES as NodeType>::ConsensusType>: ViewRunnerType<TYPES, I>,
 {
     pub fn build(self) -> TestDescription<TYPES, I> {
         let timing_config = TimingData {
@@ -508,7 +506,6 @@ where
     TYPES::SignatureKey: TestableSignatureKey,
     I::Networking: TestableNetworkingImplementation<TYPES, I::Leaf, I::Proposal>,
     I::Storage: TestableStorage<TYPES, I::Leaf>,
-    ViewRunner<<TYPES as NodeType>::ConsensusType>: ViewRunnerType<TYPES, I>,
 {
     // make sure the lengths match so zip doesn't spit out none
     if shut_down_ids.len() < submitter_ids.len() {
@@ -568,7 +565,6 @@ where
     TYPES::SignatureKey: TestableSignatureKey,
     I::Networking: TestableNetworkingImplementation<TYPES, I::Leaf, I::Proposal>,
     I::Storage: TestableStorage<TYPES, I::Leaf>,
-    ViewRunner<<TYPES as NodeType>::ConsensusType>: ViewRunnerType<TYPES, I>,
 {
     let mut rounds: TestSetup<TYPES, TYPES::Transaction, I> = Vec::new();
 
@@ -606,7 +602,6 @@ where
     TYPES::SignatureKey: TestableSignatureKey,
     I::Networking: TestableNetworkingImplementation<TYPES, I::Leaf, I::Proposal>,
     I::Storage: TestableStorage<TYPES, I::Leaf>,
-    ViewRunner<<TYPES as NodeType>::ConsensusType>: ViewRunnerType<TYPES, I>,
 {
     /// create rounds of consensus based on the data in `self`
     pub fn default_populate_rounds(&self) -> Vec<Round<TYPES, I>> {

--- a/testing/tests/consensus.rs
+++ b/testing/tests/consensus.rs
@@ -5,21 +5,15 @@ use async_lock::Mutex;
 use blake3::Hasher;
 use commit::Committable;
 use common::{
-    AppliedTestNodeImpl, AppliedTestRunner, DetailedTestDescriptionBuilder,
-    GeneralTestDescriptionBuilder, StandardNodeImplType, StaticCommitteeTestTypes,
-    StaticNodeImplType, VrfTestTypes,
+    AppliedTestRunner, DetailedTestDescriptionBuilder, GeneralTestDescriptionBuilder,
+    StandardNodeImplType, StaticCommitteeTestTypes, StaticNodeImplType, VrfTestTypes,
 };
 use either::Right;
 use futures::{
     future::{join_all, LocalBoxFuture},
     FutureExt,
 };
-use hotshot::{
-    demos::dentry::random_validating_leaf,
-    tasks::{ViewRunner, ViewRunnerType},
-    traits::election::vrf::VrfImpl,
-    types::Vote,
-};
+use hotshot::{demos::dentry::random_validating_leaf, traits::election::vrf::VrfImpl, types::Vote};
 use hotshot_testing::{ConsensusRoundError, RoundResult, SafetyFailedSnafu};
 use hotshot_types::{
     data::{LeafType, ValidatingLeaf, ValidatingProposal},
@@ -66,15 +60,6 @@ where
     TYPES::SignatureKey: TestableSignatureKey,
     TYPES::BlockType: TestableBlock,
     TYPES::StateType: TestableState<BlockType = TYPES::BlockType>,
-    ViewRunner<<TYPES as NodeType>::ConsensusType>: ViewRunnerType<
-        TYPES,
-        AppliedTestNodeImpl<
-            TYPES,
-            ValidatingLeaf<TYPES>,
-            ValidatingProposal<TYPES, ELECTION>,
-            ELECTION,
-        >,
-    >,
 {
     let handle = runner.get_handle(node_id).unwrap();
     let leader = handle.get_leader(view_number).await;
@@ -98,15 +83,6 @@ async fn submit_validating_proposal<
     TYPES::SignatureKey: TestableSignatureKey,
     TYPES::BlockType: TestableBlock,
     TYPES::StateType: TestableState<BlockType = TYPES::BlockType>,
-    ViewRunner<<TYPES as NodeType>::ConsensusType>: ViewRunnerType<
-        TYPES,
-        AppliedTestNodeImpl<
-            TYPES,
-            ValidatingLeaf<TYPES>,
-            ValidatingProposal<TYPES, ELECTION>,
-            ELECTION,
-        >,
-    >,
 {
     let mut rng = rand::thread_rng();
     let handle = runner.get_handle(sender_node_id).unwrap();
@@ -143,15 +119,6 @@ async fn submit_validating_vote<
     TYPES::SignatureKey: TestableSignatureKey,
     TYPES::BlockType: TestableBlock,
     TYPES::StateType: TestableState<BlockType = TYPES::BlockType>,
-    ViewRunner<<TYPES as NodeType>::ConsensusType>: ViewRunnerType<
-        TYPES,
-        AppliedTestNodeImpl<
-            TYPES,
-            ValidatingLeaf<TYPES>,
-            ValidatingProposal<TYPES, ELECTION>,
-            ELECTION,
-        >,
-    >,
 {
     let mut rng = rand::thread_rng();
     let handle = runner.get_handle(sender_node_id).unwrap();
@@ -207,15 +174,6 @@ where
     TYPES::SignatureKey: TestableSignatureKey,
     TYPES::BlockType: TestableBlock,
     TYPES::StateType: TestableState<BlockType = TYPES::BlockType>,
-    ViewRunner<<TYPES as NodeType>::ConsensusType>: ViewRunnerType<
-        TYPES,
-        AppliedTestNodeImpl<
-            TYPES,
-            ValidatingLeaf<TYPES>,
-            ValidatingProposal<TYPES, ELECTION>,
-            ELECTION,
-        >,
-    >,
 {
     async move {
         let node_id = DEFAULT_NODE_ID;
@@ -268,15 +226,6 @@ where
     TYPES::SignatureKey: TestableSignatureKey,
     TYPES::BlockType: TestableBlock,
     TYPES::StateType: TestableState<BlockType = TYPES::BlockType>,
-    ViewRunner<<TYPES as NodeType>::ConsensusType>: ViewRunnerType<
-        TYPES,
-        AppliedTestNodeImpl<
-            TYPES,
-            ValidatingLeaf<TYPES>,
-            ValidatingProposal<TYPES, ELECTION>,
-            ELECTION,
-        >,
-    >,
 {
     async move {
         let node_id = DEFAULT_NODE_ID;
@@ -309,15 +258,6 @@ where
     TYPES::SignatureKey: TestableSignatureKey,
     TYPES::BlockType: TestableBlock,
     TYPES::StateType: TestableState<BlockType = TYPES::BlockType>,
-    ViewRunner<<TYPES as NodeType>::ConsensusType>: ViewRunnerType<
-        TYPES,
-        AppliedTestNodeImpl<
-            TYPES,
-            ValidatingLeaf<TYPES>,
-            ValidatingProposal<TYPES, ELECTION>,
-            ELECTION,
-        >,
-    >,
 {
     async move {
         let node_id = DEFAULT_NODE_ID;
@@ -372,15 +312,6 @@ where
     TYPES::SignatureKey: TestableSignatureKey,
     TYPES::BlockType: TestableBlock,
     TYPES::StateType: TestableState<BlockType = TYPES::BlockType>,
-    ViewRunner<<TYPES as NodeType>::ConsensusType>: ViewRunnerType<
-        TYPES,
-        AppliedTestNodeImpl<
-            TYPES,
-            ValidatingLeaf<TYPES>,
-            ValidatingProposal<TYPES, ELECTION>,
-            ELECTION,
-        >,
-    >,
 {
     async move {
         let node_id = DEFAULT_NODE_ID;
@@ -412,15 +343,6 @@ where
     TYPES::SignatureKey: TestableSignatureKey,
     TYPES::BlockType: TestableBlock,
     TYPES::StateType: TestableState<BlockType = TYPES::BlockType>,
-    ViewRunner<<TYPES as NodeType>::ConsensusType>: ViewRunnerType<
-        TYPES,
-        AppliedTestNodeImpl<
-            TYPES,
-            ValidatingLeaf<TYPES>,
-            ValidatingProposal<TYPES, ELECTION>,
-            ELECTION,
-        >,
-    >,
 {
     async move {
         let node_id = DEFAULT_NODE_ID;
@@ -455,15 +377,6 @@ where
     TYPES::SignatureKey: TestableSignatureKey,
     TYPES::BlockType: TestableBlock,
     TYPES::StateType: TestableState<BlockType = TYPES::BlockType>,
-    ViewRunner<<TYPES as NodeType>::ConsensusType>: ViewRunnerType<
-        TYPES,
-        AppliedTestNodeImpl<
-            TYPES,
-            ValidatingLeaf<TYPES>,
-            ValidatingProposal<TYPES, ELECTION>,
-            ELECTION,
-        >,
-    >,
 {
     async move {
         let node_id = DEFAULT_NODE_ID;

--- a/testing/tests/lossy.rs
+++ b/testing/tests/lossy.rs
@@ -4,12 +4,11 @@ mod common;
 use std::sync::Arc;
 
 use common::{
-    AppliedTestNodeImpl, AppliedTestRunner, DetailedTestDescriptionBuilder,
-    GeneralTestDescriptionBuilder, StaticCommitteeTestTypes, StaticNodeImplType,
+    AppliedTestRunner, DetailedTestDescriptionBuilder, GeneralTestDescriptionBuilder,
+    StaticCommitteeTestTypes, StaticNodeImplType,
 };
 use either::Either::Right;
 use futures::{future::LocalBoxFuture, FutureExt};
-use hotshot::tasks::{ViewRunner, ViewRunnerType};
 use hotshot_testing::{
     network_reliability::{AsynchronousNetwork, PartiallySynchronousNetwork, SynchronousNetwork},
     ConsensusRoundError, RoundResult,
@@ -40,8 +39,6 @@ where
     TYPES::StateType: TestableState<BlockType = TYPES::BlockType>,
     I::Networking: TestableNetworkingImplementation<TYPES, I::Leaf, I::Proposal>,
     I::Storage: TestableStorage<TYPES, I::Leaf>,
-    ViewRunner<<TYPES as NodeType>::ConsensusType>:
-        ViewRunnerType<TYPES, AppliedTestNodeImpl<TYPES, I::Leaf, I::Proposal, I::Election>>,
 {
     async move {
         let num_nodes = runner.ids().len();
@@ -103,10 +100,7 @@ async fn test_no_loss_network() {
 )]
 #[cfg_attr(feature = "async-std-executor", async_std::test)]
 #[instrument]
-async fn test_synchronous_network()
-// where
-//     ViewRunner<ValidatingConsensus>: ViewRunnerType<StaticCommitteeTestTypes, StaticNodeImplType>,
-{
+async fn test_synchronous_network() {
     let description =
         DetailedTestDescriptionBuilder::<StaticCommitteeTestTypes, StaticNodeImplType> {
             general_info: GeneralTestDescriptionBuilder {

--- a/types/src/traits/state.rs
+++ b/types/src/traits/state.rs
@@ -75,11 +75,14 @@ where
     Self: ConsensusType,
 {
 }
-pub trait ConsensusType {}
+pub trait ConsensusType: Clone + Send + Sync {}
 
+#[derive(Clone)]
 pub struct SequencingConsensus;
 impl SequencingConsensusType for SequencingConsensus {}
 impl ConsensusType for SequencingConsensus {}
+
+#[derive(Clone)]
 pub struct ValidatingConsensus;
 impl ConsensusType for ValidatingConsensus {}
 impl ValidatingConsensusType for ValidatingConsensus {}


### PR DESCRIPTION
- Removes the `ViewRunner` struct and renames the `ViewRunnerType` trait to `ViewRunner`.
- Implements `ViewRunner` for `HotShot`.
- Removes unnecessary where clauses.

Closes https://github.com/EspressoSystems/HotShot/issues/829.