### PR TITLE
Improve docs

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Build Docs
         run: |
-          cargo doc --no-deps --workspace --profile=release-lto --document-private-items --bins --examples --features=full-ci
+          cargo doc --no-deps --workspace --profile=release-lto --document-private-items --bins --examples --features=full-ci --lib
           cargo test --doc --workspace --features=full-ci
 
       - name: Create documentation

--- a/centralized_server/src/lib.rs
+++ b/centralized_server/src/lib.rs
@@ -63,7 +63,7 @@ compile_error! {"Either feature \"async-std-executor\" or feature \"tokio-execut
 use types::*;
 
 /// 256KB, assumed to be the kernel receive buffer
-/// https://stackoverflow.com/a/2862176
+/// <https://stackoverflow.com/a/2862176>
 pub(crate) const MAX_CHUNK_SIZE: usize = 256 * 1024;
 
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]

--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -1,11 +1,5 @@
-//! The consensus layer for hotshot. This currently implements the hotstuff paper: <https://arxiv.org/abs/1803.05069>
-//!
-//! To use this library, you should:
-//! - Implement [`ConsensusApi`]
-//! - Create a new instance of [`Consensus`]
-//! - whenever a message arrives, call [`Consensus::add_consensus_message`]
-//! - whenever a transaction arrives, call [`Consensus::add_transaction`]
-//!
+//! The consensus layer for hotshot. This currently implements both sequencing and validating
+//! consensus
 
 #![warn(
     clippy::all,

--- a/docs/HotShotDocs/main.md
+++ b/docs/HotShotDocs/main.md
@@ -9,7 +9,7 @@
         - [ValidatingLeader](#sequential-leader)
         - [Replica](#sequential-replica)
      3. [Pipelined HotShot](#pipelined)
-  3. [Appendices](#appendices) 
+  3. [Appendices](#appendices)
      1. [Definitions](#definitions)
         1. [Quorum Certificate](#quorum-certificate)
         2. [Safe Node Predicate](#safe-node-predicate)
@@ -42,7 +42,7 @@ independently calculates who they think the leader is, without communication.
 
 For the sake of simplicity, the leaders are not described as voting, however, the leader in a given
 view additionally performs all the actions that a replica would, in addition to its own, including
-voting. 
+voting.
 
 All nodes maintain an internal reference to a Quorum Certificated called the LockedQC, which is
 updated when the node commits a Leaf. Nodes will only accept leaves that extend from their LockedQC
@@ -110,7 +110,7 @@ it, tagged with the nodes current prepareQC.
    * Waits to receive at least `2f + 1` Votes on the Quorum Certificate from the previous phase
    * Packages the votes into a Quorum Certificate marked as originating in the Commit Phase
    * Broadcasts the Quorum Certificate to the network
-     
+
 ### Sequential Replica
 
 1. Prepare
@@ -128,14 +128,14 @@ it, tagged with the nodes current prepareQC.
     * Waits for a Prepare QC from the leader
     * Generates a vote for the proposal for the pre-commit stage
     * Sends the vote to the leader
-    
+
 3. Commit
 
     In this phase, the replica:
   * Waits for a Pre-Commit QC from the leader
   * Generates a vote for the proposal for the commit stage
   * Sends the vote to the leader
-  
+
 4. Decide
 
     In this phase, the replica:
@@ -152,9 +152,9 @@ it, tagged with the nodes current prepareQC.
 
 One of the limitations of the sequential version of HotShot is that 3 rounds of interactions are needed before
 a leader can commit a block. In order to increase the throughput and latency one can do the following:
-* Have replicas handle the different stages (_Prepare_, _Pre-Commit_, _Commit_, _Decide_) yielding an update of the blockchain 
+* Have replicas handle the different stages (_Prepare_, _Pre-Commit_, _Commit_, _Decide_) yielding an update of the blockchain
 state in "parallel" for consecutive/chained proposals during each view.
-* Let leaders delegate the responsibility to move their initial proposal (Prepare) to the next stages 
+* Let leaders delegate the responsibility to move their initial proposal (Prepare) to the next stages
 to the subsequent leaders/groups of replicas.
 
 So in practice during each view *n*, a leader will propose a new extension to the blockchain, while
@@ -190,7 +190,7 @@ Thus, our implementation of cryptographic sortition slightly differs from the Al
 
 ### Quorum Certificate
 
-A Quorum Certificate is a threshold signature of a [`Leaf`](crate::data::Leaf), composed of
+A Quorum Certificate is a threshold signature of a [`ValidatingLeaf`](hotshot_types::data::ValidatingLeaf), composed of
 signatures from at least `2f + 1` nodes.
 
 In the case of sequential HotShot, or pipelined HotShot without committee election, `f` is
@@ -221,6 +221,6 @@ locked_qc.
 
 [^1]: Though, it should be noted, that it technically valid for the election process to specifiy
     arbitrarily many leaders for a round, but at most one of them will be able to make progress
-    
+
 [^2]: The network will complete a view and move on to the next one as fast as network conditions,
     irrespective of the timeout value for the round

--- a/justfile
+++ b/justfile
@@ -83,3 +83,7 @@ careful_tokio:
 careful_async_std:
   echo Careful-ing with async std executor
   cargo careful test --verbose --profile careful --features=full-ci --lib --bins --tests --benches --workspace --no-fail-fast -- --test-threads=1 --nocapture
+
+doc:
+  echo Generating docs
+  cargo doc --no-deps --workspace --profile=release-lto --document-private-items --bins --examples --features=full-ci --lib

--- a/libp2p-networking/src/network/node/handle.rs
+++ b/libp2p-networking/src/network/node/handle.rs
@@ -54,14 +54,21 @@ pub struct NetworkNodeHandle<S> {
     receiver: NetworkNodeReceiver,
 }
 
+/// internal network node receiver
 #[derive(Debug)]
 pub struct NetworkNodeReceiver {
+    /// whether or not the receiver is started
     receiver_spawned: AtomicBool,
+
     /// whether or not the handle has been killed
     killed: AtomicBool,
 
+    /// the receiver
     receiver: Mutex<UnboundedReceiver<NetworkEvent>>,
+
+    ///kill switch
     recv_kill: Mutex<Option<OneShotReceiver<()>>>,
+
     /// kill the event handler for events from the swarm
     kill_switch: Mutex<Option<OneShotSender<()>>>,
 }
@@ -211,7 +218,7 @@ impl<S: Default + Debug> NetworkNodeHandle<S> {
         Ok(())
     }
 
-    /// Receives a reference of the internal [`NetworkNodeReceiver`], which can be used to query for incoming messages.
+    /// Receives a reference of the internal `NetworkNodeReceiver`, which can be used to query for incoming messages.
     pub fn receiver(&self) -> &NetworkNodeReceiver {
         &self.receiver
     }

--- a/src/demos/dentry.rs
+++ b/src/demos/dentry.rs
@@ -612,7 +612,7 @@ pub fn random_quorum_certificate<TYPES: NodeType, LEAF: LeafType<NodeType = TYPE
     }
 }
 
-/// Provides a random [`Leaf`]
+/// Provides a random [`ValidatingLeaf`]
 pub fn random_validating_leaf<TYPES: NodeType<ConsensusType = ValidatingConsensus>>(
     deltas: TYPES::BlockType,
     rng: &mut dyn rand::RngCore,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1031,7 +1031,7 @@ impl<
     }
 }
 
-/// A handle that is passed to [`hotshot_hotstuff`] with to expose the interface that hotstuff needs to interact with [`HotShot`]
+/// A handle that exposes the interface that hotstuff needs to interact with [`HotShot`]
 #[derive(Clone)]
 struct HotShotConsensusApi<TYPES: NodeType, I: NodeImplementation<TYPES>> {
     /// Reference to the [`HotShotInner`]

--- a/testing/src/launcher.rs
+++ b/testing/src/launcher.rs
@@ -163,9 +163,9 @@ where
 {
     /// Launch the [`TestRunner`]. This function is only available if the following conditions are met:
     ///
-    /// - `NETWORK` implements [`NetworkingImplementation`] and [`TestableNetworkingImplementation`]
-    /// - `STORAGE` implements [`Storage`]
-    /// - `BLOCK` implements [`BlockContents`] and [`TestableBlock`]
+    /// - `NETWORK` implements and [`TestableNetworkingImplementation`]
+    /// - `STORAGE` implements [`hotshot::traits::Storage`]
+    /// - `BLOCK` implements [`hotshot::traits::Block`] and [`TestableBlock`]
     pub fn launch(self) -> TestRunner<TYPES, I> {
         TestRunner::new(self)
     }

--- a/types/src/certificate.rs
+++ b/types/src/certificate.rs
@@ -17,7 +17,7 @@ use nll::nll_todo::nll_todo;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::{collections::BTreeMap, fmt::Debug, num::NonZeroU64, ops::Deref};
-/// A `DACertificate` is a threshold signature that some data is available.  
+/// A `DACertificate` is a threshold signature that some data is available.
 /// It is signed by the members of the DA comittee, not the entire network. It is used
 /// to prove that the data will be made available to those outside of the DA committee.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -29,7 +29,7 @@ pub struct DACertificate<TYPES: NodeType> {
 
     /// The list of signatures establishing the validity of this Quorum Certifcate
     ///
-    /// This is a mapping of the byte encoded public keys provided by the [`NodeImplementation`], to
+    /// This is a mapping of the byte encoded public keys provided by the [`crate::traits::node_implementation::NodeImplementation`], to
     /// the byte encoded signatures provided by those keys.
     ///
     /// These formats are deliberatly done as a `Vec` instead of an array to prevent creating the
@@ -41,8 +41,8 @@ pub struct DACertificate<TYPES: NodeType> {
 
 /// The type used for Quorum Certificates
 ///
-/// A Quorum Certificate is a threshold signature of the [`Leaf`] being proposed, as well as some
-/// metadata, such as the [`Stage`] of consensus the quorum certificate was generated during.
+/// A Quorum Certificate is a threshold signature of the `Leaf` being proposed, as well as some
+/// metadata, such as the `Stage` of consensus the quorum certificate was generated during.
 #[derive(custom_debug::Debug, serde::Serialize, serde::Deserialize, Clone, PartialEq, Hash)]
 #[serde(bound(deserialize = ""))]
 pub struct QuorumCertificate<TYPES: NodeType, LEAF: LeafType<NodeType = TYPES>> {

--- a/types/src/event.rs
+++ b/types/src/event.rs
@@ -39,7 +39,7 @@ pub enum EventType<TYPES: NodeType, LEAF: LeafType<NodeType = TYPES>> {
         /// The QC signing the most recent leaf in `leaf_chain`.
         ///
         /// Note that the QC for each additional leaf in the chain can be obtained from the leaf
-        /// before it using [Leaf::justify_qc].
+        /// before it using
         qc: Arc<LEAF::QuorumCertificate>,
     },
     /// A replica task was canceled by a timeout interrupt

--- a/types/src/message.rs
+++ b/types/src/message.rs
@@ -254,7 +254,7 @@ pub struct DAVote<TYPES: NodeType, LEAF: LeafType<NodeType = TYPES>> {
     /// we should check a cache, and if that fails request the qc
     pub justify_qc_commitment: Commitment<LEAF::QuorumCertificate>,
     /// The signature share associated with this vote
-    /// TODO ct/vrf make ConsensusMessage generic over I instead of serializing to a Vec<u8>
+    /// TODO ct/vrf make ConsensusMessage generic over I instead of serializing to a [`Vec<u8>`]
     pub signature: (EncodedPublicKey, EncodedSignature),
     /// The block commitment being voted on.
     pub block_commitment: Commitment<TYPES::BlockType>,
@@ -273,7 +273,7 @@ pub struct YesOrNoVote<TYPES: NodeType, LEAF: LeafType<NodeType = TYPES>> {
     /// we should check a cache, and if that fails request the qc
     pub justify_qc_commitment: Commitment<LEAF::QuorumCertificate>,
     /// The signature share associated with this vote
-    /// TODO ct/vrf make ConsensusMessage generic over I instead of serializing to a Vec<u8>
+    /// TODO ct/vrf make ConsensusMessage generic over I instead of serializing to a [`Vec<u8>`]
     pub signature: (EncodedPublicKey, EncodedSignature),
     /// The leaf commitment being voted on.
     pub leaf_commitment: Commitment<LEAF>,
@@ -290,7 +290,7 @@ pub struct TimeoutVote<TYPES: NodeType, LEAF: LeafType<NodeType = TYPES>> {
     /// The justification qc for this view
     pub justify_qc: LEAF::QuorumCertificate,
     /// The signature share associated with this vote
-    /// TODO ct/vrf make ConsensusMessage generic over I instead of serializing to a Vec<u8>
+    /// TODO ct/vrf make ConsensusMessage generic over I instead of serializing to a [`Vec<u8>`]
     pub signature: (EncodedPublicKey, EncodedSignature),
     /// The view this vote was cast for
     pub current_view: TYPES::Time,

--- a/types/src/traits/block_contents.rs
+++ b/types/src/traits/block_contents.rs
@@ -1,6 +1,6 @@
 //! Abstraction over the contents of a block
 //!
-//! This module provides the [`BlockContents`] trait, which describes the behaviors that a block is
+//! This module provides the [`Block`] trait, which describes the behaviors that a block is
 //! expected to have.
 
 use commit::{Commitment, Committable};
@@ -12,13 +12,12 @@ use std::{collections::HashSet, error::Error, fmt::Debug, hash::Hash};
 /// Abstraction over the full contents of a block
 ///
 /// This trait encapsulates the behaviors that a block must have in order to be used by consensus:
-///   * Must have a predefined error type ([`BlockContents::Error`])
+///   * Must have a predefined error type ([`Block::Error`])
 ///   * Must have a transaction type that can be compared for equality, serialized and serialized,
 ///     sent between threads, and can have a hash produced of it
-///     ([`hash_transaction`](BlockContents::hash_transaction))
 ///   * Must be able to be produced incrementally by appending transactions
-///     ([`add_transaction_raw`](BlockContents::add_transaction_raw))
-///   * Must be hashable ([`hash`](BlockContents::hash))
+///     ([`add_transaction_raw`](Block::add_transaction_raw))
+///   * Must be hashable
 pub trait Block:
     Serialize + Clone + Debug + Hash + PartialEq + Eq + Send + Sync + Committable + DeserializeOwned
 {

--- a/types/src/traits/signature_key/ed25519/ed25519_priv.rs
+++ b/types/src/traits/signature_key/ed25519/ed25519_priv.rs
@@ -5,7 +5,7 @@ use std::{cmp::Ordering, fmt, str::FromStr};
 use tagged_base64::TaggedBase64;
 use tracing::{instrument, warn};
 
-/// Private key type for a ed25519 [`SignatureKey`] pair
+/// Private key type for a ed25519 keypair
 #[derive(PartialEq, Eq, Clone)]
 pub struct Ed25519Priv {
     /// The private key for  this keypair

--- a/types/src/traits/state.rs
+++ b/types/src/traits/state.rs
@@ -15,7 +15,7 @@ use std::{error::Error, fmt::Debug, hash::Hash, ops, ops::Deref};
 ///
 /// This trait represents the behaviors that the 'global' ledger state must have:
 ///   * A defined error type ([`Error`](State::Error))
-///   * The type of block that modifies this type of state ([`Block`](State::Block))
+///   * The type of block that modifies this type of state ([`Block`](State::BlockType))
 ///   * A method to get a template (empty) next block from the current state
 ///     ([`next_block`](State::next_block))
 ///   * The ability to validate that a block is actually a valid extension of this state


### PR DESCRIPTION
I noticed a bunch of warnings when generating docs. This PR fixes those warnings and adds a stricter check (checks on library items).

Related: we should do a documentation pass at some point. Some of these docs are super out of date (there's still stuff about BlockContents which was renamed ~8 months ago!)