### PR TITLE
Fix justify_qc validation in sequencing replica

### DIFF
--- a/consensus/src/sequencing_replica.rs
+++ b/consensus/src/sequencing_replica.rs
@@ -198,7 +198,7 @@ where
                                 // Validate the `justify_qc`.
                                 if !self
                                     .quorum_exchange
-                                    .is_valid_cert(&justify_qc, leaf_commitment)
+                                    .is_valid_cert(&justify_qc, parent_commitment)
                                 {
                                     invalid_qc = true;
                                     warn!("Invalid justify_qc in proposal!.");


### PR DESCRIPTION
The justify QC should reference the parent leaf (linking the new leaf to the existing chain), not the new leaf, which did not exist at the time when the justify QC was certified.