### PR TITLE
Spawn `run_view` tasks async and tie together them at the end

### DIFF
--- a/consensus/src/da_leader.rs
+++ b/consensus/src/da_leader.rs
@@ -342,7 +342,6 @@ impl<
             );
         if let Err(e) = self.api.send_da_broadcast(message.clone()).await {
             warn!(?message, ?e, "Could not broadcast leader proposal");
-            return self.high_qc;
         }
         self.high_qc
     }

--- a/consensus/src/da_member.rs
+++ b/consensus/src/da_member.rs
@@ -193,7 +193,7 @@ impl<
 
     /// Run one view of DA committee member.
     #[instrument(skip(self), fields(id = self.id, view = *self.cur_view), name = "DA Member Task", level = "error")]
-    pub async fn run_view(self) {
+    pub async fn run_view(self) -> QuorumCertificate<TYPES, DALeaf<TYPES>> {
         info!("DA Committee Member task started!");
         let view_leader_key = self.api.get_leader(self.cur_view).await;
 
@@ -201,7 +201,7 @@ impl<
 
         let Some(leaf) = maybe_leaf else {
             // We either timed out or for some reason could not accept a proposal.
-            return;
+            return self.high_qc;
         };
 
         // Update state map and leaves.
@@ -221,5 +221,6 @@ impl<
         if let Err(e) = self.api.store_leaf(self.cur_view, leaf).await {
             error!("Could not insert new anchor into the storage API: {:?}", e);
         }
+        self.high_qc
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -987,7 +987,9 @@ impl<
             high_qc: high_qc.clone(),
             api: c_api.clone(),
         };
-        async_spawn(async move { da_member.run_view() });
+        let member_handle = async_spawn(async move { da_member.run_view().await });
+        task_handles.push(member_handle);
+
         let _da_replica = {};
         // TODO: ADD DA replica task handle and push it to `task_handles`.
 
@@ -995,7 +997,6 @@ impl<
 
         async_spawn({
             let next_view_timeout = hotshot.inner.config.next_view_timeout;
-            let next_view_timeout = next_view_timeout;
             let hotshot: HotShot<TYPES::ConsensusType, TYPES, I> = hotshot.clone();
             async move {
                 async_sleep(Duration::from_millis(next_view_timeout)).await;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -292,6 +292,29 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> HotShot<TYPES::ConsensusType
         };
     }
 
+    /// Marks a given view number as timed out. This should be called a fixed period after a round is started.
+    ///
+    /// If the round has already ended then this function will essentially be a no-op. Otherwise `run_round` will return shortly after this function is called.
+    /// # Panics
+    /// Panics if the current view is not in the channel map
+    #[instrument(
+        skip_all,
+        fields(id = self.id, view = *current_view),
+        name = "Timeout consensus tasks",
+        level = "warn"
+    )]
+    pub async fn timeout_view_da_tasks<Proposal: ProposalType<NodeType = TYPES>>(
+        &self,
+        current_view: TYPES::Time,
+        send_da_member: UnboundedSender<ProcessedConsensusMessage<TYPES, I::Leaf, Proposal>>,
+    ) {
+        let msg =
+            ProcessedConsensusMessage::<TYPES, I::Leaf, Proposal>::NextViewInterrupt(current_view);
+        if send_da_member.send(msg).await.is_err() {
+            warn!("Error timing out da member");
+        };
+    }
+
     /// Publishes a transaction to the network
     ///
     /// # Errors
@@ -857,11 +880,15 @@ impl<
     > ViewRunner<TYPES, I> for HotShot<SequencingConsensus, TYPES, I>
 {
     // #[instrument]
+    #[allow(clippy::too_many_lines)]
     async fn run_view(hotshot: HotShot<SequencingConsensus, TYPES, I>) -> Result<(), ()> {
         let c_api = HotShotConsensusApi {
             inner: hotshot.inner.clone(),
         };
-        let send_to_next_leader = hotshot.next_leader_channel_map.write().await;
+        let mut send_to_next_leader = hotshot.next_leader_channel_map.write().await;
+        let leader_last_view: TYPES::Time = send_to_next_leader.cur_view;
+        send_to_next_leader.channel_map.remove(&leader_last_view);
+        send_to_next_leader.cur_view += 1;
         let (_send_da_vote_chan, recv_da_vote, cur_view) = {
             let mut consensus = hotshot.hotstuff.write().await;
             let cur_view = consensus.increment_view();
@@ -873,7 +900,7 @@ impl<
             (vq.sender_chan, vq.receiver_chan, cur_view)
         };
         let send_to_next_leader = hotshot.next_leader_channel_map.write().await;
-        let (_send_commitment_vote_chan, recv_commitment_vote_chan) = {
+        let (send_commitment_vote_chan, recv_commitment_vote_chan) = {
             let vq = HotShot::<SequencingConsensus, TYPES, I>::create_or_obtain_chan_from_write(
                 cur_view + 1,
                 send_to_next_leader,
@@ -881,6 +908,7 @@ impl<
             .await;
             (vq.sender_chan, vq.receiver_chan)
         };
+
         let (high_qc, txns) = {
             // OBTAIN read lock on consensus
             let consensus = hotshot.hotstuff.read().await;
@@ -893,7 +921,7 @@ impl<
         send_to_member.channel_map.remove(&member_last_view);
         send_to_member.cur_view += 1;
         let ViewQueue {
-            sender_chan: _,
+            sender_chan: send_member,
             receiver_chan: recv_member,
             has_received_proposal: _,
         } = HotShot::<SequencingConsensus, TYPES, I>::create_or_obtain_chan_from_write(
@@ -901,6 +929,9 @@ impl<
             send_to_member,
         )
         .await;
+
+        let mut task_handles = Vec::new();
+
         if c_api.is_leader(cur_view).await {
             let da_leader = DALeader {
                 id: hotshot.id,
@@ -912,22 +943,28 @@ impl<
                 vote_collection_chan: recv_da_vote,
                 _pd: PhantomData,
             };
-            let Some((da_cert, block, parent)) = da_leader.run_view().await else {
-                    return Ok(());
+            let hotstuff = hotshot.hotstuff.clone();
+            let qc = high_qc.clone();
+            let api = c_api.clone();
+            let leader_handle = async_spawn(async move {
+                let Some((da_cert, block, parent)) = da_leader.run_view().await else {
+                    return qc;
                 };
 
-            let consensus_leader = DAConsensusLeader {
-                id: hotshot.id,
-                consensus: hotshot.hotstuff.clone(),
-                high_qc: high_qc.clone(),
-                cert: da_cert,
-                block,
-                parent,
-                cur_view,
-                api: c_api.clone(),
-                _pd: PhantomData,
-            };
-            let _qc = consensus_leader.run_view().await;
+                let consensus_leader = DAConsensusLeader {
+                    id: hotshot.id,
+                    consensus: hotstuff,
+                    high_qc: qc,
+                    cert: da_cert,
+                    block,
+                    parent,
+                    cur_view,
+                    api: api.clone(),
+                    _pd: PhantomData,
+                };
+                consensus_leader.run_view().await
+            });
+            task_handles.push(leader_handle);
         }
         if c_api.is_leader(cur_view + 1).await {
             let next_leader = DANextLeader {
@@ -939,7 +976,8 @@ impl<
                 vote_collection_chan: recv_commitment_vote_chan,
                 _pd: PhantomData,
             };
-            let _new_qc = next_leader.run_view();
+            let next_leader_handle = async_spawn(async move { next_leader.run_view().await });
+            task_handles.push(next_leader_handle);
         }
         let da_member = DAMember {
             id: hotshot.id,
@@ -949,11 +987,45 @@ impl<
             high_qc: high_qc.clone(),
             api: c_api.clone(),
         };
-        let _ = da_member.run_view().await;
+        async_spawn(async move { da_member.run_view() });
         let _da_replica = {};
-        // TODO tie all the tasks together and do correct book keeping.
-        #[allow(deprecated)]
-        nll_todo()
+        // TODO: ADD DA replica task handle and push it to `task_handles`.
+
+        let children_finished = futures::future::join_all(task_handles);
+
+        async_spawn({
+            let next_view_timeout = hotshot.inner.config.next_view_timeout;
+            let next_view_timeout = next_view_timeout;
+            let hotshot: HotShot<TYPES::ConsensusType, TYPES, I> = hotshot.clone();
+            async move {
+                async_sleep(Duration::from_millis(next_view_timeout)).await;
+                hotshot
+                    .timeout_view(cur_view, send_member, Some(send_commitment_vote_chan))
+                    .await;
+                // TODO(da): When we have the replica channel send timeout to it and the DA leader.
+                // hotshot.timeout_da_view(curr_view, send_replica).await
+            }
+        });
+
+        let results = children_finished.await;
+
+        // unwrap is fine since results must have >= 1 item(s)
+        #[cfg(feature = "async-std-executor")]
+        let high_qc = results
+            .into_iter()
+            .max_by_key(|qc: &ELECTION::QuorumCertificate| qc.view_number)
+            .unwrap();
+        #[cfg(feature = "tokio-executor")]
+        let high_qc = results
+            .into_iter()
+            .filter_map(std::result::Result::ok)
+            .max_by_key(|qc| qc.view_number)
+            .unwrap();
+
+        let mut consensus = hotshot.hotstuff.write().await;
+        consensus.high_qc = high_qc;
+        c_api.send_view_finished(consensus.cur_view).await;
+        Ok(())
     }
 }
 

--- a/types/src/traits/election.rs
+++ b/types/src/traits/election.rs
@@ -53,7 +53,6 @@ pub enum Checked<T> {
 
 /// Data to vote on for different types of votes.
 #[derive(Serialize)]
-// TODO (da) : LEAF type should just be changed to a commitment and bounded by Commitable
 pub enum VoteData<TYPES: NodeType, LEAF: LeafType> {
     DA(Commitment<TYPES::BlockType>),
     Yes(Commitment<LEAF>),

--- a/types/src/traits/election.rs
+++ b/types/src/traits/election.rs
@@ -53,6 +53,7 @@ pub enum Checked<T> {
 
 /// Data to vote on for different types of votes.
 #[derive(Serialize)]
+// TODO (da) : LEAF type should just be changed to a commitment and bounded by Commitable
 pub enum VoteData<TYPES: NodeType, LEAF: LeafType> {
     DA(Commitment<TYPES::BlockType>),
     Yes(Commitment<LEAF>),


### PR DESCRIPTION
This does a few things each is pretty small/simple:

- Collect all the run views in tasks_handles and join them
- Update HighQC and return properly at the end of run view
- Add a new timeout function for DA with generic proposal type to be used later
- GC old leader channels

I also notice a few things still left todo and made comments on them.  The biggest one is the same issue Keyao ran into where the channel map is generic over just one proposal type.  So right now the next leader has the wrong type of channel and is collecting votes for DAProposal (which it shouldn't get) .  Fortunately the logic doesn't really change and we just need to update the type.

Closes: https://github.com/EspressoSystems/HotShot/issues/884