### PR TITLE
Add SDemo tests for libp2p and centralized network

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -973,7 +973,7 @@ version = "0.1.0"
 dependencies = [
  "async-compatibility-layer",
  "async-std",
- "clap 4.1.7",
+ "clap 4.1.8",
  "futures",
  "hotshot-centralized-server",
  "hotshot-types",
@@ -1271,9 +1271,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.1.7"
+version = "4.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f3061d6db6d8fcbbd4b05e057f2acace52e64e96b498c08c2d7a4e65addd340"
+checksum = "c3d7ae14b20b94cb02149ed21a86c423859cbe18dc7ed69845cace50e52b40a5"
 dependencies = [
  "bitflags",
  "clap_derive",
@@ -1286,9 +1286,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.1.7"
+version = "4.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34d122164198950ba84a918270a3bb3f7ededd25e15f7451673d986f55bd2667"
+checksum = "44bec8e5c9d09e439c4335b1af0abaab56dcf3b94999a936e1bb47b9134288f0"
 dependencies = [
  "heck 0.4.1",
  "proc-macro-error",
@@ -2907,7 +2907,7 @@ dependencies = [
  "bimap",
  "bincode",
  "blake3",
- "clap 4.1.7",
+ "clap 4.1.8",
  "commit 0.2.2",
  "custom_debug",
  "dashmap",
@@ -2976,7 +2976,7 @@ dependencies = [
  "async-std",
  "async-trait",
  "bincode",
- "clap 4.1.7",
+ "clap 4.1.8",
  "commit 0.1.0",
  "futures",
  "hotshot-types",
@@ -3024,7 +3024,7 @@ dependencies = [
  "async-std",
  "async-trait",
  "bincode",
- "clap 4.1.7",
+ "clap 4.1.8",
  "commit 0.1.0",
  "futures",
  "hotshot-types",
@@ -4088,7 +4088,7 @@ dependencies = [
  "async-trait",
  "bincode",
  "blake3",
- "clap 4.1.7",
+ "clap 4.1.8",
  "color-eyre",
  "custom_debug",
  "derive_builder 0.12.0",
@@ -7362,7 +7362,7 @@ version = "0.2.0"
 source = "git+https://github.com/EspressoSystems/tagged-base64.git?tag=0.2.1#4ba55dd2f9aaa63601db03a621ea2a1b50d18292"
 dependencies = [
  "base64 0.13.1",
- "clap 4.1.7",
+ "clap 4.1.8",
  "console_error_panic_hook",
  "crc-any",
  "futures-channel",
@@ -7515,7 +7515,7 @@ dependencies = [
  "async-std",
  "async-trait",
  "bincode",
- "clap 4.1.7",
+ "clap 4.1.8",
  "config",
  "derive_more",
  "dirs",
@@ -7562,7 +7562,7 @@ dependencies = [
  "async-std",
  "async-trait",
  "bincode",
- "clap 4.1.7",
+ "clap 4.1.8",
  "config",
  "derive_more",
  "dirs",
@@ -7710,9 +7710,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.25.0"
+version = "1.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e00990ebabbe4c14c08aca901caed183ecd5c09562a12c824bb53d3c3fd3af"
+checksum = "03201d01c3c27a29c8a5cee5b55a93ddae1ccf6f08f65365c2c918f8c1b76f64"
 dependencies = [
  "autocfg",
  "bytes 1.4.0",
@@ -7726,7 +7726,7 @@ dependencies = [
  "socket2",
  "tokio-macros",
  "tracing",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]

--- a/justfile
+++ b/justfile
@@ -24,7 +24,7 @@ test_async_std_all:
 
 test_pkg := "hotshot-testing"
 
-test_name := "sequencing_memory_test"
+test_name := "sequencing_memory_network_test"
 
 test_async_std_pkg_all pkg=test_pkg:
   cargo test --verbose --release --features=async-std-executor,demo,channel-async-std --lib --bins --tests --benches --package={{pkg}} --no-fail-fast -- --test-threads=1 --nocapture

--- a/testing/src/test_description.rs
+++ b/testing/src/test_description.rs
@@ -66,6 +66,59 @@ pub struct GeneralTestDescriptionBuilder {
     pub propose_max_round_time: Duration,
 }
 
+impl Default for GeneralTestDescriptionBuilder {
+    /// by default, just a single round
+    fn default() -> Self {
+        Self {
+            total_nodes: 5,
+            start_nodes: 5,
+            num_succeeds: 1,
+            failure_threshold: 0,
+            txn_ids: Right(1),
+            next_view_timeout: 10000,
+            timeout_ratio: (11, 10),
+            round_start_delay: 1,
+            start_delay: 1,
+            ids_to_shut_down: Vec::new(),
+            network_reliability: None,
+            num_bootstrap_nodes: 5,
+            propose_min_round_time: Duration::new(0, 0),
+            propose_max_round_time: Duration::new(5, 0),
+            max_transactions: NonZeroUsize::new(999999).unwrap(),
+            min_transactions: 0,
+        }
+    }
+}
+
+impl GeneralTestDescriptionBuilder {
+    /// Default constructor for multiple rounds.
+    pub fn default_multiple_rounds() -> Self {
+        GeneralTestDescriptionBuilder {
+            round_start_delay: 25,
+            total_nodes: 10,
+            start_nodes: 10,
+            num_succeeds: 20,
+            start_delay: 120000,
+            ..GeneralTestDescriptionBuilder::default()
+        }
+    }
+
+    /// Default constructor for stress testing.
+    pub fn default_stress() -> Self {
+        GeneralTestDescriptionBuilder {
+            round_start_delay: 25,
+            num_bootstrap_nodes: 15,
+            timeout_ratio: (1, 1),
+            total_nodes: 100,
+            start_nodes: 100,
+            num_succeeds: 5,
+            next_view_timeout: 2000,
+            start_delay: 20000,
+            ..GeneralTestDescriptionBuilder::default()
+        }
+    }
+}
+
 /// fine-grained spec of test
 /// including what should be run every round
 /// and how to generate more rounds
@@ -286,30 +339,6 @@ pub type GenRunner<TYPES, I> =
 /// type alias for doing setup for a consensus round
 pub type TestSetup<TYPES, TRANS, I> =
     Vec<Box<dyn FnOnce(&mut TestRunner<TYPES, I>) -> LocalBoxFuture<Vec<TRANS>>>>;
-
-impl Default for GeneralTestDescriptionBuilder {
-    /// by default, just a single round
-    fn default() -> Self {
-        Self {
-            total_nodes: 5,
-            start_nodes: 5,
-            num_succeeds: 1,
-            failure_threshold: 0,
-            txn_ids: Right(1),
-            next_view_timeout: 10000,
-            timeout_ratio: (11, 10),
-            round_start_delay: 1,
-            start_delay: 1,
-            ids_to_shut_down: Vec::new(),
-            network_reliability: None,
-            num_bootstrap_nodes: 5,
-            propose_min_round_time: Duration::new(0, 0),
-            propose_max_round_time: Duration::new(5, 0),
-            max_transactions: NonZeroUsize::new(999999).unwrap(),
-            min_transactions: 0,
-        }
-    }
-}
 
 /// given a description of rounds, generates such rounds
 /// args

--- a/testing/tests/centralized_server.rs
+++ b/testing/tests/centralized_server.rs
@@ -1,7 +1,6 @@
 use ark_bls12_381::Parameters as Param381;
 use async_compatibility_layer::logging::shutdown_logging;
 use blake3::Hasher;
-use either::Either::Right;
 use hotshot::traits::{
     election::{static_committee::StaticCommittee, vrf::VrfImpl},
     implementations::{CentralizedCommChannel, MemoryStorage},
@@ -27,18 +26,7 @@ use tracing::instrument;
 #[cfg_attr(feature = "async-std-executor", async_std::test)]
 #[instrument]
 async fn centralized_server_network_vrf() {
-    let description = GeneralTestDescriptionBuilder {
-        round_start_delay: 25,
-        num_bootstrap_nodes: 5,
-        timeout_ratio: (11, 10),
-        total_nodes: 10,
-        start_nodes: 10,
-        num_succeeds: 20,
-        txn_ids: Right(1),
-        next_view_timeout: 10000,
-        start_delay: 120000,
-        ..GeneralTestDescriptionBuilder::default()
-    };
+    let description = GeneralTestDescriptionBuilder::default_multiple_rounds();
 
     description
         .build::<VrfTestTypes, TestNodeImpl<
@@ -83,18 +71,7 @@ async fn centralized_server_network_vrf() {
 #[cfg_attr(feature = "async-std-executor", async_std::test)]
 #[instrument]
 async fn centralized_server_network() {
-    let description = GeneralTestDescriptionBuilder {
-        round_start_delay: 25,
-        num_bootstrap_nodes: 5,
-        timeout_ratio: (11, 10),
-        total_nodes: 10,
-        start_nodes: 10,
-        num_succeeds: 20,
-        txn_ids: Right(1),
-        next_view_timeout: 10000,
-        start_delay: 120000,
-        ..GeneralTestDescriptionBuilder::default()
-    };
+    let description = GeneralTestDescriptionBuilder::default_multiple_rounds();
 
     description
         .build::<StaticCommitteeTestTypes, TestNodeImpl<
@@ -130,18 +107,7 @@ async fn centralized_server_network() {
 #[instrument]
 #[ignore]
 async fn test_stress_centralized_server_network() {
-    let description = GeneralTestDescriptionBuilder {
-        round_start_delay: 25,
-        num_bootstrap_nodes: 15,
-        timeout_ratio: (1, 1),
-        total_nodes: 100,
-        start_nodes: 100,
-        num_succeeds: 5,
-        txn_ids: Right(1),
-        next_view_timeout: 2000,
-        start_delay: 20000,
-        ..GeneralTestDescriptionBuilder::default()
-    };
+    let description = GeneralTestDescriptionBuilder::default_stress();
 
     description
         .build::<StaticCommitteeTestTypes, TestNodeImpl<

--- a/testing/tests/centralized_web_server.rs
+++ b/testing/tests/centralized_web_server.rs
@@ -1,6 +1,5 @@
 use async_compatibility_layer::logging::shutdown_logging;
 
-use either::Either::Right;
 use hotshot::traits::{
     election::static_committee::StaticCommittee,
     implementations::{CentralizedWebCommChannel, MemoryStorage},
@@ -25,12 +24,7 @@ use tracing::instrument;
 async fn centralized_server_network() {
     let description = GeneralTestDescriptionBuilder {
         round_start_delay: 25,
-        num_bootstrap_nodes: 5,
-        timeout_ratio: (11, 10),
-        total_nodes: 5,
-        start_nodes: 5,
         num_succeeds: 5,
-        txn_ids: Right(1),
         next_view_timeout: 3000,
         start_delay: 120000,
         ..GeneralTestDescriptionBuilder::default()

--- a/testing/tests/libp2p.rs
+++ b/testing/tests/libp2p.rs
@@ -1,5 +1,3 @@
-use either::Either::Right;
-
 use hotshot::traits::{
     election::static_committee::StaticCommittee,
     implementations::{Libp2pCommChannel, MemoryStorage},
@@ -22,18 +20,7 @@ use tracing::instrument;
 #[cfg_attr(feature = "async-std-executor", async_std::test)]
 #[instrument]
 async fn libp2p_network() {
-    let description = GeneralTestDescriptionBuilder {
-        round_start_delay: 25,
-        num_bootstrap_nodes: 5,
-        timeout_ratio: (11, 10),
-        total_nodes: 10,
-        start_nodes: 10,
-        num_succeeds: 20,
-        txn_ids: Right(1),
-        next_view_timeout: 10000,
-        start_delay: 120000,
-        ..GeneralTestDescriptionBuilder::default()
-    };
+    let description = GeneralTestDescriptionBuilder::default_multiple_rounds();
 
     description
         .build::<StaticCommitteeTestTypes, TestNodeImpl<
@@ -67,18 +54,7 @@ async fn libp2p_network() {
 #[instrument]
 #[ignore]
 async fn test_stress_libp2p_network() {
-    let description = GeneralTestDescriptionBuilder {
-        round_start_delay: 25,
-        num_bootstrap_nodes: 15,
-        timeout_ratio: (1, 1),
-        total_nodes: 100,
-        start_nodes: 100,
-        num_succeeds: 5,
-        txn_ids: Right(1),
-        next_view_timeout: 2000,
-        start_delay: 20000,
-        ..GeneralTestDescriptionBuilder::default()
-    };
+    let description = GeneralTestDescriptionBuilder::default_stress();
 
     description
         .build::<StaticCommitteeTestTypes, TestNodeImpl<

--- a/testing/tests/sequencing_test.rs
+++ b/testing/tests/sequencing_test.rs
@@ -7,7 +7,9 @@ use hotshot::{
             static_committee::{StaticCommittee, StaticElectionConfig, StaticVoteToken},
             vrf::JfPubKey,
         },
-        implementations::{MemoryCommChannel, MemoryStorage},
+        implementations::{
+            CentralizedCommChannel, Libp2pCommChannel, MemoryCommChannel, MemoryStorage,
+        },
     },
 };
 use hotshot_testing::{test_description::GeneralTestDescriptionBuilder, TestNodeImpl};
@@ -73,6 +75,90 @@ async fn sequencing_memory_test() {
             DAProposal<SequencingTestTypes>,
             DAVote<SequencingTestTypes, SequencingLeaf<SequencingTestTypes>>,
             MemoryCommChannel<
+                SequencingTestTypes,
+                DAProposal<SequencingTestTypes>,
+                DAVote<SequencingTestTypes, SequencingLeaf<SequencingTestTypes>>,
+                StaticCommittee<SequencingTestTypes, SequencingLeaf<SequencingTestTypes>>,
+            >,
+            MemoryStorage<SequencingTestTypes, SequencingLeaf<SequencingTestTypes>>,
+            StaticCommittee<SequencingTestTypes, SequencingLeaf<SequencingTestTypes>>,
+        >>()
+        .execute()
+        .await
+        .unwrap();
+}
+
+// Test the libp2p network with sequencing consensus.
+#[cfg_attr(
+    feature = "tokio-executor",
+    tokio::test(flavor = "multi_thread", worker_threads = 2)
+)]
+#[cfg_attr(feature = "async-std-executor", async_std::test)]
+#[instrument]
+#[ignore]
+async fn sequencing_libp2p_test() {
+    let description = GeneralTestDescriptionBuilder {
+        round_start_delay: 25,
+        num_bootstrap_nodes: 5,
+        timeout_ratio: (11, 10),
+        total_nodes: 10,
+        start_nodes: 10,
+        num_succeeds: 20,
+        txn_ids: Right(1),
+        next_view_timeout: 10000,
+        start_delay: 120000,
+        ..GeneralTestDescriptionBuilder::default()
+    };
+
+    description
+        .build::<SequencingTestTypes, TestNodeImpl<
+            SequencingTestTypes,
+            SequencingLeaf<SequencingTestTypes>,
+            DAProposal<SequencingTestTypes>,
+            DAVote<SequencingTestTypes, SequencingLeaf<SequencingTestTypes>>,
+            Libp2pCommChannel<
+                SequencingTestTypes,
+                DAProposal<SequencingTestTypes>,
+                DAVote<SequencingTestTypes, SequencingLeaf<SequencingTestTypes>>,
+                StaticCommittee<SequencingTestTypes, SequencingLeaf<SequencingTestTypes>>,
+            >,
+            MemoryStorage<SequencingTestTypes, SequencingLeaf<SequencingTestTypes>>,
+            StaticCommittee<SequencingTestTypes, SequencingLeaf<SequencingTestTypes>>,
+        >>()
+        .execute()
+        .await
+        .unwrap();
+}
+
+// Test the centralized server network with sequencing consensus.
+#[cfg_attr(
+    feature = "tokio-executor",
+    tokio::test(flavor = "multi_thread", worker_threads = 2)
+)]
+#[cfg_attr(feature = "async-std-executor", async_std::test)]
+#[instrument]
+#[ignore]
+async fn sequencing_centralized_test() {
+    let description = GeneralTestDescriptionBuilder {
+        round_start_delay: 25,
+        num_bootstrap_nodes: 5,
+        timeout_ratio: (11, 10),
+        total_nodes: 10,
+        start_nodes: 10,
+        num_succeeds: 20,
+        txn_ids: Right(1),
+        next_view_timeout: 10000,
+        start_delay: 120000,
+        ..GeneralTestDescriptionBuilder::default()
+    };
+
+    description
+        .build::<SequencingTestTypes, TestNodeImpl<
+            SequencingTestTypes,
+            SequencingLeaf<SequencingTestTypes>,
+            DAProposal<SequencingTestTypes>,
+            DAVote<SequencingTestTypes, SequencingLeaf<SequencingTestTypes>>,
+            CentralizedCommChannel<
                 SequencingTestTypes,
                 DAProposal<SequencingTestTypes>,
                 DAVote<SequencingTestTypes, SequencingLeaf<SequencingTestTypes>>,

--- a/testing/tests/sequencing_test.rs
+++ b/testing/tests/sequencing_test.rs
@@ -21,6 +21,24 @@ use hotshot_types::{
 use jf_primitives::signatures::BLSSignatureScheme;
 use tracing::instrument;
 
+// Test the libp2p network with sequencing consensus.
+#[instrument]
+#[ignore]
+fn description_build() -> GeneralTestDescriptionBuilder {
+    GeneralTestDescriptionBuilder {
+        round_start_delay: 25,
+        num_bootstrap_nodes: 5,
+        timeout_ratio: (11, 10),
+        total_nodes: 10,
+        start_nodes: 10,
+        num_succeeds: 20,
+        txn_ids: Right(1),
+        next_view_timeout: 10000,
+        start_delay: 120000,
+        ..GeneralTestDescriptionBuilder::default()
+    }
+}
+
 #[derive(
     Copy,
     Clone,
@@ -55,20 +73,9 @@ impl NodeType for SequencingTestTypes {
 #[instrument]
 #[ignore]
 async fn sequencing_memory_test() {
-    let description = GeneralTestDescriptionBuilder {
-        round_start_delay: 25,
-        num_bootstrap_nodes: 5,
-        timeout_ratio: (11, 10),
-        total_nodes: 10,
-        start_nodes: 10,
-        num_succeeds: 20,
-        txn_ids: Right(1),
-        next_view_timeout: 10000,
-        start_delay: 120000,
-        ..GeneralTestDescriptionBuilder::default()
-    };
+    let builder = description_build();
 
-    description
+    builder
         .build::<SequencingTestTypes, TestNodeImpl<
             SequencingTestTypes,
             SequencingLeaf<SequencingTestTypes>,
@@ -97,20 +104,9 @@ async fn sequencing_memory_test() {
 #[instrument]
 #[ignore]
 async fn sequencing_libp2p_test() {
-    let description = GeneralTestDescriptionBuilder {
-        round_start_delay: 25,
-        num_bootstrap_nodes: 5,
-        timeout_ratio: (11, 10),
-        total_nodes: 10,
-        start_nodes: 10,
-        num_succeeds: 20,
-        txn_ids: Right(1),
-        next_view_timeout: 10000,
-        start_delay: 120000,
-        ..GeneralTestDescriptionBuilder::default()
-    };
+    let builder = description_build();
 
-    description
+    builder
         .build::<SequencingTestTypes, TestNodeImpl<
             SequencingTestTypes,
             SequencingLeaf<SequencingTestTypes>,
@@ -139,20 +135,9 @@ async fn sequencing_libp2p_test() {
 #[instrument]
 #[ignore]
 async fn sequencing_centralized_test() {
-    let description = GeneralTestDescriptionBuilder {
-        round_start_delay: 25,
-        num_bootstrap_nodes: 5,
-        timeout_ratio: (11, 10),
-        total_nodes: 10,
-        start_nodes: 10,
-        num_succeeds: 20,
-        txn_ids: Right(1),
-        next_view_timeout: 10000,
-        start_delay: 120000,
-        ..GeneralTestDescriptionBuilder::default()
-    };
+    let builder = description_build();
 
-    description
+    builder
         .build::<SequencingTestTypes, TestNodeImpl<
             SequencingTestTypes,
             SequencingLeaf<SequencingTestTypes>,

--- a/testing/tests/sequencing_tests.rs
+++ b/testing/tests/sequencing_tests.rs
@@ -72,7 +72,7 @@ impl NodeType for SequencingTestTypes {
 #[cfg_attr(feature = "async-std-executor", async_std::test)]
 #[instrument]
 #[ignore]
-async fn sequencing_memory_test() {
+async fn sequencing_memory_network_test() {
     let builder = description_build();
 
     builder
@@ -134,7 +134,7 @@ async fn sequencing_libp2p_test() {
 #[cfg_attr(feature = "async-std-executor", async_std::test)]
 #[instrument]
 #[ignore]
-async fn sequencing_centralized_test() {
+async fn sequencing_centralized_server_test() {
     let builder = description_build();
 
     builder

--- a/testing/tests/sequencing_tests.rs
+++ b/testing/tests/sequencing_tests.rs
@@ -1,5 +1,4 @@
 use ark_bls12_381::Parameters as Param381;
-use either::Either::Right;
 use hotshot::{
     demos::sdemo::{SDemoBlock, SDemoState, SDemoTransaction},
     traits::{
@@ -21,24 +20,6 @@ use hotshot_types::{
 use jf_primitives::signatures::BLSSignatureScheme;
 use tracing::instrument;
 
-// Test the libp2p network with sequencing consensus.
-#[instrument]
-#[ignore]
-fn description_build() -> GeneralTestDescriptionBuilder {
-    GeneralTestDescriptionBuilder {
-        round_start_delay: 25,
-        num_bootstrap_nodes: 5,
-        timeout_ratio: (11, 10),
-        total_nodes: 10,
-        start_nodes: 10,
-        num_succeeds: 20,
-        txn_ids: Right(1),
-        next_view_timeout: 10000,
-        start_delay: 120000,
-        ..GeneralTestDescriptionBuilder::default()
-    }
-}
-
 #[derive(
     Copy,
     Clone,
@@ -58,7 +39,7 @@ impl NodeType for SequencingTestTypes {
     type Time = ViewNumber;
     type BlockType = SDemoBlock;
     type SignatureKey = JfPubKey<BLSSignatureScheme<Param381>>;
-    type VoteTokenType = StaticVoteToken<JfPubKey<BLSSignatureScheme<Param381>>>;
+    type VoteTokenType = StaticVoteToken<Self::SignatureKey>;
     type Transaction = SDemoTransaction;
     type ElectionConfigType = StaticElectionConfig;
     type StateType = SDemoState;
@@ -73,7 +54,7 @@ impl NodeType for SequencingTestTypes {
 #[instrument]
 #[ignore]
 async fn sequencing_memory_network_test() {
-    let builder = description_build();
+    let builder = GeneralTestDescriptionBuilder::default_multiple_rounds();
 
     builder
         .build::<SequencingTestTypes, TestNodeImpl<
@@ -104,7 +85,7 @@ async fn sequencing_memory_network_test() {
 #[instrument]
 #[ignore]
 async fn sequencing_libp2p_test() {
-    let builder = description_build();
+    let builder = GeneralTestDescriptionBuilder::default_multiple_rounds();
 
     builder
         .build::<SequencingTestTypes, TestNodeImpl<
@@ -135,7 +116,7 @@ async fn sequencing_libp2p_test() {
 #[instrument]
 #[ignore]
 async fn sequencing_centralized_server_test() {
-    let builder = description_build();
+    let builder = GeneralTestDescriptionBuilder::default_multiple_rounds();
 
     builder
         .build::<SequencingTestTypes, TestNodeImpl<


### PR DESCRIPTION
* Adds tests for the other two types of network
* Extract common test code.

Closes https://github.com/EspressoSystems/HotShot/issues/992.