### PR TITLE
Replace certificate structs with associated types

### DIFF
--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -33,7 +33,6 @@ pub use utils::{SendToTasks, View, ViewInner, ViewQueue};
 use commit::Commitment;
 use hotshot_types::traits::metrics::Counter;
 use hotshot_types::{
-    certificate::QuorumCertificate,
     data::LeafType,
     error::HotShotError,
     traits::{
@@ -119,7 +118,7 @@ pub struct Consensus<TYPES: NodeType, LEAF: LeafType<NodeType = TYPES>> {
     pub locked_view: TYPES::Time,
 
     /// the highqc per spec
-    pub high_qc: QuorumCertificate<TYPES, LEAF>,
+    pub high_qc: LEAF::QuorumCertificate,
 
     /// A reference to the metrics trait
     #[debug(skip)]

--- a/consensus/src/replica.rs
+++ b/consensus/src/replica.rs
@@ -29,7 +29,11 @@ use tracing::{error, info, instrument, warn};
 pub struct Replica<
     A: ConsensusApi<TYPES, ValidatingLeaf<TYPES>, ValidatingProposal<TYPES, ELECTION>>,
     TYPES: NodeType<ConsensusType = ValidatingConsensus>,
-    ELECTION: Election<TYPES, LeafType = ValidatingLeaf<TYPES>>,
+    ELECTION: Election<
+        TYPES,
+        LeafType = ValidatingLeaf<TYPES>,
+        QuorumCertificate = QuorumCertificate<TYPES, ValidatingLeaf<TYPES>>,
+    >,
 > where
     TYPES::StateType: TestableState,
     TYPES::BlockType: TestableBlock,
@@ -50,7 +54,7 @@ pub struct Replica<
     /// view number this view is executing in
     pub cur_view: TYPES::Time,
     /// genericQC from the pseudocode
-    pub high_qc: QuorumCertificate<TYPES, ValidatingLeaf<TYPES>>,
+    pub high_qc: ELECTION::QuorumCertificate,
     /// hotshot consensus api
     pub api: A,
 }
@@ -58,7 +62,11 @@ pub struct Replica<
 impl<
         A: ConsensusApi<TYPES, ValidatingLeaf<TYPES>, ValidatingProposal<TYPES, ELECTION>>,
         TYPES: NodeType<ConsensusType = ValidatingConsensus>,
-        ELECTION: Election<TYPES, LeafType = ValidatingLeaf<TYPES>>,
+        ELECTION: Election<
+            TYPES,
+            LeafType = ValidatingLeaf<TYPES>,
+            QuorumCertificate = QuorumCertificate<TYPES, ValidatingLeaf<TYPES>>,
+        >,
     > Replica<A, TYPES, ELECTION>
 where
     TYPES::StateType: TestableState,
@@ -295,7 +303,7 @@ where
     /// run one view of replica
     /// returns the `high_qc`
     #[instrument(skip(self), fields(id = self.id, view = *self.cur_view), name = "Replica Task", level = "error")]
-    pub async fn run_view(self) -> QuorumCertificate<TYPES, ValidatingLeaf<TYPES>>
+    pub async fn run_view(self) -> ELECTION::QuorumCertificate
     where
         TYPES::StateType: TestableState,
         TYPES::BlockType: TestableBlock,

--- a/consensus/src/traits.rs
+++ b/consensus/src/traits.rs
@@ -3,16 +3,14 @@
 use async_trait::async_trait;
 use commit::Commitment;
 use hotshot_types::message::ConsensusMessage;
-use hotshot_types::traits::election::Checked;
 use hotshot_types::traits::node_implementation::NodeType;
 use hotshot_types::traits::storage::StorageError;
 use hotshot_types::{
-    certificate::QuorumCertificate,
     data::{LeafType, ProposalType},
     error::HotShotError,
     event::{Event, EventType},
     traits::{
-        election::ElectionError,
+        election::{Checked, ElectionError},
         network::NetworkError,
         signature_key::{EncodedPublicKey, EncodedSignature, SignatureKey},
     },
@@ -134,7 +132,7 @@ pub trait ConsensusApi<
         &self,
         view_number: TYPES::Time,
         leaf_views: Vec<LEAF>,
-        decide_qc: QuorumCertificate<TYPES, LEAF>,
+        decide_qc: LEAF::QuorumCertificate,
     ) {
         self.send_event(Event {
             view_number,
@@ -177,7 +175,7 @@ pub trait ConsensusApi<
 
     /// Validate a quorum certificate by checking
     /// signatures
-    fn validate_qc(&self, quorum_certificate: &QuorumCertificate<TYPES, LEAF>) -> bool;
+    fn validate_qc(&self, quorum_certificate: &LEAF::QuorumCertificate) -> bool;
 
     /// Check if a signature is valid
     fn is_valid_signature(

--- a/docs/pandoc-based-spec/src/HotShot.md
+++ b/docs/pandoc-based-spec/src/HotShot.md
@@ -185,7 +185,7 @@ impl HotShot {
     fn safe_node(&self, node: Leaf) -> Bool {
         let qc = node.justify;
         node.extends_from(self.locked_qc.node) || // Safety rule
-            qc.view_number > self.locked_qc.view_number // Liveness rule
+            qc.view_number() > self.locked_qc.view_number() // Liveness rule
     }
 }
 
@@ -237,7 +237,7 @@ for view_number in 1.. {
     if self.id == leader {
         // As a leader
         let high_qc = self.leader_messages.max_by(justify.view_number).justify;
-        if high_qc.view_number > self.generic_qc.view_number {
+        if high_qc.view_number() > self.generic_qc.view_number() {
             self.generic_qc = high_qc;
         }
         let proposal = Leaf::new(self.generic_qc.node, command, self.generic_qc);

--- a/src/demos/dentry.rs
+++ b/src/demos/dentry.rs
@@ -588,7 +588,7 @@ where
         ValidatingLeaf<DEntryTypes>,
         ValidatingProposal<DEntryTypes, ELE>,
     >,
-    ELE: Election<DEntryTypes, LeafType = ValidatingLeaf<DEntryTypes>>,
+    ELE: Election<DEntryTypes, LeafType = ValidatingLeaf<DEntryTypes>> + Debug,
 {
     type Leaf = ValidatingLeaf<DEntryTypes>;
     type Storage = MemoryStorage<DEntryTypes, ELE::LeafType>;
@@ -606,7 +606,7 @@ pub fn random_quorum_certificate<TYPES: NodeType, LEAF: LeafType<NodeType = TYPE
         leaf_commitment: random_commitment(rng),
         view_number: TYPES::Time::new(rng.gen()),
         signatures: BTreeMap::default(),
-        genesis: rng.gen(),
+        is_genesis: rng.gen(),
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -601,8 +601,8 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> HotShot<TYPES::ConsensusType
                         state,
                         // We don't have enough information in this message to validate the height
                         // of the new QC. We would need the full parent leaf, so we can check that
-                        // its commitment matches `qc.leaf_commitment()` and extract the height from
-                        // the leaf. But this message is no longer used and the whole catchup
+                        // its commitment matches `qc.leaf_commitment()` and extract the height
+                        // from the leaf. But this message is no longer used and the whole catchup
                         // protocol needs to be redesigned.
                         0,
                         parent_commitment,
@@ -697,7 +697,6 @@ impl<
         I: NodeImplementation<
             TYPES,
             Leaf = ValidatingLeaf<TYPES>,
-            Election = ELECTION,
             Proposal = ValidatingProposal<TYPES, ELECTION>,
         >,
     > ViewRunner<TYPES, I> for HotShot<ValidatingConsensus, TYPES, I>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -854,7 +854,7 @@ where
         let high_qc = results
             .into_iter()
             .filter_map(std::result::Result::ok)
-            .max_by_key(|qc| qc.view_number())
+            .max_by_key(|qc| qc.view_number)
             .unwrap();
 
         #[cfg(not(any(feature = "async-std-executor", feature = "tokio-executor")))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,7 @@ use hotshot_types::{
     message::{ConsensusMessage, DataMessage, Message},
     traits::{
         election::{
-            Checked::{self, Inval, Unchecked, Valid},
+            Checked::{self},
             Election, ElectionError,
         },
         metrics::Metrics,
@@ -79,7 +79,7 @@ use hotshot_types::{
     },
     HotShotConfig,
 };
-use hotshot_types::{message::MessageKind, traits::election::VoteToken};
+use hotshot_types::{message::MessageKind};
 use hotshot_utils::bincode::bincode_opts;
 #[allow(deprecated)]
 use nll::nll_todo::nll_todo;
@@ -991,29 +991,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>>
 
     #[instrument(skip(self, qc))]
     fn validate_qc(&self, qc: &QuorumCertificate<TYPES, I::Leaf>) -> bool {
-        if qc.genesis && qc.view_number == TYPES::Time::genesis() {
-            return true;
-        }
-        let hash = qc.leaf_commitment;
-
-        let stake = qc
-            .signatures
-            .iter()
-            .filter(|signature| {
-                self.is_valid_signature(
-                    signature.0,
-                    &signature.1 .0,
-                    hash,
-                    qc.view_number,
-                    Unchecked(signature.1 .1.clone()),
-                )
-            })
-            .fold(0, |acc, x| (acc + u64::from(x.1 .1.vote_count())));
-
-        if stake >= u64::from(self.threshold()) {
-            return true;
-        }
-        false
+        self.inner.election.is_valid_qc(qc)
     }
 
     fn is_valid_signature(
@@ -1024,24 +1002,13 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>>
         view_number: TYPES::Time,
         vote_token: Checked<TYPES::VoteTokenType>,
     ) -> bool {
-        let mut is_valid_vote_token = false;
-        let mut is_valid_signature = false;
-        if let Some(key) = <TYPES::SignatureKey as SignatureKey>::from_bytes(encoded_key) {
-            is_valid_signature = key.validate(encoded_signature, hash.as_ref());
-            let valid_vote_token =
-                self.inner
-                    .election
-                    .validate_vote_token(view_number, key, vote_token);
-            is_valid_vote_token = match valid_vote_token {
-                Err(_) => {
-                    error!("Vote token was invalid");
-                    false
-                }
-                Ok(Valid(_)) => true,
-                Ok(Inval(_) | Unchecked(_)) => false,
-            };
-        }
-        is_valid_signature && is_valid_vote_token
+        self.inner.election.is_valid_qc_signature(
+            encoded_key,
+            encoded_signature,
+            hash,
+            view_number,
+            vote_token,
+        )
     }
 
     async fn store_leaf(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,6 @@ use hotshot_consensus::{
     Consensus, ConsensusApi, ConsensusMetrics, NextValidatingLeader, Replica, SendToTasks,
     ValidatingLeader, View, ViewInner, ViewQueue,
 };
-use hotshot_types::message::MessageKind;
 use hotshot_types::{
     data::{LeafType, ValidatingLeaf, ValidatingProposal},
     error::StorageSnafu,
@@ -80,6 +79,7 @@ use hotshot_types::{
     },
     HotShotConfig,
 };
+use hotshot_types::{message::MessageKind};
 use hotshot_utils::bincode::bincode_opts;
 #[allow(deprecated)]
 use nll::nll_todo::nll_todo;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,7 @@ use hotshot_consensus::{
     Consensus, ConsensusApi, ConsensusMetrics, NextValidatingLeader, Replica, SendToTasks,
     ValidatingLeader, View, ViewInner, ViewQueue,
 };
+use hotshot_types::message::MessageKind;
 use hotshot_types::{
     data::{LeafType, ValidatingLeaf, ValidatingProposal},
     error::StorageSnafu,
@@ -79,7 +80,6 @@ use hotshot_types::{
     },
     HotShotConfig,
 };
-use hotshot_types::{message::MessageKind};
 use hotshot_utils::bincode::bincode_opts;
 #[allow(deprecated)]
 use nll::nll_todo::nll_todo;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -848,7 +848,7 @@ where
         #[cfg(feature = "async-std-executor")]
         let high_qc = results
             .into_iter()
-            .max_by_key(|qc: &ELECTION::QuorumCertificate| qc.view_number())
+            .max_by_key(|qc: &ELECTION::QuorumCertificate| qc.view_number)
             .unwrap();
         #[cfg(feature = "tokio-executor")]
         let high_qc = results

--- a/src/traits/election/static_committee.rs
+++ b/src/traits/election/static_committee.rs
@@ -95,14 +95,18 @@ where
     /// Just use the vector of public keys for the stake table
     type StakeTable = Vec<PUBKEY>;
 
+    type QuorumCertificate = QuorumCertificate<TYPES, Self::LeafType>;
+
+    type DACertificate = DACertificate<TYPES>;
+
     type LeafType = LEAF;
 
-    fn is_valid_qc(&self, _qc: &QuorumCertificate<TYPES, LEAF>) -> bool {
+    fn is_valid_qc(&self, _qc: &Self::QuorumCertificate) -> bool {
         #[allow(deprecated)]
         nll_todo()
     }
 
-    fn is_valid_dac(&self, _qc: DACertificate<TYPES>) -> bool {
+    fn is_valid_dac(&self, _qc: Self::DACertificate) -> bool {
         #[allow(deprecated)]
         nll_todo()
     }

--- a/src/traits/election/static_committee.rs
+++ b/src/traits/election/static_committee.rs
@@ -101,7 +101,7 @@ where
 
     type LeafType = LEAF;
 
-    fn is_valid_qc(&self, _qc: Self::QuorumCertificate) -> bool {
+    fn is_valid_qc(&self, _qc: &Self::QuorumCertificate) -> bool {
         #[allow(deprecated)]
         nll_todo()
     }

--- a/src/traits/election/static_committee.rs
+++ b/src/traits/election/static_committee.rs
@@ -95,18 +95,14 @@ where
     /// Just use the vector of public keys for the stake table
     type StakeTable = Vec<PUBKEY>;
 
-    type QuorumCertificate = QuorumCertificate<TYPES, Self::LeafType>;
-
-    type DACertificate = DACertificate<TYPES>;
-
     type LeafType = LEAF;
 
-    fn is_valid_qc(&self, _qc: &Self::QuorumCertificate) -> bool {
+    fn is_valid_qc(&self, _qc: &QuorumCertificate<TYPES, LEAF>) -> bool {
         #[allow(deprecated)]
         nll_todo()
     }
 
-    fn is_valid_dac(&self, _qc: Self::DACertificate) -> bool {
+    fn is_valid_dac(&self, _qc: DACertificate<TYPES>) -> bool {
         #[allow(deprecated)]
         nll_todo()
     }

--- a/src/traits/election/static_committee.rs
+++ b/src/traits/election/static_committee.rs
@@ -2,7 +2,6 @@ use ark_bls12_381::Parameters as Param381;
 use commit::{Commitment, Committable, RawCommitmentBuilder};
 use espresso_systems_common::hotshot::tag;
 use hotshot_types::{
-    certificate::DACertificate,
     data::LeafType,
     traits::{
         election::{Checked, Election, ElectionConfig, ElectionError, VoteToken},
@@ -97,7 +96,7 @@ where
 
     type QuorumCertificate = LEAF::QuorumCertificate;
 
-    type DACertificate = DACertificate<TYPES>;
+    type DACertificate = LEAF::DACertificate;
 
     type LeafType = LEAF;
 

--- a/src/traits/election/static_committee.rs
+++ b/src/traits/election/static_committee.rs
@@ -2,7 +2,7 @@ use ark_bls12_381::Parameters as Param381;
 use commit::{Commitment, Committable, RawCommitmentBuilder};
 use espresso_systems_common::hotshot::tag;
 use hotshot_types::{
-    certificate::{DACertificate, QuorumCertificate},
+    certificate::DACertificate,
     data::LeafType,
     traits::{
         election::{Checked, Election, ElectionConfig, ElectionError, VoteToken},
@@ -95,7 +95,7 @@ where
     /// Just use the vector of public keys for the stake table
     type StakeTable = Vec<PUBKEY>;
 
-    type QuorumCertificate = QuorumCertificate<TYPES, Self::LeafType>;
+    type QuorumCertificate = LEAF::QuorumCertificate;
 
     type DACertificate = DACertificate<TYPES>;
 

--- a/src/traits/election/vrf.rs
+++ b/src/traits/election/vrf.rs
@@ -457,9 +457,13 @@ where
     // pubkey -> unit of stake
     type StakeTable = VRFStakeTable<VRF, VRFHASHER, VRFPARAMS>;
 
+    type QuorumCertificate = QuorumCertificate<TYPES, Self::LeafType>;
+
+    type DACertificate = DACertificate<TYPES>;
+
     type LeafType = LEAF;
 
-    fn is_valid_qc(&self, qc: &QuorumCertificate<TYPES, LEAF>) -> bool {
+    fn is_valid_qc(&self, qc: &Self::QuorumCertificate) -> bool {
         if qc.genesis && qc.view_number == TYPES::Time::genesis() {
             return true;
         }
@@ -485,7 +489,7 @@ where
         false
     }
 
-    fn is_valid_dac(&self, _qc: DACertificate<TYPES>) -> bool {
+    fn is_valid_dac(&self, _qc: Self::DACertificate) -> bool {
         #[allow(deprecated)]
         nll_todo()
     }

--- a/src/traits/election/vrf.rs
+++ b/src/traits/election/vrf.rs
@@ -6,17 +6,14 @@ use commit::{Commitment, Committable, RawCommitmentBuilder};
 use derivative::Derivative;
 use espresso_systems_common::hotshot::tag;
 use hotshot_types::{
-    certificate::DACertificate,
     data::LeafType,
     traits::{
         election::{
-            Checked::{self, Inval, Unchecked, Valid},
-            Election, ElectionConfig, ElectionError, SignedCertificate, TestableElection,
-            VoteToken,
+            Checked::{self},
+            Election, ElectionConfig, ElectionError, TestableElection, VoteToken,
         },
         node_implementation::NodeType,
         signature_key::{EncodedPublicKey, EncodedSignature, SignatureKey, TestableSignatureKey},
-        state::ConsensusTime,
     },
 };
 use hotshot_utils::bincode::bincode_opts;
@@ -460,34 +457,13 @@ where
 
     type QuorumCertificate = LEAF::QuorumCertificate;
 
-    type DACertificate = DACertificate<TYPES>;
+    type DACertificate = LEAF::DACertificate;
 
     type LeafType = LEAF;
 
-    fn is_valid_qc(&self, qc: &Self::QuorumCertificate) -> bool {
-        if qc.is_genesis() && qc.view_number() == TYPES::Time::genesis() {
-            return true;
-        }
-        let hash = qc.leaf_commitment();
-
-        let stake = qc
-            .signatures()
-            .iter()
-            .filter(|signature| {
-                self.is_valid_qc_signature(
-                    signature.0,
-                    &signature.1 .0,
-                    hash,
-                    qc.view_number(),
-                    Unchecked(signature.1 .1.clone()),
-                )
-            })
-            .fold(0, |acc, x| (acc + u64::from(x.1 .1.vote_count())));
-
-        if stake >= u64::from(self.get_threshold()) {
-            return true;
-        }
-        false
+    fn is_valid_qc(&self, _qc: &Self::QuorumCertificate) -> bool {
+        #[allow(deprecated)]
+        nll_todo()
     }
 
     fn is_valid_dac(&self, _qc: Self::DACertificate) -> bool {
@@ -497,27 +473,14 @@ where
 
     fn is_valid_qc_signature(
         &self,
-        encoded_key: &EncodedPublicKey,
-        encoded_signature: &EncodedSignature,
-        hash: Commitment<Self::LeafType>,
-        view_number: TYPES::Time,
-        vote_token: Checked<TYPES::VoteTokenType>,
+        _encoded_key: &EncodedPublicKey,
+        _encoded_signature: &EncodedSignature,
+        _hash: Commitment<Self::LeafType>,
+        _view_number: TYPES::Time,
+        _vote_token: Checked<TYPES::VoteTokenType>,
     ) -> bool {
-        let mut is_valid_vote_token = false;
-        let mut is_valid_signature = false;
-        if let Some(key) = <TYPES::SignatureKey as SignatureKey>::from_bytes(encoded_key) {
-            is_valid_signature = key.validate(encoded_signature, hash.as_ref());
-            let valid_vote_token = self.validate_vote_token(view_number, key, vote_token);
-            is_valid_vote_token = match valid_vote_token {
-                Err(_) => {
-                    error!("Vote token was invalid");
-                    false
-                }
-                Ok(Valid(_)) => true,
-                Ok(Inval(_) | Unchecked(_)) => false,
-            };
-        }
-        is_valid_signature && is_valid_vote_token
+        #[allow(deprecated)]
+        nll_todo()
     }
 
     fn is_valid_dac_signature(

--- a/src/traits/election/vrf.rs
+++ b/src/traits/election/vrf.rs
@@ -287,17 +287,17 @@ where
 
 /// the vrf implementation
 #[derive(Derivative)]
-#[derivative(Eq, PartialEq)]
+#[derivative(Debug, Eq, PartialEq)]
 pub struct VrfImpl<TYPES, LEAF: LeafType<NodeType = TYPES>, SIGSCHEME, VRF, VRFHASHER, VRFPARAMS>
 where
     VRF: Vrf<VRFHASHER, VRFPARAMS> + Sync + Send,
     TYPES: NodeType,
 {
     /// the stake table
-    #[derivative(PartialEq = "ignore")]
+    #[derivative(Debug = "ignore", PartialEq = "ignore")]
     stake_table: VRFStakeTable<VRF, VRFHASHER, VRFPARAMS>,
     /// the proof params
-    #[derivative(PartialEq = "ignore")]
+    #[derivative(Debug = "ignore", PartialEq = "ignore")]
     proof_parameters: VRF::PublicParameter,
     /// the rng
     #[derivative(PartialEq = "ignore")]

--- a/src/traits/election/vrf.rs
+++ b/src/traits/election/vrf.rs
@@ -457,13 +457,9 @@ where
     // pubkey -> unit of stake
     type StakeTable = VRFStakeTable<VRF, VRFHASHER, VRFPARAMS>;
 
-    type QuorumCertificate = QuorumCertificate<TYPES, Self::LeafType>;
-
-    type DACertificate = DACertificate<TYPES>;
-
     type LeafType = LEAF;
 
-    fn is_valid_qc(&self, qc: &Self::QuorumCertificate) -> bool {
+    fn is_valid_qc(&self, qc: &QuorumCertificate<TYPES, LEAF>) -> bool {
         if qc.genesis && qc.view_number == TYPES::Time::genesis() {
             return true;
         }
@@ -489,7 +485,7 @@ where
         false
     }
 
-    fn is_valid_dac(&self, _qc: Self::DACertificate) -> bool {
+    fn is_valid_dac(&self, _qc: DACertificate<TYPES>) -> bool {
         #[allow(deprecated)]
         nll_todo()
     }

--- a/src/traits/storage/atomic_storage.rs
+++ b/src/traits/storage/atomic_storage.rs
@@ -158,7 +158,7 @@ impl<STATE: StateContents> Storage<STATE> for AtomicStorage<STATE> {
 
     #[instrument(name = "AtomicStorage::get_newest_qc", skip_all)]
     async fn get_newest_qc(&self) -> StorageResult<Option<QuorumCertificate<STATE>>> {
-        Ok(self.inner.qcs.load_latest(|qc| qc.view_number).await)
+        Ok(self.inner.qcs.load_latest(|qc| qc.view_number()).await)
     }
 
     #[instrument(name = "AtomicStorage::get_qc_for_view", skip_all)]
@@ -198,7 +198,7 @@ impl<STATE: StateContents> Storage<STATE> for AtomicStorage<STATE> {
         leafs.sort_by_cached_key(Leaf::hash);
 
         let mut quorum_certificates = self.inner.qcs.load_all().await;
-        quorum_certificates.sort_by_key(|qc| qc.view_number);
+        quorum_certificates.sort_by_key(|qc| qc.view_number());
 
         let mut states: Vec<(Commitment<Leaf<STATE>>, STATE)> =
             self.inner.states.load_all().await.into_iter().collect();

--- a/src/traits/storage/memory_storage.rs
+++ b/src/traits/storage/memory_storage.rs
@@ -184,7 +184,7 @@ mod test {
         StoredView::from_qc_block_and_state(
             QuorumCertificate {
                 // block_commitment: dummy_block_commit,
-                genesis: view_number == ViewNumber::genesis(),
+                is_genesis: view_number == ViewNumber::genesis(),
                 leaf_commitment: dummy_leaf_commit,
                 signatures: BTreeMap::new(),
                 view_number,

--- a/src/types/handle.rs
+++ b/src/types/handle.rs
@@ -8,11 +8,11 @@ use crate::{
 use async_compatibility_layer::async_primitives::broadcast::{BroadcastReceiver, BroadcastSender};
 use commit::Committable;
 use hotshot_types::{
-    certificate::QuorumCertificate,
     data::LeafType,
     error::{HotShotError, RoundTimedoutState},
     event::EventType,
     traits::{
+        election::SignedCertificate,
         network::NetworkingImplementation,
         node_implementation::NodeType,
         state::ConsensusTime,
@@ -158,8 +158,8 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static> HotShotHandle<TYPE
         if let Ok(anchor_leaf) = self.storage().get_anchored_view().await {
             if anchor_leaf.view_number == TYPES::Time::genesis() {
                 let leaf: I::Leaf = anchor_leaf.into();
-                let mut qc = QuorumCertificate::genesis();
-                qc.leaf_commitment = leaf.commit();
+                let mut qc = <I::Leaf as LeafType>::QuorumCertificate::genesis();
+                qc.set_leaf_commitment(leaf.commit());
                 let event = Event {
                     view_number: TYPES::Time::genesis(),
                     event: EventType::Decide {

--- a/testing/src/lib.rs
+++ b/testing/src/lib.rs
@@ -35,7 +35,7 @@ use hotshot_types::{
     HotShotConfig,
 };
 use snafu::Snafu;
-use std::{collections::HashMap, fmt, marker::PhantomData};
+use std::{collections::HashMap, fmt, fmt::Debug, marker::PhantomData};
 use tracing::{debug, error, info, warn};
 
 /// Wrapper for a function that takes a `node_id` and returns an instance of `T`.
@@ -599,7 +599,7 @@ where
     TYPES::BlockType: TestableBlock,
     TYPES::StateType: TestableState,
     TYPES::SignatureKey: TestableSignatureKey,
-    ELECTION: Election<TYPES, LeafType = LEAF>,
+    ELECTION: Election<TYPES, LeafType = LEAF> + Debug,
     NETWORK: TestableNetworkingImplementation<TYPES, LEAF, PROPOSAL>
         + NetworkingImplementation<TYPES, LEAF, PROPOSAL>,
     STORAGE: Storage<TYPES, LEAF>,
@@ -617,7 +617,7 @@ impl<
         PROPOSAL: ProposalType<NodeType = TYPES, Election = ELECTION>,
         NETWORK,
         STORAGE,
-        ELECTION: Election<TYPES, LeafType = LEAF>,
+        ELECTION: Election<TYPES, LeafType = LEAF> + Debug,
     > TestableNodeImplementation<TYPES>
     for TestNodeImpl<TYPES, LEAF, PROPOSAL, NETWORK, STORAGE, ELECTION>
 where

--- a/testing/src/lib.rs
+++ b/testing/src/lib.rs
@@ -553,7 +553,7 @@ pub enum ConsensusTestError {
 pub struct TestNodeImpl<
     TYPES: NodeType,
     LEAF: LeafType<NodeType = TYPES>,
-    PROPOSAL: ProposalType<NodeType = TYPES, Election = ELECTION>,
+    PROPOSAL: ProposalType<NodeType = TYPES>,
     NETWORK,
     STORAGE,
     ELECTION,
@@ -569,7 +569,7 @@ pub struct TestNodeImpl<
 impl<
         TYPES: NodeType,
         LEAF: LeafType<NodeType = TYPES>,
-        PROPOSAL: ProposalType<NodeType = TYPES, Election = ELECTION>,
+        PROPOSAL: ProposalType<NodeType = TYPES>,
         NETWORK,
         STORAGE,
         ELECTION,
@@ -590,7 +590,7 @@ impl<
 impl<
         TYPES: NodeType,
         LEAF: LeafType<NodeType = TYPES>,
-        PROPOSAL: ProposalType<NodeType = TYPES, Election = ELECTION>,
+        PROPOSAL: ProposalType<NodeType = TYPES>,
         NETWORK,
         STORAGE,
         ELECTION,
@@ -614,7 +614,7 @@ where
 impl<
         TYPES,
         LEAF: LeafType<NodeType = TYPES>,
-        PROPOSAL: ProposalType<NodeType = TYPES, Election = ELECTION>,
+        PROPOSAL: ProposalType<NodeType = TYPES>,
         NETWORK,
         STORAGE,
         ELECTION: Election<TYPES, LeafType = LEAF>,
@@ -634,7 +634,7 @@ where
 impl<
         TYPES: NodeType,
         LEAF: LeafType<NodeType = TYPES>,
-        PROPOSAL: ProposalType<NodeType = TYPES, Election = ELECTION>,
+        PROPOSAL: ProposalType<NodeType = TYPES>,
         NETWORK,
         STORAGE,
         ELECTION,

--- a/testing/src/lib.rs
+++ b/testing/src/lib.rs
@@ -553,7 +553,7 @@ pub enum ConsensusTestError {
 pub struct TestNodeImpl<
     TYPES: NodeType,
     LEAF: LeafType<NodeType = TYPES>,
-    PROPOSAL: ProposalType<NodeType = TYPES>,
+    PROPOSAL: ProposalType<NodeType = TYPES, Election = ELECTION>,
     NETWORK,
     STORAGE,
     ELECTION,
@@ -569,7 +569,7 @@ pub struct TestNodeImpl<
 impl<
         TYPES: NodeType,
         LEAF: LeafType<NodeType = TYPES>,
-        PROPOSAL: ProposalType<NodeType = TYPES>,
+        PROPOSAL: ProposalType<NodeType = TYPES, Election = ELECTION>,
         NETWORK,
         STORAGE,
         ELECTION,
@@ -590,7 +590,7 @@ impl<
 impl<
         TYPES: NodeType,
         LEAF: LeafType<NodeType = TYPES>,
-        PROPOSAL: ProposalType<NodeType = TYPES>,
+        PROPOSAL: ProposalType<NodeType = TYPES, Election = ELECTION>,
         NETWORK,
         STORAGE,
         ELECTION,
@@ -614,7 +614,7 @@ where
 impl<
         TYPES,
         LEAF: LeafType<NodeType = TYPES>,
-        PROPOSAL: ProposalType<NodeType = TYPES>,
+        PROPOSAL: ProposalType<NodeType = TYPES, Election = ELECTION>,
         NETWORK,
         STORAGE,
         ELECTION: Election<TYPES, LeafType = LEAF>,
@@ -634,7 +634,7 @@ where
 impl<
         TYPES: NodeType,
         LEAF: LeafType<NodeType = TYPES>,
-        PROPOSAL: ProposalType<NodeType = TYPES>,
+        PROPOSAL: ProposalType<NodeType = TYPES, Election = ELECTION>,
         NETWORK,
         STORAGE,
         ELECTION,

--- a/testing/tests/consensus.rs
+++ b/testing/tests/consensus.rs
@@ -779,13 +779,12 @@ async fn test_decide_leaf_chain() {
                             continue;
                         }
                         ensure!(
-                            qc.leaf_commitment == leaf.commit(),
-                            SafetyFailedSnafu {
+                            qc.set_leaf_commitment(leaf.commit());                            SafetyFailedSnafu {
                                 description: format!(
                                     "QC {}/{} justifies {}, but the parent leaf is {}",
                                     i + 1,
                                     leaf_chain.len() + 1,
-                                    qc.leaf_commitment,
+                                    qc.leaf_commitment(),
                                     leaf.commit()
                                 ),
                             }

--- a/testing/tests/consensus.rs
+++ b/testing/tests/consensus.rs
@@ -13,7 +13,10 @@ use futures::{
     future::{join_all, LocalBoxFuture},
     FutureExt,
 };
-use hotshot::{demos::dentry::random_validating_leaf, traits::election::vrf::VrfImpl, types::Vote};
+use hotshot::{
+    certificate::QuorumCertificate, demos::dentry::random_validating_leaf,
+    traits::election::vrf::VrfImpl, types::Vote,
+};
 use hotshot_testing::{ConsensusRoundError, RoundResult, SafetyFailedSnafu};
 use hotshot_types::{
     data::{LeafType, ValidatingLeaf, ValidatingProposal},
@@ -70,7 +73,11 @@ where
 /// Builds and submits a random proposal for the specified view number
 async fn submit_validating_proposal<
     TYPES: NodeType<ConsensusType = ValidatingConsensus>,
-    ELECTION: Election<TYPES, LeafType = ValidatingLeaf<TYPES>> + Debug,
+    ELECTION: Election<
+            TYPES,
+            LeafType = ValidatingLeaf<TYPES>,
+            QuorumCertificate = QuorumCertificate<TYPES, ValidatingLeaf<TYPES>>,
+        > + Debug,
 >(
     runner: &AppliedTestRunner<
         TYPES,
@@ -300,7 +307,11 @@ where
 /// Submits proposals for 0..NUM_VIEWS rounds where `node_id` is the leader
 fn test_validating_proposal_queueing_round_setup<
     TYPES: NodeType<ConsensusType = ValidatingConsensus>,
-    ELECTION: Election<TYPES, LeafType = ValidatingLeaf<TYPES>> + Debug,
+    ELECTION: Election<
+            TYPES,
+            LeafType = ValidatingLeaf<TYPES>,
+            QuorumCertificate = QuorumCertificate<TYPES, ValidatingLeaf<TYPES>>,
+        > + Debug,
 >(
     runner: &mut AppliedTestRunner<
         TYPES,
@@ -331,7 +342,11 @@ where
 /// Submits proposals for views where `node_id` is not the leader, and submits multiple proposals for views where `node_id` is the leader
 fn test_bad_validating_proposal_round_setup<
     TYPES: NodeType<ConsensusType = ValidatingConsensus>,
-    ELECTION: Election<TYPES, LeafType = ValidatingLeaf<TYPES>> + Debug,
+    ELECTION: Election<
+            TYPES,
+            LeafType = ValidatingLeaf<TYPES>,
+            QuorumCertificate = QuorumCertificate<TYPES, ValidatingLeaf<TYPES>>,
+        > + Debug,
 >(
     runner: &mut AppliedTestRunner<
         TYPES,

--- a/types/src/certificate.rs
+++ b/types/src/certificate.rs
@@ -50,7 +50,6 @@ pub struct QuorumCertificate<TYPES: NodeType, LEAF: LeafType<NodeType = TYPES>> 
     /// TODO (da) we need to check
     ///   - parent QC PROPOSAL
     ///   - somehow make this semantically equivalent to what is currently `Leaf`
-    /// Is this needed, given the proposal also contain this?
     #[debug(skip)]
     pub leaf_commitment: Commitment<LEAF>,
 

--- a/types/src/certificate.rs
+++ b/types/src/certificate.rs
@@ -128,7 +128,6 @@ impl<TYPES: NodeType, LEAF: LeafType<NodeType = TYPES>>
 
     fn genesis() -> Self {
         Self {
-            // block_commitment: fake_commitment(),
             leaf_commitment: fake_commitment::<LEAF>(),
             view_number: <TYPES::Time as ConsensusTime>::genesis(),
             signatures: BTreeMap::default(),

--- a/types/src/certificate.rs
+++ b/types/src/certificate.rs
@@ -59,42 +59,34 @@ pub struct QuorumCertificate<TYPES: NodeType, LEAF: LeafType<NodeType = TYPES>> 
     /// Threshold Signature
     pub signatures: BTreeMap<EncodedPublicKey, (EncodedSignature, TYPES::VoteTokenType)>,
     /// If this QC is for the genesis block
-    pub genesis: bool,
-}
-
-impl<TYPES: NodeType, LEAF: LeafType<NodeType = TYPES>> QuorumCertificate<TYPES, LEAF> {
-    /// To be used only for generating the genesis quorum certificate; will fail if used anywhere else
-    pub fn genesis() -> Self {
-        Self {
-            // block_commitment: fake_commitment(),
-            leaf_commitment: fake_commitment::<LEAF>(),
-            view_number: <TYPES::Time as ConsensusTime>::genesis(),
-            signatures: BTreeMap::default(),
-            genesis: true,
-        }
-    }
+    pub is_genesis: bool,
 }
 
 /// `CertificateAccumulator` is describes the process of collecting signatures
 /// to form a QC or a DA certificate.
 #[allow(clippy::missing_docs_in_private_items)]
-pub struct CertificateAccumulator<SIGNATURE, CERT>
+pub struct CertificateAccumulator<SIGNATURE, TIME, TOKEN, LEAF, CERT>
 where
     SIGNATURE: SignatureKey,
-    CERT: SignedCertificate<SIGNATURE>,
+    LEAF: Committable,
+    CERT: SignedCertificate<SIGNATURE, TIME, TOKEN, LEAF>,
 {
     _pd_0: PhantomData<SIGNATURE>,
     _pd_1: PhantomData<CERT>,
+    _pd_2: PhantomData<TIME>,
+    _pd_3: PhantomData<TOKEN>,
+    _pd_4: PhantomData<LEAF>,
     _valid_signatures: Vec<(EncodedSignature, SIGNATURE)>,
     _threshold: NonZeroU64,
     // TODO
 }
 
-impl<SIGNATURE, CERT> Accumulator<(EncodedSignature, SIGNATURE), CERT>
-    for CertificateAccumulator<SIGNATURE, CERT>
+impl<SIGNATURE, TIME, CERT, TOKEN, LEAF> Accumulator<(EncodedSignature, SIGNATURE), CERT>
+    for CertificateAccumulator<SIGNATURE, TIME, TOKEN, LEAF, CERT>
 where
     SIGNATURE: SignatureKey,
-    CERT: SignedCertificate<SIGNATURE>,
+    LEAF: Committable,
+    CERT: SignedCertificate<SIGNATURE, TIME, TOKEN, LEAF>,
 {
     fn append(_val: Vec<(EncodedSignature, SIGNATURE)>) -> Either<Self, CERT> {
         #[allow(deprecated)]
@@ -102,10 +94,47 @@ where
     }
 }
 
-impl<TYPES: NodeType, LEAF: LeafType<NodeType = TYPES>> SignedCertificate<TYPES::SignatureKey>
+impl<TYPES: NodeType, LEAF: LeafType<NodeType = TYPES>>
+    SignedCertificate<TYPES::SignatureKey, TYPES::Time, TYPES::VoteTokenType, LEAF>
     for QuorumCertificate<TYPES, LEAF>
 {
-    type Accumulator = CertificateAccumulator<TYPES::SignatureKey, QuorumCertificate<TYPES, LEAF>>;
+    type Accumulator = CertificateAccumulator<
+        TYPES::SignatureKey,
+        TYPES::Time,
+        TYPES::VoteTokenType,
+        LEAF,
+        QuorumCertificate<TYPES, LEAF>,
+    >;
+
+    fn view_number(&self) -> TYPES::Time {
+        self.view_number
+    }
+
+    fn signatures(&self) -> BTreeMap<EncodedPublicKey, (EncodedSignature, TYPES::VoteTokenType)> {
+        self.signatures.clone()
+    }
+
+    fn leaf_commitment(&self) -> Commitment<LEAF> {
+        self.leaf_commitment
+    }
+
+    fn set_leaf_commitment(&mut self, commitment: Commitment<LEAF>) {
+        self.leaf_commitment = commitment;
+    }
+
+    fn is_genesis(&self) -> bool {
+        self.is_genesis
+    }
+
+    fn genesis() -> Self {
+        Self {
+            // block_commitment: fake_commitment(),
+            leaf_commitment: fake_commitment::<LEAF>(),
+            view_number: <TYPES::Time as ConsensusTime>::genesis(),
+            signatures: BTreeMap::default(),
+            is_genesis: true,
+        }
+    }
 }
 
 impl<TYPES: NodeType, LEAF: LeafType<NodeType = TYPES>> Eq for QuorumCertificate<TYPES, LEAF> {}
@@ -127,7 +156,9 @@ impl<TYPES: NodeType, LEAF: LeafType<NodeType = TYPES>> Committable
                 .field(&format!("Signature {idx} signature"), v.1.commit());
         }
 
-        builder.u64_field("Genesis", self.genesis.into()).finalize()
+        builder
+            .u64_field("Is genesis", self.is_genesis.into())
+            .finalize()
     }
 
     fn tag() -> String {
@@ -135,8 +166,48 @@ impl<TYPES: NodeType, LEAF: LeafType<NodeType = TYPES>> Committable
     }
 }
 
-impl<TYPES: NodeType> SignedCertificate<TYPES::SignatureKey> for DACertificate<TYPES> {
-    type Accumulator = CertificateAccumulator<TYPES::SignatureKey, DACertificate<TYPES>>;
+impl<TYPES: NodeType, LEAF: LeafType<NodeType = TYPES>>
+    SignedCertificate<TYPES::SignatureKey, TYPES::Time, TYPES::VoteTokenType, LEAF>
+    for DACertificate<TYPES>
+{
+    type Accumulator = CertificateAccumulator<
+        TYPES::SignatureKey,
+        TYPES::Time,
+        TYPES::VoteTokenType,
+        LEAF,
+        DACertificate<TYPES>,
+    >;
+
+    fn view_number(&self) -> TYPES::Time {
+        self.view_number
+    }
+
+    fn signatures(&self) -> BTreeMap<EncodedPublicKey, (EncodedSignature, TYPES::VoteTokenType)> {
+        self.signatures.clone()
+    }
+
+    fn leaf_commitment(&self) -> Commitment<LEAF> {
+        // This function is only useful for QC. Will be removed after we have separated cert traits.
+        #[allow(deprecated)]
+        nll_todo()
+    }
+
+    fn set_leaf_commitment(&mut self, _commitment: Commitment<LEAF>) {
+        // This function is only useful for QC. Will be removed after we have separated cert traits.
+        #[allow(deprecated)]
+        nll_todo()
+    }
+
+    fn is_genesis(&self) -> bool {
+        // This function is only useful for QC. Will be removed after we have separated cert traits.
+        false
+    }
+
+    fn genesis() -> Self {
+        // This function is only useful for QC. Will be removed after we have separated cert traits.
+        #[allow(deprecated)]
+        nll_todo()
+    }
 }
 
 impl<TYPES: NodeType> Eq for DACertificate<TYPES> {}

--- a/types/src/certificate.rs
+++ b/types/src/certificate.rs
@@ -50,7 +50,7 @@ pub struct QuorumCertificate<TYPES: NodeType, LEAF: LeafType<NodeType = TYPES>> 
     /// TODO (da) we need to check
     ///   - parent QC PROPOSAL
     ///   - somehow make this semantically equivalent to what is currently `Leaf`
-    ///
+    /// Is this needed, given the proposal also contain this?
     #[debug(skip)]
     pub leaf_commitment: Commitment<LEAF>,
 

--- a/types/src/certificate.rs
+++ b/types/src/certificate.rs
@@ -193,8 +193,6 @@ impl<TYPES: NodeType, LEAF: LeafType<NodeType = TYPES>>
 
     fn set_leaf_commitment(&mut self, _commitment: Commitment<LEAF>) {
         // This function is only useful for QC. Will be removed after we have separated cert traits.
-        #[allow(deprecated)]
-        nll_todo()
     }
 
     fn is_genesis(&self) -> bool {

--- a/types/src/data.rs
+++ b/types/src/data.rs
@@ -6,7 +6,7 @@
 #![allow(missing_docs)]
 
 use crate::{
-    certificate::QuorumCertificate,
+    certificate::{DACertificate, QuorumCertificate},
     constants::genesis_proposer_id,
     traits::{
         election::{Election, SignedCertificate},
@@ -231,6 +231,15 @@ pub trait LeafType:
         + Eq
         + PartialEq
         + Send;
+    type DACertificate: SignedCertificate<
+            <Self::NodeType as NodeType>::SignatureKey,
+            <Self::NodeType as NodeType>::Time,
+            <Self::NodeType as NodeType>::VoteTokenType,
+            Self,
+        > + Debug
+        + Eq
+        + PartialEq
+        + Send;
 
     fn new(
         view_number: <Self::NodeType as NodeType>::Time,
@@ -354,6 +363,7 @@ where
     type NodeType = TYPES;
     type StateCommitmentType = TYPES::StateType;
     type QuorumCertificate = QuorumCertificate<Self::NodeType, Self>;
+    type DACertificate = DACertificate<Self::NodeType>;
 
     fn new(
         view_number: <Self::NodeType as NodeType>::Time,
@@ -443,6 +453,7 @@ impl<TYPES: NodeType> LeafType for DALeaf<TYPES> {
     type NodeType = TYPES;
     type StateCommitmentType = Either<TYPES::StateType, Commitment<TYPES::StateType>>;
     type QuorumCertificate = QuorumCertificate<Self::NodeType, Self>;
+    type DACertificate = DACertificate<Self::NodeType>;
 
     fn new(
         view_number: <Self::NodeType as NodeType>::Time,

--- a/types/src/data.rs
+++ b/types/src/data.rs
@@ -6,7 +6,7 @@
 #![allow(missing_docs)]
 
 use crate::{
-    certificate::QuorumCertificate,
+    certificate::{DACertificate, QuorumCertificate},
     constants::genesis_proposer_id,
     traits::{
         election::Election,
@@ -126,18 +126,16 @@ where
 }
 
 #[derive(custom_debug::Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
-pub struct DAProposal<TYPES: NodeType, ELECTION: Election<TYPES>> {
+pub struct DAProposal<TYPES: NodeType> {
     /// Block leaf wants to apply
     pub deltas: TYPES::BlockType,
     /// View this proposal applies to
     pub view_number: TYPES::Time,
-
-    pub _pd: PhantomData<ELECTION>,
 }
 
 #[derive(custom_debug::Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
 #[serde(bound(deserialize = ""))]
-pub struct CommitmentProposal<TYPES: NodeType, ELECTION: Election<TYPES>> {
+pub struct CommitmentProposal<TYPES: NodeType, LEAF: LeafType<NodeType = TYPES>> {
     #[allow(clippy::missing_docs_in_private_items)]
     pub block_commitment: Commitment<TYPES::BlockType>,
 
@@ -145,10 +143,10 @@ pub struct CommitmentProposal<TYPES: NodeType, ELECTION: Election<TYPES>> {
     pub view_number: TYPES::Time,
 
     /// Per spec, justification
-    pub justify_qc: ELECTION::QuorumCertificate,
+    pub justify_qc: QuorumCertificate<TYPES, LEAF>,
 
     /// Data availibity certificate
-    pub availability_certificate: ELECTION::DACertificate,
+    pub availability_certificate: DACertificate<TYPES>,
 
     /// parent commitment alrady in justify_qqc
 
@@ -165,31 +163,26 @@ pub struct CommitmentProposal<TYPES: NodeType, ELECTION: Election<TYPES>> {
 
 impl<TYPES: NodeType, ELECTION: Election<TYPES>> ProposalType
     for ValidatingProposal<TYPES, ELECTION>
-where
-    ELECTION::LeafType: Committable,
 {
     type NodeType = TYPES;
-    type Election = ELECTION;
     fn get_view_number(&self) -> <Self::NodeType as NodeType>::Time {
         self.view_number
     }
 }
 
-impl<TYPES: NodeType, ELECTION: Election<TYPES>> ProposalType for DAProposal<TYPES, ELECTION> {
+impl<TYPES: NodeType> ProposalType for DAProposal<TYPES> {
     type NodeType = TYPES;
-    type Election = ELECTION;
     fn get_view_number(&self) -> <Self::NodeType as NodeType>::Time {
         self.view_number
     }
 }
 
-impl<TYPES: NodeType, ELECTION: Election<TYPES>> ProposalType
-    for CommitmentProposal<TYPES, ELECTION>
+impl<TYPES: NodeType, LEAF: LeafType<NodeType = TYPES>> ProposalType
+    for CommitmentProposal<TYPES, LEAF>
 where
     TYPES::ApplicationMetadataType: Send + Sync,
 {
     type NodeType = TYPES;
-    type Election = ELECTION;
     fn get_view_number(&self) -> <Self::NodeType as NodeType>::Time {
         self.view_number
     }
@@ -198,7 +191,6 @@ pub trait ProposalType:
     Debug + Clone + 'static + Serialize + for<'a> Deserialize<'a> + Send + Sync + PartialEq + Eq
 {
     type NodeType: NodeType;
-    type Election: Election<Self::NodeType>;
     fn get_view_number(&self) -> <Self::NodeType as NodeType>::Time;
 }
 

--- a/types/src/data.rs
+++ b/types/src/data.rs
@@ -9,7 +9,7 @@ use crate::{
     certificate::QuorumCertificate,
     constants::genesis_proposer_id,
     traits::{
-        election::Election,
+        election::{Election, SignedCertificate},
         node_implementation::NodeType,
         signature_key::EncodedPublicKey,
         state::{ConsensusTime, TestableBlock, TestableState, ValidatingConsensusType},
@@ -222,10 +222,19 @@ pub trait LeafType:
         + Send
         + Serialize
         + Sync;
+    type QuorumCertificate: SignedCertificate<
+            <Self::NodeType as NodeType>::SignatureKey,
+            <Self::NodeType as NodeType>::Time,
+            <Self::NodeType as NodeType>::VoteTokenType,
+            Self,
+        > + Debug
+        + Eq
+        + PartialEq
+        + Send;
 
     fn new(
         view_number: <Self::NodeType as NodeType>::Time,
-        justify_qc: QuorumCertificate<Self::NodeType, Self>,
+        justify_qc: Self::QuorumCertificate,
         deltas: <Self::NodeType as NodeType>::BlockType,
         state: <Self::NodeType as NodeType>::StateType,
     ) -> Self;
@@ -236,7 +245,7 @@ pub trait LeafType:
 
     fn set_height(&mut self, height: u64);
 
-    fn get_justify_qc(&self) -> QuorumCertificate<Self::NodeType, Self>;
+    fn get_justify_qc(&self) -> Self::QuorumCertificate;
 
     fn get_parent_commitment(&self) -> Commitment<Self>;
 
@@ -344,6 +353,7 @@ where
 {
     type NodeType = TYPES;
     type StateCommitmentType = TYPES::StateType;
+    type QuorumCertificate = QuorumCertificate<Self::NodeType, Self>;
 
     fn new(
         view_number: <Self::NodeType as NodeType>::Time,
@@ -432,6 +442,7 @@ where
 impl<TYPES: NodeType> LeafType for DALeaf<TYPES> {
     type NodeType = TYPES;
     type StateCommitmentType = Either<TYPES::StateType, Commitment<TYPES::StateType>>;
+    type QuorumCertificate = QuorumCertificate<Self::NodeType, Self>;
 
     fn new(
         view_number: <Self::NodeType as NodeType>::Time,
@@ -554,7 +565,7 @@ where
             .u64(*self.justify_qc.view_number)
             .field(
                 "justify_qc leaf commitment",
-                self.justify_qc.leaf_commitment,
+                self.justify_qc.leaf_commitment(),
             )
             .constant_str("justify_qc signatures")
             .var_size_bytes(&signatures_bytes)

--- a/types/src/event.rs
+++ b/types/src/event.rs
@@ -1,9 +1,6 @@
 //! Events that a `HotShot` instance can emit
 
-use crate::{
-    certificate::QuorumCertificate, data::LeafType, error::HotShotError,
-    traits::node_implementation::NodeType,
-};
+use crate::{data::LeafType, error::HotShotError, traits::node_implementation::NodeType};
 use std::sync::Arc;
 
 /// A status event emitted by a `HotShot` instance
@@ -43,7 +40,7 @@ pub enum EventType<TYPES: NodeType, LEAF: LeafType<NodeType = TYPES>> {
         ///
         /// Note that the QC for each additional leaf in the chain can be obtained from the leaf
         /// before it using [Leaf::justify_qc].
-        qc: Arc<QuorumCertificate<TYPES, LEAF>>,
+        qc: Arc<LEAF::QuorumCertificate>,
     },
     /// A replica task was canceled by a timeout interrupt
     ReplicaViewTimeout {

--- a/types/src/message.rs
+++ b/types/src/message.rs
@@ -4,7 +4,6 @@
 //! `HotShot` nodes can send among themselves.
 
 use crate::{
-    certificate::QuorumCertificate,
     data::{LeafType, ProposalType},
     traits::{
         node_implementation::NodeType,
@@ -158,7 +157,7 @@ pub struct TimedOut<TYPES: NodeType, LEAF: LeafType<NodeType = TYPES>> {
     /// The current view
     pub current_view: TYPES::Time,
     /// The justification qc for this view
-    pub justify_qc: QuorumCertificate<TYPES, LEAF>,
+    pub justify_qc: LEAF::QuorumCertificate,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
@@ -183,7 +182,7 @@ pub struct Vote<TYPES: NodeType, LEAF: LeafType<NodeType = TYPES>> {
     /// TODO we should remove this
     /// this is correct, but highly inefficient
     /// we should check a cache, and if that fails request the qc
-    pub justify_qc_commitment: Commitment<QuorumCertificate<TYPES, LEAF>>,
+    pub justify_qc_commitment: Commitment<LEAF::QuorumCertificate>,
     /// The signature share associated with this vote
     /// TODO ct/vrf make ConsensusMessage generic over I instead of serializing to a Vec<u8>
     pub signature: (EncodedPublicKey, EncodedSignature),

--- a/types/src/message.rs
+++ b/types/src/message.rs
@@ -125,7 +125,7 @@ pub enum DataMessage<TYPES: NodeType, LEAF: LeafType<NodeType = TYPES>> {
     /// The newest entry that a node knows. This is send from existing nodes to a new node when the new node joins the network
     NewestQuorumCertificate {
         /// The newest [`QuorumCertificate`]
-        quorum_certificate: QuorumCertificate<TYPES, LEAF>,
+        quorum_certificate: LEAF::QuorumCertificate,
 
         /// The relevant [`BlockContents`]
         ///

--- a/types/src/traits/election.rs
+++ b/types/src/traits/election.rs
@@ -121,6 +121,7 @@ pub trait Election<TYPES: NodeType>: Clone + Eq + PartialEq + Send + Sync + 'sta
         + Clone
         + Debug
         + Eq
+        + Hash
         + PartialEq;
 
     /// certificate for data availability

--- a/types/src/traits/election.rs
+++ b/types/src/traits/election.rs
@@ -133,7 +133,7 @@ pub trait Election<TYPES: NodeType>: Clone + Eq + PartialEq + Send + Sync + 'sta
     type LeafType: LeafType<NodeType = TYPES, QuorumCertificate = Self::QuorumCertificate>;
 
     /// check that the quorum certificate is valid
-    fn is_valid_qc(&self, qc: &Self::QuorumCertificate) -> bool;
+    fn is_valid_qc(&self, qc: &<Self::LeafType as LeafType>::QuorumCertificate) -> bool;
 
     /// check that the data availability certificate is valid
     fn is_valid_dac(&self, qc: Self::DACertificate) -> bool;

--- a/types/src/traits/election.rs
+++ b/types/src/traits/election.rs
@@ -4,11 +4,8 @@
 
 use super::node_implementation::NodeType;
 use super::signature_key::{EncodedPublicKey, EncodedSignature};
+use crate::data::LeafType;
 use crate::traits::signature_key::SignatureKey;
-use crate::{
-    certificate::{DACertificate, QuorumCertificate},
-    data::LeafType,
-};
 use commit::{Commitment, Committable};
 use either::Either;
 use serde::Deserialize;
@@ -97,13 +94,19 @@ pub trait Election<TYPES: NodeType>: Clone + Eq + PartialEq + Send + Sync + 'sta
     /// TODO make this a trait so we can pass in places
     type StakeTable: Send + Sync;
 
+    /// certificate for quorum on consenus
+    type QuorumCertificate: SignedCertificate<TYPES::SignatureKey> + Clone + Debug + Eq + PartialEq;
+
+    /// certificate for data availability
+    type DACertificate: SignedCertificate<TYPES::SignatureKey> + Clone + Debug + Eq + PartialEq;
+
     type LeafType: LeafType<NodeType = TYPES>;
 
     /// check that the quorum certificate is valid
-    fn is_valid_qc(&self, qc: &QuorumCertificate<TYPES, Self::LeafType>) -> bool;
+    fn is_valid_qc(&self, qc: &Self::QuorumCertificate) -> bool;
 
     /// check that the data availability certificate is valid
-    fn is_valid_dac(&self, qc: DACertificate<TYPES>) -> bool;
+    fn is_valid_dac(&self, qc: Self::DACertificate) -> bool;
 
     /// confirm that a quorum certificate signature is valid
     fn is_valid_qc_signature(

--- a/types/src/traits/election.rs
+++ b/types/src/traits/election.rs
@@ -103,7 +103,7 @@ pub trait Election<TYPES: NodeType>: Clone + Eq + PartialEq + Send + Sync + 'sta
     type LeafType: LeafType<NodeType = TYPES>;
 
     /// check that the quorum certificate is valid
-    fn is_valid_qc(&self, qc: Self::QuorumCertificate) -> bool;
+    fn is_valid_qc(&self, qc: &Self::QuorumCertificate) -> bool;
 
     /// check that the data availability certificate is valid
     fn is_valid_dac(&self, qc: Self::DACertificate) -> bool;

--- a/types/src/traits/election.rs
+++ b/types/src/traits/election.rs
@@ -11,6 +11,7 @@ use either::Either;
 use serde::Deserialize;
 use serde::{de::DeserializeOwned, Serialize};
 use snafu::Snafu;
+use std::collections::BTreeMap;
 use std::fmt::Debug;
 use std::hash::Hash;
 use std::num::NonZeroU64;
@@ -79,11 +80,32 @@ pub trait Accumulator<T, U>: Sized {
 /// - signature key
 /// - encoded things
 /// -
-pub trait SignedCertificate<SIGNATURE: SignatureKey>
+pub trait SignedCertificate<SIGNATURE: SignatureKey, TIME, TOKEN, LEAF>
 where
     Self: Send + Sync + Clone + Serialize + for<'a> Deserialize<'a>,
+    LEAF: Committable,
 {
     type Accumulator: Accumulator<(EncodedSignature, SIGNATURE), Self>;
+
+    /// Get the view number.
+    fn view_number(&self) -> TIME;
+
+    /// Get signatures.
+    fn signatures(&self) -> BTreeMap<EncodedPublicKey, (EncodedSignature, TOKEN)>;
+
+    // TODO (da) the following functions should be refactored into a QC-specific trait.
+
+    // Get the leaf commitment.
+    fn leaf_commitment(&self) -> Commitment<LEAF>;
+
+    // Set the leaf commitment.
+    fn set_leaf_commitment(&mut self, commitment: Commitment<LEAF>);
+
+    /// Get whether the certificate is for the genesis block.
+    fn is_genesis(&self) -> bool;
+
+    /// To be used only for generating the genesis quorum certificate; will fail if used anywhere else
+    fn genesis() -> Self;
 }
 
 /// Describes how `HotShot` chooses committees and leaders
@@ -95,12 +117,20 @@ pub trait Election<TYPES: NodeType>: Clone + Eq + PartialEq + Send + Sync + 'sta
     type StakeTable: Send + Sync;
 
     /// certificate for quorum on consenus
-    type QuorumCertificate: SignedCertificate<TYPES::SignatureKey> + Clone + Debug + Eq + PartialEq;
+    type QuorumCertificate: SignedCertificate<TYPES::SignatureKey, TYPES::Time, TYPES::VoteTokenType, Self::LeafType>
+        + Clone
+        + Debug
+        + Eq
+        + PartialEq;
 
     /// certificate for data availability
-    type DACertificate: SignedCertificate<TYPES::SignatureKey> + Clone + Debug + Eq + PartialEq;
+    type DACertificate: SignedCertificate<TYPES::SignatureKey, TYPES::Time, TYPES::VoteTokenType, Self::LeafType>
+        + Clone
+        + Debug
+        + Eq
+        + PartialEq;
 
-    type LeafType: LeafType<NodeType = TYPES>;
+    type LeafType: LeafType<NodeType = TYPES, QuorumCertificate = Self::QuorumCertificate>;
 
     /// check that the quorum certificate is valid
     fn is_valid_qc(&self, qc: &Self::QuorumCertificate) -> bool;

--- a/types/src/traits/election.rs
+++ b/types/src/traits/election.rs
@@ -4,8 +4,11 @@
 
 use super::node_implementation::NodeType;
 use super::signature_key::{EncodedPublicKey, EncodedSignature};
-use crate::data::LeafType;
 use crate::traits::signature_key::SignatureKey;
+use crate::{
+    certificate::{DACertificate, QuorumCertificate},
+    data::LeafType,
+};
 use commit::{Commitment, Committable};
 use either::Either;
 use serde::Deserialize;
@@ -94,19 +97,13 @@ pub trait Election<TYPES: NodeType>: Clone + Eq + PartialEq + Send + Sync + 'sta
     /// TODO make this a trait so we can pass in places
     type StakeTable: Send + Sync;
 
-    /// certificate for quorum on consenus
-    type QuorumCertificate: SignedCertificate<TYPES::SignatureKey> + Clone + Debug + Eq + PartialEq;
-
-    /// certificate for data availability
-    type DACertificate: SignedCertificate<TYPES::SignatureKey> + Clone + Debug + Eq + PartialEq;
-
     type LeafType: LeafType<NodeType = TYPES>;
 
     /// check that the quorum certificate is valid
-    fn is_valid_qc(&self, qc: &Self::QuorumCertificate) -> bool;
+    fn is_valid_qc(&self, qc: &QuorumCertificate<TYPES, Self::LeafType>) -> bool;
 
     /// check that the data availability certificate is valid
-    fn is_valid_dac(&self, qc: Self::DACertificate) -> bool;
+    fn is_valid_dac(&self, qc: DACertificate<TYPES>) -> bool;
 
     /// confirm that a quorum certificate signature is valid
     fn is_valid_qc_signature(

--- a/types/src/traits/election.rs
+++ b/types/src/traits/election.rs
@@ -136,7 +136,7 @@ pub trait Election<TYPES: NodeType>: Clone + Eq + PartialEq + Send + Sync + 'sta
     fn is_valid_qc(&self, qc: &<Self::LeafType as LeafType>::QuorumCertificate) -> bool;
 
     /// check that the data availability certificate is valid
-    fn is_valid_dac(&self, qc: Self::DACertificate) -> bool;
+    fn is_valid_dac(&self, qc: <Self::LeafType as LeafType>::DACertificate) -> bool;
 
     /// confirm that a quorum certificate signature is valid
     fn is_valid_qc_signature(

--- a/types/src/traits/node_implementation.rs
+++ b/types/src/traits/node_implementation.rs
@@ -46,7 +46,7 @@ pub trait NodeImplementation<TYPES: NodeType>: Send + Sync + Debug + Clone + 'st
     /// consensus protocols
     type Election: Election<TYPES, LeafType = Self::Leaf>;
 
-    type Proposal: ProposalType<NodeType = TYPES>;
+    type Proposal: ProposalType<NodeType = TYPES, Election = Self::Election>;
 }
 
 /// Trait with all the type definitions that are used in the current hotshot setup.

--- a/types/src/traits/node_implementation.rs
+++ b/types/src/traits/node_implementation.rs
@@ -44,7 +44,7 @@ pub trait NodeImplementation<TYPES: NodeType>: Send + Sync + Debug + Clone + 'st
     /// Election
     /// Time is generic here to allow multiple implementations of election trait for difference
     /// consensus protocols
-    type Election: Election<TYPES, LeafType = Self::Leaf>;
+    type Election: Election<TYPES, LeafType = Self::Leaf> + Debug;
 
     type Proposal: ProposalType<NodeType = TYPES, Election = Self::Election>;
 }

--- a/types/src/traits/node_implementation.rs
+++ b/types/src/traits/node_implementation.rs
@@ -46,7 +46,7 @@ pub trait NodeImplementation<TYPES: NodeType>: Send + Sync + Debug + Clone + 'st
     /// consensus protocols
     type Election: Election<TYPES, LeafType = Self::Leaf>;
 
-    type Proposal: ProposalType<NodeType = TYPES, Election = Self::Election>;
+    type Proposal: ProposalType<NodeType = TYPES>;
 }
 
 /// Trait with all the type definitions that are used in the current hotshot setup.

--- a/types/src/traits/storage.rs
+++ b/types/src/traits/storage.rs
@@ -2,7 +2,10 @@
 #![allow(missing_docs)]
 
 use super::{node_implementation::NodeType, signature_key::EncodedPublicKey};
-use crate::{certificate::QuorumCertificate, data::LeafType, traits::Block};
+use crate::{
+    data::LeafType,
+    traits::{election::SignedCertificate, Block},
+};
 use async_trait::async_trait;
 use commit::Commitment;
 use derivative::Derivative;
@@ -130,7 +133,7 @@ pub struct StoredView<TYPES: NodeType, LEAF: LeafType<NodeType = TYPES>> {
     /// The parent of this view
     pub parent: Commitment<LEAF>,
     /// The justify QC of this view. See the hotstuff paper for more information on this.
-    pub justify_qc: QuorumCertificate<TYPES, LEAF>,
+    pub justify_qc: LEAF::QuorumCertificate,
     /// The state of this view
     pub state: LEAF::StateCommitmentType,
     /// The history of how this view came to be
@@ -154,7 +157,7 @@ where
     ///
     /// Note that this will set the `parent` to `LeafHash::default()`, so this will not have a parent.
     pub fn from_qc_block_and_state(
-        qc: QuorumCertificate<TYPES, LEAF>,
+        qc: LEAF::QuorumCertificate,
         block: TYPES::BlockType,
         state: LEAF::StateCommitmentType,
         height: u64,
@@ -164,7 +167,7 @@ where
     ) -> Self {
         Self {
             append: ViewAppend::Block { block },
-            view_number: qc.view_number,
+            view_number: qc.view_number(),
             height,
             parent: parent_commitment,
             justify_qc: qc,


### PR DESCRIPTION
- Adds QC and DAC associated types to `LeafType`.
- Makes the certificate types consistent between `Election` and its associated `LeafType`.
- Replaces the use of certificate structs with associated types.

Closes https://github.com/EspressoSystems/HotShot/issues/837.