### PR TITLE
Support two network types in test structs

### DIFF
--- a/consensus/src/next_leader.rs
+++ b/consensus/src/next_leader.rs
@@ -70,8 +70,8 @@ where
     //     Certificate = QuorumCertificate<TYPES, ValidatingLeaf<TYPES>>,
     // >,
     I::QuorumExchange: QuorumExchangeType<
-        TYPES, 
-        ValidatingLeaf<TYPES>, 
+        TYPES,
+        ValidatingLeaf<TYPES>,
         Message<TYPES, I>,
         Vote = QuorumVote<TYPES, I::Leaf>,
         Certificate = QuorumCertificate<TYPES, ValidatingLeaf<TYPES>>,

--- a/examples/infra/mod.rs
+++ b/examples/infra/mod.rs
@@ -535,8 +535,13 @@ pub trait CliConfig<
             pk.clone(),
             sk.clone(),
         );
-        let committee_exchange =
-            NODE::CommitteeExchange::create(known_nodes, election_config, network, pk.clone(), sk.clone());
+        let committee_exchange = NODE::CommitteeExchange::create(
+            known_nodes,
+            election_config,
+            network,
+            pk.clone(),
+            sk.clone(),
+        );
         let hotshot = HotShot::init(
             pk,
             sk,

--- a/src/types/handle.rs
+++ b/src/types/handle.rs
@@ -72,35 +72,35 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static> Clone for HotShotH
     }
 }
 
-type QuorumNetwork<TYPES: NodeType, I: NodeImplementation<TYPES>> =
+type QuorumNetwork<TYPES, I> =
     <<I as NodeImplementation<TYPES>>::QuorumExchange as ConsensusExchange<
         TYPES,
-        I::Leaf,
+        <I as NodeImplementation<TYPES>>::Leaf,
         Message<TYPES, I>,
     >>::Networking;
 
-type QuorumVoteType<TYPES: NodeType, I: NodeImplementation<TYPES>> =
+type QuorumVoteType<TYPES, I> =
     <<I as NodeImplementation<TYPES>>::QuorumExchange as ConsensusExchange<
         TYPES,
-        I::Leaf,
+        <I as NodeImplementation<TYPES>>::Leaf,
         Message<TYPES, I>,
     >>::Vote;
-type CommitteeVote<TYPES: NodeType, I: NodeImplementation<TYPES>> =
+type CommitteeVote<TYPES, I> =
     <<I as NodeImplementation<TYPES>>::CommitteeExchange as ConsensusExchange<
         TYPES,
-        I::Leaf,
+        <I as NodeImplementation<TYPES>>::Leaf,
         Message<TYPES, I>,
     >>::Vote;
-type QuorumProposal<TYPES: NodeType, I: NodeImplementation<TYPES>> =
+type QuorumProposal<TYPES, I> =
     <<I as NodeImplementation<TYPES>>::QuorumExchange as ConsensusExchange<
         TYPES,
-        I::Leaf,
+        <I as NodeImplementation<TYPES>>::Leaf,
         Message<TYPES, I>,
     >>::Proposal;
-type CommitteeProposal<TYPES: NodeType, I: NodeImplementation<TYPES>> =
+type CommitteeProposal<TYPES, I> =
     <<I as NodeImplementation<TYPES>>::CommitteeExchange as ConsensusExchange<
         TYPES,
-        I::Leaf,
+        <I as NodeImplementation<TYPES>>::Leaf,
         Message<TYPES, I>,
     >>::Proposal;
 

--- a/src/types/handle.rs
+++ b/src/types/handle.rs
@@ -10,6 +10,7 @@ use crate::{
 use async_compatibility_layer::async_primitives::broadcast::{BroadcastReceiver, BroadcastSender};
 use commit::Committable;
 use hotshot_types::traits::election::QuorumExchangeType;
+use hotshot_types::traits::node_implementation::CommitteeNetwork;
 use hotshot_types::{
     data::LeafType,
     error::{HotShotError, RoundTimedoutState},
@@ -270,10 +271,16 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static> HotShotHandle<TYPE
         &self.storage
     }
 
-    /// Provides a reference to the underlying networking interface for this [`HotShot`], allowing access to
-    /// networking stats.
-    pub fn networking(&self) -> &QuorumNetwork<TYPES, I> {
+    /// Provides a reference to the underlying quorum networking interface for this [`HotShot`],
+    /// allowing access to networking stats.
+    pub fn quorum_network(&self) -> &QuorumNetwork<TYPES, I> {
         &self.hotshot.inner.quorum_exchange.network()
+    }
+
+    /// Provides a reference to the underlying committee networking interface for this [`HotShot`],
+    /// allowing access to networking stats.
+    pub fn committee_network(&self) -> &CommitteeNetwork<TYPES, I> {
+        &self.hotshot.inner.committee_exchange.network()
     }
 
     /// Shut down the the inner hotshot and wait until all background threads are closed.

--- a/types/src/traits/node_implementation.rs
+++ b/types/src/traits/node_implementation.rs
@@ -86,8 +86,21 @@ pub type QuorumNetwork<TYPES: NodeType, I: NodeImplementation<TYPES>> =
         I::Leaf,
         Message<TYPES, I>,
     >>::Networking;
+pub type CommitteeNetwork<TYPES: NodeType, I: NodeImplementation<TYPES>> =
+    <<I as NodeImplementation<TYPES>>::CommitteeExchange as ConsensusExchange<
+        TYPES,
+        I::Leaf,
+        Message<TYPES, I>,
+    >>::Networking;
+
 pub type QuorumMembership<TYPES: NodeType, I: NodeImplementation<TYPES>> =
     <<I as NodeImplementation<TYPES>>::QuorumExchange as ConsensusExchange<
+        TYPES,
+        I::Leaf,
+        Message<TYPES, I>,
+    >>::Membership;
+pub type CommitteeMembership<TYPES: NodeType, I: NodeImplementation<TYPES>> =
+    <<I as NodeImplementation<TYPES>>::CommitteeExchange as ConsensusExchange<
         TYPES,
         I::Leaf,
         Message<TYPES, I>,

--- a/types/src/traits/node_implementation.rs
+++ b/types/src/traits/node_implementation.rs
@@ -54,55 +54,55 @@ pub trait NodeImplementation<TYPES: NodeType>: Send + Sync + Debug + Clone + 'st
     type CommitteeExchange: ConsensusExchange<TYPES, Self::Leaf, Message<TYPES, Self>>;
 }
 
-pub type QuorumProposal<TYPES: NodeType, I: NodeImplementation<TYPES>> =
+pub type QuorumProposal<TYPES, I> =
     <<I as NodeImplementation<TYPES>>::QuorumExchange as ConsensusExchange<
         TYPES,
-        I::Leaf,
+        <I as NodeImplementation<TYPES>>::Leaf,
         Message<TYPES, I>,
     >>::Proposal;
-pub type CommitteeProposal<TYPES: NodeType, I: NodeImplementation<TYPES>> =
+pub type CommitteeProposal<TYPES, I> =
     <<I as NodeImplementation<TYPES>>::CommitteeExchange as ConsensusExchange<
         TYPES,
-        I::Leaf,
+        <I as NodeImplementation<TYPES>>::Leaf,
         Message<TYPES, I>,
     >>::Proposal;
 
-pub type QuorumVoteType<TYPES: NodeType, I: NodeImplementation<TYPES>> =
+pub type QuorumVoteType<TYPES, I> =
     <<I as NodeImplementation<TYPES>>::QuorumExchange as ConsensusExchange<
         TYPES,
-        I::Leaf,
+        <I as NodeImplementation<TYPES>>::Leaf,
         Message<TYPES, I>,
     >>::Vote;
-pub type CommitteeVote<TYPES: NodeType, I: NodeImplementation<TYPES>> =
+pub type CommitteeVote<TYPES, I> =
     <<I as NodeImplementation<TYPES>>::CommitteeExchange as ConsensusExchange<
         TYPES,
-        I::Leaf,
+        <I as NodeImplementation<TYPES>>::Leaf,
         Message<TYPES, I>,
     >>::Vote;
 
-pub type QuorumNetwork<TYPES: NodeType, I: NodeImplementation<TYPES>> =
+pub type QuorumNetwork<TYPES, I> =
     <<I as NodeImplementation<TYPES>>::QuorumExchange as ConsensusExchange<
         TYPES,
-        I::Leaf,
+        <I as NodeImplementation<TYPES>>::Leaf,
         Message<TYPES, I>,
     >>::Networking;
-pub type CommitteeNetwork<TYPES: NodeType, I: NodeImplementation<TYPES>> =
+pub type CommitteeNetwork<TYPES, I> =
     <<I as NodeImplementation<TYPES>>::CommitteeExchange as ConsensusExchange<
         TYPES,
-        I::Leaf,
+        <I as NodeImplementation<TYPES>>::Leaf,
         Message<TYPES, I>,
     >>::Networking;
 
-pub type QuorumMembership<TYPES: NodeType, I: NodeImplementation<TYPES>> =
+pub type QuorumMembership<TYPES, I> =
     <<I as NodeImplementation<TYPES>>::QuorumExchange as ConsensusExchange<
         TYPES,
-        I::Leaf,
+        <I as NodeImplementation<TYPES>>::Leaf,
         Message<TYPES, I>,
     >>::Membership;
-pub type CommitteeMembership<TYPES: NodeType, I: NodeImplementation<TYPES>> =
+pub type CommitteeMembership<TYPES, I> =
     <<I as NodeImplementation<TYPES>>::CommitteeExchange as ConsensusExchange<
         TYPES,
-        I::Leaf,
+        <I as NodeImplementation<TYPES>>::Leaf,
         Message<TYPES, I>,
     >>::Membership;
 


### PR DESCRIPTION
- Adds committee network to `TestRunner` and `TestLauncher`, besides the existing quorum network.
- Fixes type alias bounds.
- To be merged into the [consensus-exchange](https://github.com/EspressoSystems/HotShot/tree/consensus-exchange) branch for https://github.com/EspressoSystems/HotShot/pull/996.