### PR TITLE
Remove Testable Trait Bounds from Non-test Code

### DIFF
--- a/consensus/src/da.rs
+++ b/consensus/src/da.rs
@@ -23,7 +23,6 @@ use hotshot_types::{
         election::{Checked::Unchecked, Election, VoteData, VoteToken},
         node_implementation::NodeType,
         signature_key::SignatureKey,
-        state::{TestableBlock, TestableState},
         Block, State,
     },
 };
@@ -39,10 +38,7 @@ pub struct DALeader<
     A: ConsensusApi<TYPES, DALeaf<TYPES>, DAProposal<TYPES, ELECTION>>,
     TYPES: NodeType,
     ELECTION: Election<TYPES, LeafType = DALeaf<TYPES>>,
-> where
-    TYPES::StateType: TestableState,
-    TYPES::BlockType: TestableBlock,
-{
+> {
     /// id of node
     pub id: u64,
     /// Reference to consensus. Leader will require a read lock on this.
@@ -73,9 +69,6 @@ impl<
         TYPES: NodeType<ConsensusType = SequencingConsensus>,
         ELECTION: Election<TYPES, LeafType = DALeaf<TYPES>>,
     > DALeader<A, TYPES, ELECTION>
-where
-    TYPES::StateType: TestableState,
-    TYPES::BlockType: TestableBlock,
 {
     /// Accumulate votes for a proposal and return either the cert or None if the threshold was not reached in time
     /// TODO: Refactor this to use new `Elecetion` trait and call accumulate
@@ -292,10 +285,7 @@ pub struct DAConsensusLeader<
         QuorumCertificate = QuorumCertificate<TYPES, DALeaf<TYPES>>,
         DACertificate = DACertificate<TYPES>,
     >,
-> where
-    TYPES::StateType: TestableState,
-    TYPES::BlockType: TestableBlock,
-{
+> {
     /// id of node
     pub id: u64,
     /// Reference to consensus. Leader will require a read lock on this.
@@ -327,9 +317,6 @@ impl<
             DACertificate = DACertificate<TYPES>,
         >,
     > DAConsensusLeader<A, TYPES, ELECTION>
-where
-    TYPES::StateType: TestableState,
-    TYPES::BlockType: TestableBlock,
 {
     /// Run one view of the DA leader task
     #[instrument(skip(self), fields(id = self.id, view = *self.cur_view), name = "Sequencing DALeader Task", level = "error")]
@@ -392,10 +379,7 @@ pub struct DANextLeader<
     A: ConsensusApi<TYPES, DALeaf<TYPES>, DAProposal<TYPES, ELECTION>>,
     TYPES: NodeType,
     ELECTION: Election<TYPES, LeafType = DALeaf<TYPES>>,
-> where
-    TYPES::StateType: TestableState,
-    TYPES::BlockType: TestableBlock,
-{
+> {
     /// id of node
     pub id: u64,
     /// Reference to consensus. Leader will require a read lock on this.
@@ -424,9 +408,6 @@ impl<
         TYPES: NodeType<ConsensusType = SequencingConsensus>,
         ELECTION: Election<TYPES, LeafType = DALeaf<TYPES>>,
     > DANextLeader<A, TYPES, ELECTION>
-where
-    TYPES::StateType: TestableState,
-    TYPES::BlockType: TestableBlock,
 {
     /// Run one view of the next leader, collect votes and build a QC for the last views `CommitmentProposal`
     /// # Panics

--- a/consensus/src/leader.rs
+++ b/consensus/src/leader.rs
@@ -16,7 +16,6 @@ use hotshot_types::{
         node_implementation::NodeType,
         signature_key::SignatureKey,
         state::ValidatingConsensus,
-        state::{TestableBlock, TestableState},
         Block, State,
     },
 };
@@ -33,10 +32,7 @@ pub struct ValidatingLeader<
         LeafType = ValidatingLeaf<TYPES>,
         QuorumCertificate = QuorumCertificate<TYPES, ValidatingLeaf<TYPES>>,
     >,
-> where
-    TYPES::StateType: TestableState,
-    TYPES::BlockType: TestableBlock,
-{
+> {
     /// id of node
     pub id: u64,
     /// Reference to consensus. Validating leader will require a read lock on this.
@@ -64,9 +60,6 @@ impl<
             QuorumCertificate = QuorumCertificate<TYPES, ValidatingLeaf<TYPES>>,
         >,
     > ValidatingLeader<A, TYPES, ELECTION>
-where
-    TYPES::StateType: TestableState,
-    TYPES::BlockType: TestableBlock,
 {
     /// Run one view of the leader task
     #[instrument(skip(self), fields(id = self.id, view = *self.cur_view), name = "Validating ValidatingLeader Task", level = "error")]

--- a/consensus/src/next_leader.rs
+++ b/consensus/src/next_leader.rs
@@ -6,12 +6,9 @@ use async_compatibility_layer::channel::UnboundedReceiver;
 use async_lock::Mutex;
 use hotshot_types::data::{ValidatingLeaf, ValidatingProposal};
 use hotshot_types::message::ProcessedConsensusMessage;
+use hotshot_types::traits::election::{Checked::Unchecked, Election, VoteData, VoteToken};
 use hotshot_types::traits::node_implementation::NodeType;
 use hotshot_types::traits::signature_key::SignatureKey;
-use hotshot_types::traits::{
-    election::{Checked::Unchecked, Election, VoteData, VoteToken},
-    state::{TestableBlock, TestableState},
-};
 use hotshot_types::{
     certificate::QuorumCertificate,
     message::{ConsensusMessage, Vote},
@@ -33,10 +30,7 @@ pub struct NextValidatingLeader<
         LeafType = ValidatingLeaf<TYPES>,
         QuorumCertificate = QuorumCertificate<TYPES, ValidatingLeaf<TYPES>>,
     >,
-> where
-    TYPES::StateType: TestableState,
-    TYPES::BlockType: TestableBlock,
-{
+> {
     /// id of node
     pub id: u64,
     /// generic_qc before starting this
@@ -72,9 +66,6 @@ impl<
             QuorumCertificate = QuorumCertificate<TYPES, ValidatingLeaf<TYPES>>,
         >,
     > NextValidatingLeader<A, TYPES, ELECTION>
-where
-    TYPES::StateType: TestableState,
-    TYPES::BlockType: TestableBlock,
 {
     /// Run one view of the next leader task
     /// # Panics

--- a/consensus/src/replica.rs
+++ b/consensus/src/replica.rs
@@ -13,11 +13,8 @@ use hotshot_types::{
     data::{ValidatingLeaf, ValidatingProposal},
     message::{ConsensusMessage, ProcessedConsensusMessage, TimeoutVote, Vote, YesOrNoVote},
     traits::{
-        election::Election,
-        node_implementation::NodeType,
-        signature_key::SignatureKey,
-        state::{TestableBlock, TestableState, ValidatingConsensus},
-        Block, State,
+        election::Election, node_implementation::NodeType, signature_key::SignatureKey,
+        state::ValidatingConsensus, Block, State,
     },
 };
 use hotshot_utils::bincode::bincode_opts;
@@ -34,10 +31,7 @@ pub struct Replica<
         LeafType = ValidatingLeaf<TYPES>,
         QuorumCertificate = QuorumCertificate<TYPES, ValidatingLeaf<TYPES>>,
     >,
-> where
-    TYPES::StateType: TestableState,
-    TYPES::BlockType: TestableBlock,
-{
+> {
     /// id of node
     pub id: u64,
     /// Reference to consensus. Replica will require a write lock on this.
@@ -72,9 +66,6 @@ impl<
             QuorumCertificate = QuorumCertificate<TYPES, ValidatingLeaf<TYPES>>,
         >,
     > Replica<A, TYPES, ELECTION>
-where
-    TYPES::StateType: TestableState,
-    TYPES::BlockType: TestableBlock,
 {
     /// portion of the replica task that spins until a valid QC can be signed or
     /// timeout is hit.
@@ -330,11 +321,7 @@ where
     /// run one view of replica
     /// returns the `high_qc`
     #[instrument(skip(self), fields(id = self.id, view = *self.cur_view), name = "Replica Task", level = "error")]
-    pub async fn run_view(self) -> ELECTION::QuorumCertificate
-    where
-        TYPES::StateType: TestableState,
-        TYPES::BlockType: TestableBlock,
-    {
+    pub async fn run_view(self) -> ELECTION::QuorumCertificate {
         info!("Replica task started!");
         let consensus = self.consensus.upgradable_read().await;
         let view_leader_key = self.api.get_leader(self.cur_view).await;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,10 +74,7 @@ use hotshot_types::{
         network::{NetworkError, TransmitType},
         node_implementation::NodeType,
         signature_key::{EncodedPublicKey, EncodedSignature, SignatureKey},
-        state::{
-            ConsensusTime, ConsensusType, SequencingConsensus, TestableBlock, TestableState,
-            ValidatingConsensus,
-        },
+        state::{ConsensusTime, ConsensusType, SequencingConsensus, ValidatingConsensus},
         storage::StoredView,
         State,
     },
@@ -675,9 +672,6 @@ impl<
             Proposal = ValidatingProposal<TYPES, ELECTION>,
         >,
     > ViewRunner<TYPES, I> for HotShot<ValidatingConsensus, TYPES, I>
-where
-    TYPES::StateType: TestableState,
-    TYPES::BlockType: TestableBlock,
 {
     #[instrument(skip(hotshot), fields(id = hotshot.id), name = "Validating View Runner Task", level = "error")]
     async fn run_view(hotshot: HotShot<TYPES::ConsensusType, TYPES, I>) -> Result<(), ()> {
@@ -859,9 +853,6 @@ impl<
         >,
         I: NodeImplementation<TYPES, Leaf = DALeaf<TYPES>, Proposal = DAProposal<TYPES, ELECTION>>,
     > ViewRunner<TYPES, I> for HotShot<SequencingConsensus, TYPES, I>
-where
-    TYPES::StateType: TestableState,
-    TYPES::BlockType: TestableBlock,
 {
     // #[instrument]
     async fn run_view(hotshot: HotShot<SequencingConsensus, TYPES, I>) -> Result<(), ()> {

--- a/testing/src/launcher.rs
+++ b/testing/src/launcher.rs
@@ -1,4 +1,5 @@
 use super::{Generator, TestRunner};
+use crate::TestableLeaf;
 use hotshot::types::SignatureKey;
 use hotshot_types::{
     traits::{
@@ -158,6 +159,7 @@ where
     TYPES::SignatureKey: TestableSignatureKey,
     I::Networking: TestableNetworkingImplementation<TYPES, I::Leaf, I::Proposal>,
     I::Storage: TestableStorage<TYPES, I::Leaf>,
+    I::Leaf: TestableLeaf<NodeType = TYPES>,
 {
     /// Launch the [`TestRunner`]. This function is only available if the following conditions are met:
     ///

--- a/testing/tests/common/mod.rs
+++ b/testing/tests/common/mod.rs
@@ -21,6 +21,7 @@ use hotshot_testing::{
     ConsensusRoundError, Round, RoundPostSafetyCheck, RoundResult, RoundSetup, TestLauncher,
     TestNodeImpl, TestRunner,
 };
+use hotshot_types::data::TestableLeaf;
 use hotshot_types::{
     data::{ValidatingLeaf, ValidatingProposal, ViewNumber},
     traits::{
@@ -116,6 +117,7 @@ where
     TYPES::SignatureKey: TestableSignatureKey,
     I::Networking: TestableNetworkingImplementation<TYPES, I::Leaf, I::Proposal>,
     I::Storage: TestableStorage<TYPES, I::Leaf>,
+    I::Leaf: TestableLeaf<NodeType = TYPES>,
 {
     pub general_info: GeneralTestDescriptionBuilder,
 
@@ -133,6 +135,7 @@ where
     TYPES::SignatureKey: TestableSignatureKey,
     I::Networking: TestableNetworkingImplementation<TYPES, I::Leaf, I::Proposal>,
     I::Storage: TestableStorage<TYPES, I::Leaf>,
+    I::Leaf: TestableLeaf<NodeType = TYPES>,
 {
     /// default implementation of generate runner
     pub fn gen_runner(&self) -> TestRunner<TYPES, I> {
@@ -205,6 +208,7 @@ impl GeneralTestDescriptionBuilder {
         TYPES::SignatureKey: TestableSignatureKey,
         I::Networking: TestableNetworkingImplementation<TYPES, I::Leaf, I::Proposal>,
         I::Storage: TestableStorage<TYPES, I::Leaf>,
+        I::Leaf: TestableLeaf<NodeType = TYPES>,
     {
         DetailedTestDescriptionBuilder {
             general_info: self,
@@ -222,6 +226,7 @@ where
     TYPES::SignatureKey: TestableSignatureKey,
     I::Networking: TestableNetworkingImplementation<TYPES, I::Leaf, I::Proposal>,
     I::Storage: TestableStorage<TYPES, I::Leaf>,
+    I::Leaf: TestableLeaf<NodeType = TYPES>,
 {
     pub fn build(self) -> TestDescription<TYPES, I> {
         let timing_config = TimingData {
@@ -262,6 +267,7 @@ where
     TYPES::SignatureKey: TestableSignatureKey,
     I::Networking: TestableNetworkingImplementation<TYPES, I::Leaf, I::Proposal>,
     I::Storage: TestableStorage<TYPES, I::Leaf>,
+    I::Leaf: TestableLeaf<NodeType = TYPES>,
 {
     /// TODO unneeded (should be sufficient to have gen runner)
     /// the ronds to run for the test
@@ -505,6 +511,7 @@ where
     TYPES::SignatureKey: TestableSignatureKey,
     I::Networking: TestableNetworkingImplementation<TYPES, I::Leaf, I::Proposal>,
     I::Storage: TestableStorage<TYPES, I::Leaf>,
+    I::Leaf: TestableLeaf<NodeType = TYPES>,
 {
     // make sure the lengths match so zip doesn't spit out none
     if shut_down_ids.len() < submitter_ids.len() {
@@ -564,6 +571,7 @@ where
     TYPES::SignatureKey: TestableSignatureKey,
     I::Networking: TestableNetworkingImplementation<TYPES, I::Leaf, I::Proposal>,
     I::Storage: TestableStorage<TYPES, I::Leaf>,
+    I::Leaf: TestableLeaf<NodeType = TYPES>,
 {
     let mut rounds: TestSetup<TYPES, TYPES::Transaction, I> = Vec::new();
 
@@ -601,6 +609,7 @@ where
     TYPES::SignatureKey: TestableSignatureKey,
     I::Networking: TestableNetworkingImplementation<TYPES, I::Leaf, I::Proposal>,
     I::Storage: TestableStorage<TYPES, I::Leaf>,
+    I::Leaf: TestableLeaf<NodeType = TYPES>,
 {
     /// create rounds of consensus based on the data in `self`
     pub fn default_populate_rounds(&self) -> Vec<Round<TYPES, I>> {

--- a/testing/tests/lossy.rs
+++ b/testing/tests/lossy.rs
@@ -13,6 +13,7 @@ use hotshot_testing::{
     network_reliability::{AsynchronousNetwork, PartiallySynchronousNetwork, SynchronousNetwork},
     ConsensusRoundError, RoundResult,
 };
+use hotshot_types::data::TestableLeaf;
 use hotshot_types::traits::{
     network::TestableNetworkingImplementation,
     node_implementation::{NodeImplementation, NodeType, TestableNodeImplementation},
@@ -21,7 +22,6 @@ use hotshot_types::traits::{
     storage::TestableStorage,
 };
 use tracing::{error, instrument};
-
 /// checks safety requirement; relatively lax
 /// marked as success if 2f+1 nodes "succeeded" and committed the same thing
 pub fn check_safety<TYPES: NodeType, I: TestableNodeImplementation<TYPES>>(
@@ -39,6 +39,7 @@ where
     TYPES::StateType: TestableState<BlockType = TYPES::BlockType>,
     I::Networking: TestableNetworkingImplementation<TYPES, I::Leaf, I::Proposal>,
     I::Storage: TestableStorage<TYPES, I::Leaf>,
+    I::Leaf: TestableLeaf<NodeType = TYPES>,
 {
     async move {
         let num_nodes = runner.ids().len();


### PR DESCRIPTION
This PR does the following
- Split out `create_random_transaction` from LeafType into `TestableLeaf` trait
- Remove Trait bounds with Testable* from any non-test file
- Add Testable* trait bounds where needed in the testing code

Closes: https://github.com/EspressoSystems/HotShot/issues/890, https://github.com/EspressoSystems/HotShot/issues/889