### PR TITLE
Rename non-DA structs and files

### DIFF
--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -17,22 +17,22 @@
 )]
 #![allow(clippy::module_name_repetitions, clippy::unused_async)]
 
-mod da_leader;
 mod da_member;
-mod da_replica;
 mod leader;
 mod next_leader;
 mod replica;
+mod sequencing_leader;
+mod sequencing_replica;
 mod traits;
 mod utils;
 
 use async_compatibility_layer::async_primitives::subscribable_rwlock::SubscribableRwLock;
-pub use da_leader::{DAConsensusLeader, DALeader, DANextLeader};
 pub use da_member::DAMember;
-pub use da_replica::DAReplica;
 pub use leader::ValidatingLeader;
 pub use next_leader::NextValidatingLeader;
 pub use replica::Replica;
+pub use sequencing_leader::{ConsensusLeader, ConsensusNextLeader, DALeader};
+pub use sequencing_replica::SequencingReplica;
 pub use traits::ConsensusApi;
 pub use utils::{SendToTasks, View, ViewInner, ViewQueue};
 

--- a/consensus/src/sequencing_leader.rs
+++ b/consensus/src/sequencing_leader.rs
@@ -1,4 +1,4 @@
-//! Contains the [`DALeader`], [`DAConsensusLeader`] and [`DANextLeader`] structs used for the
+//! Contains the [`DALeader`], [`ConsensusLeader`] and [`ConsensusNextLeader`] structs used for the
 //! leader steps in the consensus algorithm with DA committee, i.e. in the sequencing consensus.
 
 use crate::{utils::ViewInner, CommitmentMap, Consensus, ConsensusApi};
@@ -18,7 +18,7 @@ use hotshot_types::message::{ProcessedConsensusMessage, Vote};
 use hotshot_types::traits::state::SequencingConsensus;
 use hotshot_types::{
     certificate::QuorumCertificate,
-    data::{DALeaf, DAProposal},
+    data::{DAProposal, SequencingLeaf},
     message::{ConsensusMessage, Proposal},
     traits::{
         election::{Checked::Unchecked, Election, SignedCertificate, VoteData, VoteToken},
@@ -36,14 +36,14 @@ use tracing::{error, info, instrument, warn};
 /// This view's DA committee leader
 #[derive(Debug, Clone)]
 pub struct DALeader<
-    A: ConsensusApi<TYPES, DALeaf<TYPES>, DAProposal<TYPES, ELECTION>>,
+    A: ConsensusApi<TYPES, SequencingLeaf<TYPES>, DAProposal<TYPES, ELECTION>>,
     TYPES: NodeType,
-    ELECTION: Election<TYPES, LeafType = DALeaf<TYPES>>,
+    ELECTION: Election<TYPES, LeafType = SequencingLeaf<TYPES>>,
 > {
     /// id of node
     pub id: u64,
     /// Reference to consensus. Leader will require a read lock on this.
-    pub consensus: Arc<RwLock<Consensus<TYPES, DALeaf<TYPES>>>>,
+    pub consensus: Arc<RwLock<Consensus<TYPES, SequencingLeaf<TYPES>>>>,
     /// The `high_qc` per spec
     pub high_qc: ELECTION::QuorumCertificate,
     /// The view number we're running on
@@ -57,7 +57,11 @@ pub struct DALeader<
     pub vote_collection_chan: Arc<
         Mutex<
             UnboundedReceiver<
-                ProcessedConsensusMessage<TYPES, DALeaf<TYPES>, DAProposal<TYPES, ELECTION>>,
+                ProcessedConsensusMessage<
+                    TYPES,
+                    SequencingLeaf<TYPES>,
+                    DAProposal<TYPES, ELECTION>,
+                >,
             >,
         >,
     >,
@@ -66,9 +70,9 @@ pub struct DALeader<
     pub _pd: PhantomData<ELECTION>,
 }
 impl<
-        A: ConsensusApi<TYPES, DALeaf<TYPES>, DAProposal<TYPES, ELECTION>>,
+        A: ConsensusApi<TYPES, SequencingLeaf<TYPES>, DAProposal<TYPES, ELECTION>>,
         TYPES: NodeType<ConsensusType = SequencingConsensus>,
-        ELECTION: Election<TYPES, LeafType = DALeaf<TYPES>>,
+        ELECTION: Election<TYPES, LeafType = SequencingLeaf<TYPES>>,
     > DALeader<A, TYPES, ELECTION>
 {
     /// Accumulate votes for a proposal and return either the cert or None if the threshold was not reached in time
@@ -141,7 +145,7 @@ impl<
         None
     }
     /// Returns the parent leaf of the proposal we are building
-    async fn parent_leaf(&self) -> Option<DALeaf<TYPES>> {
+    async fn parent_leaf(&self) -> Option<SequencingLeaf<TYPES>> {
         let parent_view_number = &self.high_qc.view_number();
         let consensus = self.consensus.read().await;
         let parent_leaf = if let Some(parent_view) = consensus.state_map.get(parent_view_number) {
@@ -212,7 +216,13 @@ impl<
     }
     /// Run one view of the DA leader task
     #[instrument(skip(self), fields(id = self.id, view = *self.cur_view), name = "Sequencing DALeader Task", level = "error")]
-    pub async fn run_view(self) -> Option<(DACertificate<TYPES>, TYPES::BlockType, DALeaf<TYPES>)> {
+    pub async fn run_view(
+        self,
+    ) -> Option<(
+        DACertificate<TYPES>,
+        TYPES::BlockType,
+        SequencingLeaf<TYPES>,
+    )> {
         // Prepare the DA Proposal
         let Some(parent_leaf) = self.parent_leaf().await else {
              warn!("Couldn't find high QC parent in state map.");
@@ -238,7 +248,7 @@ impl<
             _pd: PhantomData,
         };
         let message =
-            ConsensusMessage::<TYPES, DALeaf<TYPES>, DAProposal<TYPES, ELECTION>>::Proposal(
+            ConsensusMessage::<TYPES, SequencingLeaf<TYPES>, DAProposal<TYPES, ELECTION>>::Proposal(
                 Proposal { data, signature },
             );
         // Brodcast DA proposal
@@ -262,22 +272,22 @@ impl<
 
 /// Implemenation of the consensus leader for a DA/Sequencing consensus.  Handles sending out a proposal to the entire network
 /// For now this step happens after the `DALeader` completes it's proposal and collects enough votes.
-pub struct DAConsensusLeader<
-    A: ConsensusApi<TYPES, DALeaf<TYPES>, DAProposal<TYPES, ELECTION>>,
+pub struct ConsensusLeader<
+    A: ConsensusApi<TYPES, SequencingLeaf<TYPES>, DAProposal<TYPES, ELECTION>>,
     TYPES: NodeType,
     ELECTION: Election<
         TYPES,
-        LeafType = DALeaf<TYPES>,
-        QuorumCertificate = QuorumCertificate<TYPES, DALeaf<TYPES>>,
+        LeafType = SequencingLeaf<TYPES>,
+        QuorumCertificate = QuorumCertificate<TYPES, SequencingLeaf<TYPES>>,
         DACertificate = DACertificate<TYPES>,
     >,
 > {
     /// id of node
     pub id: u64,
     /// Reference to consensus. Leader will require a read lock on this.
-    pub consensus: Arc<RwLock<Consensus<TYPES, DALeaf<TYPES>>>>,
+    pub consensus: Arc<RwLock<Consensus<TYPES, SequencingLeaf<TYPES>>>>,
     /// The `high_qc` per spec
-    pub high_qc: QuorumCertificate<TYPES, DALeaf<TYPES>>,
+    pub high_qc: QuorumCertificate<TYPES, SequencingLeaf<TYPES>>,
     /// The view number we're running on
     pub cur_view: TYPES::Time,
     /// The Certificate generated for the transactions commited to in the proposal the leader will build
@@ -285,7 +295,7 @@ pub struct DAConsensusLeader<
     /// The block corresponding to the DA cert
     pub block: TYPES::BlockType,
     /// Leaf this proposal will chain from
-    pub parent: DALeaf<TYPES>,
+    pub parent: SequencingLeaf<TYPES>,
     /// Limited access to the consensus protocol
     pub api: A,
 
@@ -294,21 +304,21 @@ pub struct DAConsensusLeader<
     pub _pd: PhantomData<ELECTION>,
 }
 impl<
-        A: ConsensusApi<TYPES, DALeaf<TYPES>, DAProposal<TYPES, ELECTION>>,
+        A: ConsensusApi<TYPES, SequencingLeaf<TYPES>, DAProposal<TYPES, ELECTION>>,
         TYPES: NodeType<ConsensusType = SequencingConsensus, ApplicationMetadataType = ()>,
         ELECTION: Election<
             TYPES,
-            LeafType = DALeaf<TYPES>,
-            QuorumCertificate = QuorumCertificate<TYPES, DALeaf<TYPES>>,
+            LeafType = SequencingLeaf<TYPES>,
+            QuorumCertificate = QuorumCertificate<TYPES, SequencingLeaf<TYPES>>,
             DACertificate = DACertificate<TYPES>,
         >,
-    > DAConsensusLeader<A, TYPES, ELECTION>
+    > ConsensusLeader<A, TYPES, ELECTION>
 {
     /// Run one view of the DA leader task
     #[instrument(skip(self), fields(id = self.id, view = *self.cur_view), name = "Sequencing DALeader Task", level = "error")]
-    pub async fn run_view(self) -> Option<QuorumCertificate<TYPES, DALeaf<TYPES>>> {
+    pub async fn run_view(self) -> Option<QuorumCertificate<TYPES, SequencingLeaf<TYPES>>> {
         let block_commitment = self.block.commit();
-        let leaf = DALeaf {
+        let leaf = SequencingLeaf {
             view_number: self.cur_view,
             height: self.parent.height + 1,
             justify_qc: self.high_qc.clone(),
@@ -334,13 +344,14 @@ impl<
             application_metadata: {},
         };
 
-        let message =
-            ConsensusMessage::<TYPES, DALeaf<TYPES>, CommitmentProposal<TYPES, ELECTION>>::Proposal(
-                Proposal {
-                    data: proposal,
-                    signature,
-                },
-            );
+        let message = ConsensusMessage::<
+            TYPES,
+            SequencingLeaf<TYPES>,
+            CommitmentProposal<TYPES, ELECTION>,
+        >::Proposal(Proposal {
+            data: proposal,
+            signature,
+        });
         if let Err(e) = self.api.send_da_broadcast(message.clone()).await {
             warn!(?message, ?e, "Could not broadcast leader proposal");
             return None;
@@ -350,27 +361,31 @@ impl<
 }
 
 /// Implenting the next leader.  Collect votes on the previous leaders proposal and return the QC
-pub struct DANextLeader<
-    A: ConsensusApi<TYPES, DALeaf<TYPES>, DAProposal<TYPES, ELECTION>>,
+pub struct ConsensusNextLeader<
+    A: ConsensusApi<TYPES, SequencingLeaf<TYPES>, DAProposal<TYPES, ELECTION>>,
     TYPES: NodeType,
-    ELECTION: Election<TYPES, LeafType = DALeaf<TYPES>>,
+    ELECTION: Election<TYPES, LeafType = SequencingLeaf<TYPES>>,
 > {
     /// id of node
     pub id: u64,
     /// Reference to consensus. Leader will require a read lock on this.
-    pub consensus: Arc<RwLock<Consensus<TYPES, DALeaf<TYPES>>>>,
+    pub consensus: Arc<RwLock<Consensus<TYPES, SequencingLeaf<TYPES>>>>,
     /// The view number we're running on
     pub cur_view: TYPES::Time,
     /// Limited access to the consensus protocol
     pub api: A,
     /// generic_qc before starting this
-    pub generic_qc: QuorumCertificate<TYPES, DALeaf<TYPES>>,
+    pub generic_qc: QuorumCertificate<TYPES, SequencingLeaf<TYPES>>,
     /// channel through which the leader collects votes
     #[allow(clippy::type_complexity)]
     pub vote_collection_chan: Arc<
         Mutex<
             UnboundedReceiver<
-                ProcessedConsensusMessage<TYPES, DALeaf<TYPES>, DAProposal<TYPES, ELECTION>>,
+                ProcessedConsensusMessage<
+                    TYPES,
+                    SequencingLeaf<TYPES>,
+                    DAProposal<TYPES, ELECTION>,
+                >,
             >,
         >,
     >,
@@ -379,17 +394,17 @@ pub struct DANextLeader<
     pub _pd: PhantomData<ELECTION>,
 }
 impl<
-        A: ConsensusApi<TYPES, DALeaf<TYPES>, DAProposal<TYPES, ELECTION>>,
+        A: ConsensusApi<TYPES, SequencingLeaf<TYPES>, DAProposal<TYPES, ELECTION>>,
         TYPES: NodeType<ConsensusType = SequencingConsensus>,
-        ELECTION: Election<TYPES, LeafType = DALeaf<TYPES>>,
-    > DANextLeader<A, TYPES, ELECTION>
+        ELECTION: Election<TYPES, LeafType = SequencingLeaf<TYPES>>,
+    > ConsensusNextLeader<A, TYPES, ELECTION>
 {
     /// Run one view of the next leader, collect votes and build a QC for the last views `CommitmentProposal`
     /// # Panics
     /// While we are unwrapping, this function can logically never panic
     /// unless there is a bug in std
-    pub async fn run_view(self) -> QuorumCertificate<TYPES, DALeaf<TYPES>> {
-        let mut qcs = HashSet::<QuorumCertificate<TYPES, DALeaf<TYPES>>>::new();
+    pub async fn run_view(self) -> QuorumCertificate<TYPES, SequencingLeaf<TYPES>> {
+        let mut qcs = HashSet::<QuorumCertificate<TYPES, SequencingLeaf<TYPES>>>::new();
         qcs.insert(self.generic_qc.clone());
 
         let mut valid_signatures = BTreeMap::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,12 +54,13 @@ use async_trait::async_trait;
 use bincode::Options;
 use commit::{Commitment, Committable};
 use hotshot_consensus::{
-    Consensus, ConsensusApi, ConsensusMetrics, DAConsensusLeader, DALeader, DAMember, DANextLeader,
-    NextValidatingLeader, Replica, SendToTasks, ValidatingLeader, View, ViewInner, ViewQueue,
+    Consensus, ConsensusApi, ConsensusLeader, ConsensusMetrics, ConsensusNextLeader, DALeader,
+    DAMember, NextValidatingLeader, Replica, SendToTasks, ValidatingLeader, View, ViewInner,
+    ViewQueue,
 };
 use hotshot_types::certificate::DACertificate;
 use hotshot_types::data::ProposalType;
-use hotshot_types::data::{DALeaf, DAProposal};
+use hotshot_types::data::{DAProposal, SequencingLeaf};
 use hotshot_types::message::{MessageKind, ProcessedConsensusMessage};
 use hotshot_types::{
     data::{LeafType, ValidatingLeaf, ValidatingProposal},
@@ -849,11 +850,15 @@ impl<
         TYPES: NodeType<ConsensusType = SequencingConsensus, ApplicationMetadataType = ()>,
         ELECTION: Election<
             TYPES,
-            LeafType = DALeaf<TYPES>,
-            QuorumCertificate = QuorumCertificate<TYPES, DALeaf<TYPES>>,
+            LeafType = SequencingLeaf<TYPES>,
+            QuorumCertificate = QuorumCertificate<TYPES, SequencingLeaf<TYPES>>,
             DACertificate = DACertificate<TYPES>,
         >,
-        I: NodeImplementation<TYPES, Leaf = DALeaf<TYPES>, Proposal = DAProposal<TYPES, ELECTION>>,
+        I: NodeImplementation<
+            TYPES,
+            Leaf = SequencingLeaf<TYPES>,
+            Proposal = DAProposal<TYPES, ELECTION>,
+        >,
     > ViewRunner<TYPES, I> for HotShot<SequencingConsensus, TYPES, I>
 {
     // #[instrument]
@@ -916,7 +921,7 @@ impl<
                     return Ok(());
                 };
 
-            let consensus_leader = DAConsensusLeader {
+            let consensus_leader = ConsensusLeader {
                 id: hotshot.id,
                 consensus: hotshot.hotstuff.clone(),
                 high_qc: high_qc.clone(),
@@ -930,7 +935,7 @@ impl<
             let _qc = consensus_leader.run_view().await;
         }
         if c_api.is_leader(cur_view + 1).await {
-            let next_leader = DANextLeader {
+            let next_leader = ConsensusNextLeader {
                 id: hotshot.id,
                 consensus: hotshot.hotstuff.clone(),
                 cur_view,

--- a/types/src/data.rs
+++ b/types/src/data.rs
@@ -326,7 +326,7 @@ pub struct ValidatingLeaf<TYPES: NodeType> {
 #[derive(Serialize, Deserialize, Clone, Debug, Derivative, Eq)]
 #[derivative(PartialEq, Hash)]
 #[serde(bound(deserialize = ""))]
-pub struct DALeaf<TYPES: NodeType> {
+pub struct SequencingLeaf<TYPES: NodeType> {
     /// CurView from leader when proposing leaf
     pub view_number: TYPES::Time,
 
@@ -336,9 +336,9 @@ pub struct DALeaf<TYPES: NodeType> {
     /// Per spec, justification
     pub justify_qc: QuorumCertificate<TYPES, Self>,
 
-    /// The hash of the parent `DALeaf`
+    /// The hash of the parent `SequencingLeaf`
     /// So we can ask if it extends
-    pub parent_commitment: Commitment<DALeaf<TYPES>>,
+    pub parent_commitment: Commitment<SequencingLeaf<TYPES>>,
 
     /// The block or block commitment to be applied
     pub deltas: Either<TYPES::BlockType, Commitment<TYPES::BlockType>>,
@@ -451,7 +451,7 @@ where
     }
 }
 
-impl<TYPES: NodeType> LeafType for DALeaf<TYPES> {
+impl<TYPES: NodeType> LeafType for SequencingLeaf<TYPES> {
     type NodeType = TYPES;
     type DeltasType = Either<TYPES::BlockType, Commitment<TYPES::BlockType>>;
     type StateCommitmentType = ();
@@ -500,7 +500,7 @@ impl<TYPES: NodeType> LeafType for DALeaf<TYPES> {
         self.deltas.clone()
     }
 
-    // The DA Leaf doesn't have a state.
+    // The Sequencing Leaf doesn't have a state.
     fn get_state(&self) -> Self::StateCommitmentType {}
 
     fn get_rejected(&self) -> Vec<<TYPES::BlockType as Block>::Transaction> {
@@ -529,7 +529,7 @@ impl<TYPES: NodeType> LeafType for DALeaf<TYPES> {
     }
 }
 
-impl<TYPES: NodeType> TestableLeaf for DALeaf<TYPES>
+impl<TYPES: NodeType> TestableLeaf for SequencingLeaf<TYPES>
 where
     TYPES::StateType: TestableState,
     TYPES::BlockType: TestableBlock,
@@ -588,7 +588,7 @@ impl<TYPES: NodeType> Committable for ValidatingLeaf<TYPES> {
     }
 }
 
-impl<TYPES: NodeType> Committable for DALeaf<TYPES> {
+impl<TYPES: NodeType> Committable for SequencingLeaf<TYPES> {
     fn commit(&self) -> commit::Commitment<Self> {
         // Commit the block commitment, rather than the block, so that the replicas can reconstruct
         // the leaf.


### PR DESCRIPTION
Replaces the `DA` prefix with `Sequencing` or `Consensus` for non-DA structs or files.

Closes https://github.com/EspressoSystems/HotShot/issues/896.