### PR TITLE
Enable the replica to reconstruct the leaf and verify the proposal

### DIFF
--- a/consensus/src/da_leader.rs
+++ b/consensus/src/da_leader.rs
@@ -11,7 +11,7 @@ use async_lock::{Mutex, RwLock};
 use commit::Commitment;
 use commit::Committable;
 use either::Either;
-use either::Either::Left;
+use either::Right;
 use hotshot_types::certificate::DACertificate;
 use hotshot_types::data::CommitmentProposal;
 use hotshot_types::message::{ProcessedConsensusMessage, Vote};
@@ -24,7 +24,7 @@ use hotshot_types::{
         election::{Checked::Unchecked, Election, SignedCertificate, VoteData, VoteToken},
         node_implementation::NodeType,
         signature_key::SignatureKey,
-        Block, State,
+        Block,
     },
 };
 use std::num::NonZeroU64;
@@ -170,7 +170,10 @@ impl<
         let task_start_time = Instant::now();
 
         let parent_leaf = self.parent_leaf().await?;
-        let previous_used_txns_vec = parent_leaf.deltas.contained_transactions();
+        let previous_used_txns_vec = match parent_leaf.deltas {
+            Either::Left(block) => block.contained_transactions(),
+            Either::Right(_commitment) => HashSet::new(),
+        };
         let previous_used_txns = previous_used_txns_vec.into_iter().collect::<HashSet<_>>();
         let receiver = self.transactions.subscribe().await;
 
@@ -218,49 +221,36 @@ impl<
             warn!("Couldn't find high QC parent in state map.");
             return None;
         };
-        let starting_state = if let Left(state) = &parent_leaf.state {
-            state
-        } else {
-            warn!("Don't have last state on parent leaf");
-            return None;
-        };
-        let mut block = starting_state.next_block();
+        let mut block = TYPES::BlockType::new();
         let txns = self.wait_for_transactions().await?;
 
         for txn in txns {
             let new_block_check = block.add_transaction_raw(&txn);
             // TODO (da) We probably don't need this check here or replace with "structural validate"
             if let Ok(new_block) = new_block_check {
-                if starting_state.validate_block(&new_block, &self.cur_view) {
-                    block = new_block;
-                    continue;
-                }
+                block = new_block;
+                continue;
             }
         }
         let block_commitment = block.commit();
 
-        if let Ok(_new_state) = starting_state.append(&block, &self.cur_view) {
-            let consensus = self.consensus.read().await;
-            let signature = self.api.sign_da_proposal(&block.commit());
-            let data: DAProposal<TYPES, ELECTION> = DAProposal {
-                deltas: block.clone(),
-                view_number: self.cur_view,
-                _pd: PhantomData,
-            };
-            let message =
-                ConsensusMessage::<TYPES, DALeaf<TYPES>, DAProposal<TYPES, ELECTION>>::Proposal(
-                    Proposal { data, signature },
-                );
-            // Brodcast DA proposal
-            if let Err(e) = self.api.send_broadcast_message(message.clone()).await {
-                consensus.metrics.failed_to_send_messages.add(1);
-                warn!(?message, ?e, "Could not broadcast leader proposal");
-            } else {
-                consensus.metrics.outgoing_broadcast_messages.add(1);
-            }
+        let consensus = self.consensus.read().await;
+        let signature = self.api.sign_da_proposal(&block.commit());
+        let data: DAProposal<TYPES, ELECTION> = DAProposal {
+            deltas: block.clone(),
+            view_number: self.cur_view,
+            _pd: PhantomData,
+        };
+        let message =
+            ConsensusMessage::<TYPES, DALeaf<TYPES>, DAProposal<TYPES, ELECTION>>::Proposal(
+                Proposal { data, signature },
+            );
+        // Brodcast DA proposal
+        if let Err(e) = self.api.send_broadcast_message(message.clone()).await {
+            consensus.metrics.failed_to_send_messages.add(1);
+            warn!(?message, ?e, "Could not broadcast leader proposal");
         } else {
-            error!("Could not append state in high qc for proposal. Failed to send out proposal.");
-            return None;
+            consensus.metrics.outgoing_broadcast_messages.add(1);
         }
 
         // Wait for DA votes or Timeout
@@ -321,53 +311,42 @@ impl<
     /// Run one view of the DA leader task
     #[instrument(skip(self), fields(id = self.id, view = *self.cur_view), name = "Sequencing DALeader Task", level = "error")]
     pub async fn run_view(self) -> Option<QuorumCertificate<TYPES, DALeaf<TYPES>>> {
-        let starting_state = if let Left(state) = &self.parent.state {
-            state
-        } else {
-            warn!("Don't have last state on parent leaf");
-            return None;
+        let block_commitment = self.block.commit();
+        let leaf = DALeaf {
+            view_number: self.cur_view,
+            // TODO: what is this height for?
+            height: 0,
+            justify_qc: self.high_qc.clone(),
+            parent_commitment: self.parent.commit(),
+            // Use the block commitment rather than the block, so that the replica can construct
+            // the same leaf with the commitment.
+            deltas: Right(block_commitment),
+            rejected: vec![],
+            timestamp: time::OffsetDateTime::now_utc().unix_timestamp_nanos(),
+            proposer_id: self.api.public_key().to_bytes(),
         };
-        if let Ok(new_state) = starting_state.append(&self.block, &self.cur_view) {
-            let leaf = DALeaf {
-                view_number: self.cur_view,
-                // TODO: what is this height for?
-                height: 0,
-                justify_qc: self.high_qc.clone(),
-                parent_commitment: self.parent.commit(),
-                deltas: self.block,
-                state: Either::Left(new_state.clone()),
-                rejected: vec![],
-                timestamp: time::OffsetDateTime::now_utc().unix_timestamp_nanos(),
-                proposer_id: self.api.public_key().to_bytes(),
-            };
-            let signature = self
-                .api
-                .sign_validating_or_commitment_proposal(&leaf.commit());
-            // TODO: DA cert is sent as part of the proposal here, we should split this out so we don't have to wait for it.
-            let proposal = CommitmentProposal {
-                block_commitment: leaf.deltas.commit(),
-                view_number: leaf.view_number,
-                justify_qc: self.high_qc.clone(),
-                dac: self.cert,
-                state_commitment: new_state.commit(),
-                proposer_id: leaf.proposer_id,
-                application_metadata: {},
-            };
+        let signature = self
+            .api
+            .sign_validating_or_commitment_proposal(&leaf.commit());
+        // TODO: DA cert is sent as part of the proposal here, we should split this out so we don't have to wait for it.
+        let proposal = CommitmentProposal {
+            block_commitment,
+            view_number: leaf.view_number,
+            justify_qc: self.high_qc.clone(),
+            dac: self.cert,
+            proposer_id: leaf.proposer_id,
+            application_metadata: {},
+        };
 
-            let message = ConsensusMessage::<
-                TYPES,
-                DALeaf<TYPES>,
-                CommitmentProposal<TYPES, ELECTION>,
-            >::Proposal(Proposal {
-                data: proposal,
-                signature,
-            });
-            if let Err(e) = self.api.send_da_broadcast(message.clone()).await {
-                warn!(?message, ?e, "Could not broadcast leader proposal");
-                return None;
-            }
-        } else {
-            error!("Could not append state in high qc for proposal. Failed to send out proposal.");
+        let message =
+            ConsensusMessage::<TYPES, DALeaf<TYPES>, CommitmentProposal<TYPES, ELECTION>>::Proposal(
+                Proposal {
+                    data: proposal,
+                    signature,
+                },
+            );
+        if let Err(e) = self.api.send_da_broadcast(message.clone()).await {
+            warn!(?message, ?e, "Could not broadcast leader proposal");
             return None;
         }
         Some(self.high_qc)

--- a/src/bin/orchestrator-vrf.rs
+++ b/src/bin/orchestrator-vrf.rs
@@ -383,6 +383,10 @@ mod tests {
         type Error = TestError;
         type Transaction = TestTransaction;
 
+        fn new() -> Self {
+            Self {}
+        }
+
         fn add_transaction_raw(
             &self,
             _tx: &Self::Transaction,

--- a/src/bin/orchestrator.rs
+++ b/src/bin/orchestrator.rs
@@ -384,6 +384,10 @@ mod tests {
         type Error = TestError;
         type Transaction = TestTransaction;
 
+        fn new() -> Self {
+            Self {}
+        }
+
         fn add_transaction_raw(
             &self,
             _tx: &Self::Transaction,

--- a/src/demos/dentry.rs
+++ b/src/demos/dentry.rs
@@ -459,6 +459,10 @@ impl Block for DEntryBlock {
 
     type Error = DEntryError;
 
+    fn new() -> Self {
+        <Self as TestableBlock>::genesis()
+    }
+
     fn add_transaction_raw(
         &self,
         tx: &Self::Transaction,

--- a/src/types/handle.rs
+++ b/src/types/handle.rs
@@ -192,7 +192,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static> HotShotHandle<TYPE
     ) -> Result<
         (
             Vec<<I::Leaf as LeafType>::StateCommitmentType>,
-            Vec<TYPES::BlockType>,
+            Vec<<I::Leaf as LeafType>::DeltasType>,
         ),
         HotShotError<TYPES>,
     > {

--- a/testing/src/lib.rs
+++ b/testing/src/lib.rs
@@ -54,7 +54,7 @@ pub struct RoundResult<TYPES: NodeType, LEAF: LeafType<NodeType = TYPES>> {
     /// Transactions that were submitted
     pub txns: Vec<TYPES::Transaction>,
     /// Nodes that committed this round
-    pub results: HashMap<u64, StateAndBlock<LEAF::StateCommitmentType, TYPES::BlockType>>,
+    pub results: HashMap<u64, StateAndBlock<LEAF::StateCommitmentType, LEAF::DeltasType>>,
     /// Nodes that failed to commit this round
     pub failures: HashMap<u64, HotShotError<TYPES>>,
 }

--- a/types/src/data.rs
+++ b/types/src/data.rs
@@ -13,7 +13,7 @@ use crate::{
         node_implementation::NodeType,
         signature_key::EncodedPublicKey,
         state::{ConsensusTime, TestableBlock, TestableState, ValidatingConsensusType},
-        storage::{StoredView, ViewAppend},
+        storage::StoredView,
         Block, State,
     },
 };
@@ -150,12 +150,6 @@ pub struct CommitmentProposal<TYPES: NodeType, ELECTION: Election<TYPES>> {
     /// Data availibity certificate
     pub dac: ELECTION::DACertificate,
 
-    /// parent commitment alrady in justify_qqc
-
-    /// What the state should be after applying `self.deltas`
-    #[debug(skip)]
-    pub state_commitment: Commitment<TYPES::StateType>,
-
     /// the propser id
     pub proposer_id: EncodedPublicKey,
 
@@ -215,6 +209,7 @@ pub trait LeafType:
     + std::hash::Hash
 {
     type NodeType: NodeType;
+    type DeltasType: Clone + Debug + for<'a> Deserialize<'a> + PartialEq + Send + Serialize + Sync;
     type StateCommitmentType: Clone
         + Debug
         + for<'a> Deserialize<'a>
@@ -260,7 +255,7 @@ pub trait LeafType:
 
     fn get_parent_commitment(&self) -> Commitment<Self>;
 
-    fn get_deltas(&self) -> <Self::NodeType as NodeType>::BlockType;
+    fn get_deltas(&self) -> Self::DeltasType;
 
     fn get_state(&self) -> Self::StateCommitmentType;
 
@@ -342,12 +337,8 @@ pub struct DALeaf<TYPES: NodeType> {
     /// So we can ask if it extends
     pub parent_commitment: Commitment<DALeaf<TYPES>>,
 
-    /// Block leaf wants to apply
-    pub deltas: TYPES::BlockType,
-
-    /// What the state should be AFTER applying `self.deltas`
-    /// dependent on whether we have the state yet
-    pub state: Either<TYPES::StateType, Commitment<TYPES::StateType>>,
+    /// The block or block commitment to be applied
+    pub deltas: Either<TYPES::BlockType, Commitment<TYPES::BlockType>>,
 
     /// Transactions that were marked for rejection while collecting deltas
     pub rejected: Vec<<TYPES::BlockType as Block>::Transaction>,
@@ -363,6 +354,7 @@ pub struct DALeaf<TYPES: NodeType> {
 
 impl<TYPES: NodeType> LeafType for ValidatingLeaf<TYPES> {
     type NodeType = TYPES;
+    type DeltasType = TYPES::BlockType;
     type StateCommitmentType = TYPES::StateType;
     type QuorumCertificate = QuorumCertificate<Self::NodeType, Self>;
     type DACertificate = DACertificate<Self::NodeType>;
@@ -406,7 +398,7 @@ impl<TYPES: NodeType> LeafType for ValidatingLeaf<TYPES> {
         self.parent_commitment
     }
 
-    fn get_deltas(&self) -> TYPES::BlockType {
+    fn get_deltas(&self) -> Self::DeltasType {
         self.deltas.clone()
     }
 
@@ -427,15 +419,12 @@ impl<TYPES: NodeType> LeafType for ValidatingLeaf<TYPES> {
     }
 
     fn from_stored_view(stored_view: StoredView<Self::NodeType, Self>) -> Self {
-        let deltas = match stored_view.append {
-            ViewAppend::Block { block } => block,
-        };
         Self {
             view_number: stored_view.view_number,
             height: 0,
             justify_qc: stored_view.justify_qc,
             parent_commitment: stored_view.parent,
-            deltas,
+            deltas: stored_view.deltas,
             state: stored_view.state,
             rejected: stored_view.rejected,
             timestamp: stored_view.timestamp,
@@ -461,7 +450,8 @@ where
 
 impl<TYPES: NodeType> LeafType for DALeaf<TYPES> {
     type NodeType = TYPES;
-    type StateCommitmentType = Either<TYPES::StateType, Commitment<TYPES::StateType>>;
+    type DeltasType = Either<TYPES::BlockType, Commitment<TYPES::BlockType>>;
+    type StateCommitmentType = ();
     type QuorumCertificate = QuorumCertificate<Self::NodeType, Self>;
     type DACertificate = DACertificate<Self::NodeType>;
 
@@ -469,15 +459,14 @@ impl<TYPES: NodeType> LeafType for DALeaf<TYPES> {
         view_number: <Self::NodeType as NodeType>::Time,
         justify_qc: QuorumCertificate<Self::NodeType, Self>,
         deltas: <Self::NodeType as NodeType>::BlockType,
-        state: <Self::NodeType as NodeType>::StateType,
+        _state: <Self::NodeType as NodeType>::StateType,
     ) -> Self {
         Self {
             view_number,
             height: 0,
             justify_qc,
             parent_commitment: fake_commitment(),
-            deltas,
-            state: Either::Left(state),
+            deltas: Either::Left(deltas),
             rejected: Vec::new(),
             timestamp: time::OffsetDateTime::now_utc().unix_timestamp_nanos(),
             proposer_id: genesis_proposer_id(),
@@ -504,13 +493,12 @@ impl<TYPES: NodeType> LeafType for DALeaf<TYPES> {
         self.parent_commitment
     }
 
-    fn get_deltas(&self) -> TYPES::BlockType {
+    fn get_deltas(&self) -> Self::DeltasType {
         self.deltas.clone()
     }
 
-    fn get_state(&self) -> Self::StateCommitmentType {
-        self.state.clone()
-    }
+    // The DA Leaf doesn't have a state.
+    fn get_state(&self) -> Self::StateCommitmentType {}
 
     fn get_rejected(&self) -> Vec<<TYPES::BlockType as Block>::Transaction> {
         self.rejected.clone()
@@ -525,16 +513,12 @@ impl<TYPES: NodeType> LeafType for DALeaf<TYPES> {
     }
 
     fn from_stored_view(stored_view: StoredView<Self::NodeType, Self>) -> Self {
-        let deltas = match stored_view.append {
-            ViewAppend::Block { block } => block,
-        };
         Self {
             view_number: stored_view.view_number,
             height: 0,
             justify_qc: stored_view.justify_qc,
             parent_commitment: stored_view.parent,
-            deltas,
-            state: stored_view.state,
+            deltas: stored_view.deltas,
             rejected: stored_view.rejected,
             timestamp: stored_view.timestamp,
             proposer_id: stored_view.proposer_id,
@@ -583,7 +567,7 @@ impl<TYPES: NodeType> Committable for ValidatingLeaf<TYPES> {
             .u64_field("view_number", *self.view_number)
             .u64_field("height", self.height)
             .field("parent Leaf commitment", self.parent_commitment)
-            .field("deltas commitment", self.deltas.commit())
+            .field("block commitment", self.deltas.commit())
             .field("state commitment", self.state.commit())
             .constant_str("justify_qc view number")
             .u64(*self.justify_qc.view_number)
@@ -603,8 +587,32 @@ impl<TYPES: NodeType> Committable for ValidatingLeaf<TYPES> {
 
 impl<TYPES: NodeType> Committable for DALeaf<TYPES> {
     fn commit(&self) -> commit::Commitment<Self> {
-        #[allow(deprecated)]
-        nll_todo()
+        // Commit the block commitment, rather than the block, so that the replicas can reconstruct
+        // the leaf.
+        let block_commitment = match &self.deltas {
+            Either::Left(block) => block.commit(),
+            Either::Right(commitment) => *commitment,
+        };
+        let mut signatures_bytes = vec![];
+        for (k, v) in &self.justify_qc.signatures {
+            signatures_bytes.extend(&k.0);
+            signatures_bytes.extend(&v.0 .0);
+            signatures_bytes.extend::<&[u8]>(v.1.commit().as_ref());
+        }
+        commit::RawCommitmentBuilder::new("Leaf Comm")
+            .u64_field("view_number", *self.view_number)
+            .u64_field("height", self.height)
+            .field("parent Leaf commitment", self.parent_commitment)
+            .field("block commitment", block_commitment)
+            .constant_str("justify_qc view number")
+            .u64(*self.justify_qc.view_number)
+            .field(
+                "justify_qc leaf commitment",
+                self.justify_qc.leaf_commitment(),
+            )
+            .constant_str("justify_qc signatures")
+            .var_size_bytes(&signatures_bytes)
+            .finalize()
     }
 }
 
@@ -705,7 +713,7 @@ where
     fn from(append: StoredView<TYPES, ValidatingLeaf<TYPES>>) -> Self {
         ValidatingLeaf::new(
             append.state,
-            append.append.into_deltas(),
+            append.deltas,
             append.parent,
             append.justify_qc,
             append.view_number,
@@ -729,7 +737,7 @@ where
             parent: leaf.get_parent_commitment(),
             justify_qc: leaf.get_justify_qc(),
             state: leaf.get_state(),
-            append: leaf.get_deltas().into(),
+            deltas: leaf.get_deltas(),
             rejected: leaf.get_rejected(),
             timestamp: leaf.get_timestamp(),
             proposer_id: leaf.get_proposer_id(),

--- a/types/src/traits/block_contents.rs
+++ b/types/src/traits/block_contents.rs
@@ -28,6 +28,9 @@ pub trait Block:
     /// The type of the transitions we are applying
     type Transaction: Transaction;
 
+    /// Construct an empty or genesis block.
+    fn new() -> Self;
+
     /// Attempts to add a transaction, returning an Error if it would result in a structurally
     /// invalid block
     ///
@@ -113,6 +116,10 @@ pub mod dummy {
         type Error = DummyError;
 
         type Transaction = DummyTransaction;
+
+        fn new() -> Self {
+            <Self as TestableBlock>::genesis()
+        }
 
         fn add_transaction_raw(
             &self,

--- a/types/src/traits/storage.rs
+++ b/types/src/traits/storage.rs
@@ -136,8 +136,8 @@ pub struct StoredView<TYPES: NodeType, LEAF: LeafType<NodeType = TYPES>> {
     pub justify_qc: LEAF::QuorumCertificate,
     /// The state of this view
     pub state: LEAF::StateCommitmentType,
-    /// The history of how this view came to be
-    pub append: ViewAppend<TYPES::BlockType>,
+    /// The deltas of this view
+    pub deltas: LEAF::DeltasType,
     /// transactions rejected in this view
     pub rejected: Vec<TYPES::Transaction>,
     /// the timestamp this view was recv-ed in nanonseconds
@@ -158,7 +158,7 @@ where
     /// Note that this will set the `parent` to `LeafHash::default()`, so this will not have a parent.
     pub fn from_qc_block_and_state(
         qc: LEAF::QuorumCertificate,
-        block: TYPES::BlockType,
+        deltas: LEAF::DeltasType,
         state: LEAF::StateCommitmentType,
         height: u64,
         parent_commitment: Commitment<LEAF>,
@@ -166,7 +166,7 @@ where
         proposer_id: EncodedPublicKey,
     ) -> Self {
         Self {
-            append: ViewAppend::Block { block },
+            deltas,
             view_number: qc.view_number(),
             height,
             parent: parent_commitment,
@@ -176,30 +176,5 @@ where
             timestamp: time::OffsetDateTime::now_utc().unix_timestamp_nanos(),
             proposer_id,
         }
-    }
-}
-
-/// Indicates how a view came to be
-#[derive(Debug, PartialEq, Eq, Clone)]
-pub enum ViewAppend<BLOCK: Block> {
-    /// The view was created by appending a block to the previous view
-    Block {
-        /// The block that was appended
-        block: BLOCK,
-    },
-}
-
-impl<BLOCK: Block> ViewAppend<BLOCK> {
-    /// Get the block deltas from this append
-    pub fn into_deltas(self) -> BLOCK {
-        match self {
-            Self::Block { block, .. } => block,
-        }
-    }
-}
-
-impl<BLOCK: Block> From<BLOCK> for ViewAppend<BLOCK> {
-    fn from(block: BLOCK) -> Self {
-        Self::Block { block }
     }
 }


### PR DESCRIPTION
- Modifies `DALeaf` and `CommitmentProposal`.
- Modifies the signature on `DALeaf`.
- Adds constructor to `Block`.

Closes https://github.com/EspressoSystems/HotShot/issues/895.