### PR TITLE
Remove a lot of #[allow] attributes and fix lints

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -2,4 +2,4 @@
 watch_file flake.nix
 watch_file flake.lock
 # load the flake devShell
-eval "$(nix print-dev-env)"
+use nix

--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -174,9 +174,8 @@ pub struct ConsensusMetrics {
 
 impl ConsensusMetrics {
     /// Create a new instance of this [`ConsensusMetrics`] struct, setting all the counters and gauges
-    #[allow(clippy::needless_pass_by_value)] // with the metrics API is it more ergonomic to pass a `Box<dyn Metrics>` around
     #[must_use]
-    pub fn new(metrics: Box<dyn Metrics>) -> Self {
+    pub fn new(metrics: &dyn Metrics) -> Self {
         Self {
             current_view: metrics.create_gauge(String::from("current_view"), None),
             vote_validate_duration: metrics.create_histogram(

--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -9,7 +9,7 @@
     clippy::missing_docs_in_private_items,
     clippy::panic
 )]
-#![allow(clippy::module_name_repetitions, clippy::unused_async)]
+#![allow(clippy::module_name_repetitions)]
 
 mod da_member;
 mod leader;
@@ -287,6 +287,7 @@ impl<TYPES: NodeType, LEAF: LeafType<NodeType = TYPES>> Consensus<TYPES, LEAF> {
     /// garbage collects based on state change
     /// right now, this removes from both the `saved_leaves`
     /// and `state_map` fields of `Consensus`
+    #[allow(clippy::unused_async)] // async for API compatibility reasons
     pub async fn collect_garbage(
         &mut self,
         old_anchor_view: TYPES::Time,

--- a/consensus/src/replica.rs
+++ b/consensus/src/replica.rs
@@ -468,10 +468,9 @@ where
                     *txns = txns
                         .drain()
                         .filter(|(txn_hash, txn)| {
-                            #[allow(clippy::cast_possible_wrap)]
                             if included_txns_set.contains(txn_hash) {
                                 included_txn_size +=
-                                    bincode_opts().serialized_size(txn).unwrap_or_default() as i64;
+                                    bincode_opts().serialized_size(txn).unwrap_or_default();
                                 false
                             } else {
                                 true
@@ -487,7 +486,7 @@ where
             consensus
                 .metrics
                 .outstanding_transactions_memory_size
-                .update(-included_txn_size);
+                .update(-(i64::try_from(included_txn_size).unwrap_or(i64::MAX)));
 
             consensus
                 .metrics

--- a/consensus/src/sequencing_leader.rs
+++ b/consensus/src/sequencing_leader.rs
@@ -449,8 +449,6 @@ where
                             continue;
                         }
 
-                        // FIXME is there a way around this?
-                        #[allow(unused_assignments)]
                         match self.quorum_exchange.accumulate_vote(
                             &vote.signature.0,
                             &vote.signature.1,

--- a/consensus/src/sequencing_replica.rs
+++ b/consensus/src/sequencing_replica.rs
@@ -522,10 +522,9 @@ where
                     *txns = txns
                         .drain()
                         .filter(|(txn_hash, txn)| {
-                            #[allow(clippy::cast_possible_wrap)]
                             if included_txns_set.contains(txn_hash) {
                                 included_txn_size +=
-                                    bincode_opts().serialized_size(txn).unwrap_or_default() as i64;
+                                    bincode_opts().serialized_size(txn).unwrap_or_default();
                                 false
                             } else {
                                 true
@@ -541,7 +540,7 @@ where
             consensus
                 .metrics
                 .outstanding_transactions_memory_size
-                .update(-included_txn_size);
+                .update(-(i64::try_from(included_txn_size).unwrap_or(i64::MAX)));
 
             consensus
                 .metrics

--- a/examples/infra/mod.rs
+++ b/examples/infra/mod.rs
@@ -261,7 +261,7 @@ pub trait Run<
             sk,
             config.node_index,
             config.config,
-            MemoryStorage::new(),
+            MemoryStorage::empty(),
             quorum_exchange,
             committee_exchange,
             initializer,

--- a/examples/infra/mod.rs
+++ b/examples/infra/mod.rs
@@ -265,7 +265,7 @@ pub trait Run<
             quorum_exchange,
             committee_exchange,
             initializer,
-            NoMetrics::new(),
+            NoMetrics::boxed(),
         )
         .await
         .expect("Could not init hotshot");
@@ -566,7 +566,7 @@ where
 
         let node_config = config_builder.build().unwrap();
         let network = Libp2pNetwork::new(
-            NoMetrics::new(),
+            NoMetrics::boxed(),
             node_config,
             pubkey.clone(),
             Arc::new(RwLock::new(

--- a/examples/infra/mod.rs
+++ b/examples/infra/mod.rs
@@ -819,7 +819,6 @@ impl OrchestratorClient {
 
     /// Tells the orchestrator this validator is ready to start
     /// Blocks until the orchestrator indicates all nodes are ready to start
-    #[allow(clippy::let_unit_value)]
     async fn wait_for_all_nodes_ready(&self, node_index: u64) -> bool {
         let send_ready_f = |client: Client<ClientError>| {
             async move {
@@ -833,7 +832,8 @@ impl OrchestratorClient {
             }
             .boxed()
         };
-        () = self.wait_for_fn_from_orchestrator(send_ready_f).await;
+        self.wait_for_fn_from_orchestrator::<_, _, ()>(send_ready_f)
+            .await;
 
         let wait_for_all_nodes_ready_f = |client: Client<ClientError>| {
             async move { client.get("api/start").send().await }.boxed()

--- a/libp2p-networking/examples/common/mod.rs
+++ b/libp2p-networking/examples/common/mod.rs
@@ -354,7 +354,6 @@ pub async fn regular_handle_network_event(
 ) -> Result<(), NetworkNodeHandleError> {
     debug!("node={} handling event {:?}", handle.id(), event);
 
-    #[allow(clippy::enum_glob_use)]
     use NetworkEvent::*;
     match event {
         IsBootstrapped => {}
@@ -713,7 +712,6 @@ pub async fn conductor_handle_network_event(
     event: NetworkEvent,
     handle: Arc<NetworkNodeHandle<ConductorState>>,
 ) -> Result<(), NetworkNodeHandleError> {
-    #[allow(clippy::enum_glob_use)]
     use NetworkEvent::*;
     match event {
         IsBootstrapped => {}

--- a/libp2p-networking/src/lib.rs
+++ b/libp2p-networking/src/lib.rs
@@ -6,11 +6,8 @@
     clippy::panic
 )]
 #![allow(
-    clippy::option_if_let_else,
     clippy::must_use_candidate,
     clippy::module_name_repetitions,
-    clippy::similar_names,
-    clippy::unused_self
 )]
 //! Library for p2p communication
 

--- a/libp2p-networking/src/lib.rs
+++ b/libp2p-networking/src/lib.rs
@@ -5,10 +5,7 @@
     missing_docs,
     clippy::panic
 )]
-#![allow(
-    clippy::must_use_candidate,
-    clippy::module_name_repetitions,
-)]
+#![allow(clippy::module_name_repetitions)]
 //! Library for p2p communication
 
 /// Example message used by the UI library

--- a/libp2p-networking/src/network/behaviours/dht.rs
+++ b/libp2p-networking/src/network/behaviours/dht.rs
@@ -105,6 +105,7 @@ impl DHTBehaviour {
     }
 
     /// Create a new DHT behaviour
+    #[must_use]
     pub fn new(
         kadem: Kademlia<MemoryStore>,
         pid: PeerId,

--- a/libp2p-networking/src/network/behaviours/direct_message.rs
+++ b/libp2p-networking/src/network/behaviours/direct_message.rs
@@ -254,6 +254,7 @@ impl NetworkBehaviour for DMBehaviour {
 
 impl DMBehaviour {
     /// Create new behaviour based on request response
+    #[must_use]
     pub fn new(request_response: Behaviour<DirectMessageCodec>) -> Self {
         Self {
             request_response,

--- a/libp2p-networking/src/network/behaviours/exponential_backoff.rs
+++ b/libp2p-networking/src/network/behaviours/exponential_backoff.rs
@@ -16,6 +16,7 @@ pub struct ExponentialBackoff {
 
 impl ExponentialBackoff {
     /// Create new backoff
+    #[must_use]
     pub fn new(backoff_factor: u32, next_timeout: Duration) -> Self {
         ExponentialBackoff {
             backoff_factor,
@@ -52,6 +53,7 @@ impl ExponentialBackoff {
     }
 
     /// Whether or not the timeout is expired
+    #[must_use]
     pub fn is_expired(&self) -> bool {
         if let Some(then) = self.started {
             then.elapsed() > self.timeout

--- a/libp2p-networking/src/network/behaviours/gossip.rs
+++ b/libp2p-networking/src/network/behaviours/gossip.rs
@@ -195,6 +195,7 @@ impl NetworkBehaviour for GossipBehaviour {
 
 impl GossipBehaviour {
     /// Create new gossip behavioru based on gossipsub
+    #[must_use]
     pub fn new(gossipsub: Behaviour) -> Self {
         Self {
             backoff: ExponentialBackoff::default(),

--- a/libp2p-networking/src/network/def.rs
+++ b/libp2p-networking/src/network/def.rs
@@ -55,6 +55,7 @@ pub struct NetworkDef {
 
 impl NetworkDef {
     /// Create a new instance of a `NetworkDef`
+    #[must_use]
     pub fn new(
         gossipsub: GossipBehaviour,
         dht: DHTBehaviour,

--- a/libp2p-networking/src/network/mod.rs
+++ b/libp2p-networking/src/network/mod.rs
@@ -192,6 +192,7 @@ pub enum NetworkEventInternal {
 
 /// Bind all interfaces on port `port`
 /// NOTE we may want something more general in the fture.
+#[must_use]
 pub fn gen_multiaddr(port: u16) -> Multiaddr {
     build_multiaddr!(Ip4([0, 0, 0, 0]), Tcp(port))
 }

--- a/libp2p-networking/src/network/node.rs
+++ b/libp2p-networking/src/network/node.rs
@@ -558,7 +558,6 @@ impl NetworkNode {
 
     /// Spawn a task to listen for requests on the returned channel
     /// as well as any events produced by libp2p
-    #[allow(clippy::panic)]
     #[instrument]
     pub async fn spawn_listeners(
         mut self,

--- a/libp2p-networking/tests/counter.rs
+++ b/libp2p-networking/tests/counter.rs
@@ -58,7 +58,6 @@ pub async fn counter_handle_network_event(
     event: NetworkEvent,
     handle: Arc<NetworkNodeHandle<CounterState>>,
 ) -> Result<(), NetworkNodeHandleError> {
-    #[allow(clippy::enum_glob_use)]
     use CounterMessage::*;
     use NetworkEvent::*;
     match event {

--- a/src/demos/sdemo.rs
+++ b/src/demos/sdemo.rs
@@ -53,6 +53,7 @@ impl Transaction for SDemoTransaction {}
 
 impl SDemoTransaction {
     /// create a new transaction
+    #[must_use]
     pub fn new(id: u64) -> Self {
         Self {
             id,

--- a/src/demos/vdemo.rs
+++ b/src/demos/vdemo.rs
@@ -103,6 +103,7 @@ impl Transaction for VDemoTransaction {}
 
 impl VDemoTransaction {
     /// Ensures that this transaction is at least consistent with itself
+    #[must_use]
     pub fn validate_independence(&self) -> bool {
         // Ensure that we are adding to one account exactly as much as we are subtracting from
         // another
@@ -217,6 +218,7 @@ impl Committable for VDemoTransaction {
 
 impl VDemoBlock {
     /// generate a genesis block with the provided initial accounts and balances
+    #[must_use]
     pub fn genesis_from(accounts: BTreeMap<Account, Balance>) -> Self {
         Self::Genesis(VDemoGenesisBlock { accounts })
     }
@@ -526,6 +528,7 @@ where
     MEMBERSHIP: Membership<VDemoTypes> + std::fmt::Debug,
 {
     /// Create a new `VDemoNode`
+    #[must_use]
     pub fn new() -> Self {
         VDemoNode(PhantomData)
     }

--- a/src/demos/vdemo.rs
+++ b/src/demos/vdemo.rs
@@ -379,7 +379,6 @@ impl State for VDemoState {
     }
 }
 
-#[allow(clippy::panic)]
 impl TestableState for VDemoState {
     fn create_random_transaction(
         state: Option<&Self>,
@@ -388,7 +387,7 @@ impl TestableState for VDemoState {
     ) -> <Self::BlockType as Block>::Transaction {
         use rand::seq::IteratorRandom;
 
-        let state = state.unwrap_or_else(|| panic!("Missing state"));
+        let state = state.expect("Missing state");
 
         let non_zero_balances = state
             .balances

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -675,11 +675,10 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> HotShot<TYPES::ConsensusType
                     // If this is a new transaction, update metrics.
                     let consensus = self.hotstuff.read().await;
                     consensus.metrics.outstanding_transactions.update(1);
-                    #[allow(clippy::cast_possible_wrap)]
                     consensus
                         .metrics
                         .outstanding_transactions_memory_size
-                        .update(size as i64);
+                        .update(i64::try_from(size).unwrap_or(i64::MAX));
                 }
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,10 +6,7 @@
     clippy::missing_docs_in_private_items,
     clippy::panic
 )]
-#![allow(
-    clippy::module_name_repetitions,
-    clippy::unused_async, // For API reasons
-)]
+#![allow(clippy::module_name_repetitions)]
 // Temporary
 #![allow(clippy::cast_possible_truncation)]
 // Temporary, should be disabled after the completion of the NodeImplementation refactor
@@ -681,6 +678,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> HotShot<TYPES::ConsensusType
     }
 
     /// Handle an incoming [`DataMessage`] that directed at this node
+    #[allow(clippy::unused_async)] // async for API compatibility reasons
     async fn handle_direct_data_message(
         &self,
         msg: DataMessage<TYPES>,
@@ -728,6 +726,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> HotShot<TYPES::ConsensusType
 
     /// given a view number and a write lock on a channel map, inserts entry into map if it
     /// doesn't exist, or creates entry. Then returns a clone of the entry
+    #[allow(clippy::unused_async)] // async for API compatibility reasons
     pub async fn create_or_obtain_chan_from_write(
         view_num: TYPES::Time,
         mut channel_map: RwLockWriteGuard<'_, SendToTasks<TYPES, I>>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,6 @@
 #![allow(
     clippy::must_use_candidate,
     clippy::module_name_repetitions,
-    clippy::unused_self,
     clippy::unused_async, // For API reasons
 )]
 // Temporary

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,10 +7,8 @@
     clippy::panic
 )]
 #![allow(
-    clippy::option_if_let_else,
     clippy::must_use_candidate,
     clippy::module_name_repetitions,
-    clippy::similar_names,
     clippy::unused_self,
     clippy::unused_async, // For API reasons
 )]
@@ -746,7 +744,6 @@ pub trait ViewRunner<TYPES: NodeType, I: NodeImplementation<TYPES>> {
     async fn run_view(hotshot: HotShot<TYPES::ConsensusType, TYPES, I>) -> Result<(), ()>;
 }
 
-#[allow(clippy::too_many_lines)]
 #[async_trait]
 impl<
         TYPES: NodeType<ConsensusType = ValidatingConsensus>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -250,7 +250,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> HotShot<TYPES::ConsensusType
             high_qc: anchored_leaf.get_justify_qc(),
 
             metrics: Arc::new(ConsensusMetrics::new(
-                inner.metrics.subgroup("consensus".to_string()),
+                &*inner.metrics.subgroup("consensus".to_string()),
             )),
             invalid_qc: 0,
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,6 @@
     clippy::panic
 )]
 #![allow(
-    clippy::must_use_candidate,
     clippy::module_name_repetitions,
     clippy::unused_async, // For API reasons
 )]
@@ -697,6 +696,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> HotShot<TYPES::ConsensusType
     }
 
     /// return the timeout for a view for `self`
+    #[must_use]
     pub fn get_next_view_timeout(&self) -> u64 {
         self.inner.config.next_view_timeout
     }

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -46,7 +46,10 @@ pub struct TaskHandle<TYPES: NodeType> {
 }
 impl<TYPES: NodeType> TaskHandle<TYPES> {
     /// Start the round runner. This will make it run until `pause` is called
-    #[allow(clippy::missing_panics_doc)]
+    ///
+    /// # Panics
+    ///
+    /// If the [`TaskHandle`] has not been properly initialized.
     pub async fn start(&self) {
         let handle = self.inner.read().await;
         if handle.is_some() {
@@ -57,7 +60,10 @@ impl<TYPES: NodeType> TaskHandle<TYPES> {
 
     /// Make the round runner run 1 round.
     /// Does/should not block.
-    #[allow(clippy::missing_panics_doc)]
+    ///
+    /// # Panics
+    ///
+    /// If the [`TaskHandle`] has not been properly initialized.
     pub async fn start_one_round(&self) {
         let handle = self.inner.read().await;
         if handle.is_some() {
@@ -72,7 +78,10 @@ impl<TYPES: NodeType> TaskHandle<TYPES> {
     }
 
     /// Wait until all underlying handles are shut down
-    #[allow(clippy::missing_panics_doc)]
+    ///
+    /// # Panics
+    ///
+    /// If the [`TaskHandle`] has not been properly initialized.
     pub async fn wait_shutdown(&self, send_network_lookup: UnboundedSender<Option<TYPES::Time>>) {
         let inner = self.inner.write().await.take().unwrap();
 

--- a/src/traits/election/static_committee.rs
+++ b/src/traits/election/static_committee.rs
@@ -36,6 +36,7 @@ impl<T, LEAF: LeafType<NodeType = T>, PUBKEY: SignatureKey>
     GeneralStaticCommittee<T, LEAF, PUBKEY>
 {
     /// Creates a new dummy elector
+    #[must_use]
     pub fn new(nodes: Vec<PUBKEY>) -> Self {
         Self {
             nodes,

--- a/src/traits/election/vrf.rs
+++ b/src/traits/election/vrf.rs
@@ -265,6 +265,7 @@ where
 
 impl<VRF, VRFHASHER, VRFPARAMS> VRFStakeTable<VRF, VRFHASHER, VRFPARAMS> {
     /// get total stake
+    #[must_use]
     pub fn get_all_stake(&self) -> NonZeroU64 {
         self.total_stake
     }
@@ -651,6 +652,7 @@ pub struct BinomialQuery {
 impl BinomialQuery {
     /// get the committee parameter
     /// for this query
+    #[must_use]
     pub fn get_p(&self) -> Ratio<BigUint> {
         let sortition_parameter_big: BigUint = BigUint::from(self.sortition_parameter);
         let total_stake_big: BigUint = BigUint::from(self.total_stake);
@@ -871,6 +873,7 @@ where
     /// create stake table with this initial stake
     /// # Panics
     /// TODO
+    #[must_use]
     pub fn with_initial_stake(
         known_nodes: Vec<JfPubKey<SIGSCHEME>>,
         config: &VRFStakeTableConfig,

--- a/src/traits/election/vrf.rs
+++ b/src/traits/election/vrf.rs
@@ -250,9 +250,7 @@ where
         let new_seed = *hasher.finalize().as_bytes();
         let mut prng = rand::rngs::StdRng::from_seed(new_seed);
 
-        #[allow(clippy::let_unit_value)]
-        let parameters = SIGSCHEME::param_gen(Some(&mut prng)).unwrap();
-        let (sk, pk) = SIGSCHEME::key_gen(&parameters, &mut prng).unwrap();
+        let (sk, pk) = SIGSCHEME::key_gen(&(), &mut prng).unwrap();
         (
             Self {
                 pk: pk.clone(),
@@ -1149,10 +1147,7 @@ impl ElectionConfig for VRFStakeTableConfig {}
 //         let stake_per_node = NonZeroU64::new(100).unwrap();
 //         let genesis_seed = [0u8; 32];
 //         for _i in 0..num_nodes {
-//             // TODO we should make this more general/use different parameters
-//             #[allow(clippy::let_unit_value)]
-//             let parameters = BLSSignatureScheme::<Param381>::param_gen(Some(rng)).unwrap();
-//             let (sk, pk) = BLSSignatureScheme::<Param381>::key_gen(&parameters, rng).unwrap();
+//             let (sk, pk) = BLSSignatureScheme::<Param381>::key_gen(&(), rng).unwrap();
 //             keys.push((sk.clone(), pk.clone()));
 //             known_nodes.push(JfPubKey::from_native(pk.clone()));
 //             stake_distribution.push(stake_per_node);

--- a/src/traits/networking.rs
+++ b/src/traits/networking.rs
@@ -37,8 +37,7 @@ pub(self) struct NetworkingMetrics {
 
 impl NetworkingMetrics {
     /// Create a new instance of this [`NetworkingMetrics`] struct, setting all the counters and gauges
-    #[allow(clippy::needless_pass_by_value)] // with the metrics API is it more ergonomic to pass a `Box<dyn Metrics>` around
-    pub(self) fn new(metrics: Box<dyn Metrics>) -> Self {
+    pub(self) fn new(metrics: &dyn Metrics) -> Self {
         Self {
             connected_peers: metrics.create_gauge(String::from("connected_peers"), None),
             incoming_message_count: metrics

--- a/src/traits/networking/centralized_server_network.rs
+++ b/src/traits/networking/centralized_server_network.rs
@@ -717,6 +717,7 @@ impl<K: SignatureKey + 'static, E: ElectionConfig + 'static> CentralizedServerNe
     }
 
     /// Returns `true` if the server indicated that the current run was ready to start
+    #[must_use]
     pub fn run_ready(&self) -> bool {
         self.inner.run_ready.load(Ordering::Relaxed)
     }
@@ -1097,6 +1098,7 @@ impl<
     > CentralizedCommChannel<TYPES, I, PROPOSAL, VOTE, MEMBERSHIP>
 {
     /// create new communication channel
+    #[must_use]
     pub fn new(
         network: CentralizedServerNetwork<TYPES::SignatureKey, TYPES::ElectionConfigType>,
     ) -> Self {

--- a/src/traits/networking/centralized_server_network.rs
+++ b/src/traits/networking/centralized_server_network.rs
@@ -1229,7 +1229,7 @@ where
         Box::new(move |id| {
             let sender = Arc::clone(&sender);
             let mut network = CentralizedServerNetwork::connect(
-                NoMetrics::new(),
+                NoMetrics::boxed(),
                 known_nodes.clone(),
                 addr,
                 known_nodes[id as usize].clone(),

--- a/src/traits/networking/centralized_server_network.rs
+++ b/src/traits/networking/centralized_server_network.rs
@@ -30,9 +30,9 @@ use hotshot_types::{
         election::{ElectionConfig, Membership},
         metrics::{Metrics, NoMetrics},
         network::{
-            CentralizedServerNetworkError, CommunicationChannel, ConnectedNetwork,
-            FailedToDeserializeSnafu, FailedToSerializeSnafu, NetworkError, NetworkMsg,
-            TestableNetworkingImplementation, TransmitType,
+            CommunicationChannel, ConnectedNetwork, FailedToDeserializeSnafu,
+            FailedToSerializeSnafu, NetworkError, NetworkMsg, TestableNetworkingImplementation,
+            TransmitType,
         },
         node_implementation::NodeType,
         signature_key::{ed25519::Ed25519Pub, SignatureKey, TestableSignatureKey},
@@ -181,95 +181,6 @@ impl<K: SignatureKey, E: ElectionConfig> Inner<K, E> {
             .expect("Background thread exited");
     }
 
-    /// Remove the first message from the internal queue, or the internal receiving channel, if the given `c` method returns `Some(RET)` on that entry.
-    ///
-    /// This will block this entire `Inner` struct until a message is found.
-    #[allow(dead_code)]
-    async fn remove_next_message_from_queue<F, FAIL, RET>(&self, c: F, f: FAIL) -> RET
-    where
-        F: Fn(
-            &(FromServer<K, E>, Vec<u8>),
-            usize,
-            &mut HashMap<K, MsgStepContext>,
-        ) -> MsgStepOutcome<RET>,
-        FAIL: FnOnce(usize, &mut HashMap<K, MsgStepContext>) -> RET,
-    {
-        let incoming_queue = self.incoming_queue.upgradable_read().await;
-        let mut context_map: HashMap<_, MsgStepContext> = HashMap::new();
-        // pop all messages from the incoming stream, push them onto `result` if they match `c`, else push them onto our `lock`
-        let temp_start_index = incoming_queue.len();
-        for (i, msg) in incoming_queue.iter().enumerate() {
-            match c(msg, i, &mut context_map) {
-                MsgStepOutcome::Skip | MsgStepOutcome::Begin | MsgStepOutcome::Continue => {
-                    continue;
-                }
-                MsgStepOutcome::Complete(indexes, ret) => {
-                    let mut incoming_queue_mutation =
-                        RwLockUpgradableReadGuard::upgrade(incoming_queue).await;
-
-                    let incoming_queue = std::mem::take(&mut *incoming_queue_mutation);
-                    *incoming_queue_mutation = incoming_queue
-                        .into_iter()
-                        .enumerate()
-                        .filter_map(|(i, msg)| {
-                            if indexes.contains(&i) {
-                                None
-                            } else {
-                                Some(msg)
-                            }
-                        })
-                        .collect::<Vec<_>>();
-
-                    self.metrics.incoming_message_count.add(1);
-                    return ret;
-                }
-            }
-        }
-        let mut temp_queue = Vec::new();
-        let mut i = temp_start_index;
-        while let Ok(msg) = self.receiving.recv().await {
-            let step_outcome = c(&msg, i, &mut context_map);
-            i += 1;
-            match step_outcome {
-                MsgStepOutcome::Skip | MsgStepOutcome::Begin | MsgStepOutcome::Continue => {
-                    temp_queue.push(msg);
-                    continue;
-                }
-                MsgStepOutcome::Complete(indexes, ret) => {
-                    // no queued messages taken,
-                    // all received messages taken (including this one)
-                    let unchanged = indexes.iter().peekable().peek() == Some(&&temp_start_index)
-                        && indexes.len() == temp_queue.len() + 1;
-                    if !unchanged {
-                        let mut incoming_queue_mutation =
-                            RwLockUpgradableReadGuard::upgrade(incoming_queue).await;
-
-                        let incoming_queue = std::mem::take(&mut *incoming_queue_mutation);
-                        *incoming_queue_mutation = incoming_queue
-                            .into_iter()
-                            .chain(temp_queue)
-                            .enumerate()
-                            .filter_map(|(i, msg)| {
-                                if indexes.contains(&i) {
-                                    None
-                                } else {
-                                    Some(msg)
-                                }
-                            })
-                            .collect::<Vec<_>>();
-                    }
-
-                    self.metrics.incoming_message_count.add(1);
-                    return ret;
-                }
-            }
-        }
-        let mut incoming_queue_mutation = RwLockUpgradableReadGuard::upgrade(incoming_queue).await;
-        incoming_queue_mutation.append(&mut temp_queue);
-        tracing::error!("Could not receive message from centralized server queue");
-        f(incoming_queue_mutation.len(), &mut context_map)
-    }
-
     /// Remove all messages from the internal queue, and then the internal receiving channel, if the given `c` method returns `Some(RET)` on that entry.
     ///
     /// This will not block, and will return 0 items if nothing is in the internal queue or channel.
@@ -399,79 +310,6 @@ impl<K: SignatureKey, E: ElectionConfig> Inner<K, E> {
         .await
     }
 
-    /// Get the next incoming broadcast message received from the server. Will lock up this struct internally until a message was received.
-    #[allow(dead_code)]
-    async fn get_next_broadcast<M: Serialize + DeserializeOwned + Send + Sync + Clone + 'static>(
-        &self,
-    ) -> Result<M, NetworkError> {
-        self.remove_next_message_from_queue(|msg, index, context_map| {
-            match msg {
-                (FromServer::Broadcast {
-                    source,
-                    message_len,
-                    ..
-                }, payload) =>
-                {
-                    let mut consumed_indexes = BTreeSet::new();
-                    consumed_indexes.insert(index);
-                    match (payload.len() as u64).cmp(message_len) {
-                        cmp::Ordering::Less => {
-                            let prev = context_map.insert(source.clone(), MsgStepContext {
-                                consumed_indexes,
-                                message_len: *message_len,
-                                accumulated_stream: payload.clone(),
-                            });
-
-                            if prev.is_some() {
-                                tracing::error!(?source, "FromServer::Broadcast encountered, incomplete prior Broadcast from same source");
-
-                            }
-
-                            MsgStepOutcome::Begin
-                        },
-                        cmp::Ordering::Greater => {
-                            tracing::error!("FromServer::Broadcast with message_len {message_len}b, payload is {}b", payload.len());
-                            MsgStepOutcome::Skip
-                        },
-                        cmp::Ordering::Equal => MsgStepOutcome::Complete(consumed_indexes, bincode_opts().deserialize(payload).context(FailedToDeserializeSnafu)),
-                    }
-                },
-                (FromServer::BroadcastPayload { source, .. }, payload) => {
-                    if let Entry::Occupied(mut context) = context_map.entry(source.clone()) {
-                        context.get_mut().consumed_indexes.insert(index);
-                        if context.get().accumulated_stream.is_empty() && context.get().message_len as usize == payload.len() {
-                            let (_, context) = context.remove_entry();
-                            MsgStepOutcome::Complete(context.consumed_indexes, bincode_opts().deserialize(payload).context(FailedToDeserializeSnafu))
-                        } else {
-                            context.get_mut().accumulated_stream.append(&mut payload.clone());
-                            match context.get().accumulated_stream.len().cmp(&(context.get().message_len as usize)) {
-                                cmp::Ordering::Less => MsgStepOutcome::Continue,
-                                cmp::Ordering::Greater => {
-                                    let (_, context) = context.remove_entry();
-                                    tracing::error!("FromServer::Broadcast with message_len {}b, accumulated payload with {}b", context.message_len, context.accumulated_stream.len());
-                                    MsgStepOutcome::Skip
-                                }
-                                cmp::Ordering::Equal => {
-                                let (_, context) = context.remove_entry();
-                                MsgStepOutcome::Complete(context.consumed_indexes, bincode_opts().deserialize(&context.accumulated_stream).context(FailedToDeserializeSnafu))
-                            }
-                        }
-                        }
-                    } else {
-                        tracing::error!("FromServer::BroadcastPayload found, but no incomplete FromServer::Broadcast exists");
-                        MsgStepOutcome::Skip
-                    }
-                },
-                (_, _) => MsgStepOutcome::Skip,
-            }
-        },
-        |_, _| {
-            Err(NetworkError::CentralizedServer { source: CentralizedServerNetworkError::NoMessagesInQueue })
-        },
-)
-        .await
-    }
-
     /// Get all the incoming direct messages received from the server. Returning 0 messages if nothing was received.
     async fn get_direct_messages<
         M: Serialize + DeserializeOwned + Send + Sync + Clone + 'static,
@@ -541,83 +379,6 @@ impl<K: SignatureKey, E: ElectionConfig> Inner<K, E> {
                 },
                 (_, _) => MsgStepOutcome::Skip,
             }
-        })
-        .await
-    }
-
-    /// Get the next incoming direct message received from the server. Will lock up this struct internally until a message was received.
-    #[allow(dead_code)]
-    async fn get_next_direct_message<
-        M: Serialize + DeserializeOwned + Send + Sync + Clone + 'static,
-    >(
-        &self,
-    ) -> Result<M, NetworkError> {
-        self.remove_next_message_from_queue(|msg, index, context_map| {
-            match msg {
-                (FromServer::Direct {
-                    source,
-                    message_len,
-                    ..
-                }, payload) =>
-                {
-                    let mut consumed_indexes = BTreeSet::new();
-                    consumed_indexes.insert(index);
-                    match (payload.len() as u64).cmp(message_len) {
-                        cmp::Ordering::Less => {
-                            let prev = context_map.insert(source.clone(), MsgStepContext {
-                                consumed_indexes,
-                                message_len: *message_len,
-                                accumulated_stream: payload.clone(),
-                            });
-
-                            if prev.is_some() {
-                                tracing::error!(?source, "FromServer::Direct encountered, incomplete prior Direct from same source");
-                            }
-
-                            MsgStepOutcome::Begin
-                        },
-                        cmp::Ordering::Greater => {
-                            tracing::error!("FromServer::Direct with message_len {message_len}b, payload is {}b", payload.len());
-                            MsgStepOutcome::Skip
-                        },
-                        cmp::Ordering::Equal => {
-                            MsgStepOutcome::Complete(consumed_indexes, bincode_opts().deserialize(payload).context(FailedToDeserializeSnafu))
-                        },
-                    }
-                },
-                (FromServer::DirectPayload { source, .. }, payload) => {
-                    if let Entry::Occupied(mut context) = context_map.entry(source.clone()) {
-                        context.get_mut().consumed_indexes.insert(index);
-                        if context.get().accumulated_stream.is_empty() && context.get().message_len as usize == payload.len() {
-                            let (_, context) = context.remove_entry();
-                            MsgStepOutcome::Complete(context.consumed_indexes, bincode_opts().deserialize(payload).context(FailedToDeserializeSnafu))
-                        } else {
-                            context.get_mut().accumulated_stream.append(&mut payload.clone());
-                            match context.get().accumulated_stream.len().cmp(&(context.get().message_len as usize)) {
-                                cmp::Ordering::Less => {
-                                    MsgStepOutcome::Continue
-                                }
-                                cmp::Ordering::Greater => {
-                                    let (_, context) = context.remove_entry();
-                                    tracing::error!("FromServer::Broadcast with message_len {}b, accumulated payload with {}b", context.message_len, context.accumulated_stream.len());
-                                    MsgStepOutcome::Skip
-                                }
-                                cmp::Ordering::Equal => {
-                                    let (_, context) = context.remove_entry();
-                                    MsgStepOutcome::Complete(context.consumed_indexes, bincode_opts().deserialize(&context.accumulated_stream).context(FailedToDeserializeSnafu))
-                                }
-                            }
-                        }
-                    } else {
-                        tracing::error!("FromServer::BroadcastPayload found, but no incomplete FromServer::Broadcast exists");
-                        MsgStepOutcome::Skip
-                    }
-                },
-                (_, _) => MsgStepOutcome::Skip,
-            }
-        },
-        |_, _| {
-            Err(NetworkError::CentralizedServer { source: CentralizedServerNetworkError::NoMessagesInQueue })
         })
         .await
     }

--- a/src/traits/networking/centralized_server_network.rs
+++ b/src/traits/networking/centralized_server_network.rs
@@ -686,7 +686,7 @@ impl<K: SignatureKey + 'static, E: ElectionConfig + 'static> CentralizedServerNe
         let mut streams = Some(streams);
 
         let result = Self::create(
-            metrics,
+            &*metrics,
             known_nodes,
             move || {
                 let streams = streams.take();
@@ -750,12 +750,7 @@ impl<K: SignatureKey + 'static, E: ElectionConfig + 'static> CentralizedServerNe
         .boxed()
     }
     /// Connect to a centralized server
-    pub fn connect(
-        metrics: Box<dyn Metrics>,
-        known_nodes: Vec<K>,
-        addr: SocketAddr,
-        key: K,
-    ) -> Self {
+    pub fn connect(metrics: &dyn Metrics, known_nodes: Vec<K>, addr: SocketAddr, key: K) -> Self {
         Self::create(metrics, known_nodes, move || Self::connect_to(addr), key)
     }
 
@@ -763,7 +758,7 @@ impl<K: SignatureKey + 'static, E: ElectionConfig + 'static> CentralizedServerNe
     ///
     /// This will auto-reconnect when the network loses connection to the server.
     fn create<F>(
-        metrics: Box<dyn Metrics>,
+        metrics: &dyn Metrics,
         known_nodes: Vec<K>,
         mut create_connection: F,
         key: K,
@@ -1229,7 +1224,7 @@ where
         Box::new(move |id| {
             let sender = Arc::clone(&sender);
             let mut network = CentralizedServerNetwork::connect(
-                NoMetrics::boxed(),
+                &NoMetrics::default(),
                 known_nodes.clone(),
                 addr,
                 known_nodes[id as usize].clone(),

--- a/src/traits/networking/libp2p_network.rs
+++ b/src/traits/networking/libp2p_network.rs
@@ -311,7 +311,7 @@ impl<M: NetworkMsg, K: SignatureKey + 'static> Libp2pNetwork<M, K> {
                 is_ready: Arc::new(AtomicBool::new(false)),
                 dht_timeout: Duration::from_secs(30),
                 is_bootstrapped: Arc::new(AtomicBool::new(false)),
-                metrics: NetworkingMetrics::new(metrics),
+                metrics: NetworkingMetrics::new(&*metrics),
                 topic_map,
             }),
         };

--- a/src/traits/networking/libp2p_network.rs
+++ b/src/traits/networking/libp2p_network.rs
@@ -697,6 +697,7 @@ impl<
     > Libp2pCommChannel<TYPES, I, PROPOSAL, VOTE, MEMBERSHIP>
 {
     /// create a new libp2p communication channel
+    #[must_use]
     pub fn new(network: Libp2pNetwork<Message<TYPES, I>, TYPES::SignatureKey>) -> Self {
         Self(network, PhantomData::default())
     }

--- a/src/traits/networking/libp2p_network.rs
+++ b/src/traits/networking/libp2p_network.rs
@@ -204,7 +204,7 @@ where
                 async_block_on(async move {
                     Libp2pCommChannel(
                         Libp2pNetwork::new(
-                            NoMetrics::new(),
+                            NoMetrics::boxed(),
                             config,
                             pubkey,
                             bootstrap_addrs_ref,

--- a/src/traits/networking/memory_network.rs
+++ b/src/traits/networking/memory_network.rs
@@ -315,7 +315,7 @@ where
             let pubkey = TYPES::SignatureKey::from_private(&privkey);
             MemoryCommChannel::new(MemoryNetwork::new(
                 pubkey,
-                NoMetrics::new(),
+                NoMetrics::boxed(),
                 master.clone(),
                 None,
             ))
@@ -683,7 +683,7 @@ mod tests {
             MasterMap::new();
         trace!(?group);
         let pub_key = get_pubkey();
-        let _network = MemoryNetwork::new(pub_key, NoMetrics::new(), group, Option::None);
+        let _network = MemoryNetwork::new(pub_key, NoMetrics::boxed(), group, Option::None);
     }
 
     // // Spawning a two MemoryNetworks and connecting them should produce no errors
@@ -700,9 +700,9 @@ mod tests {
         trace!(?group);
         let pub_key_1 = get_pubkey();
         let _network_1 =
-            MemoryNetwork::new(pub_key_1, NoMetrics::new(), group.clone(), Option::None);
+            MemoryNetwork::new(pub_key_1, NoMetrics::boxed(), group.clone(), Option::None);
         let pub_key_2 = get_pubkey();
-        let _network_2 = MemoryNetwork::new(pub_key_2, NoMetrics::new(), group, Option::None);
+        let _network_2 = MemoryNetwork::new(pub_key_2, NoMetrics::boxed(), group, Option::None);
     }
 
     // Check to make sure direct queue works
@@ -722,9 +722,10 @@ mod tests {
             MasterMap::new();
         trace!(?group);
         let pub_key_1 = get_pubkey();
-        let network1 = MemoryNetwork::new(pub_key_1, NoMetrics::new(), group.clone(), Option::None);
+        let network1 =
+            MemoryNetwork::new(pub_key_1, NoMetrics::boxed(), group.clone(), Option::None);
         let pub_key_2 = get_pubkey();
-        let network2 = MemoryNetwork::new(pub_key_2, NoMetrics::new(), group, Option::None);
+        let network2 = MemoryNetwork::new(pub_key_2, NoMetrics::boxed(), group, Option::None);
 
         let first_messages: Vec<Message<Test, TestImpl>> = gen_messages(5, 100, pub_key_1);
 
@@ -778,9 +779,10 @@ mod tests {
             MasterMap::new();
         trace!(?group);
         let pub_key_1 = get_pubkey();
-        let network1 = MemoryNetwork::new(pub_key_1, NoMetrics::new(), group.clone(), Option::None);
+        let network1 =
+            MemoryNetwork::new(pub_key_1, NoMetrics::boxed(), group.clone(), Option::None);
         let pub_key_2 = get_pubkey();
-        let network2 = MemoryNetwork::new(pub_key_2, NoMetrics::new(), group, Option::None);
+        let network2 = MemoryNetwork::new(pub_key_2, NoMetrics::boxed(), group, Option::None);
 
         let first_messages: Vec<Message<Test, TestImpl>> = gen_messages(5, 100, pub_key_1);
 
@@ -840,9 +842,9 @@ mod tests {
         // > = MasterMap::new();
         // trace!(?group);
         // let pub_key_1 = get_pubkey();
-        // let network1 = MemoryNetwork::new(pub_key_1, NoMetrics::new(), group.clone(), Option::None);
+        // let network1 = MemoryNetwork::new(pub_key_1, NoMetrics::boxed(), group.clone(), Option::None);
         // let pub_key_2 = get_pubkey();
-        // let network2 = MemoryNetwork::new(pub_key_2, NoMetrics::new(), group, Option::None);
+        // let network2 = MemoryNetwork::new(pub_key_2, NoMetrics::boxed(), group, Option::None);
         //
         // // Create some dummy messages
         // let messages: Vec<Message<Test, TestImpl>> = gen_messages(5, 100, pub_key_1);

--- a/src/traits/networking/memory_network.rs
+++ b/src/traits/networking/memory_network.rs
@@ -255,7 +255,7 @@ impl<M: NetworkMsg, K: SignatureKey> MemoryNetwork<M, K> {
                 direct_output: Mutex::new(direct_output),
                 master_map: master_map.clone(),
                 in_flight_message_count,
-                metrics: NetworkingMetrics::new(metrics),
+                metrics: NetworkingMetrics::new(&*metrics),
             }),
         };
         master_map.map.insert(pub_key, mn.clone());

--- a/src/traits/networking/memory_network.rs
+++ b/src/traits/networking/memory_network.rs
@@ -91,9 +91,6 @@ enum Combo<T> {
 
 /// Internal state for a `MemoryNetwork` instance
 struct MemoryNetworkInner<M: NetworkMsg, K: SignatureKey> {
-    /// The public key of this node
-    #[allow(dead_code)]
-    pub_key: K,
     /// Input for broadcast messages
     broadcast_input: RwLock<Option<Sender<Vec<u8>>>>,
     /// Input for direct messages
@@ -248,7 +245,6 @@ impl<M: NetworkMsg, K: SignatureKey> MemoryNetwork<M, K> {
         trace!("Task spawned, creating MemoryNetwork");
         let mn = MemoryNetwork {
             inner: Arc::new(MemoryNetworkInner {
-                pub_key: pub_key.clone(),
                 broadcast_input: RwLock::new(Some(broadcast_input)),
                 direct_input: RwLock::new(Some(direct_input)),
                 broadcast_output: Mutex::new(broadcast_output),

--- a/src/traits/networking/memory_network.rs
+++ b/src/traits/networking/memory_network.rs
@@ -72,6 +72,7 @@ pub struct MasterMap<M: NetworkMsg, K: SignatureKey> {
 
 impl<M: NetworkMsg, K: SignatureKey> MasterMap<M, K> {
     /// Create a new, empty, `MasterMap`
+    #[must_use]
     pub fn new() -> Arc<MasterMap<M, K>> {
         Arc::new(MasterMap {
             map: DashMap::new(),
@@ -476,6 +477,7 @@ impl<
     > MemoryCommChannel<TYPES, I, PROPOSAL, VOTE, MEMBERSHIP>
 {
     /// create new communication channel
+    #[must_use]
     pub fn new(network: MemoryNetwork<Message<TYPES, I>, TYPES::SignatureKey>) -> Self {
         Self(network, PhantomData::default())
     }

--- a/src/traits/networking/web_server_network.rs
+++ b/src/traits/networking/web_server_network.rs
@@ -385,7 +385,6 @@ impl<
         VOTE: VoteType<TYPES> + 'static,
     > WebServerNetwork<M, K, E, TYPES, PROPOSAL, VOTE>
 {
-    #[allow(clippy::panic)]
     /// Creates a new instance of the `WebServerNetwork`
     /// # Panics
     /// if the web server url is malformed

--- a/src/traits/networking/web_server_network.rs
+++ b/src/traits/networking/web_server_network.rs
@@ -76,6 +76,7 @@ impl<
     > WebCommChannel<TYPES, I, PROPOSAL, VOTE, MEMBERSHIP>
 {
     /// Create new communication channel
+    #[must_use]
     pub fn new(
         network: WebServerNetwork<
             Message<TYPES, I>,

--- a/src/traits/networking/web_server_network.rs
+++ b/src/traits/networking/web_server_network.rs
@@ -92,7 +92,6 @@ impl<
     /// Parses a message to find the appropriate endpoint
     /// Returns a `SendMsg` containing the endpoint
     fn parse_post_message(
-        &self,
         message: Message<TYPES, I>,
     ) -> Result<SendMsg<Message<TYPES, I>>, WebServerNetworkError> {
         let view_number: TYPES::Time = message.get_view_number();
@@ -557,7 +556,7 @@ impl<
         message: Message<TYPES, I>,
         _election: &MEMBERSHIP,
     ) -> Result<(), NetworkError> {
-        let network_msg = self.parse_post_message(message);
+        let network_msg = Self::parse_post_message(message);
         match network_msg {
             Ok(network_msg) => self.0.broadcast_message(network_msg, BTreeSet::new()).await,
             Err(network_msg) => Err(NetworkError::WebServer {
@@ -573,7 +572,7 @@ impl<
         message: Message<TYPES, I>,
         recipient: TYPES::SignatureKey,
     ) -> Result<(), NetworkError> {
-        let network_msg = self.parse_post_message(message);
+        let network_msg = Self::parse_post_message(message);
         match network_msg {
             Ok(network_msg) => self.0.direct_message(network_msg, recipient).await,
             Err(network_msg) => Err(NetworkError::WebServer {

--- a/src/traits/storage/memory_storage.rs
+++ b/src/traits/storage/memory_storage.rs
@@ -33,13 +33,10 @@ pub struct MemoryStorage<TYPES: NodeType, LEAF: LeafType<NodeType = TYPES>> {
     inner: Arc<RwLock<MemoryStorageInternal<TYPES, LEAF>>>,
 }
 
-#[allow(clippy::new_without_default)]
 impl<TYPES: NodeType, LEAF: LeafType<NodeType = TYPES>> MemoryStorage<TYPES, LEAF> {
     /// Create a new instance of the memory storage with the given block and state
-    /// NOTE: left as `new` because this API is not stable
-    /// we may add arguments to new in the future
     #[must_use]
-    pub fn new() -> Self {
+    pub fn empty() -> Self {
         let inner = MemoryStorageInternal {
             stored: BTreeMap::new(),
             failed: BTreeSet::new(),
@@ -55,7 +52,7 @@ impl<TYPES: NodeType, LEAF: LeafType<NodeType = TYPES>> TestableStorage<TYPES, L
     for MemoryStorage<TYPES, LEAF>
 {
     fn construct_tmp_storage() -> Result<Self> {
-        Ok(Self::new())
+        Ok(Self::empty())
     }
 
     async fn get_full_state(&self) -> StorageState<TYPES, LEAF> {

--- a/src/traits/storage/memory_storage.rs
+++ b/src/traits/storage/memory_storage.rs
@@ -38,6 +38,7 @@ impl<TYPES: NodeType, LEAF: LeafType<NodeType = TYPES>> MemoryStorage<TYPES, LEA
     /// Create a new instance of the memory storage with the given block and state
     /// NOTE: left as `new` because this API is not stable
     /// we may add arguments to new in the future
+    #[must_use]
     pub fn new() -> Self {
         let inner = MemoryStorageInternal {
             stored: BTreeMap::new(),

--- a/src/traits/storage/memory_storage.rs
+++ b/src/traits/storage/memory_storage.rs
@@ -126,8 +126,7 @@ mod test {
     use hotshot_types::constants::genesis_proposer_id;
     use hotshot_types::data::fake_commitment;
     use hotshot_types::data::{ValidatingLeaf, ViewNumber};
-    #[allow(clippy::wildcard_imports)]
-    use hotshot_types::traits::block_contents::dummy::*;
+    use hotshot_types::traits::block_contents::dummy::{DummyBlock, DummyState};
     use hotshot_types::traits::node_implementation::NodeType;
     use hotshot_types::traits::signature_key::ed25519::Ed25519Pub;
     use hotshot_types::traits::state::ConsensusTime;

--- a/src/types/handle.rs
+++ b/src/types/handle.rs
@@ -277,6 +277,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static> HotShotHandle<TYPE
     // Below is for testing only:
 
     /// Wrapper for `HotShotConsensusApi`'s `get_leader` function
+    #[allow(clippy::unused_async)] // async for API compatibility reasons
     #[cfg(feature = "hotshot-testing")]
     pub async fn get_leader(&self, view_number: TYPES::Time) -> TYPES::SignatureKey {
         self.hotshot.inner.quorum_exchange.get_leader(view_number)

--- a/testing/src/lib.rs
+++ b/testing/src/lib.rs
@@ -228,7 +228,7 @@ impl<TYPES: NodeType, I: TestableNodeImplementation<TYPES>> TestRunner<TYPES, I>
             quorum_exchange,
             committee_exchange,
             initializer,
-            NoMetrics::new(),
+            NoMetrics::boxed(),
         )
         .await
         .expect("Could not init hotshot");

--- a/testing/src/network_reliability.rs
+++ b/testing/src/network_reliability.rs
@@ -8,7 +8,7 @@ use rand::{
 
 /// A synchronous network. Packets may be delayed, but are guaranteed
 /// to arrive within `timeout` ns
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct SynchronousNetwork {
     /// Max delay of packet before arrival
     timeout_ms: u64,
@@ -92,17 +92,6 @@ impl NetworkReliability for PartiallySynchronousNetwork {
         } else {
             // act syncronous after gst
             self.synchronous.sample_delay()
-        }
-    }
-}
-
-#[allow(clippy::derivable_impls)]
-impl Default for SynchronousNetwork {
-    // disable all chance of failure
-    fn default() -> Self {
-        SynchronousNetwork {
-            delay_low_ms: 0,
-            timeout_ms: 0,
         }
     }
 }

--- a/testing/src/test_types.rs
+++ b/testing/src/test_types.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 use crate::TestRunner;
 use ark_bls12_381::Parameters as Param381;
 use blake3::Hasher;

--- a/types/src/constants.rs
+++ b/types/src/constants.rs
@@ -8,6 +8,7 @@ pub const LOOK_AHEAD: u64 = 5;
 /// the genesis proposer pk
 /// unfortunately need to allocate on the heap (for vec), so this ends up as a function instead of a
 /// const
+#[must_use]
 pub fn genesis_proposer_id() -> EncodedPublicKey {
     EncodedPublicKey(vec![4, 2])
 }

--- a/types/src/data.rs
+++ b/types/src/data.rs
@@ -2,8 +2,6 @@
 //!
 //! This module provides types for representing consensus internal state, such as leaves,
 //! `HotShot`'s version of a block, and proposals, messages upon which to reach the consensus.
-#![allow(clippy::missing_docs_in_private_items)]
-#![allow(missing_docs)]
 
 use crate::{
     certificate::{DACertificate, QuorumCertificate},
@@ -120,6 +118,7 @@ where
     pub proposer_id: EncodedPublicKey,
 }
 
+/// A proposal to start providing data availability for a block.
 #[derive(custom_debug::Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
 pub struct DAProposal<TYPES: NodeType> {
     /// Block leaf wants to apply
@@ -128,10 +127,11 @@ pub struct DAProposal<TYPES: NodeType> {
     pub view_number: TYPES::Time,
 }
 
+/// A proposal to append a new block commitment to the log.
 #[derive(custom_debug::Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
 #[serde(bound(deserialize = ""))]
 pub struct CommitmentProposal<TYPES: NodeType, LEAF: LeafType<NodeType = TYPES>> {
-    #[allow(clippy::missing_docs_in_private_items)]
+    /// The commitment to append.
     pub block_commitment: Commitment<TYPES::BlockType>,
 
     /// CurView from leader when proposing leaf
@@ -174,13 +174,19 @@ impl<TYPES: NodeType, LEAF: LeafType<NodeType = TYPES>> ProposalType
         self.view_number
     }
 }
+
+/// A proposal to a network of voting nodes.
 pub trait ProposalType:
     Debug + Clone + 'static + Serialize + for<'a> Deserialize<'a> + Send + Sync + PartialEq + Eq
 {
+    /// Type of nodes that can vote on this proposal.
     type NodeType: NodeType;
+
+    /// Time at which this proposal is valid.
     fn get_view_number(&self) -> <Self::NodeType as NodeType>::Time;
 }
 
+/// An item which is appended to a blockchain.
 pub trait LeafType:
     Debug
     + Clone
@@ -193,8 +199,11 @@ pub trait LeafType:
     + Eq
     + std::hash::Hash
 {
+    /// Type of nodes participating in the network.
     type NodeType: NodeType;
+    /// Type of block contained by this leaf.
     type DeltasType: Clone + Debug + for<'a> Deserialize<'a> + PartialEq + Send + Serialize + Sync;
+    /// Commitment to the blockchain state.
     type StateCommitmentType: Clone
         + Debug
         + for<'a> Deserialize<'a>
@@ -203,39 +212,45 @@ pub trait LeafType:
         + Serialize
         + Sync;
 
+    /// Create a new leaf from its components.
     fn new(
         view_number: <Self::NodeType as NodeType>::Time,
         justify_qc: QuorumCertificate<Self::NodeType, Self>,
         deltas: <Self::NodeType as NodeType>::BlockType,
         state: <Self::NodeType as NodeType>::StateType,
     ) -> Self;
-
+    /// Time when this leaf was created.
     fn get_view_number(&self) -> <Self::NodeType as NodeType>::Time;
-
+    /// Height of this leaf in the chain.
+    ///
+    /// Equivalently, this is the number of leaves before this one in the chain.
     fn get_height(&self) -> u64;
-
+    /// Change the height of this leaf.
     fn set_height(&mut self, height: u64);
-
+    /// The QC linking this leaf to its parent in the chain.
     fn get_justify_qc(&self) -> QuorumCertificate<Self::NodeType, Self>;
-
+    /// Commitment to this leaf's parent.
     fn get_parent_commitment(&self) -> Commitment<Self>;
-
+    /// The block contained in this leaf.
     fn get_deltas(&self) -> Self::DeltasType;
-
+    /// The blockchain state after appending this leaf.
     fn get_state(&self) -> Self::StateCommitmentType;
-
+    /// Transactions rejected or invalidated by the application of this leaf.
     fn get_rejected(&self) -> Vec<<<Self::NodeType as NodeType>::BlockType as Block>::Transaction>;
-
+    /// Real-world time when this leaf was created.
     fn get_timestamp(&self) -> i128;
-
+    /// Identity of the network participant who proposed this leaf.
     fn get_proposer_id(&self) -> EncodedPublicKey;
-
+    /// Create a leaf from information stored about a view.
     fn from_stored_view(stored_view: StoredView<Self::NodeType, Self>) -> Self;
 }
 
+/// Additional functions required to use a [`LeafType`] with hotshot-testing.
 pub trait TestableLeaf {
+    /// Type of nodes participating in the network.
     type NodeType: NodeType;
 
+    /// Create a transaction that can be added to the block contained in this leaf.
     fn create_random_transaction(
         &self,
         rng: &mut dyn rand::RngCore,

--- a/types/src/data.rs
+++ b/types/src/data.rs
@@ -509,11 +509,13 @@ where
     }
 }
 /// Fake the thing a genesis block points to. Needed to avoid infinite recursion
+#[must_use]
 pub fn fake_commitment<S: Committable>() -> Commitment<S> {
     commit::RawCommitmentBuilder::new("Dummy commitment for arbitrary genesis").finalize()
 }
 
 /// create a random commitment
+#[must_use]
 pub fn random_commitment<S: Committable>(rng: &mut dyn rand::RngCore) -> Commitment<S> {
     let random_array: Vec<u8> = (0u8..100u8).map(|_| rng.gen_range(0..255)).collect();
     commit::RawCommitmentBuilder::new("Random Commitment")

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -7,7 +7,7 @@
     clippy::missing_docs_in_private_items,
     clippy::panic
 )]
-#![allow(clippy::must_use_candidate, clippy::module_name_repetitions)]
+#![allow(clippy::module_name_repetitions)]
 
 use std::{num::NonZeroUsize, time::Duration};
 

--- a/types/src/traits/block_contents.rs
+++ b/types/src/traits/block_contents.rs
@@ -56,8 +56,7 @@ pub trait Transaction:
 
 /// Dummy implementation of `BlockContents` for unit tests
 pub mod dummy {
-    #[allow(clippy::wildcard_imports)]
-    use super::*;
+    use super::{Block, Commitment, Committable, Debug, Hash, HashSet, Serialize};
     use rand::Rng;
     use serde::Deserialize;
 

--- a/types/src/traits/metrics.rs
+++ b/types/src/traits/metrics.rs
@@ -28,15 +28,14 @@ pub trait Metrics: Send + Sync {
 }
 
 /// Use this if you're not planning to use any metrics. All methods are implemented as a no-op
+#[derive(Clone, Copy, Debug, Default)]
 pub struct NoMetrics;
 
 impl NoMetrics {
     /// Create a new `Box<dyn Metrics>` with this [`NoMetrics`]
-    // with our API it is more ergonomic to return `Box<dyn Metrics>`
-    #[allow(clippy::new_ret_no_self)]
     #[must_use]
-    pub fn new() -> Box<dyn Metrics> {
-        Box::new(NoMetrics)
+    pub fn boxed() -> Box<dyn Metrics> {
+        Box::<Self>::default()
     }
 }
 

--- a/types/src/traits/metrics.rs
+++ b/types/src/traits/metrics.rs
@@ -182,12 +182,11 @@ mod test {
                 .entry(self.prefix.clone())
                 .or_default() = amount;
         }
-        #[allow(clippy::cast_possible_truncation)]
-        #[allow(clippy::cast_sign_loss)]
         fn update(&self, delta: i64) {
             let mut values = self.values.lock().unwrap();
             let value = values.gauges.entry(self.prefix.clone()).or_default();
-            *value = (*value as i64 + delta) as usize;
+            let signed_value = i64::try_from(*value).unwrap_or(i64::MAX);
+            *value = usize::try_from(signed_value + delta).unwrap_or(0);
         }
     }
 

--- a/types/src/traits/metrics.rs
+++ b/types/src/traits/metrics.rs
@@ -34,6 +34,7 @@ impl NoMetrics {
     /// Create a new `Box<dyn Metrics>` with this [`NoMetrics`]
     // with our API it is more ergonomic to return `Box<dyn Metrics>`
     #[allow(clippy::new_ret_no_self)]
+    #[must_use]
     pub fn new() -> Box<dyn Metrics> {
         Box::new(NoMetrics)
     }

--- a/types/src/traits/signature_key/ed25519/ed25519_priv.rs
+++ b/types/src/traits/signature_key/ed25519/ed25519_priv.rs
@@ -14,6 +14,7 @@ pub struct Ed25519Priv {
 
 impl Ed25519Priv {
     /// Generate a new private key from scratch
+    #[must_use]
     pub fn generate() -> Self {
         let key_pair = KeyPair::generate();
         let priv_key = key_pair.sk;
@@ -21,6 +22,7 @@ impl Ed25519Priv {
     }
 
     /// Generate a new private key from a seed
+    #[must_use]
     pub fn generate_from_seed(seed: [u8; 32]) -> Self {
         let key_pair = KeyPair::from_seed(Seed::new(seed));
         let priv_key = key_pair.sk;
@@ -31,6 +33,7 @@ impl Ed25519Priv {
     ///
     /// Hashes the seed and the number together using blake3. This method is
     /// useful for testing
+    #[must_use]
     pub fn generated_from_seed_indexed(seed: [u8; 32], index: u64) -> Self {
         let mut hasher = blake3::Hasher::new();
         hasher.update(&seed);
@@ -52,12 +55,14 @@ impl Ed25519Priv {
     }
 
     /// Convert a private key to bytes
+    #[must_use]
     pub fn to_bytes(&self) -> Vec<u8> {
         self.priv_key.to_vec()
     }
 
     /// Return the [`TaggedBase64`] representation of this key.
     #[allow(clippy::missing_panics_doc)] // `TaggedBase64::new()` only panics if `PRIVKEY_ID` is not valid base64, which it is.
+    #[must_use]
     pub fn to_tagged_base64(&self) -> TaggedBase64 {
         TaggedBase64::new(PRIVKEY_ID, self.priv_key.as_ref()).unwrap()
     }

--- a/types/src/traits/signature_key/ed25519/ed25519_pub.rs
+++ b/types/src/traits/signature_key/ed25519/ed25519_pub.rs
@@ -42,6 +42,7 @@ impl Ord for Ed25519Pub {
 impl Ed25519Pub {
     /// Return the [`TaggedBase64`] representation of this key.
     #[allow(clippy::missing_panics_doc)] // `TaggedBase64::new()` only panics if `PEER_ID` is not valid base64, which it is.
+    #[must_use]
     pub fn to_tagged_base64(&self) -> TaggedBase64 {
         TaggedBase64::new(PEER_ID, self.pub_key.as_ref()).unwrap()
     }

--- a/types/src/traits/state.rs
+++ b/types/src/traits/state.rs
@@ -106,6 +106,7 @@ pub trait ConsensusTime:
     + 'static
 {
     /// Create a new instance of this time unit at time number 0
+    #[must_use]
     fn genesis() -> Self {
         Self::new(0)
     }

--- a/types/src/traits/state.rs
+++ b/types/src/traits/state.rs
@@ -2,8 +2,6 @@
 //!
 //! This module provides the [`State`] trait, which serves as an compatibility over the current
 //! network state, which is modified by the transactions contained within blocks.
-#![allow(clippy::missing_docs_in_private_items)]
-#![allow(missing_docs)]
 
 use crate::traits::Block;
 use commit::Committable;
@@ -65,24 +63,30 @@ pub trait State:
 
 // TODO Seuqnecing here means involving DA in consensus
 
-/// may need to make these public
+/// Marker trait for consensus which provides availability and ordering but not execution.
 pub trait SequencingConsensusType
 where
     Self: ConsensusType,
 {
 }
+
+/// Marker trait for consensus which provides ordering and execution.
 pub trait ValidatingConsensusType
 where
     Self: ConsensusType,
 {
 }
+
+/// Marker trait for different flavors of consensus.
 pub trait ConsensusType: Clone + Send + Sync {}
 
+/// Consensus which provides availability and ordering but not execution.
 #[derive(Clone)]
 pub struct SequencingConsensus;
 impl SequencingConsensusType for SequencingConsensus {}
 impl ConsensusType for SequencingConsensus {}
 
+/// Consensus which provides ordering and execution.
 #[derive(Clone)]
 pub struct ValidatingConsensus;
 impl ConsensusType for ValidatingConsensus {}
@@ -134,6 +138,7 @@ pub trait TestableBlock: Block + std::fmt::Debug {
     /// generate a genesis block
     fn genesis() -> Self;
 
+    /// the number of transactions in this block
     fn txn_count(&self) -> u64;
 }
 

--- a/types/src/traits/state.rs
+++ b/types/src/traits/state.rs
@@ -139,8 +139,7 @@ pub trait TestableBlock: Block + std::fmt::Debug {
 
 /// Dummy implementation of `State` for unit tests
 pub mod dummy {
-    #[allow(clippy::wildcard_imports)]
-    use super::*;
+    use super::{tag, Committable, Debug, Hash, Serialize, State, TestableState};
     use crate::{
         data::ViewNumber,
         traits::block_contents::dummy::{DummyBlock, DummyError, DummyTransaction},

--- a/types/src/traits/storage.rs
+++ b/types/src/traits/storage.rs
@@ -1,5 +1,4 @@
 //! Abstraction over on-disk storage of node state
-#![allow(missing_docs)]
 
 use super::{node_implementation::NodeType, signature_key::EncodedPublicKey};
 use crate::certificate::QuorumCertificate;

--- a/types/src/vote.rs
+++ b/types/src/vote.rs
@@ -124,7 +124,6 @@ type VoteMap<C, TOKEN> =
 
 /// Describe the process of collecting signatures on block or leaf commitment, to form a DAC or QC,
 /// respectively.
-#[allow(clippy::missing_docs_in_private_items)]
 pub struct VoteAccumulator<TOKEN, LEAF: Committable> {
     /// Map of all signatures accumlated so far
     pub vote_outcomes: VoteMap<LEAF, TOKEN>,

--- a/utils/src/bincode.rs
+++ b/utils/src/bincode.rs
@@ -1,8 +1,4 @@
-#![allow(
-    clippy::must_use_candidate,
-    clippy::module_name_repetitions,
-    clippy::type_complexity
-)]
+#![allow(clippy::module_name_repetitions, clippy::type_complexity)]
 use bincode::{
     config::{
         LittleEndian, RejectTrailing, VarintEncoding, WithOtherEndian, WithOtherIntEncoding,
@@ -16,6 +12,7 @@ use bincode::{
 ///   - Litte endian encoding
 ///   - Varint encoding
 ///   - Reject trailing bytes
+#[must_use]
 pub fn bincode_opts() -> WithOtherTrailing<
     WithOtherIntEncoding<
         WithOtherEndian<WithOtherLimit<DefaultOptions, bincode::config::Infinite>, LittleEndian>,


### PR DESCRIPTION
Progress on #1056. There’s more to do but this is a good start. This does not apply @dieracdelta’s commit 4cac2885e38eebf0bdfa71c1b234c552438c7eae from #1055, which causes over 400 new errors. I'll work on that next.

Thoughts on the remaining #[allow]ed lints:
* The cast precision loss ones are probably ok, especially since they are mostly used for metrics. I think it is fine to continue allowing these, with localized #[allow] attributes as warning flags.  I got rid of all the cast-possible-wrap lints as wrapping is (1) easier to prevent, by clamping, and (2) potentially worse behavior as it can give wildly erroneous results instead of just rounded results.
* The deprecated lints we should try to get rid of, but it might be more involved than the scope of this PR
* too_many_arguments and too_many_lines are good heuristics for refactoring, but not urgent, so I think it’s fine to continue #[allow]ing those with localized exceptions.
* Panic in test code is fine
* type_complexity is in a similar category as too_many_arguments, in that it’s a light code smell but not an urgent problem. I’m leaving those alone because many if not all of them seem like they will be addressed after the current round of refactoring
