### PR TITLE
Nuke State::ConsensusType

### DIFF
--- a/src/demos/sdemo.rs
+++ b/src/demos/sdemo.rs
@@ -12,7 +12,7 @@ use hotshot_types::{
     data::{fake_commitment, ViewNumber},
     traits::{
         block_contents::Transaction,
-        state::{ConsensusTime, TestableBlock, TestableState, ValidatingConsensus},
+        state::{ConsensusTime, TestableBlock, TestableState},
         Block, State,
     },
 };
@@ -211,8 +211,6 @@ impl State for SDemoState {
     type BlockType = SDemoBlock;
 
     type Time = ViewNumber;
-
-    type ConsensusType = ValidatingConsensus;
 
     fn next_block(&self) -> Self::BlockType {
         SDemoBlock::Normal(SDemoNormalBlock {

--- a/src/demos/vdemo.rs
+++ b/src/demos/vdemo.rs
@@ -230,8 +230,6 @@ impl State for VDemoState {
 
     type Time = ViewNumber;
 
-    type ConsensusType = ValidatingConsensus;
-
     fn next_block(&self) -> Self::BlockType {
         VDemoBlock::Normal(VDemoNormalBlock {
             previous_state: self.commit(),

--- a/types/src/traits/node_implementation.rs
+++ b/types/src/traits/node_implementation.rs
@@ -112,10 +112,7 @@ pub trait NodeType:
     type ElectionConfigType: ElectionConfig;
 
     /// The state type that this hotshot setup is using.
-    type StateType: State<
-        BlockType = Self::BlockType,
-        Time = Self::Time,
-    >;
+    type StateType: State<BlockType = Self::BlockType, Time = Self::Time>;
 }
 
 /// testable node implmeentation trait

--- a/types/src/traits/node_implementation.rs
+++ b/types/src/traits/node_implementation.rs
@@ -115,7 +115,6 @@ pub trait NodeType:
     type StateType: State<
         BlockType = Self::BlockType,
         Time = Self::Time,
-        ConsensusType = Self::ConsensusType,
     >;
 }
 

--- a/types/src/traits/state.rs
+++ b/types/src/traits/state.rs
@@ -42,8 +42,6 @@ pub trait State:
     /// Time compatibility needed for reward collection
     type Time: ConsensusTime;
 
-    type ConsensusType: ConsensusType;
-
     /// Returns an empty, template next block given this current state
     fn next_block(&self) -> Self::BlockType;
 
@@ -182,7 +180,6 @@ pub mod dummy {
 
         type BlockType = DummyBlock;
         type Time = ViewNumber;
-        type ConsensusType = ValidatingConsensus;
 
         fn next_block(&self) -> Self::BlockType {
             DummyBlock { nonce: self.nonce }


### PR DESCRIPTION
I think we established this isn't need in zulip, so here's a PR nuking it.