### PR TITLE
Fix bug where next leader channel is created with wrong view number.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -991,7 +991,7 @@ where
         send_to_next_leader.cur_view += 1;
         let (send_commitment_vote_chan, recv_commitment_vote_chan) = {
             let vq = HotShot::<SequencingConsensus, TYPES, I>::create_or_obtain_chan_from_write(
-                cur_view + 1,
+                cur_view,
                 send_to_next_leader,
             )
             .await;


### PR DESCRIPTION
The channel to send/receive votes is index by the current view number (the view number of the vote) not the next view number.

With this change, the sequencer tests get farther (previously the leader was never receiving votes, now it receives them but the replicas eventually get out of sync).

Having problems running the tests locally so I don't know if this actually works yet.