### PR TITLE
Refactor Vote Collection

### DIFF
--- a/consensus/src/da_leader.rs
+++ b/consensus/src/da_leader.rs
@@ -422,7 +422,6 @@ impl<
             _pd_1: PhantomData,
             _pd_2: PhantomData,
             _pd_3: PhantomData,
-            _pd_4: PhantomData,
             valid_signatures,
             threshold: self.api.threshold(),
             stake_casted: 0,

--- a/consensus/src/da_leader.rs
+++ b/consensus/src/da_leader.rs
@@ -13,7 +13,7 @@ use commit::Committable;
 use either::Either;
 use either::Either::Left;
 use hotshot_types::certificate::{CertificateAccumulator, DACertificate};
-use hotshot_types::data::{CommitmentProposal, LeafType};
+use hotshot_types::data::CommitmentProposal;
 use hotshot_types::message::{ProcessedConsensusMessage, Vote};
 use hotshot_types::traits::state::SequencingConsensus;
 use hotshot_types::{
@@ -416,12 +416,12 @@ impl<
         let mut qcs = HashSet::<QuorumCertificate<TYPES, DALeaf<TYPES>>>::new();
         qcs.insert(self.generic_qc.clone());
 
-        let mut valid_signatures = BTreeMap::new();
+        let valid_signatures = BTreeMap::new();
         let mut accumlator = CertificateAccumulator {
-            _pd_0: PhantomData,
-            _pd_1: PhantomData,
-            _pd_2: PhantomData,
-            _pd_3: PhantomData,
+            // _pd_0: PhantomData,
+            // _pd_1: PhantomData,
+            // _pd_2: PhantomData,
+            // _pd_3: PhantomData,
             valid_signatures,
             threshold: self.api.threshold(),
             stake_casted: 0,

--- a/consensus/src/da_leader.rs
+++ b/consensus/src/da_leader.rs
@@ -21,16 +21,15 @@ use hotshot_types::{
     data::{DALeaf, DAProposal},
     message::{ConsensusMessage, Proposal},
     traits::{
-        election::{Checked::Unchecked, Election, SignedCertificate, VoteData, VoteToken},
+        election::{Election, SignedCertificate},
         node_implementation::NodeType,
         signature_key::SignatureKey,
         Block, State,
     },
 };
+use std::collections::HashMap;
 use std::num::NonZeroU64;
-use std::{
-    collections::BTreeMap, collections::HashSet, marker::PhantomData, sync::Arc, time::Instant,
-};
+use std::{collections::HashSet, marker::PhantomData, sync::Arc, time::Instant};
 use tracing::{error, info, instrument, warn};
 
 /// This view's DA committee leader
@@ -80,55 +79,46 @@ impl<
         block_commitment: Commitment<<TYPES as NodeType>::BlockType>,
     ) -> Option<DACertificate<TYPES>> {
         let lock = self.vote_collection_chan.lock().await;
-        let mut valid_signatures = BTreeMap::new();
-        let mut stake_casted = 0;
+        let mut accumulator = CertificateAccumulator {
+            vote_outcomes: HashMap::new(),
+            threshold,
+        };
 
         while let Ok(msg) = lock.recv().await {
             if Into::<ConsensusMessage<_, _, _>>::into(msg.clone()).view_number() != cur_view {
                 continue;
             }
             match msg {
-                ProcessedConsensusMessage::Vote(vote_message, sender) => {
-                    match vote_message {
-                        Vote::DA(vote) => {
-                            if vote.signature.0
-                                != <TYPES::SignatureKey as SignatureKey>::to_bytes(&sender)
-                            {
-                                continue;
+                ProcessedConsensusMessage::Vote(vote_message, sender) => match vote_message {
+                    Vote::DA(vote) => {
+                        if vote.signature.0
+                            != <TYPES::SignatureKey as SignatureKey>::to_bytes(&sender)
+                        {
+                            continue;
+                        }
+                        if vote.block_commitment != block_commitment {
+                            continue;
+                        }
+                        match self.api.accumulate_da_vote(
+                            &vote.signature.0,
+                            &vote.signature.1,
+                            vote.block_commitment,
+                            vote.vote_token.clone(),
+                            self.cur_view,
+                            accumulator,
+                        ) {
+                            Either::Left(acc) => {
+                                accumulator = acc;
                             }
-
-                            if !self.api.is_valid_vote(
-                                &vote.signature.0,
-                                &vote.signature.1,
-                                VoteData::DA(block_commitment),
-                                self.cur_view,
-                                // Ignoring deserialization errors below since we are getting rid of it soon
-                                Unchecked(vote.vote_token.clone()),
-                            ) {
-                                continue;
-                            }
-
-                            valid_signatures.insert(
-                                vote.signature.0.clone(),
-                                (vote.signature.1.clone(), vote.vote_token.clone()),
-                            );
-
-                            stake_casted += u64::from(vote.vote_token.vote_count());
-
-                            if stake_casted >= u64::from(threshold) {
-                                // construct QC
-                                let qc = DACertificate {
-                                    view_number: self.cur_view,
-                                    signatures: valid_signatures,
-                                };
+                            Either::Right(qc) => {
                                 return Some(qc);
                             }
                         }
-                        _ => {
-                            warn!("The DA leader has received an unexpected vote!");
-                        }
                     }
-                }
+                    _ => {
+                        warn!("The DA leader has received an unexpected vote!");
+                    }
+                },
                 ProcessedConsensusMessage::NextViewInterrupt(_view_number) => {
                     self.api.send_next_leader_timeout(self.cur_view).await;
                     break;
@@ -416,15 +406,9 @@ impl<
         let mut qcs = HashSet::<QuorumCertificate<TYPES, DALeaf<TYPES>>>::new();
         qcs.insert(self.generic_qc.clone());
 
-        let valid_signatures = BTreeMap::new();
         let mut accumlator = CertificateAccumulator {
-            // _pd_0: PhantomData,
-            // _pd_1: PhantomData,
-            // _pd_2: PhantomData,
-            // _pd_3: PhantomData,
-            valid_signatures,
+            vote_outcomes: HashMap::new(),
             threshold: self.api.threshold(),
-            stake_casted: 0,
         };
 
         let lock = self.vote_collection_chan.lock().await;

--- a/consensus/src/traits.rs
+++ b/consensus/src/traits.rs
@@ -262,6 +262,7 @@ pub trait ConsensusApi<
         vote_token: Checked<TYPES::VoteTokenType>,
     ) -> bool;
 
+    /// Add a vote for a QC, if the threshold is reached return the QC if not return the accumulator
     fn accumulate_qc_vote(
         &self,
         encoded_key: &EncodedPublicKey,
@@ -269,16 +270,10 @@ pub trait ConsensusApi<
         leaf_commitment: Commitment<LEAF>,
         vote_token: TYPES::VoteTokenType,
         view_number: TYPES::Time,
-        accumlator: CertificateAccumulator<
-            TYPES::SignatureKey,
-            TYPES::Time,
-            TYPES::VoteTokenType,
-            LEAF,
-        >,
-    ) -> Either<
-        CertificateAccumulator<TYPES::SignatureKey, TYPES::Time, TYPES::VoteTokenType, LEAF>,
-        QuorumCertificate<TYPES, LEAF>,
-    >;
+        accumlator: CertificateAccumulator<TYPES::VoteTokenType>,
+    ) -> Either<CertificateAccumulator<TYPES::VoteTokenType>, QuorumCertificate<TYPES, LEAF>>;
+
+    /// Add a vote for a DA QC, if the threshold is reached return the Certificate if not return the accumulator
     fn accumulate_da_vote(
         &self,
         encoded_key: &EncodedPublicKey,
@@ -286,19 +281,6 @@ pub trait ConsensusApi<
         block_commitment: Commitment<TYPES::BlockType>,
         vote_token: TYPES::VoteTokenType,
         view_number: TYPES::Time,
-        accumlator: CertificateAccumulator<
-            TYPES::SignatureKey,
-            TYPES::Time,
-            TYPES::VoteTokenType,
-            TYPES::BlockType,
-        >,
-    ) -> Either<
-        CertificateAccumulator<
-            TYPES::SignatureKey,
-            TYPES::Time,
-            TYPES::VoteTokenType,
-            TYPES::BlockType,
-        >,
-        DACertificate<TYPES>,
-    >;
+        accumlator: CertificateAccumulator<TYPES::VoteTokenType>,
+    ) -> Either<CertificateAccumulator<TYPES::VoteTokenType>, DACertificate<TYPES>>;
 }

--- a/consensus/src/traits.rs
+++ b/consensus/src/traits.rs
@@ -17,6 +17,9 @@ use hotshot_types::{
 };
 use std::num::NonZeroU64;
 use std::{num::NonZeroUsize, sync::Arc, time::Duration};
+use hotshot_types::certificate::CertificateAccumulator;
+use hotshot_types::certificate::{QuorumCertificate, DACertificate};
+use either::Either;
 
 // FIXME these should be nonzero u64s
 /// The API that [`HotStuff`] needs to talk to the system. This should be implemented in the `hotshot` crate and passed to all functions on `HotStuff`.
@@ -258,4 +261,53 @@ pub trait ConsensusApi<
         view_number: TYPES::Time,
         vote_token: Checked<TYPES::VoteTokenType>,
     ) -> bool;
+
+    fn accumulate_qc_vote(
+        &self,
+        encoded_key: &EncodedPublicKey,
+        encoded_signature: &EncodedSignature,
+        leaf_commitment: Commitment<LEAF>,
+        vote_token: TYPES::VoteTokenType,
+        view_number: TYPES::Time,
+        accumlator: CertificateAccumulator<
+            TYPES::SignatureKey,
+            TYPES::Time,
+            TYPES::VoteTokenType,
+            LEAF,
+            QuorumCertificate<TYPES, LEAF>,
+        >,
+    ) -> Either<
+        CertificateAccumulator<
+            TYPES::SignatureKey,
+            TYPES::Time,
+            TYPES::VoteTokenType,
+            LEAF,
+            QuorumCertificate<TYPES, LEAF>,
+        >,
+        QuorumCertificate<TYPES, LEAF>,
+    >;
+    fn accumulate_da_vote(
+        &self,
+        encoded_key: &EncodedPublicKey,
+        encoded_signature: &EncodedSignature,
+        block_commitment: Commitment<TYPES::BlockType>,
+        vote_token: TYPES::VoteTokenType,
+        view_number: TYPES::Time,
+        accumlator: CertificateAccumulator<
+            TYPES::SignatureKey,
+            TYPES::Time,
+            TYPES::VoteTokenType,
+            TYPES::BlockType,
+            DACertificate<TYPES>,
+        >,
+    ) -> Either<
+        CertificateAccumulator<
+            TYPES::SignatureKey,
+            TYPES::Time,
+            TYPES::VoteTokenType,
+            TYPES::BlockType,
+            DACertificate<TYPES>,
+        >,
+        DACertificate<TYPES>,
+    >;
 }

--- a/consensus/src/traits.rs
+++ b/consensus/src/traits.rs
@@ -2,6 +2,9 @@
 
 use async_trait::async_trait;
 use commit::Commitment;
+use either::Either;
+use hotshot_types::certificate::CertificateAccumulator;
+use hotshot_types::certificate::{DACertificate, QuorumCertificate};
 use hotshot_types::message::ConsensusMessage;
 use hotshot_types::traits::node_implementation::NodeType;
 use hotshot_types::traits::storage::StorageError;
@@ -17,9 +20,6 @@ use hotshot_types::{
 };
 use std::num::NonZeroU64;
 use std::{num::NonZeroUsize, sync::Arc, time::Duration};
-use hotshot_types::certificate::CertificateAccumulator;
-use hotshot_types::certificate::{QuorumCertificate, DACertificate};
-use either::Either;
 
 // FIXME these should be nonzero u64s
 /// The API that [`HotStuff`] needs to talk to the system. This should be implemented in the `hotshot` crate and passed to all functions on `HotStuff`.
@@ -274,16 +274,9 @@ pub trait ConsensusApi<
             TYPES::Time,
             TYPES::VoteTokenType,
             LEAF,
-            QuorumCertificate<TYPES, LEAF>,
         >,
     ) -> Either<
-        CertificateAccumulator<
-            TYPES::SignatureKey,
-            TYPES::Time,
-            TYPES::VoteTokenType,
-            LEAF,
-            QuorumCertificate<TYPES, LEAF>,
-        >,
+        CertificateAccumulator<TYPES::SignatureKey, TYPES::Time, TYPES::VoteTokenType, LEAF>,
         QuorumCertificate<TYPES, LEAF>,
     >;
     fn accumulate_da_vote(
@@ -298,7 +291,6 @@ pub trait ConsensusApi<
             TYPES::Time,
             TYPES::VoteTokenType,
             TYPES::BlockType,
-            DACertificate<TYPES>,
         >,
     ) -> Either<
         CertificateAccumulator<
@@ -306,7 +298,6 @@ pub trait ConsensusApi<
             TYPES::Time,
             TYPES::VoteTokenType,
             TYPES::BlockType,
-            DACertificate<TYPES>,
         >,
         DACertificate<TYPES>,
     >;

--- a/consensus/src/traits.rs
+++ b/consensus/src/traits.rs
@@ -270,8 +270,8 @@ pub trait ConsensusApi<
         leaf_commitment: Commitment<LEAF>,
         vote_token: TYPES::VoteTokenType,
         view_number: TYPES::Time,
-        accumlator: CertificateAccumulator<TYPES::VoteTokenType>,
-    ) -> Either<CertificateAccumulator<TYPES::VoteTokenType>, QuorumCertificate<TYPES, LEAF>>;
+        accumlator: CertificateAccumulator<TYPES::VoteTokenType, LEAF>,
+    ) -> Either<CertificateAccumulator<TYPES::VoteTokenType, LEAF>, QuorumCertificate<TYPES, LEAF>>;
 
     /// Add a vote for a DA QC, if the threshold is reached return the Certificate if not return the accumulator
     fn accumulate_da_vote(
@@ -281,6 +281,6 @@ pub trait ConsensusApi<
         block_commitment: Commitment<TYPES::BlockType>,
         vote_token: TYPES::VoteTokenType,
         view_number: TYPES::Time,
-        accumlator: CertificateAccumulator<TYPES::VoteTokenType>,
-    ) -> Either<CertificateAccumulator<TYPES::VoteTokenType>, DACertificate<TYPES>>;
+        accumlator: CertificateAccumulator<TYPES::VoteTokenType, TYPES::BlockType>,
+    ) -> Either<CertificateAccumulator<TYPES::VoteTokenType, TYPES::BlockType>, DACertificate<TYPES>>;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,6 +92,8 @@ use std::{
     time::{Duration, Instant},
 };
 use tracing::{debug, error, info, instrument, trace, warn};
+use hotshot_types::certificate::CertificateAccumulator;
+use either::Either;
 
 // -- Rexports
 // External
@@ -1114,6 +1116,59 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>>
             view_number,
             vote_token,
         )
+    }
+
+    fn accumulate_qc_vote(
+        &self,
+        encoded_key: &EncodedPublicKey,
+        encoded_signature: &EncodedSignature,
+        leaf_commitment: Commitment<I::Leaf>,
+        vote_token: TYPES::VoteTokenType,
+        view_number: TYPES::Time,
+        accumlator: CertificateAccumulator<
+            TYPES::SignatureKey,
+            TYPES::Time,
+            TYPES::VoteTokenType,
+            I::Leaf,
+            QuorumCertificate<TYPES, I::Leaf>,
+        >,
+    ) -> Either<
+        CertificateAccumulator<
+            TYPES::SignatureKey,
+            TYPES::Time,
+            TYPES::VoteTokenType,
+            I::Leaf,
+            QuorumCertificate<TYPES, I::Leaf>,
+        >,
+        QuorumCertificate<TYPES, I::Leaf>,
+    > {
+        self.inner.election.accumulate_qc_vote(encoded_key, encoded_signature, leaf_commitment, vote_token, view_number, accumlator)
+    }
+    fn accumulate_da_vote(
+        &self,
+        encoded_key: &EncodedPublicKey,
+        encoded_signature: &EncodedSignature,
+        block_commitment: Commitment<TYPES::BlockType>,
+        vote_token: TYPES::VoteTokenType,
+        view_number: TYPES::Time,
+        accumlator: CertificateAccumulator<
+            TYPES::SignatureKey,
+            TYPES::Time,
+            TYPES::VoteTokenType,
+            TYPES::BlockType,
+            DACertificate<TYPES>,
+        >,
+    ) -> Either<
+        CertificateAccumulator<
+            TYPES::SignatureKey,
+            TYPES::Time,
+            TYPES::VoteTokenType,
+            TYPES::BlockType,
+            DACertificate<TYPES>,
+        >,
+        DACertificate<TYPES>,
+    > {
+        self.inner.election.accumulate_qc_vote(encoded_key, encoded_signature, block_commitment, vote_token, view_number, accumlator)
     }
 
     async fn store_leaf(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1124,16 +1124,9 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>>
         leaf_commitment: Commitment<I::Leaf>,
         vote_token: TYPES::VoteTokenType,
         view_number: TYPES::Time,
-        accumlator: CertificateAccumulator<
-            TYPES::SignatureKey,
-            TYPES::Time,
-            TYPES::VoteTokenType,
-            I::Leaf,
-        >,
-    ) -> Either<
-        CertificateAccumulator<TYPES::SignatureKey, TYPES::Time, TYPES::VoteTokenType, I::Leaf>,
-        QuorumCertificate<TYPES, I::Leaf>,
-    > {
+        accumlator: CertificateAccumulator<TYPES::VoteTokenType>,
+    ) -> Either<CertificateAccumulator<TYPES::VoteTokenType>, QuorumCertificate<TYPES, I::Leaf>>
+    {
         self.inner.election.accumulate_qc_vote(
             encoded_key,
             encoded_signature,
@@ -1150,21 +1143,8 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>>
         block_commitment: Commitment<TYPES::BlockType>,
         vote_token: TYPES::VoteTokenType,
         view_number: TYPES::Time,
-        accumlator: CertificateAccumulator<
-            TYPES::SignatureKey,
-            TYPES::Time,
-            TYPES::VoteTokenType,
-            TYPES::BlockType,
-        >,
-    ) -> Either<
-        CertificateAccumulator<
-            TYPES::SignatureKey,
-            TYPES::Time,
-            TYPES::VoteTokenType,
-            TYPES::BlockType,
-        >,
-        DACertificate<TYPES>,
-    > {
+        accumlator: CertificateAccumulator<TYPES::VoteTokenType>,
+    ) -> Either<CertificateAccumulator<TYPES::VoteTokenType>, DACertificate<TYPES>> {
         self.inner.election.accumulate_da_vote(
             encoded_key,
             encoded_signature,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1124,9 +1124,11 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>>
         leaf_commitment: Commitment<I::Leaf>,
         vote_token: TYPES::VoteTokenType,
         view_number: TYPES::Time,
-        accumlator: CertificateAccumulator<TYPES::VoteTokenType>,
-    ) -> Either<CertificateAccumulator<TYPES::VoteTokenType>, QuorumCertificate<TYPES, I::Leaf>>
-    {
+        accumlator: CertificateAccumulator<TYPES::VoteTokenType, I::Leaf>,
+    ) -> Either<
+        CertificateAccumulator<TYPES::VoteTokenType, I::Leaf>,
+        QuorumCertificate<TYPES, I::Leaf>,
+    > {
         self.inner.election.accumulate_qc_vote(
             encoded_key,
             encoded_signature,
@@ -1143,8 +1145,9 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>>
         block_commitment: Commitment<TYPES::BlockType>,
         vote_token: TYPES::VoteTokenType,
         view_number: TYPES::Time,
-        accumlator: CertificateAccumulator<TYPES::VoteTokenType>,
-    ) -> Either<CertificateAccumulator<TYPES::VoteTokenType>, DACertificate<TYPES>> {
+        accumlator: CertificateAccumulator<TYPES::VoteTokenType, TYPES::BlockType>,
+    ) -> Either<CertificateAccumulator<TYPES::VoteTokenType, TYPES::BlockType>, DACertificate<TYPES>>
+    {
         self.inner.election.accumulate_da_vote(
             encoded_key,
             encoded_signature,

--- a/src/traits/election/static_committee.rs
+++ b/src/traits/election/static_committee.rs
@@ -1,6 +1,8 @@
+use super::vrf::JfPubKey;
 use ark_bls12_381::Parameters as Param381;
 use commit::{Commitment, Committable, RawCommitmentBuilder};
 use espresso_systems_common::hotshot::tag;
+use hotshot_types::certificate::DACertificate;
 use hotshot_types::{
     data::LeafType,
     traits::{
@@ -14,8 +16,6 @@ use jf_primitives::signatures::BLSSignatureScheme;
 use serde::{Deserialize, Serialize};
 use std::marker::PhantomData;
 use std::num::NonZeroU64;
-use hotshot_types::certificate::DACertificate;
-use super::vrf::JfPubKey;
 
 /// Dummy implementation of [`Election`]
 

--- a/src/traits/election/static_committee.rs
+++ b/src/traits/election/static_committee.rs
@@ -2,7 +2,6 @@ use super::vrf::JfPubKey;
 use ark_bls12_381::Parameters as Param381;
 use commit::{Commitment, Committable, RawCommitmentBuilder};
 use espresso_systems_common::hotshot::tag;
-use hotshot_types::certificate::DACertificate;
 use hotshot_types::{
     data::LeafType,
     traits::{
@@ -95,7 +94,8 @@ where
 
     type QuorumCertificate = LEAF::QuorumCertificate;
 
-    type DACertificate = DACertificate<TYPES>;
+    type DACertificate = LEAF::DACertificate;
+    // type DACertificate = DACertificate<TYPES>;
 
     type LeafType = LEAF;
 

--- a/src/traits/election/static_committee.rs
+++ b/src/traits/election/static_committee.rs
@@ -14,7 +14,7 @@ use jf_primitives::signatures::BLSSignatureScheme;
 use serde::{Deserialize, Serialize};
 use std::marker::PhantomData;
 use std::num::NonZeroU64;
-
+use hotshot_types::certificate::DACertificate;
 use super::vrf::JfPubKey;
 
 /// Dummy implementation of [`Election`]
@@ -95,7 +95,7 @@ where
 
     type QuorumCertificate = LEAF::QuorumCertificate;
 
-    type DACertificate = LEAF::DACertificate;
+    type DACertificate = DACertificate<TYPES>;
 
     type LeafType = LEAF;
 

--- a/src/traits/election/vrf.rs
+++ b/src/traits/election/vrf.rs
@@ -43,6 +43,7 @@ use std::{
     sync::{Arc, Mutex},
 };
 use tracing::{error, info, instrument};
+use hotshot_types::certificate::DACertificate;
 
 // TODO wrong palce for this
 /// the sortition committee size parameter
@@ -456,7 +457,7 @@ where
 
     type QuorumCertificate = LEAF::QuorumCertificate;
 
-    type DACertificate = LEAF::DACertificate;
+    type DACertificate = DACertificate<TYPES>;
 
     type LeafType = LEAF;
 

--- a/src/traits/election/vrf.rs
+++ b/src/traits/election/vrf.rs
@@ -5,6 +5,7 @@ use blake3::Hasher;
 use commit::{Commitment, Committable, RawCommitmentBuilder};
 use derivative::Derivative;
 use espresso_systems_common::hotshot::tag;
+use hotshot_types::certificate::DACertificate;
 use hotshot_types::{
     data::LeafType,
     traits::{
@@ -43,7 +44,6 @@ use std::{
     sync::{Arc, Mutex},
 };
 use tracing::{error, info, instrument};
-use hotshot_types::certificate::DACertificate;
 
 // TODO wrong palce for this
 /// the sortition committee size parameter

--- a/types/src/certificate.rs
+++ b/types/src/certificate.rs
@@ -3,7 +3,7 @@
 use crate::{
     data::{fake_commitment, LeafType},
     traits::{
-        election::{Accumulator, SignedCertificate, VoteToken},
+        election::{Accumulator, SignedCertificate, VoteData, VoteToken},
         node_implementation::NodeType,
         signature_key::{EncodedPublicKey, EncodedSignature},
         state::ConsensusTime,
@@ -59,6 +59,22 @@ pub struct QuorumCertificate<TYPES: NodeType, LEAF: LeafType<NodeType = TYPES>> 
     pub signatures: BTreeMap<EncodedPublicKey, (EncodedSignature, TYPES::VoteTokenType)>,
     /// If this QC is for the genesis block
     pub is_genesis: bool,
+}
+
+/// Data from a vote needed to accumulate into a `SignedCertificate`
+pub struct VoteMetaData<TYPES: NodeType, C: Committable, T: VoteToken, TIME, LEAF: LeafType> {
+    /// Voter's public key
+    pub encoded_key: EncodedPublicKey,
+    /// Votes signature
+    pub encoded_signature: EncodedSignature,
+    /// Commitment to what's voted on.  E.g. the leaf for a `QuorumCertificate`
+    pub commitment: Commitment<C>,
+    /// Data of the vote, yes, no, timeout, or DA
+    pub data: VoteData<TYPES, LEAF>,
+    /// The votes's token
+    pub vote_token: T,
+    /// View number for the vote
+    pub view_number: TIME,
 }
 
 /// Mapping of leaf commitments to votes by key

--- a/types/src/certificate.rs
+++ b/types/src/certificate.rs
@@ -64,28 +64,28 @@ pub struct QuorumCertificate<TYPES: NodeType, LEAF: LeafType<NodeType = TYPES>> 
 /// `CertificateAccumulator` is describes the process of collecting signatures
 /// to form a QC or a DA certificate.
 #[allow(clippy::missing_docs_in_private_items)]
-pub struct CertificateAccumulator<SIGNATURE, TIME, TOKEN, LEAF, CERT>
+pub struct CertificateAccumulator<SIGNATURE, TIME, TOKEN, LEAF>
 where
     SIGNATURE: SignatureKey,
     LEAF: Committable,
-    CERT: SignedCertificate<SIGNATURE, TIME, TOKEN, LEAF>,
 {
     pub _pd_0: PhantomData<SIGNATURE>,
-    pub _pd_1: PhantomData<CERT>,
-    pub _pd_2: PhantomData<TIME>,
-    pub _pd_3: PhantomData<TOKEN>,
-    pub _pd_4: PhantomData<LEAF>,
+    pub _pd_1: PhantomData<TIME>,
+    pub _pd_2: PhantomData<TOKEN>,
+    pub _pd_3: PhantomData<LEAF>,
     pub valid_signatures: BTreeMap<EncodedPublicKey, (EncodedSignature, TOKEN)>,
     pub threshold: NonZeroU64,
     pub stake_casted: u64,
 }
 
-impl<SIGNATURE, TIME, CERT, TOKEN, LEAF> Accumulator<(EncodedPublicKey, (EncodedSignature, TOKEN)), BTreeMap<EncodedPublicKey, (EncodedSignature, TOKEN)>>
-    for CertificateAccumulator<SIGNATURE, TIME, TOKEN, LEAF, CERT>
+impl<SIGNATURE, TIME, TOKEN, LEAF>
+    Accumulator<
+        (EncodedPublicKey, (EncodedSignature, TOKEN)),
+        BTreeMap<EncodedPublicKey, (EncodedSignature, TOKEN)>,
+    > for CertificateAccumulator<SIGNATURE, TIME, TOKEN, LEAF>
 where
     SIGNATURE: SignatureKey,
     LEAF: Committable,
-    CERT: SignedCertificate<SIGNATURE, TIME, TOKEN, LEAF>,
     TOKEN: Clone + VoteToken,
 {
     fn append(
@@ -93,7 +93,8 @@ where
         val: (EncodedPublicKey, (EncodedSignature, TOKEN)),
     ) -> Either<Self, BTreeMap<EncodedPublicKey, (EncodedSignature, TOKEN)>> {
         let (key, (sig, token)) = val;
-        self.valid_signatures.insert(key, (sig.clone(), token.clone()));
+        self.valid_signatures
+            .insert(key, (sig.clone(), token.clone()));
 
         self.stake_casted += u64::from(token.vote_count());
 
@@ -108,13 +109,8 @@ impl<TYPES: NodeType, LEAF: LeafType<NodeType = TYPES>>
     SignedCertificate<TYPES::SignatureKey, TYPES::Time, TYPES::VoteTokenType, LEAF>
     for QuorumCertificate<TYPES, LEAF>
 {
-    type Accumulator = CertificateAccumulator<
-        TYPES::SignatureKey,
-        TYPES::Time,
-        TYPES::VoteTokenType,
-        LEAF,
-        QuorumCertificate<TYPES, LEAF>,
-    >;
+    type Accumulator =
+        CertificateAccumulator<TYPES::SignatureKey, TYPES::Time, TYPES::VoteTokenType, LEAF>;
     fn from_signatures_and_commitment(
         view_number: TYPES::Time,
         signatures: BTreeMap<EncodedPublicKey, (EncodedSignature, TYPES::VoteTokenType)>,
@@ -191,13 +187,8 @@ impl<TYPES: NodeType, LEAF: commit::Committable>
     SignedCertificate<TYPES::SignatureKey, TYPES::Time, TYPES::VoteTokenType, LEAF>
     for DACertificate<TYPES>
 {
-    type Accumulator = CertificateAccumulator<
-        TYPES::SignatureKey,
-        TYPES::Time,
-        TYPES::VoteTokenType,
-        LEAF,
-        DACertificate<TYPES>,
-    >;
+    type Accumulator =
+        CertificateAccumulator<TYPES::SignatureKey, TYPES::Time, TYPES::VoteTokenType, LEAF>;
 
     fn from_signatures_and_commitment(
         view_number: TYPES::Time,

--- a/types/src/data.rs
+++ b/types/src/data.rs
@@ -237,7 +237,7 @@ pub trait LeafType:
             <Self::NodeType as NodeType>::SignatureKey,
             <Self::NodeType as NodeType>::Time,
             <Self::NodeType as NodeType>::VoteTokenType,
-            Self,
+            <Self::NodeType as NodeType>::BlockType,
         > + Debug
         + Eq
         + PartialEq

--- a/types/src/traits/election.rs
+++ b/types/src/traits/election.rs
@@ -105,44 +105,11 @@ pub trait Accumulator<T, U>: Sized {
     fn append(self, val: T) -> Either<Self, U>;
 }
 
-// pub struct DAAccumulator<TIME, CERT: SignedCertificate, TOKEN> {
-//     valid_signatures: BTreeMap<(EncodedPublicKey, (EncodedSignature, TOKEN))>,
-//     stake_casted: NonZeroU64,
-//     threshold: NonZeroU64,
-//     view_num: TIME,
-// }
-
-// impl<TIME, CERT, TOKEN> Accumulator<(EncodedPublicKey, (EncodedSignature, TOKEN))>
-//     for DAAccumulator<TIME>
-// {
-//     fn append(
-//         val: (EncodedPublicKey, (EncodedSignature, TOKEN)),
-//     ) -> Either<Self, BTreeMap<(EncodedPublicKey, EncodedSignature)>> {
-//         let (key, (sig, token)) = val;
-//         valid_signatures.insert(key, (sig.clone(), token.clone()));
-
-//         stake_casted += u64::from(token.vote_count());
-
-//         if stake_casted >= u64::from(threshold) {
-//             return Either::Right((self.valid_signatures));
-//         }
-//         Either::Left(self)
-//     }
-// }
-/// todo associated types for:
-/// - signature key
-/// - encoded things
-/// -
 pub trait SignedCertificate<SIGNATURE: SignatureKey, TIME, TOKEN, LEAF>
 where
     Self: Send + Sync + Clone + Serialize + for<'a> Deserialize<'a>,
     LEAF: Committable,
 {
-    // type Accumulator: Accumulator<
-    //     (Commitment<LEAF>, (EncodedPublicKey, (EncodedSignature, TOKEN))),
-    //     BTreeMap<EncodedPublicKey, (EncodedSignature, TOKEN)>,
-    // >;
-
     /// Build a QC from the threshold signature and commitment
     fn from_signatures_and_commitment(
         view_number: TIME,
@@ -269,7 +236,7 @@ pub trait Election<TYPES: NodeType>: Clone + Eq + PartialEq + Send + Sync + 'sta
         is_valid_signature && is_valid_vote_token
     }
 
-    /// Accumlate the vote, return the QC if the threshold was reached, if not return the updated accumlator
+    /// Accumlate the vote, return the QC if the threshold was reached, if not return the updated accumulator
     #[allow(clippy::type_complexity)]
     fn accumulate_qc_vote(
         &self,
@@ -278,7 +245,7 @@ pub trait Election<TYPES: NodeType>: Clone + Eq + PartialEq + Send + Sync + 'sta
         leaf_commitment: Commitment<Self::LeafType>,
         vote_token: TYPES::VoteTokenType,
         view_number: TYPES::Time,
-        accumlator: CertificateAccumulator<TYPES::VoteTokenType, Self::LeafType>,
+        accumulator: CertificateAccumulator<TYPES::VoteTokenType, Self::LeafType>,
     ) -> Either<
         CertificateAccumulator<TYPES::VoteTokenType, Self::LeafType>,
         QuorumCertificate<TYPES, Self::LeafType>,
@@ -291,14 +258,14 @@ pub trait Election<TYPES: NodeType>: Clone + Eq + PartialEq + Send + Sync + 'sta
             // Ignoring deserialization errors below since we are getting rid of it soon
             Unchecked(vote_token.clone()),
         ) {
-            return Either::Left(accumlator);
+            return Either::Left(accumulator);
         }
 
-        match accumlator.append((
+        match accumulator.append((
             leaf_commitment,
             (encoded_key.clone(), (encoded_signature.clone(), vote_token)),
         )) {
-            Either::Left(accumlator) => Either::Left(accumlator),
+            Either::Left(accumulator) => Either::Left(accumulator),
             Either::Right(signatures) => {
                 Either::Right(QuorumCertificate::from_signatures_and_commitment(
                     view_number,
@@ -308,7 +275,7 @@ pub trait Election<TYPES: NodeType>: Clone + Eq + PartialEq + Send + Sync + 'sta
             }
         }
     }
-    /// Accumlate the vote, return the QC if the threshold was reached, if not return the updated accumlator
+    /// Accumlate the vote, return the QC if the threshold was reached, if not return the updated accumulator
     #[allow(clippy::type_complexity)]
     fn accumulate_da_vote(
         &self,
@@ -317,7 +284,7 @@ pub trait Election<TYPES: NodeType>: Clone + Eq + PartialEq + Send + Sync + 'sta
         block_commitment: Commitment<TYPES::BlockType>,
         vote_token: TYPES::VoteTokenType,
         view_number: TYPES::Time,
-        accumlator: CertificateAccumulator<TYPES::VoteTokenType, TYPES::BlockType>,
+        accumulator: CertificateAccumulator<TYPES::VoteTokenType, TYPES::BlockType>,
     ) -> Either<CertificateAccumulator<TYPES::VoteTokenType, TYPES::BlockType>, DACertificate<TYPES>>
     {
         if !self.is_valid_vote(
@@ -325,17 +292,16 @@ pub trait Election<TYPES: NodeType>: Clone + Eq + PartialEq + Send + Sync + 'sta
             encoded_signature,
             VoteData::DA(block_commitment),
             view_number,
-            // Ignoring deserialization errors below since we are getting rid of it soon
             Unchecked(vote_token.clone()),
         ) {
-            return Either::Left(accumlator);
+            return Either::Left(accumulator);
         }
 
-        match accumlator.append((
+        match accumulator.append((
             block_commitment,
             (encoded_key.clone(), (encoded_signature.clone(), vote_token)),
         )) {
-            Either::Left(accumlator) => Either::Left(accumlator),
+            Either::Left(accumulator) => Either::Left(accumulator),
             Either::Right(signatures) => {
                 Either::Right(DACertificate::from_signatures_and_commitment(
                     view_number,


### PR DESCRIPTION
We collect votes in 3 places and the logic was just duplicated everywhere.  This removes most of that duplication and puts it into an `Accumlator`.  There is still some funkiness in election because it has both DA and QC certificate types.  I also couldn't figure a way not have a `accumulate_da_vote` and `accumulate_qc_vote` functions despite the logic looking the same

Closes: https://github.com/EspressoSystems/HotShot/issues/883