### PR TITLE
Add sequencing demo

### DIFF
--- a/examples/centralized.rs
+++ b/examples/centralized.rs
@@ -1,6 +1,6 @@
 use clap::Parser;
 use hotshot::{
-    demos::dentry::{DEntryNode, DEntryTypes},
+    demos::vdemo::{VDemoNode, VDemoTypes},
     traits::{
         election::static_committee::GeneralStaticCommittee, implementations::CentralizedCommChannel,
     },
@@ -16,13 +16,13 @@ use crate::infra::{main_entry_point, CliOrchestrated};
 
 pub mod infra;
 
-type ThisLeaf = ValidatingLeaf<DEntryTypes>;
+type ThisLeaf = ValidatingLeaf<VDemoTypes>;
 type ThisElection =
-    GeneralStaticCommittee<DEntryTypes, ThisLeaf, <DEntryTypes as NodeType>::SignatureKey>;
-type ThisNetwork = CentralizedCommChannel<DEntryTypes, ThisLeaf, ThisProposal, ThisElection>;
-type ThisProposal = ValidatingProposal<DEntryTypes, ThisElection>;
-type ThisNode = DEntryNode<ThisNetwork, ThisElection>;
-type ThisConfig = CentralizedConfig<DEntryTypes, ThisElection>;
+    GeneralStaticCommittee<VDemoTypes, ThisLeaf, <VDemoTypes as NodeType>::SignatureKey>;
+type ThisNetwork = CentralizedCommChannel<VDemoTypes, ThisLeaf, ThisProposal, ThisElection>;
+type ThisProposal = ValidatingProposal<VDemoTypes, ThisElection>;
+type ThisNode = VDemoNode<ThisNetwork, ThisElection>;
+type ThisConfig = CentralizedConfig<VDemoTypes, ThisElection>;
 
 #[cfg_attr(
     feature = "tokio-executor",
@@ -33,5 +33,5 @@ type ThisConfig = CentralizedConfig<DEntryTypes, ThisElection>;
 async fn main() {
     let args = CliOrchestrated::parse();
 
-    main_entry_point::<DEntryTypes, ThisElection, ThisNetwork, ThisNode, ThisConfig>(args).await;
+    main_entry_point::<VDemoTypes, ThisElection, ThisNetwork, ThisNode, ThisConfig>(args).await;
 }

--- a/examples/infra/mod.rs
+++ b/examples/infra/mod.rs
@@ -17,7 +17,7 @@ use async_lock::RwLock;
 use async_trait::async_trait;
 use clap::Parser;
 use hotshot::{
-    demos::dentry::DEntryTypes,
+    demos::vdemo::VDemoTypes,
     traits::{
         implementations::{
             CentralizedCommChannel, CentralizedServerNetwork, Libp2pCommChannel, Libp2pNetwork,
@@ -160,7 +160,7 @@ where
             .expect("Could not reach server");
         let mut stream = TcpStreamUtil::new(stream);
         stream
-            .send(ToServer::<<DEntryTypes as NodeType>::SignatureKey>::GetConfig)
+            .send(ToServer::<<VDemoTypes as NodeType>::SignatureKey>::GetConfig)
             .await
             .unwrap();
         error!("Waiting for server config...");

--- a/examples/libp2p.rs
+++ b/examples/libp2p.rs
@@ -1,6 +1,6 @@
 use clap::Parser;
-use hotshot::demos::dentry::DEntryNode;
-use hotshot::demos::dentry::DEntryTypes;
+use hotshot::demos::vdemo::VDemoNode;
+use hotshot::demos::vdemo::VDemoTypes;
 use hotshot::traits::election::static_committee::GeneralStaticCommittee;
 use hotshot::traits::implementations::Libp2pCommChannel;
 use hotshot_types::data::ValidatingLeaf;
@@ -14,13 +14,13 @@ use infra::main_entry_point;
 use infra::CliOrchestrated;
 use infra::Libp2pClientConfig;
 
-type ThisLeaf = ValidatingLeaf<DEntryTypes>;
+type ThisLeaf = ValidatingLeaf<VDemoTypes>;
 type ThisElection =
-    GeneralStaticCommittee<DEntryTypes, ThisLeaf, <DEntryTypes as NodeType>::SignatureKey>;
-type ThisNetwork = Libp2pCommChannel<DEntryTypes, ThisLeaf, ThisProposal, ThisElection>;
-type ThisProposal = ValidatingProposal<DEntryTypes, ThisElection>;
-type ThisNode = DEntryNode<ThisNetwork, ThisElection>;
-type ThisConfig = Libp2pClientConfig<DEntryTypes, ThisElection>;
+    GeneralStaticCommittee<VDemoTypes, ThisLeaf, <VDemoTypes as NodeType>::SignatureKey>;
+type ThisNetwork = Libp2pCommChannel<VDemoTypes, ThisLeaf, ThisProposal, ThisElection>;
+type ThisProposal = ValidatingProposal<VDemoTypes, ThisElection>;
+type ThisNode = VDemoNode<ThisNetwork, ThisElection>;
+type ThisConfig = Libp2pClientConfig<VDemoTypes, ThisElection>;
 
 #[cfg_attr(
     feature = "tokio-executor",
@@ -31,5 +31,5 @@ type ThisConfig = Libp2pClientConfig<DEntryTypes, ThisElection>;
 async fn main() {
     let args = CliOrchestrated::parse();
 
-    main_entry_point::<DEntryTypes, ThisElection, ThisNetwork, ThisNode, ThisConfig>(args).await;
+    main_entry_point::<VDemoTypes, ThisElection, ThisNetwork, ThisNode, ThisConfig>(args).await;
 }

--- a/justfile
+++ b/justfile
@@ -24,7 +24,7 @@ test_async_std_all:
 
 test_pkg := "hotshot-testing"
 
-test_name := "ten_tx_seven_nodes"
+test_name := "sequencing_test"
 
 test_async_std_pkg_all pkg=test_pkg:
   cargo test --verbose --release --features=async-std-executor,demo,channel-async-std --lib --bins --tests --benches --package={{pkg}} --no-fail-fast -- --test-threads=1 --nocapture

--- a/src/demos.rs
+++ b/src/demos.rs
@@ -2,4 +2,7 @@
 //!
 //! These implementations are not suitable for production use.
 
-pub mod dentry;
+/// this is a demo for sequencing consensus
+pub mod sdemo;
+/// this is a demo for validating consensus
+pub mod vdemo;

--- a/src/demos/sdemo.rs
+++ b/src/demos/sdemo.rs
@@ -1,3 +1,10 @@
+//! Sequencing consensus demo
+//!
+//! This module provides an implementation of the `HotShot` suite of traits that implements a
+//! basic demonstration of sequencing consensus.
+//!
+//! These implementations are useful in examples and integration testing, but are not suitable for
+//! production use.
 use std::{collections::HashSet, ops::Deref};
 
 use commit::{Commitment, Committable};

--- a/src/demos/sdemo.rs
+++ b/src/demos/sdemo.rs
@@ -1,0 +1,266 @@
+use std::{collections::HashSet, ops::Deref};
+
+use commit::{Commitment, Committable};
+use espresso_systems_common::hotshot::tag;
+use hotshot_types::{
+    data::{fake_commitment, ViewNumber},
+    traits::{
+        block_contents::Transaction,
+        node_implementation::ApplicationMetadata,
+        state::{ConsensusTime, TestableBlock, TestableState, ValidatingConsensus},
+        Block, State,
+    },
+};
+use rand::Rng;
+use serde::{Deserialize, Serialize};
+use snafu::Snafu;
+
+/// The transaction for the sequencing demo
+#[derive(PartialEq, Eq, Hash, Serialize, Deserialize, Clone, Debug)]
+pub struct SDemoTransaction {
+    /// identifier for the transaction
+    pub id: u64,
+    /// padding to add to txn (to make it larger and thereby more realistic)
+    pub padding: Vec<u8>,
+}
+
+impl Deref for SDemoTransaction {
+    type Target = u64;
+
+    fn deref(&self) -> &Self::Target {
+        &self.id
+    }
+}
+
+impl Committable for SDemoTransaction {
+    fn commit(&self) -> Commitment<Self> {
+        commit::RawCommitmentBuilder::new("SDemo Txn Comm")
+            .u64_field("id", self.id)
+            .finalize()
+    }
+
+    fn tag() -> String {
+        tag::DENTRY_TXN.to_string()
+    }
+}
+
+impl Transaction for SDemoTransaction {}
+
+impl SDemoTransaction {
+    /// create a new transaction
+    pub fn new(id: u64) -> Self {
+        Self {
+            id,
+            padding: vec![],
+        }
+    }
+}
+
+/// genesis block
+#[derive(PartialEq, Eq, Hash, Serialize, Deserialize, Clone, Debug)]
+pub struct SDemoGenesisBlock {}
+
+/// Any block after genesis
+#[derive(PartialEq, Eq, Hash, Serialize, Deserialize, Clone, Debug)]
+pub struct SDemoNormalBlock {
+    /// Block state commitment
+    pub previous_state: Commitment<SDemoState>,
+    /// Transaction vector
+    pub transactions: Vec<SDemoTransaction>,
+}
+
+/// The block for the sequencing demo
+#[derive(PartialEq, Eq, Hash, Serialize, Deserialize, Clone, Debug)]
+pub enum SDemoBlock {
+    /// genesis block
+    Genesis(SDemoGenesisBlock),
+    /// normal block
+    Normal(SDemoNormalBlock),
+}
+
+impl Committable for SDemoBlock {
+    fn commit(&self) -> Commitment<Self> {
+        match &self {
+            SDemoBlock::Genesis(_) => {
+                commit::RawCommitmentBuilder::new("SDemo Genesis Comm").finalize()
+            }
+            SDemoBlock::Normal(block) => {
+                let mut builder = commit::RawCommitmentBuilder::new("SDemo Normal Comm")
+                    .var_size_field("Previous State", block.previous_state.as_ref());
+                for txn in &block.transactions {
+                    builder = builder.u64_field("transaction", **txn);
+                }
+                builder.finalize()
+            }
+        }
+    }
+
+    fn tag() -> String {
+        tag::DENTRY_BLOCK.to_string()
+    }
+}
+
+/// sequencing demo entry state
+#[derive(PartialEq, Eq, Hash, Serialize, Deserialize, Clone, Debug)]
+pub struct SDemoState {
+    /// the block height
+    block_height: u64,
+    /// the view number
+    view_number: ViewNumber,
+    /// the previous state commitment
+    prev_state_commitment: Commitment<Self>,
+}
+
+impl Committable for SDemoState {
+    fn commit(&self) -> Commitment<Self> {
+        commit::RawCommitmentBuilder::new("SDemo State Commit")
+            .u64_field("block_height", self.block_height)
+            .u64_field("view_number", *self.view_number)
+            .field("prev_state_commitment", self.prev_state_commitment)
+            .finalize()
+    }
+
+    fn tag() -> String {
+        tag::DENTRY_STATE.to_string()
+    }
+}
+
+/// application metadata stub
+/// FIXME this is deprecated right?
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
+pub struct SDemoMetaData {}
+impl ApplicationMetadata for SDemoMetaData {}
+
+impl Default for SDemoState {
+    fn default() -> Self {
+        Self {
+            block_height: 0,
+            view_number: ViewNumber::genesis(),
+            prev_state_commitment: fake_commitment(),
+        }
+    }
+}
+
+/// The error type for the sequencing demo
+#[derive(Snafu, Debug)]
+pub enum SDemoError {
+    /// Previous state commitment does not match
+    PreviousStateMismatch,
+    /// Nonce was reused
+    ReusedTxn,
+    /// Genesis failure
+    GenesisFailed,
+    /// Genesis reencountered after initialization
+    GenesisAfterStart,
+    /// no transasctions added to genesis
+    GenesisCantHaveTransactions,
+    /// invalid block
+    InvalidBlock,
+}
+
+impl TestableBlock for SDemoBlock {
+    fn genesis() -> Self {
+        SDemoBlock::Genesis(SDemoGenesisBlock {})
+    }
+
+    fn txn_count(&self) -> u64 {
+        match self {
+            SDemoBlock::Genesis(_) => 0,
+            SDemoBlock::Normal(n) => n.transactions.len() as u64,
+        }
+    }
+}
+
+impl Block for SDemoBlock {
+    type Error = SDemoError;
+
+    type Transaction = SDemoTransaction;
+
+    fn new() -> Self {
+        <Self as TestableBlock>::genesis()
+    }
+
+    fn add_transaction_raw(
+        &self,
+        tx: &Self::Transaction,
+    ) -> std::result::Result<Self, Self::Error> {
+        match self {
+            SDemoBlock::Genesis(_) => Err(SDemoError::GenesisCantHaveTransactions),
+            SDemoBlock::Normal(n) => {
+                let mut new = n.clone();
+                new.transactions.push(tx.clone());
+                Ok(SDemoBlock::Normal(new))
+            }
+        }
+    }
+
+    fn contained_transactions(&self) -> HashSet<Commitment<Self::Transaction>> {
+        match self {
+            SDemoBlock::Genesis(_) => HashSet::new(),
+            SDemoBlock::Normal(n) => n
+                .transactions
+                .iter()
+                .map(commit::Committable::commit)
+                .collect(),
+        }
+    }
+}
+
+impl State for SDemoState {
+    type Error = SDemoError;
+
+    type BlockType = SDemoBlock;
+
+    type Time = ViewNumber;
+
+    type ConsensusType = ValidatingConsensus;
+
+    fn next_block(&self) -> Self::BlockType {
+        SDemoBlock::Normal(SDemoNormalBlock {
+            previous_state: self.commit(),
+            transactions: Vec::new(),
+        })
+    }
+
+    fn validate_block(&self, block: &Self::BlockType, view_number: &Self::Time) -> bool {
+        match block {
+            SDemoBlock::Genesis(_) => {
+                view_number > &ViewNumber::genesis() && *view_number > self.view_number
+            }
+            SDemoBlock::Normal(n) => {
+                n.previous_state == self.commit() && self.view_number < *view_number
+            }
+        }
+    }
+
+    fn append(
+        &self,
+        block: &Self::BlockType,
+        view_number: &Self::Time,
+    ) -> Result<Self, Self::Error> {
+        if !self.validate_block(block, view_number) {
+            return Err(SDemoError::InvalidBlock);
+        }
+
+        Ok(SDemoState {
+            block_height: self.block_height + 1,
+            view_number: *view_number,
+            prev_state_commitment: self.commit(),
+        })
+    }
+
+    fn on_commit(&self) {}
+}
+
+impl TestableState for SDemoState {
+    fn create_random_transaction(
+        &self,
+        rng: &mut dyn rand::RngCore,
+        padding: u64,
+    ) -> <Self::BlockType as Block>::Transaction {
+        SDemoTransaction {
+            id: rng.gen_range(0..10),
+            padding: vec![0; padding as usize],
+        }
+    }
+}

--- a/src/demos/sdemo.rs
+++ b/src/demos/sdemo.rs
@@ -8,7 +8,6 @@
 use std::{collections::HashSet, ops::Deref};
 
 use commit::{Commitment, Committable};
-use espresso_systems_common::hotshot::tag;
 use hotshot_types::{
     data::{fake_commitment, ViewNumber},
     traits::{
@@ -47,7 +46,7 @@ impl Committable for SDemoTransaction {
     }
 
     fn tag() -> String {
-        tag::DENTRY_TXN.to_string()
+        "SEQUENCING_DEMO_TXN".to_string()
     }
 }
 
@@ -103,7 +102,7 @@ impl Committable for SDemoBlock {
     }
 
     fn tag() -> String {
-        tag::DENTRY_BLOCK.to_string()
+        "SEQUENCING_DEMO_BLOCK".to_string()
     }
 }
 
@@ -128,7 +127,7 @@ impl Committable for SDemoState {
     }
 
     fn tag() -> String {
-        tag::DENTRY_STATE.to_string()
+        "SEQUENCING_DEMO_STATE".to_string()
     }
 }
 

--- a/src/demos/vdemo.rs
+++ b/src/demos/vdemo.rs
@@ -1,7 +1,7 @@
-//! Double entry accounting demo
+//! Validating (vanilla) consensus demo
 //!
 //! This module provides an implementation of the `HotShot` suite of traits that implements a
-//! basic demonstration of double entry accounting.
+//! basic demonstration of validating consensus.
 //!
 //! These implementations are useful in examples and integration testing, but are not suitable for
 //! production use.

--- a/src/demos/vdemo.rs
+++ b/src/demos/vdemo.rs
@@ -13,7 +13,6 @@ use crate::traits::{
 };
 use commit::{Commitment, Committable};
 use derivative::Derivative;
-use espresso_systems_common::hotshot::tag;
 use hotshot_types::{
     certificate::QuorumCertificate,
     constants::genesis_proposer_id,
@@ -145,7 +144,7 @@ impl Committable for VDemoState {
     }
 
     fn tag() -> String {
-        tag::DENTRY_STATE.to_string()
+        "VALIDATING_DEMO_STATE".to_string()
     }
 }
 
@@ -203,7 +202,7 @@ impl Committable for VDemoBlock {
     }
 
     fn tag() -> String {
-        tag::DENTRY_BLOCK.to_string()
+        "VALIDATING_DEMO_BLOCK".to_string()
     }
 }
 
@@ -218,7 +217,7 @@ impl Committable for VDemoTransaction {
     }
 
     fn tag() -> String {
-        tag::DENTRY_TXN.to_string()
+        "VALIDATING_DEMO_TXN".to_string()
     }
 }
 

--- a/src/demos/vdemo.rs
+++ b/src/demos/vdemo.rs
@@ -40,9 +40,9 @@ use tracing::error;
 
 /// application metadata stub
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
-pub struct DEntryMetaData {}
+pub struct VDemoMetaData {}
 
-impl ApplicationMetadata for DEntryMetaData {}
+impl ApplicationMetadata for VDemoMetaData {}
 
 /// The account identifier type used by the demo
 ///
@@ -72,9 +72,9 @@ pub struct Addition {
     pub amount: Balance,
 }
 
-/// The error type for the dentry demo
+/// The error type for the validating demo
 #[derive(Snafu, Debug)]
-pub enum DEntryError {
+pub enum VDemoError {
     /// The subtraction and addition amounts for this transaction were not equal
     InconsistentTransaction,
     /// No such input account exists
@@ -93,9 +93,9 @@ pub enum DEntryError {
     GenesisAfterStart,
 }
 
-/// The transaction for the dentry demo
+/// The transaction for the validating demo
 #[derive(PartialEq, Eq, Hash, Serialize, Deserialize, Clone, Debug)]
-pub struct DEntryTransaction {
+pub struct VDemoTransaction {
     /// An increment to an account balance
     pub add: Addition,
     /// A decrement to an account balance
@@ -106,9 +106,9 @@ pub struct DEntryTransaction {
     pub padding: Vec<u8>,
 }
 
-impl Transaction for DEntryTransaction {}
+impl Transaction for VDemoTransaction {}
 
-impl DEntryTransaction {
+impl VDemoTransaction {
     /// Ensures that this transaction is at least consistent with itself
     pub fn validate_independence(&self) -> bool {
         // Ensure that we are adding to one account exactly as much as we are subtracting from
@@ -117,20 +117,20 @@ impl DEntryTransaction {
     }
 }
 
-/// The state for the dentry demo
+/// The state for the validating demo
 /// NOTE both fields are btrees because we need
 /// ordered-ing otherwise commitments will not match
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize, Hash)]
-pub struct DEntryState {
+pub struct VDemoState {
     /// Key/value store of accounts and balances
     pub balances: BTreeMap<Account, Balance>,
     // /// Set of previously seen nonces
     // pub nonces: BTreeSet<u64>,
 }
 
-impl Committable for DEntryState {
+impl Committable for VDemoState {
     fn commit(&self) -> Commitment<Self> {
-        let mut builder = commit::RawCommitmentBuilder::new("DEntry State Comm");
+        let mut builder = commit::RawCommitmentBuilder::new("VDemo State Comm");
 
         for (k, v) in &self.balances {
             builder = builder.u64_field(k, *v);
@@ -151,42 +151,42 @@ impl Committable for DEntryState {
 
 /// initializes the first state on genesis
 #[derive(PartialEq, Eq, Hash, Serialize, Deserialize, Clone, Debug)]
-pub struct DEntryGenesisBlock {
+pub struct VDemoGenesisBlock {
     /// initializes the first state
     pub accounts: BTreeMap<Account, Balance>,
 }
 
 /// Any block after genesis
 #[derive(PartialEq, Eq, Hash, Serialize, Deserialize, Clone, Debug)]
-pub struct DEntryNormalBlock {
+pub struct VDemoNormalBlock {
     /// Block state commitment
-    pub previous_state: Commitment<DEntryState>,
+    pub previous_state: Commitment<VDemoState>,
     /// Transaction vector
-    pub transactions: Vec<DEntryTransaction>,
+    pub transactions: Vec<VDemoTransaction>,
 }
 
-/// The block for the dentry demo
+/// The block for the validating demo
 #[derive(PartialEq, Eq, Hash, Serialize, Deserialize, Clone, Debug)]
-pub enum DEntryBlock {
+pub enum VDemoBlock {
     /// genesis block
-    Genesis(DEntryGenesisBlock),
+    Genesis(VDemoGenesisBlock),
     /// normal block
-    Normal(DEntryNormalBlock),
+    Normal(VDemoNormalBlock),
 }
 
-impl Committable for DEntryBlock {
+impl Committable for VDemoBlock {
     fn commit(&self) -> Commitment<Self> {
         match &self {
-            DEntryBlock::Genesis(block) => {
-                let mut builder = commit::RawCommitmentBuilder::new("DEntry Genesis Comm")
+            VDemoBlock::Genesis(block) => {
+                let mut builder = commit::RawCommitmentBuilder::new("VDemo Genesis Comm")
                     .u64_field("account_count", block.accounts.len() as u64);
                 for account in &block.accounts {
                     builder = builder.u64_field(account.0, *account.1);
                 }
                 builder.finalize()
             }
-            DEntryBlock::Normal(block) => {
-                let mut builder = commit::RawCommitmentBuilder::new("DEntry Block Comm")
+            VDemoBlock::Normal(block) => {
+                let mut builder = commit::RawCommitmentBuilder::new("VDemo Block Comm")
                     .var_size_field("Previous State", block.previous_state.as_ref());
 
                 for txn in &block.transactions {
@@ -207,9 +207,9 @@ impl Committable for DEntryBlock {
     }
 }
 
-impl Committable for DEntryTransaction {
+impl Committable for VDemoTransaction {
     fn commit(&self) -> Commitment<Self> {
-        commit::RawCommitmentBuilder::new("DEntry Txn Comm")
+        commit::RawCommitmentBuilder::new("VDemo Txn Comm")
             .u64_field(&self.add.account, self.add.amount)
             .u64_field(&self.sub.account, self.sub.amount)
             .constant_str("nonce")
@@ -222,24 +222,24 @@ impl Committable for DEntryTransaction {
     }
 }
 
-impl DEntryBlock {
+impl VDemoBlock {
     /// generate a genesis block with the provided initial accounts and balances
     pub fn genesis_from(accounts: BTreeMap<Account, Balance>) -> Self {
-        Self::Genesis(DEntryGenesisBlock { accounts })
+        Self::Genesis(VDemoGenesisBlock { accounts })
     }
 }
 
-impl State for DEntryState {
-    type Error = DEntryError;
+impl State for VDemoState {
+    type Error = VDemoError;
 
-    type BlockType = DEntryBlock;
+    type BlockType = VDemoBlock;
 
     type Time = ViewNumber;
 
     type ConsensusType = ValidatingConsensus;
 
     fn next_block(&self) -> Self::BlockType {
-        DEntryBlock::Normal(DEntryNormalBlock {
+        VDemoBlock::Normal(VDemoNormalBlock {
             previous_state: self.commit(),
             transactions: Vec::new(),
         })
@@ -249,8 +249,8 @@ impl State for DEntryState {
     // for clarity, the logic is duplicated with append_to
     fn validate_block(&self, block: &Self::BlockType, _view_number: &Self::Time) -> bool {
         match block {
-            DEntryBlock::Genesis(_) => self.balances.is_empty(), //  && self.nonces.is_empty(),
-            DEntryBlock::Normal(block) => {
+            VDemoBlock::Genesis(_) => self.balances.is_empty(), //  && self.nonces.is_empty(),
+            VDemoBlock::Normal(block) => {
                 let state = self;
                 // A valid block is one in which every transaction is internally consistent, and results in
                 // nobody having a negative balance
@@ -310,7 +310,7 @@ impl State for DEntryState {
         _view_number: &Self::Time,
     ) -> std::result::Result<Self, Self::Error> {
         match block {
-            DEntryBlock::Genesis(block) => {
+            VDemoBlock::Genesis(block) => {
                 if self.balances.is_empty() {
                     // && self.nonces.is_empty()
                     let mut new_state = Self::default();
@@ -321,15 +321,15 @@ impl State for DEntryState {
                             .is_some()
                         {
                             error!("Adding the same account twice during application of genesis block!");
-                            return Err(DEntryError::GenesisFailed);
+                            return Err(VDemoError::GenesisFailed);
                         }
                     }
                     Ok(new_state)
                 } else {
-                    Err(DEntryError::GenesisAfterStart)
+                    Err(VDemoError::GenesisAfterStart)
                 }
             }
-            DEntryBlock::Normal(block) => {
+            VDemoBlock::Normal(block) => {
                 let state = self;
                 // A valid block is one in which every transaction is internally consistent, and results in
                 // nobody having a negative balance
@@ -348,18 +348,18 @@ impl State for DEntryState {
                     if let Some(input_account) = trial_balances.get_mut(&tx.sub.account) {
                         *input_account -= tx.sub.amount;
                     } else {
-                        return Err(DEntryError::NoSuchInputAccount);
+                        return Err(VDemoError::NoSuchInputAccount);
                     }
                     // Find the output account, and add the transfer balance to it, failing if it doesn't
                     // exist
                     if let Some(output_account) = trial_balances.get_mut(&tx.add.account) {
                         *output_account += tx.add.amount;
                     } else {
-                        return Err(DEntryError::NoSuchOutputAccount);
+                        return Err(VDemoError::NoSuchOutputAccount);
                     }
                     // // Check for nonce reuse
                     // if state.nonces.contains(&tx.nonce) {
-                    //     return Err(DEntryError::ReusedNonce);
+                    //     return Err(VDemoError::ReusedNonce);
                     // }
                 }
                 // Make sure our previous state commitment matches the provided state
@@ -370,12 +370,12 @@ impl State for DEntryState {
                     // for tx in &block.transactions {
                     //     nonces.insert(tx.nonce);
                     // }
-                    Ok(DEntryState {
+                    Ok(VDemoState {
                         balances: trial_balances,
                         // nonces,
                     })
                 } else {
-                    Err(DEntryError::PreviousStateMismatch)
+                    Err(VDemoError::PreviousStateMismatch)
                 }
             }
         }
@@ -386,7 +386,7 @@ impl State for DEntryState {
     }
 }
 
-impl TestableState for DEntryState {
+impl TestableState for VDemoState {
     fn create_random_transaction(
         &self,
         rng: &mut dyn rand::RngCore,
@@ -409,7 +409,7 @@ impl TestableState for DEntryState {
         let output_account = self.balances.keys().choose(rng).unwrap();
         let amount = rng.gen_range(0..100);
 
-        DEntryTransaction {
+        VDemoTransaction {
             add: Addition {
                 account: output_account.to_string(),
                 amount,
@@ -424,7 +424,7 @@ impl TestableState for DEntryState {
     }
 }
 
-impl TestableBlock for DEntryBlock {
+impl TestableBlock for VDemoBlock {
     fn genesis() -> Self {
         let accounts: BTreeMap<Account, Balance> = vec![
             ("Joe", 1_000_000),
@@ -436,11 +436,11 @@ impl TestableBlock for DEntryBlock {
         .into_iter()
         .map(|(x, y)| (x.to_string(), y))
         .collect();
-        Self::Genesis(DEntryGenesisBlock { accounts })
+        Self::Genesis(VDemoGenesisBlock { accounts })
     }
 
     fn txn_count(&self) -> u64 {
-        if let DEntryBlock::Normal(block) = self {
+        if let VDemoBlock::Normal(block) = self {
             block.transactions.len() as u64
         } else {
             0
@@ -448,10 +448,10 @@ impl TestableBlock for DEntryBlock {
     }
 }
 
-impl Block for DEntryBlock {
-    type Transaction = DEntryTransaction;
+impl Block for VDemoBlock {
+    type Transaction = VDemoTransaction;
 
-    type Error = DEntryError;
+    type Error = VDemoError;
 
     fn new() -> Self {
         <Self as TestableBlock>::genesis()
@@ -462,28 +462,28 @@ impl Block for DEntryBlock {
         tx: &Self::Transaction,
     ) -> std::result::Result<Self, Self::Error> {
         match self {
-            DEntryBlock::Genesis(_) => Err(DEntryError::GenesisAfterStart),
-            DEntryBlock::Normal(block) => {
+            VDemoBlock::Genesis(_) => Err(VDemoError::GenesisAfterStart),
+            VDemoBlock::Normal(block) => {
                 // first, make sure that the transaction is internally valid
                 if tx.validate_independence() {
                     // Then check the previous transactions in the block
                     if block.transactions.iter().any(|x| x.nonce == tx.nonce) {
-                        return Err(DEntryError::ReusedNonce);
+                        return Err(VDemoError::ReusedNonce);
                     }
                     let mut new_block = block.clone();
                     // Insert our transaction and return
                     new_block.transactions.push(tx.clone());
-                    Ok(DEntryBlock::Normal(new_block))
+                    Ok(VDemoBlock::Normal(new_block))
                 } else {
-                    Err(DEntryError::InconsistentTransaction)
+                    Err(VDemoError::InconsistentTransaction)
                 }
             }
         }
     }
-    fn contained_transactions(&self) -> HashSet<Commitment<DEntryTransaction>> {
+    fn contained_transactions(&self) -> HashSet<Commitment<VDemoTransaction>> {
         match self {
-            DEntryBlock::Genesis(_) => HashSet::new(),
-            DEntryBlock::Normal(block) => block
+            VDemoBlock::Genesis(_) => HashSet::new(),
+            VDemoBlock::Normal(block) => block
                 .transactions
                 .clone()
                 .into_iter()
@@ -493,7 +493,7 @@ impl Block for DEntryBlock {
     }
 }
 
-/// Implementation of [`NodeType`] for [`DEntryNode`]
+/// Implementation of [`NodeType`] for [`VDemoNode`]
 #[derive(
     Copy,
     Clone,
@@ -507,96 +507,96 @@ impl Block for DEntryBlock {
     serde::Serialize,
     serde::Deserialize,
 )]
-pub struct DEntryTypes;
+pub struct VDemoTypes;
 
-impl NodeType for DEntryTypes {
+impl NodeType for VDemoTypes {
     type ConsensusType = ValidatingConsensus;
     type Time = ViewNumber;
-    type BlockType = DEntryBlock;
+    type BlockType = VDemoBlock;
     type SignatureKey = Ed25519Pub;
     type VoteTokenType = StaticVoteToken<Self::SignatureKey>;
-    type Transaction = DEntryTransaction;
+    type Transaction = VDemoTransaction;
     type ElectionConfigType = StaticElectionConfig;
-    type StateType = DEntryState;
-    type ApplicationMetadataType = DEntryMetaData;
+    type StateType = VDemoState;
+    type ApplicationMetadataType = VDemoMetaData;
 }
 
-/// The node implementation for the dentry demo
+/// The node implementation for the validating demo
 #[derive(Derivative)]
 #[derivative(Clone(bound = ""))]
-pub struct DEntryNode<NET, ELE>(PhantomData<NET>, PhantomData<ELE>)
+pub struct VDemoNode<NET, ELE>(PhantomData<NET>, PhantomData<ELE>)
 where
     NET: CommunicationChannel<
-        DEntryTypes,
-        ValidatingLeaf<DEntryTypes>,
-        ValidatingProposal<DEntryTypes, ELE>,
+        VDemoTypes,
+        ValidatingLeaf<VDemoTypes>,
+        ValidatingProposal<VDemoTypes, ELE>,
         ELE,
     >,
-    ELE: Election<DEntryTypes, LeafType = ValidatingLeaf<DEntryTypes>>;
+    ELE: Election<VDemoTypes, LeafType = ValidatingLeaf<VDemoTypes>>;
 
-impl<NET, ELE> DEntryNode<NET, ELE>
+impl<NET, ELE> VDemoNode<NET, ELE>
 where
     NET: CommunicationChannel<
-        DEntryTypes,
-        ValidatingLeaf<DEntryTypes>,
-        ValidatingProposal<DEntryTypes, ELE>,
+        VDemoTypes,
+        ValidatingLeaf<VDemoTypes>,
+        ValidatingProposal<VDemoTypes, ELE>,
         ELE,
     >,
-    ELE: Election<DEntryTypes, LeafType = ValidatingLeaf<DEntryTypes>>,
+    ELE: Election<VDemoTypes, LeafType = ValidatingLeaf<VDemoTypes>>,
 {
-    /// Create a new `DEntryNode`
+    /// Create a new `VDemoNode`
     pub fn new() -> Self {
-        DEntryNode(PhantomData, PhantomData)
+        VDemoNode(PhantomData, PhantomData)
     }
 }
 
-impl<NET, ELE> Debug for DEntryNode<NET, ELE>
+impl<NET, ELE> Debug for VDemoNode<NET, ELE>
 where
     NET: CommunicationChannel<
-        DEntryTypes,
-        ValidatingLeaf<DEntryTypes>,
-        ValidatingProposal<DEntryTypes, ELE>,
+        VDemoTypes,
+        ValidatingLeaf<VDemoTypes>,
+        ValidatingProposal<VDemoTypes, ELE>,
         ELE,
     >,
-    ELE: Election<DEntryTypes, LeafType = ValidatingLeaf<DEntryTypes>>,
+    ELE: Election<VDemoTypes, LeafType = ValidatingLeaf<VDemoTypes>>,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("DEntryNode")
+        f.debug_struct("VDemoNode")
             .field("_phantom", &"phantom")
             .finish()
     }
 }
 
-impl<NET, ELE> Default for DEntryNode<NET, ELE>
+impl<NET, ELE> Default for VDemoNode<NET, ELE>
 where
     NET: CommunicationChannel<
-        DEntryTypes,
-        ValidatingLeaf<DEntryTypes>,
-        ValidatingProposal<DEntryTypes, ELE>,
+        VDemoTypes,
+        ValidatingLeaf<VDemoTypes>,
+        ValidatingProposal<VDemoTypes, ELE>,
         ELE,
     >,
-    ELE: Election<DEntryTypes, LeafType = ValidatingLeaf<DEntryTypes>>,
+    ELE: Election<VDemoTypes, LeafType = ValidatingLeaf<VDemoTypes>>,
 {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<NET, ELE> NodeImplementation<DEntryTypes> for DEntryNode<NET, ELE>
+impl<NET, ELE> NodeImplementation<VDemoTypes> for VDemoNode<NET, ELE>
 where
     NET: CommunicationChannel<
-        DEntryTypes,
-        ValidatingLeaf<DEntryTypes>,
-        ValidatingProposal<DEntryTypes, ELE>,
+        VDemoTypes,
+        ValidatingLeaf<VDemoTypes>,
+        ValidatingProposal<VDemoTypes, ELE>,
         ELE,
     >,
-    ELE: Election<DEntryTypes, LeafType = ValidatingLeaf<DEntryTypes>> + Debug,
+    ELE: Election<VDemoTypes, LeafType = ValidatingLeaf<VDemoTypes>> + Debug,
 {
-    type Leaf = ValidatingLeaf<DEntryTypes>;
-    type Storage = MemoryStorage<DEntryTypes, ELE::LeafType>;
+    type Leaf = ValidatingLeaf<VDemoTypes>;
+    type Storage = MemoryStorage<VDemoTypes, ELE::LeafType>;
     type Networking = NET;
     type Election = ELE;
-    type Proposal = ValidatingProposal<DEntryTypes, ELE>;
+    type Proposal = ValidatingProposal<VDemoTypes, ELE>;
 }
 
 /// Provides a random [`QuorumCertificate`]

--- a/src/traits/networking/memory_network.rs
+++ b/src/traits/networking/memory_network.rs
@@ -511,7 +511,7 @@ impl<
 mod tests {
     use super::*;
     use crate::{
-        demos::dentry::{Addition, DEntryBlock, DEntryState, DEntryTransaction, Subtraction},
+        demos::vdemo::{Addition, Subtraction, VDemoBlock, VDemoState, VDemoTransaction},
         traits::election::static_committee::{
             GeneralStaticCommittee, StaticElectionConfig, StaticVoteToken,
         },
@@ -559,12 +559,12 @@ mod tests {
         // TODO (da) can this be SequencingConsensus?
         type ConsensusType = ValidatingConsensus;
         type Time = ViewNumber;
-        type BlockType = DEntryBlock;
+        type BlockType = VDemoBlock;
         type SignatureKey = Ed25519Pub;
         type VoteTokenType = StaticVoteToken<Ed25519Pub>;
-        type Transaction = DEntryTransaction;
+        type Transaction = VDemoTransaction;
         type ElectionConfigType = StaticElectionConfig;
-        type StateType = DEntryState;
+        type StateType = VDemoState;
         type ApplicationMetadataType = TestMetaData;
     }
 
@@ -608,7 +608,7 @@ mod tests {
             let message = Message {
                 sender: pk,
                 kind: MessageKind::Data(DataMessage::SubmitTransaction(
-                    DEntryTransaction {
+                    VDemoTransaction {
                         add: Addition {
                             account: "A".to_string(),
                             amount: 50 + i + seed,

--- a/testing/tests/atomic_storage.rs
+++ b/testing/tests/atomic_storage.rs
@@ -4,9 +4,9 @@ mod common;
 use hotshot::{
     certificate::QuorumCertificate,
     data::LeafType,
-    demos::dentry::{
-        random_quorom_certificate, random_transaction, random_validating_leaf, DEntryBlock,
-        DEntryState,
+    demos::vdemo::{
+        random_quorom_certificate, random_transaction, random_validating_leaf, VDemoBlock,
+        VDemoState,
     },
     traits::{Block, State, Storage},
 };
@@ -27,7 +27,7 @@ async fn test_happy_path_blocks() {
     println!("Using store in {:?}", path);
     let mut store = AtomicStorage::open(path).expect("Could not open atomic store");
 
-    let block = DEntryBlock::default();
+    let block = VDEntryBlock::default();
     let hash = block.hash();
     store
         .update(|mut m| {

--- a/testing/tests/common/mod.rs
+++ b/testing/tests/common/mod.rs
@@ -6,6 +6,7 @@ use blake3::Hasher;
 use either::Either;
 use futures::{future::LocalBoxFuture, FutureExt};
 use hotshot::{
+    demos::vdemo::{VDemoBlock, VDemoState, VDemoTransaction},
     traits::{
         dummy::DummyState,
         election::{
@@ -358,41 +359,16 @@ impl ApplicationMetadata for StaticCommitteeMetaData {}
 )]
 pub struct StaticCommitteeTestTypes;
 impl NodeType for StaticCommitteeTestTypes {
-    // TODO (da) can this be SequencingConsensus?
     type ConsensusType = ValidatingConsensus;
     type Time = ViewNumber;
-    type BlockType = DummyBlock;
+    type BlockType = VDemoBlock;
     type SignatureKey = JfPubKey<BLSSignatureScheme<Param381>>;
     type VoteTokenType = StaticVoteToken<JfPubKey<BLSSignatureScheme<Param381>>>;
-    type Transaction = DummyTransaction;
+    type Transaction = VDemoTransaction;
     type ElectionConfigType = StaticElectionConfig;
-    type StateType = DummyState;
+    type StateType = VDemoState;
     type ApplicationMetadataType = StaticCommitteeMetaData;
 }
-// #[derive(
-//     Copy,
-//     Clone,
-//     Debug,
-//     Default,
-//     Hash,
-//     PartialEq,
-//     Eq,
-//     PartialOrd,
-//     Ord,
-//     serde::Serialize,
-//     serde::Deserialize,
-// )]
-// pub struct DACommitteeTestTypes;
-// impl NodeType for DACommitteeTestTypes {
-//     type ConsensusType = SequencingConsensus;
-//     type Time = ViewNumber;
-//     type BlockType = DABlock<DummyBlock>;
-//     type SignatureKey = JfPubKey<BLSSignatureScheme<Param381>>;
-//     type VoteTokenType = StaticVoteToken<JfPubKey<BLSSignatureScheme<Param381>>>;
-//     type Transaction = DATransaction<DummyBlock>;
-//     type ElectionConfigType = StaticElectionConfig;
-//     type StateType = DAState<DummyBlock>;
-// }
 
 /// type synonym for vrf committee election
 /// with in-memory network
@@ -978,8 +954,8 @@ macro_rules! cross_all_types {
             cross_tests!(
                 [ MemoryCommChannel ],
                 [ MemoryStorage ],
-                [ DEntryBlock  ],
-                [ DEntryState ],
+                [ VDEntryBlock  ],
+                [ VDEntryState ],
                 $fn_name,
                 $e,
                 keep: $keep,
@@ -1012,8 +988,8 @@ macro_rules! cross_all_types_proptest {
             cross_tests!(
                 [ MemoryCommChannel ],
                 [ MemoryStorage ], // AtomicStorage
-                [ DEntryBlock  ],
-                [ DEntryState ],
+                [ VDEntryBlock  ],
+                [ VDEntryState ],
                 $fn_name,
                 $e,
                 keep: $keep,

--- a/testing/tests/consensus.rs
+++ b/testing/tests/consensus.rs
@@ -14,7 +14,7 @@ use futures::{
     FutureExt,
 };
 use hotshot::{
-    certificate::QuorumCertificate, demos::dentry::random_validating_leaf,
+    certificate::QuorumCertificate, demos::vdemo::random_validating_leaf,
     traits::election::vrf::VrfImpl,
 };
 use hotshot_testing::{ConsensusRoundError, RoundResult, SafetyFailedSnafu};

--- a/testing/tests/random_tests.rs
+++ b/testing/tests/random_tests.rs
@@ -8,7 +8,7 @@ use common::{get_tolerance, GeneralTestDescriptionBuilder, TestDescription};
 use either::Either::{Left, Right};
 #[cfg(feature = "slow-tests")]
 use hotshot::{
-    demos::dentry::DEntryState,
+    demos::vdemo::VDemoState,
     traits::implementations::{Libp2pNetwork, MemoryCommChannel, MemoryStorage}, // AtomicStorage,
 };
 #[cfg(feature = "slow-tests")]

--- a/testing/tests/sequencing_test.rs
+++ b/testing/tests/sequencing_test.rs
@@ -15,7 +15,8 @@ use hotshot::{
 use hotshot_testing::TestNodeImpl;
 use hotshot_types::{
     data::{ValidatingLeaf, ValidatingProposal, ViewNumber},
-    traits::{node_implementation::NodeType, state::ValidatingConsensus}, message::QuorumVote,
+    message::QuorumVote,
+    traits::{node_implementation::NodeType, state::ValidatingConsensus},
 };
 use jf_primitives::signatures::BLSSignatureScheme;
 use tracing::instrument;

--- a/testing/tests/sequencing_test.rs
+++ b/testing/tests/sequencing_test.rs
@@ -1,0 +1,94 @@
+mod common;
+use ark_bls12_381::Parameters as Param381;
+use common::*;
+use either::Either::Right;
+use hotshot::{
+    demos::sdemo::{SDemoBlock, SDemoState, SDemoTransaction},
+    traits::{
+        election::{
+            static_committee::{StaticCommittee, StaticElectionConfig, StaticVoteToken},
+            vrf::JfPubKey,
+        },
+        implementations::{MemoryCommChannel, MemoryStorage},
+    },
+};
+use hotshot_testing::TestNodeImpl;
+use hotshot_types::{
+    data::{ValidatingLeaf, ValidatingProposal, ViewNumber},
+    traits::{node_implementation::NodeType, state::ValidatingConsensus},
+};
+use jf_primitives::signatures::BLSSignatureScheme;
+use tracing::instrument;
+
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    Hash,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    serde::Serialize,
+    serde::Deserialize,
+)]
+pub struct SequencingTestTypes;
+impl NodeType for SequencingTestTypes {
+    type ConsensusType = ValidatingConsensus;
+    type Time = ViewNumber;
+    type BlockType = SDemoBlock;
+    type SignatureKey = JfPubKey<BLSSignatureScheme<Param381>>;
+    type VoteTokenType = StaticVoteToken<JfPubKey<BLSSignatureScheme<Param381>>>;
+    type Transaction = SDemoTransaction;
+    type ElectionConfigType = StaticElectionConfig;
+    type StateType = SDemoState;
+    type ApplicationMetadataType = StaticCommitteeMetaData;
+}
+
+// stress test for libp2p
+#[cfg_attr(
+    feature = "tokio-executor",
+    tokio::test(flavor = "multi_thread", worker_threads = 2)
+)]
+#[cfg_attr(feature = "async-std-executor", async_std::test)]
+#[instrument]
+#[ignore]
+async fn sequencing_test() {
+    let description = GeneralTestDescriptionBuilder {
+        round_start_delay: 25,
+        num_bootstrap_nodes: 15,
+        timeout_ratio: (1, 1),
+        total_nodes: 100,
+        start_nodes: 100,
+        num_succeeds: 5,
+        txn_ids: Right(1),
+        next_view_timeout: 2000,
+        start_delay: 20000,
+        ..GeneralTestDescriptionBuilder::default()
+    };
+
+    description
+        .build::<SequencingTestTypes, TestNodeImpl<
+            SequencingTestTypes,
+            ValidatingLeaf<SequencingTestTypes>,
+            ValidatingProposal<
+                SequencingTestTypes,
+                StaticCommittee<SequencingTestTypes, ValidatingLeaf<SequencingTestTypes>>,
+            >,
+            MemoryCommChannel<
+                SequencingTestTypes,
+                ValidatingLeaf<SequencingTestTypes>,
+                ValidatingProposal<
+                    SequencingTestTypes,
+                    StaticCommittee<SequencingTestTypes, ValidatingLeaf<SequencingTestTypes>>,
+                >,
+                StaticCommittee<SequencingTestTypes, ValidatingLeaf<SequencingTestTypes>>,
+            >,
+            MemoryStorage<SequencingTestTypes, ValidatingLeaf<SequencingTestTypes>>,
+            StaticCommittee<SequencingTestTypes, ValidatingLeaf<SequencingTestTypes>>,
+        >>()
+        .execute()
+        .await
+        .unwrap();
+}

--- a/types/src/traits/block_contents.rs
+++ b/types/src/traits/block_contents.rs
@@ -4,7 +4,6 @@
 //! expected to have.
 
 use commit::{Commitment, Committable};
-use espresso_systems_common::hotshot::tag;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 use std::{collections::HashSet, error::Error, fmt::Debug, hash::Hash};
@@ -99,7 +98,7 @@ pub mod dummy {
         }
 
         fn tag() -> String {
-            tag::DUMMY_TXN.to_string()
+            "DUMMY_TXN".to_string()
         }
     }
     impl super::Transaction for DummyTransaction {}
@@ -153,7 +152,7 @@ pub mod dummy {
         }
 
         fn tag() -> String {
-            tag::DUMMY_BLOCK.to_string()
+            "DUMMY_BLOCK".to_string()
         }
     }
 }

--- a/types/src/traits/state.rs
+++ b/types/src/traits/state.rs
@@ -46,8 +46,10 @@ pub trait State:
 
     /// Returns an empty, template next block given this current state
     fn next_block(&self) -> Self::BlockType;
+
     /// Returns true if and only if the provided block is valid and can extend this state
     fn validate_block(&self, block: &Self::BlockType, view_number: &Self::Time) -> bool;
+
     /// Appends the given block to this state, returning an new state
     ///
     /// # Errors
@@ -58,6 +60,7 @@ pub trait State:
         block: &Self::BlockType,
         view_number: &Self::Time,
     ) -> Result<Self, Self::Error>;
+
     /// Gets called to notify the persistence backend that this state has been committed
     fn on_commit(&self);
 }


### PR DESCRIPTION
Adds sequencing demo mirroring espresso-sequencer's implementation and test. Renames DEntry to VDEntry for validating demo entry.

Switches most of the test suite to use VDEntry instead of dummy.

Closes #938 . NOTE: will need to rebase once #941 is merged.