### PR TITLE
Replace NextViewInterrupt with InternalTrigger

### DIFF
--- a/consensus/src/da_member.rs
+++ b/consensus/src/da_member.rs
@@ -171,8 +171,8 @@ impl<
                         }
                         break leaf;
                     }
-                    ProcessedConsensusMessage::NextViewInterrupt(_view_number) => {
-                        warn!("DA committee member receieved a next view interrupt message. This is not what the member expects. Skipping.");
+                    ProcessedConsensusMessage::InternalTrigger(_trigger) => {
+                        warn!("DA committee member receieved an internal trigger message. This is not what the member expects. Skipping.");
                         continue;
                     }
                     ProcessedConsensusMessage::Vote(_, _) => {

--- a/consensus/src/next_leader.rs
+++ b/consensus/src/next_leader.rs
@@ -11,7 +11,7 @@ use hotshot_types::traits::node_implementation::NodeType;
 use hotshot_types::traits::signature_key::SignatureKey;
 use hotshot_types::{
     certificate::QuorumCertificate,
-    message::{ConsensusMessage, Vote},
+    message::{ConsensusMessage, InternalTrigger, Vote},
 };
 use std::time::Instant;
 use std::{
@@ -150,10 +150,12 @@ impl<
                         }
                     }
                 }
-                ProcessedConsensusMessage::NextViewInterrupt(_view_number) => {
-                    self.api.send_next_leader_timeout(self.cur_view).await;
-                    break;
-                }
+                ProcessedConsensusMessage::InternalTrigger(trigger) => match trigger {
+                    InternalTrigger::Timeout(_) => {
+                        self.api.send_next_leader_timeout(self.cur_view).await;
+                        break;
+                    }
+                },
                 ProcessedConsensusMessage::Proposal(_p, _sender) => {
                     warn!("The next leader has received an unexpected proposal!");
                 }

--- a/consensus/src/sequencing_leader.rs
+++ b/consensus/src/sequencing_leader.rs
@@ -14,7 +14,7 @@ use either::Either;
 use either::Right;
 use hotshot_types::certificate::DACertificate;
 use hotshot_types::data::CommitmentProposal;
-use hotshot_types::message::{ProcessedConsensusMessage, Vote};
+use hotshot_types::message::{InternalTrigger, ProcessedConsensusMessage, Vote};
 use hotshot_types::traits::state::SequencingConsensus;
 use hotshot_types::{
     certificate::QuorumCertificate,
@@ -133,10 +133,12 @@ impl<
                         }
                     }
                 }
-                ProcessedConsensusMessage::NextViewInterrupt(_view_number) => {
-                    self.api.send_next_leader_timeout(self.cur_view).await;
-                    break;
-                }
+                ProcessedConsensusMessage::InternalTrigger(trigger) => match trigger {
+                    InternalTrigger::Timeout(_) => {
+                        self.api.send_next_leader_timeout(self.cur_view).await;
+                        break;
+                    }
+                },
                 ProcessedConsensusMessage::Proposal(_p, _sender) => {
                     warn!("The next leader has received an unexpected proposal!");
                 }
@@ -469,10 +471,12 @@ impl<
                         }
                     }
                 }
-                ProcessedConsensusMessage::NextViewInterrupt(_view_number) => {
-                    self.api.send_next_leader_timeout(self.cur_view).await;
-                    break;
-                }
+                ProcessedConsensusMessage::InternalTrigger(trigger) => match trigger {
+                    InternalTrigger::Timeout(_) => {
+                        self.api.send_next_leader_timeout(self.cur_view).await;
+                        break;
+                    }
+                },
                 ProcessedConsensusMessage::Proposal(_p, _sender) => {
                     warn!("The next leader has received an unexpected proposal!");
                 }

--- a/consensus/src/sequencing_replica.rs
+++ b/consensus/src/sequencing_replica.rs
@@ -13,7 +13,7 @@ use either::{Left, Right};
 use hotshot_types::{
     certificate::{DACertificate, QuorumCertificate},
     data::{CommitmentProposal, SequencingLeaf},
-    message::{ConsensusMessage, ProcessedConsensusMessage},
+    message::{ConsensusMessage, InternalTrigger, ProcessedConsensusMessage},
     traits::{
         election::{Election, SignedCertificate},
         node_implementation::NodeType,
@@ -277,55 +277,62 @@ impl<
                         }
                         break valid_leaf;
                     }
-                    ProcessedConsensusMessage::NextViewInterrupt(_view_number) => {
-                        let next_leader = self.api.get_leader(self.cur_view + 1).await;
+                    ProcessedConsensusMessage::InternalTrigger(trigger) => {
+                        match trigger {
+                            InternalTrigger::Timeout(_) => {
+                                let next_leader = self.api.get_leader(self.cur_view + 1).await;
 
-                        consensus.metrics.number_of_timeouts.add(1);
+                                consensus.metrics.number_of_timeouts.add(1);
 
-                        let vote_token = self.api.make_vote_token(self.cur_view);
+                                let vote_token = self.api.make_vote_token(self.cur_view);
 
-                        match vote_token {
-                            Err(e) => {
-                                error!(
-                                    "Failed to generate vote token for {:?} {:?}",
-                                    self.cur_view, e
-                                );
-                            }
-                            Ok(None) => {
-                                info!("We were not chosen for committee on {:?}", self.cur_view);
-                            }
-                            Ok(Some(vote_token)) => {
-                                let timed_out_msg = self.api.create_timeout_message(
-                                    self.high_qc.clone(),
-                                    self.cur_view,
-                                    vote_token,
-                                );
-                                warn!(
-                                    "Timed out! Sending timeout to next leader {:?}",
-                                    timed_out_msg
-                                );
+                                match vote_token {
+                                    Err(e) => {
+                                        error!(
+                                            "Failed to generate vote token for {:?} {:?}",
+                                            self.cur_view, e
+                                        );
+                                    }
+                                    Ok(None) => {
+                                        info!(
+                                            "We were not chosen for committee on {:?}",
+                                            self.cur_view
+                                        );
+                                    }
+                                    Ok(Some(vote_token)) => {
+                                        let timed_out_msg = self.api.create_timeout_message(
+                                            self.high_qc.clone(),
+                                            self.cur_view,
+                                            vote_token,
+                                        );
+                                        warn!(
+                                            "Timed out! Sending timeout to next leader {:?}",
+                                            timed_out_msg
+                                        );
 
-                                // send timedout message to the next leader
-                                if let Err(e) = self
-                                    .api
-                                    .send_direct_message(next_leader.clone(), timed_out_msg)
-                                    .await
-                                {
-                                    consensus.metrics.failed_to_send_messages.add(1);
-                                    warn!(
-                                        ?next_leader,
-                                        ?e,
-                                        "Could not send time out message to next_leader"
-                                    );
-                                } else {
-                                    consensus.metrics.outgoing_direct_messages.add(1);
+                                        // send timedout message to the next leader
+                                        if let Err(e) = self
+                                            .api
+                                            .send_direct_message(next_leader.clone(), timed_out_msg)
+                                            .await
+                                        {
+                                            consensus.metrics.failed_to_send_messages.add(1);
+                                            warn!(
+                                                ?next_leader,
+                                                ?e,
+                                                "Could not send time out message to next_leader"
+                                            );
+                                        } else {
+                                            consensus.metrics.outgoing_direct_messages.add(1);
+                                        }
+
+                                        // exits from entire function
+                                        self.api.send_replica_timeout(self.cur_view).await;
+                                    }
                                 }
-
-                                // exits from entire function
-                                self.api.send_replica_timeout(self.cur_view).await;
+                                return (consensus, None);
                             }
                         }
-                        return (consensus, None);
                     }
                     ProcessedConsensusMessage::Vote(_, _) => {
                         // should only be for leader, never replica

--- a/types/src/message.rs
+++ b/types/src/message.rs
@@ -54,7 +54,9 @@ impl<
                     Vote::Yes(v) | Vote::No(v) => v.current_view,
                     Vote::Timeout(v) => v.current_view,
                 },
-                ConsensusMessage::NextViewInterrupt(v) => *v,
+                ConsensusMessage::InternalTrigger(trigger) => match trigger {
+                    InternalTrigger::Timeout(v) => *v,
+                },
             },
             MessageKind::Data(DataMessage::SubmitTransaction(_, v)) => *v,
         }

--- a/types/src/message.rs
+++ b/types/src/message.rs
@@ -87,8 +87,9 @@ pub enum Vote<TYPES: NodeType, LEAF: LeafType<NodeType = TYPES>> {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 #[serde(bound(deserialize = ""))]
 pub enum InternalTrigger<TYPES: NodeType> {
+    // May add other triggers if necessary.
     /// Internal timeout at the specified view number.
-    Timeout(TYPES::Time), // May add other triggers if necessary.
+    Timeout(TYPES::Time),
 }
 
 /// a processed consensus message
@@ -103,7 +104,7 @@ pub enum ProcessedConsensusMessage<
     Proposal(Proposal<PROPOSAL>, TYPES::SignatureKey),
     /// Replica's vote on a proposal.
     Vote(Vote<TYPES, LEAF>, TYPES::SignatureKey),
-    /// Internal ONLY message indicating an view interrupt.
+    /// Internal ONLY message indicating a view interrupt.
     #[serde(skip)]
     InternalTrigger(InternalTrigger<TYPES>),
 }
@@ -156,9 +157,7 @@ pub enum ConsensusMessage<
     Proposal(Proposal<PROPOSAL>),
     /// Replica's vote on a proposal.
     Vote(Vote<TYPES, LEAF>),
-    /// Internal ONLY message indicating a NextView interrupt
-    /// View number this nextview interrupt was generated for
-    /// used so we ignore stale nextview interrupts within a task
+    /// Internal ONLY message indicating a view interrupt.
     #[serde(skip)]
     InternalTrigger(InternalTrigger<TYPES>),
 }

--- a/types/src/message.rs
+++ b/types/src/message.rs
@@ -83,6 +83,14 @@ pub enum Vote<TYPES: NodeType, LEAF: LeafType<NodeType = TYPES>> {
     Timeout(TimeoutVote<TYPES, LEAF>),
 }
 
+/// Internal triggers sent by consensus messages.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[serde(bound(deserialize = ""))]
+pub enum InternalTrigger<TYPES: NodeType> {
+    /// Internal timeout at the specified view number.
+    Timeout(TYPES::Time), // May add other triggers if necessary.
+}
+
 /// a processed consensus message
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 #[serde(bound(deserialize = ""))]
@@ -95,11 +103,9 @@ pub enum ProcessedConsensusMessage<
     Proposal(Proposal<PROPOSAL>, TYPES::SignatureKey),
     /// Replica's vote on a proposal.
     Vote(Vote<TYPES, LEAF>, TYPES::SignatureKey),
-    /// Internal ONLY message indicating a NextView interrupt
-    /// View number this nextview interrupt was generated for
-    /// used so we ignore stale nextview interrupts within a task
+    /// Internal ONLY message indicating an view interrupt.
     #[serde(skip)]
-    NextViewInterrupt(TYPES::Time),
+    InternalTrigger(InternalTrigger<TYPES>),
 }
 
 impl<
@@ -114,9 +120,7 @@ impl<
         match value {
             ProcessedConsensusMessage::Proposal(p, _) => ConsensusMessage::Proposal(p),
             ProcessedConsensusMessage::Vote(v, _) => ConsensusMessage::Vote(v),
-            ProcessedConsensusMessage::NextViewInterrupt(a) => {
-                ConsensusMessage::NextViewInterrupt(a)
-            }
+            ProcessedConsensusMessage::InternalTrigger(a) => ConsensusMessage::InternalTrigger(a),
         }
     }
 }
@@ -135,9 +139,7 @@ impl<
         match value {
             ConsensusMessage::Proposal(p) => ProcessedConsensusMessage::Proposal(p, sender),
             ConsensusMessage::Vote(v) => ProcessedConsensusMessage::Vote(v, sender),
-            ConsensusMessage::NextViewInterrupt(a) => {
-                ProcessedConsensusMessage::NextViewInterrupt(a)
-            }
+            ConsensusMessage::InternalTrigger(a) => ProcessedConsensusMessage::InternalTrigger(a),
         }
     }
 }
@@ -158,7 +160,7 @@ pub enum ConsensusMessage<
     /// View number this nextview interrupt was generated for
     /// used so we ignore stale nextview interrupts within a task
     #[serde(skip)]
-    NextViewInterrupt(TYPES::Time),
+    InternalTrigger(InternalTrigger<TYPES>),
 }
 
 impl<
@@ -181,7 +183,9 @@ impl<
                 Vote::Yes(v) | Vote::No(v) => v.current_view,
                 Vote::Timeout(v) => v.current_view,
             },
-            ConsensusMessage::NextViewInterrupt(time) => *time,
+            ConsensusMessage::InternalTrigger(trigger) => match trigger {
+                InternalTrigger::Timeout(time) => *time,
+            },
         }
     }
 }


### PR DESCRIPTION
Adds `InternalTrigger` enum and replaces `NextViewInterrupt` with it.

Closes https://github.com/EspressoSystems/HotShot/issues/874.