### PR TITLE
Fix node mismatch warnings

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Run any test repeatedly until failure is detected
+# NOTE: test is hardcoded to be hotshot-testing and ten_tx_seven_nodes
+
+counter=0
+
+while true; do
+  ((counter++))
+  echo "Iteration: $counter"
+  rm "test_log.txt" || true
+  just test_async_std_pkg_test hotshot-testing ten_tx_seven_nodes >> "test_log.txt" 2>&1
+  error_code=$?
+  if [ "$error_code" -ne 0 ]; then
+    break
+  fi
+done

--- a/testing/src/lib.rs
+++ b/testing/src/lib.rs
@@ -395,7 +395,7 @@ where
             if first_leaf != leaf {
                 eprintln!("Leaf dump for {:?}", idx);
                 eprintln!("\texpected: {:#?}", first_leaf);
-                eprintln!("\tgot:      {:#?}", remaining);
+                eprintln!("\tgot:      {:#?}", leaf);
                 eprintln!("Node {} storage state does not match the first node", idx);
                 mismatch_count += 1;
             }

--- a/types/src/data.rs
+++ b/types/src/data.rs
@@ -281,8 +281,9 @@ pub trait LeafType:
 /// This is the consensus-internal analogous concept to a block, and it contains the block proper,
 /// as well as the hash of its parent `Leaf`.
 /// NOTE: `State` is constrained to implementing `BlockContents`, is `TypeMap::Block`
-#[derive(Serialize, Deserialize, Clone, Debug, Derivative, PartialEq, Eq, std::hash::Hash)]
+#[derive(Serialize, Deserialize, Clone, Debug, Derivative)]
 #[serde(bound(deserialize = ""))]
+#[derivative(Hash, PartialEq, Eq)]
 pub struct ValidatingLeaf<TYPES: NodeType>
 where
     TYPES::StateType: TestableState,
@@ -312,17 +313,20 @@ where
 
     /// the timestamp the leaf was constructed at, in nanoseconds. Only exposed for dashboard stats
     #[derivative(PartialEq = "ignore")]
+    #[derivative(Hash = "ignore")]
     pub timestamp: i128,
 
     /// the proposer id of the leaf
     #[derivative(PartialEq = "ignore")]
+    #[derivative(Hash = "ignore")]
     pub proposer_id: EncodedPublicKey,
 }
 
 /// This is the consensus-internal analogous concept to a block, and it contains the block proper,
 /// as well as the hash of its parent `Leaf`.
 /// NOTE: `State` is constrained to implementing `BlockContents`, is `TypeMap::Block`
-#[derive(Serialize, Deserialize, Clone, Debug, Derivative, PartialEq, Eq, std::hash::Hash)]
+#[derive(Serialize, Deserialize, Clone, Debug, Derivative, Eq)]
+#[derivative(PartialEq, Hash)]
 #[serde(bound(deserialize = ""))]
 pub struct DALeaf<TYPES: NodeType> {
     /// CurView from leader when proposing leaf


### PR DESCRIPTION
Turns out the node mismatch warnings and failures on aarch64 are being caused by hashing/eq mismatches. This fixes that by invoking derivative. Not sure why this causes failures on aarch64 but not other archs... Related: we should devote time to improving our leaf comparison assertions in the testing framework. 

Those who have Apple silicon, could you double check that the tests pass for you on this branch?