### PR TITLE
DA changes to libp2p

### DIFF
--- a/libp2p-networking/examples/common/mod.rs
+++ b/libp2p-networking/examples/common/mod.rs
@@ -7,6 +7,7 @@ pub mod lossy_network;
 use async_compatibility_layer::logging::{setup_backtrace, setup_logging};
 #[cfg(feature = "async-std-executor")]
 use async_std::prelude::StreamExt;
+use libp2p_networking::network::CONSENSUS_TOPIC;
 #[cfg(feature = "tokio-executor")]
 use tokio_stream::StreamExt;
 #[cfg(not(any(feature = "async-std-executor", feature = "tokio-executor")))]
@@ -416,7 +417,7 @@ pub async fn regular_handle_network_event(
                             // if the conductor says to broadcast
                             // perform broadcast with gossip protocol
                             ConductorMessageMethod::Broadcast => {
-                                handle.gossip("global".to_string(), &response).await?;
+                                handle.gossip(CONSENSUS_TOPIC.to_string(), &response).await?;
                             }
                             ConductorMessageMethod::DirectMessage(pid) => {
                                 handle.direct_request(
@@ -580,7 +581,7 @@ pub async fn start_main(opts: CliOpt) -> Result<(), CounterError> {
                         // must wait for the listener to start
                         let msg = Message::ConductorIdIs(conductor_peerid);
                         if let Err(e) = handle
-                            .gossip("global".to_string(), &msg)
+                            .gossip(CONSENSUS_TOPIC.to_string(), &msg)
                             .await
                             .context(HandleSnafu)
                         {

--- a/libp2p-networking/src/network/mod.rs
+++ b/libp2p-networking/src/network/mod.rs
@@ -49,6 +49,9 @@ use tcp::tokio::Transport as TcpTransport;
 #[cfg(not(any(feature = "async-std-executor", feature = "tokio-executor")))]
 std::compile_error! {"Either feature \"async-std-executor\" or feature \"tokio-executor\" must be enabled for this crate."}
 
+/// the topic used for consensus messages
+pub const CONSENSUS_TOPIC: &str = "global_consensus_topic";
+
 /// this is mostly to estimate how many network connections
 /// a node should allow
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Deserialize, Serialize)]
@@ -261,7 +264,7 @@ pub async fn spin_up_swarm<S: std::fmt::Debug + Default>(
     info!("known_nodes{:?}", known_nodes);
     handle.add_known_peers(known_nodes).await?;
     handle.wait_to_connect(4, idx, timeout_len).await?;
-    handle.subscribe("global".to_string()).await?;
+    handle.subscribe(CONSENSUS_TOPIC.to_string()).await?;
 
     Ok(())
 }

--- a/libp2p-networking/tests/common/mod.rs
+++ b/libp2p-networking/tests/common/mod.rs
@@ -4,6 +4,7 @@ use async_compatibility_layer::logging::{setup_backtrace, setup_logging};
 use futures::FutureExt;
 use futures::{future::join_all, Future};
 use libp2p::{identity::Keypair, Multiaddr, PeerId};
+use libp2p_networking::network::CONSENSUS_TOPIC;
 use libp2p_networking::network::{
     network_node_handle_error::NodeConfigSnafu, NetworkEvent, NetworkNodeConfigBuilder,
     NetworkNodeHandle, NetworkNodeHandleError, NetworkNodeType,
@@ -212,7 +213,7 @@ pub async fn spin_up_swarms<S: std::fmt::Debug + Default>(
 
     for handle in &handles {
         handle
-            .subscribe("global".to_string())
+            .subscribe(CONSENSUS_TOPIC.to_string())
             .await
             .context(HandleSnafu)?;
     }

--- a/libp2p-networking/tests/counter.rs
+++ b/libp2p-networking/tests/counter.rs
@@ -7,7 +7,7 @@ use bincode::Options;
 use common::{test_bed, HandleSnafu, TestError};
 use hotshot_utils::bincode::bincode_opts;
 use libp2p_networking::network::{
-    get_random_handle, NetworkEvent, NetworkNodeHandle, NetworkNodeHandleError,
+    get_random_handle, NetworkEvent, NetworkNodeHandle, NetworkNodeHandleError, CONSENSUS_TOPIC,
 };
 use serde::{Deserialize, Serialize};
 use snafu::ResultExt;
@@ -211,7 +211,7 @@ async fn run_gossip_round(
     }
 
     msg_handle
-        .gossip("global".to_string(), &msg)
+        .gossip(CONSENSUS_TOPIC.to_string(), &msg)
         .await
         .context(HandleSnafu)?;
 

--- a/src/traits/networking/libp2p_network.rs
+++ b/src/traits/networking/libp2p_network.rs
@@ -31,6 +31,7 @@ use libp2p_networking::{
         MeshParams,
         NetworkEvent::{self, DirectRequest, DirectResponse, GossipMsg},
         NetworkNodeConfig, NetworkNodeConfigBuilder, NetworkNodeHandle, NetworkNodeType,
+        CONSENSUS_TOPIC,
     },
     reexport::{Multiaddr, PeerId},
 };
@@ -47,9 +48,6 @@ use std::{
     time::Duration,
 };
 use tracing::{error, info, instrument, warn};
-
-/// hardcoded topic of QC used
-pub const QC_TOPIC: &str = "global";
 
 /// Stubbed out Ack
 #[derive(Serialize)]
@@ -495,12 +493,7 @@ impl<
             .send(message.clone())
             .await
             .unwrap();
-        match self
-            .inner
-            .handle
-            .gossip(QC_TOPIC.to_string(), &message)
-            .await
-        {
+        match self.inner.handle.gossip(CONSENSUS_TOPIC, &message).await {
             Ok(()) => {
                 self.inner.metrics.outgoing_message_count.add(1);
                 Ok(())


### PR DESCRIPTION
Libp2p needs to expose topics in order to handle DA. This PR will expose an API for topics and make subscriptions explicit.