### PR TITLE
Fix parent commitment computation in replica and add block storage for DA members

### DIFF
--- a/consensus/src/da_member.rs
+++ b/consensus/src/da_member.rs
@@ -164,9 +164,9 @@ where
 
         let maybe_block = self.find_valid_msg(view_leader_key).await;
 
-        let Some(_block) = maybe_block else {
-            // We either timed out or for some reason could not accept a proposal.
-            return self.high_qc;
+        if let Some(block) = maybe_block {
+            let mut consensus = self.consensus.write().await;
+            consensus.saved_blocks.insert(block.commit(), block);
         };
 
         self.high_qc

--- a/consensus/src/sequencing_leader.rs
+++ b/consensus/src/sequencing_leader.rs
@@ -1,7 +1,7 @@
 //! Contains the [`DALeader`], [`ConsensusLeader`] and [`ConsensusNextLeader`] structs used for the
 //! leader steps in the consensus algorithm with DA committee, i.e. in the sequencing consensus.
 
-use crate::{utils::ViewInner, CommitmentMap, Consensus, ConsensusApi};
+use crate::{CommitmentMap, Consensus, ConsensusApi};
 use async_compatibility_layer::channel::UnboundedReceiver;
 use async_compatibility_layer::{
     art::async_timeout,
@@ -157,19 +157,20 @@ where
         let parent_view_number = &self.high_qc.view_number();
         let consensus = self.consensus.read().await;
         let parent_leaf = if let Some(parent_view) = consensus.state_map.get(parent_view_number) {
-            match &parent_view.view_inner {
-                ViewInner::Leaf { leaf } => {
-                    if let Some(leaf) = consensus.saved_leaves.get(leaf) {
-                        leaf
-                    } else {
-                        warn!("Failed to find high QC parent.");
-                        return None;
-                    }
-                }
-                ViewInner::Failed => {
-                    warn!("Parent of high QC points to a failed QC");
+            if let Some(leaf) = parent_view.get_leaf_commitment() {
+                if let Some(leaf) = consensus.saved_leaves.get(&leaf) {
+                    leaf
+                } else {
+                    warn!("Failed to find high QC parent.");
                     return None;
                 }
+            } else {
+                warn!(
+                    ?parent_view_number,
+                    ?parent_view,
+                    "Parent of high QC points to a view without a proposal"
+                );
+                return None;
             }
         } else {
             warn!("Couldn't find high QC parent in state map.");

--- a/consensus/src/sequencing_replica.rs
+++ b/consensus/src/sequencing_replica.rs
@@ -17,6 +17,7 @@ use hotshot_types::traits::election::{CommitteeExchangeType, ConsensusExchange};
 use hotshot_types::traits::node_implementation::NodeImplementation;
 use hotshot_types::traits::node_implementation::QuorumProposal;
 use hotshot_types::traits::node_implementation::QuorumVoteType;
+use hotshot_types::traits::state::ConsensusTime;
 use hotshot_types::vote::DAVote;
 use hotshot_types::{
     certificate::{DACertificate, QuorumCertificate},
@@ -91,30 +92,31 @@ where
             Commitment = TYPES::BlockType,
         > + CommitteeExchangeType<TYPES, I::Leaf, Message<TYPES, I>>,
 {
-    // TODO (da) Move this function so that it can be used by leader, replica, and committee member logic.
-    /// Returns the parent leaf of the proposal we are voting on
-    async fn parent_leaf(&self) -> Option<SequencingLeaf<TYPES>> {
-        let parent_view_number = &self.high_qc.view_number();
+    /// The leaf from the genesis view.
+    ///
+    /// This will be used as the parent leaf for the proposal in the first view after genesis.
+    async fn genesis_leaf(&self) -> Option<SequencingLeaf<TYPES>> {
         let consensus = self.consensus.read().await;
-        let parent_leaf = if let Some(parent_view) = consensus.state_map.get(parent_view_number) {
-            match &parent_view.view_inner {
-                ViewInner::Leaf { leaf } => {
-                    if let Some(leaf) = consensus.saved_leaves.get(leaf) {
-                        leaf
-                    } else {
-                        warn!("Failed to find high QC parent.");
+        let parent_leaf =
+            if let Some(parent_view) = consensus.state_map.get(&TYPES::Time::genesis()) {
+                match &parent_view.view_inner {
+                    ViewInner::Leaf { leaf } => {
+                        if let Some(leaf) = consensus.saved_leaves.get(leaf) {
+                            leaf
+                        } else {
+                            warn!("Failed to find genesis leaf.");
+                            return None;
+                        }
+                    }
+                    ViewInner::Failed => {
+                        warn!("Genesis view points to a failed QC");
                         return None;
                     }
                 }
-                ViewInner::Failed => {
-                    warn!("Parent of high QC points to a failed QC");
-                    return None;
-                }
-            }
-        } else {
-            warn!("Couldn't find high QC parent in state map.");
-            return None;
-        };
+            } else {
+                warn!("Couldn't find genesis view in state map.");
+                return None;
+            };
         Some(parent_leaf.clone())
     }
 
@@ -174,12 +176,19 @@ where
 
                                 // Construct the leaf.
                                 let justify_qc = p.data.justify_qc;
-                                let parent_commitment = match self.parent_leaf().await {
-                                    Some(parent) => parent.commit(),
-                                    None => {
-                                        break None;
-                                    }
+                                let parent = if justify_qc.is_genesis() {
+                                    self.genesis_leaf().await
+                                } else {
+                                    consensus
+                                        .saved_leaves
+                                        .get(&justify_qc.leaf_commitment())
+                                        .cloned()
                                 };
+                                let Some(parent) = parent else {
+                                    warn!("Proposal's parent missing from storage");
+                                    continue;
+                                };
+                                let parent_commitment = parent.commit();
                                 let block_commitment = p.data.block_commitment;
                                 let leaf = SequencingLeaf {
                                     view_number: self.cur_view,
@@ -202,6 +211,21 @@ where
                                 {
                                     invalid_qc = true;
                                     warn!("Invalid justify_qc in proposal!.");
+                                    message = self.quorum_exchange.create_no_message(
+                                        justify_qc_commitment,
+                                        leaf_commitment,
+                                        self.cur_view,
+                                        vote_token,
+                                    );
+                                }
+                                // Validate the `height`.
+                                else if leaf.height != parent.height + 1 {
+                                    invalid_qc = true;
+                                    warn!(
+                                        "Incorrect height in proposal (expected {}, got {})",
+                                        parent.height + 1,
+                                        leaf.height
+                                    );
                                     message = self.quorum_exchange.create_no_message(
                                         justify_qc_commitment,
                                         leaf_commitment,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,7 @@ use hotshot_consensus::{
 use hotshot_types::certificate::DACertificate;
 
 use hotshot_types::data::CommitmentProposal;
-use hotshot_types::data::{DAProposal, SequencingLeaf};
+use hotshot_types::data::{DAProposal, DeltasType, SequencingLeaf};
 use hotshot_types::traits::election::CommitteeExchangeType;
 use hotshot_types::traits::election::QuorumExchangeType;
 use hotshot_types::traits::network::CommunicationChannel;
@@ -234,7 +234,11 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> HotShot<TYPES::ConsensusType
         );
 
         let mut saved_leaves = HashMap::new();
+        let mut saved_blocks = HashMap::new();
         saved_leaves.insert(anchored_leaf.commit(), anchored_leaf.clone());
+        if let Ok(block) = anchored_leaf.get_deltas().try_resolve() {
+            saved_blocks.insert(block.commit(), block);
+        }
 
         let start_view = anchored_leaf.get_view_number();
 
@@ -244,6 +248,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> HotShot<TYPES::ConsensusType
             last_decided_view: anchored_leaf.get_view_number(),
             transactions: Arc::default(),
             saved_leaves,
+            saved_blocks,
             // TODO this is incorrect
             // https://github.com/EspressoSystems/HotShot/issues/560
             locked_view: anchored_leaf.get_view_number(),

--- a/types/src/data.rs
+++ b/types/src/data.rs
@@ -22,6 +22,7 @@ use either::Either;
 use espresso_systems_common::hotshot::tag;
 use rand::Rng;
 use serde::{Deserialize, Serialize};
+use snafu::{ensure, Snafu};
 use std::{fmt::Debug, hash::Hash};
 
 /// Type-safe wrapper around `u64` so we know the thing we're talking about is a view number.
@@ -186,6 +187,120 @@ pub trait ProposalType:
     fn get_view_number(&self) -> <Self::NodeType as NodeType>::Time;
 }
 
+/// A state change encoded in a leaf.
+///
+/// [`DeltasType`] represents a [block](NodeType::BlockType), but it may not contain the block in
+/// full. It is guaranteed to contain, at least, a cryptographic commitment to the block, and it
+/// provides an interface for resolving the commitment to a full block if the full block is
+/// available.
+pub trait DeltasType<Block: Committable>:
+    Clone + Debug + for<'a> Deserialize<'a> + PartialEq + Send + Serialize + Sync
+{
+    /// Errors reported by this type.
+    type Error: std::error::Error;
+
+    /// Get a cryptographic commitment to the block represented by this delta.
+    fn block_commitment(&self) -> Commitment<Block>;
+
+    /// Get the full block if it is available, otherwise return this object unchanged.
+    ///
+    /// # Errors
+    ///
+    /// Returns the original [`DeltasType`], unchanged, in an [`Err`] variant in the case where the
+    /// full block is not currently available.
+    fn try_resolve(self) -> Result<Block, Self>;
+
+    /// Fill this [`DeltasType`] by providing a complete block.
+    ///
+    /// After this function succeeds, [`try_resolve`](Self::try_resolve) is guaranteed to return
+    /// `Ok(block)`.
+    ///
+    /// # Errors
+    ///
+    /// Fails if `block` does not match `self.block_commitment()`, or if the block is not able to be
+    /// stored for some implementation-defined reason.
+    fn fill(&mut self, block: Block) -> Result<(), Self::Error>;
+}
+
+/// Error which occurs when [`DeltasType::fill`] is called with a block that does not match the
+/// deltas' internal block commitment.
+#[derive(Clone, Copy, Debug, Snafu)]
+#[snafu(display("the block {:?} has commitment {} (expected {})", block, block.commit(), commitment))]
+pub struct InconsistentDeltasError<Block: Committable + Debug> {
+    /// The block with the wrong commitment.
+    block: Block,
+    /// The expected commitment.
+    commitment: Commitment<Block>,
+}
+
+impl<Block> DeltasType<Block> for Block
+where
+    Block:
+        Committable + Clone + Debug + for<'a> Deserialize<'a> + PartialEq + Send + Serialize + Sync,
+{
+    type Error = InconsistentDeltasError<Block>;
+
+    fn block_commitment(&self) -> Commitment<Block> {
+        self.commit()
+    }
+
+    fn try_resolve(self) -> Result<Block, Self> {
+        Ok(self)
+    }
+
+    fn fill(&mut self, block: Block) -> Result<(), Self::Error> {
+        ensure!(
+            block.commit() == self.commit(),
+            InconsistentDeltasSnafu {
+                block,
+                commitment: self.commit()
+            }
+        );
+        // If the commitments are equal the blocks are equal, and we already have the block, so we
+        // don't have to do anything.
+        Ok(())
+    }
+}
+
+impl<Block> DeltasType<Block> for Either<Block, Commitment<Block>>
+where
+    Block:
+        Committable + Clone + Debug + for<'a> Deserialize<'a> + PartialEq + Send + Serialize + Sync,
+{
+    type Error = InconsistentDeltasError<Block>;
+
+    fn block_commitment(&self) -> Commitment<Block> {
+        match self {
+            Either::Left(block) => block.commit(),
+            Either::Right(comm) => *comm,
+        }
+    }
+
+    fn try_resolve(self) -> Result<Block, Self> {
+        match self {
+            Either::Left(block) => Ok(block),
+            Either::Right(_) => Err(self),
+        }
+    }
+
+    fn fill(&mut self, block: Block) -> Result<(), Self::Error> {
+        match self {
+            Either::Left(curr) => curr.fill(block),
+            Either::Right(comm) => {
+                ensure!(
+                    *comm == block.commit(),
+                    InconsistentDeltasSnafu {
+                        block,
+                        commitment: *comm
+                    }
+                );
+                *self = Either::Left(block);
+                Ok(())
+            }
+        }
+    }
+}
+
 /// An item which is appended to a blockchain.
 pub trait LeafType:
     Debug
@@ -202,7 +317,7 @@ pub trait LeafType:
     /// Type of nodes participating in the network.
     type NodeType: NodeType;
     /// Type of block contained by this leaf.
-    type DeltasType: Clone + Debug + for<'a> Deserialize<'a> + PartialEq + Send + Serialize + Sync;
+    type DeltasType: DeltasType<LeafBlock<Self>>;
     /// Commitment to the blockchain state.
     type StateCommitmentType: Clone
         + Debug
@@ -214,13 +329,13 @@ pub trait LeafType:
 
     /// Create a new leaf from its components.
     fn new(
-        view_number: <Self::NodeType as NodeType>::Time,
+        view_number: LeafTime<Self>,
         justify_qc: QuorumCertificate<Self::NodeType, Self>,
-        deltas: <Self::NodeType as NodeType>::BlockType,
-        state: <Self::NodeType as NodeType>::StateType,
+        deltas: LeafBlock<Self>,
+        state: LeafState<Self>,
     ) -> Self;
     /// Time when this leaf was created.
-    fn get_view_number(&self) -> <Self::NodeType as NodeType>::Time;
+    fn get_view_number(&self) -> LeafTime<Self>;
     /// Height of this leaf in the chain.
     ///
     /// Equivalently, this is the number of leaves before this one in the chain.
@@ -233,17 +348,47 @@ pub trait LeafType:
     fn get_parent_commitment(&self) -> Commitment<Self>;
     /// The block contained in this leaf.
     fn get_deltas(&self) -> Self::DeltasType;
+    /// Fill this leaf with the entire corresponding block.
+    ///
+    /// After this function succeeds, `self.get_deltas().try_resolve()` is guaranteed to return
+    /// `Ok(block)`.
+    ///
+    /// # Errors
+    ///
+    /// Fails if `block` does not match `self.get_deltas_commitment()`, or if the block is not able
+    /// to be stored for some implementation-defined reason.
+    fn fill_deltas(&mut self, block: LeafBlock<Self>) -> Result<(), LeafDeltasError<Self>>;
     /// The blockchain state after appending this leaf.
     fn get_state(&self) -> Self::StateCommitmentType;
     /// Transactions rejected or invalidated by the application of this leaf.
-    fn get_rejected(&self) -> Vec<<<Self::NodeType as NodeType>::BlockType as Block>::Transaction>;
+    fn get_rejected(&self) -> Vec<LeafTransaction<Self>>;
     /// Real-world time when this leaf was created.
     fn get_timestamp(&self) -> i128;
     /// Identity of the network participant who proposed this leaf.
     fn get_proposer_id(&self) -> EncodedPublicKey;
     /// Create a leaf from information stored about a view.
     fn from_stored_view(stored_view: StoredView<Self::NodeType, Self>) -> Self;
+
+    /// A commitment to the block contained in this leaf.
+    fn get_deltas_commitment(&self) -> Commitment<LeafBlock<Self>> {
+        self.get_deltas().block_commitment()
+    }
 }
+
+/// The [`DeltasType`] in a [`LeafType`].
+pub type LeafDeltas<LEAF> = <LEAF as LeafType>::DeltasType;
+/// Errors reported by the [`DeltasType`] in a [`LeafType`].
+pub type LeafDeltasError<LEAF> = <LeafDeltas<LEAF> as DeltasType<LeafBlock<LEAF>>>::Error;
+/// The [`NodeType`] in a [`LeafType`].
+pub type LeafNode<LEAF> = <LEAF as LeafType>::NodeType;
+/// The [`StateType`] in a [`LeafType`].
+pub type LeafState<LEAF> = <LeafNode<LEAF> as NodeType>::StateType;
+/// The [`Block`] in a [`LeafType`].
+pub type LeafBlock<LEAF> = <LeafNode<LEAF> as NodeType>::BlockType;
+/// The [`Transaction`] in a [`LeafType`].
+pub type LeafTransaction<LEAF> = <LeafBlock<LEAF> as Block>::Transaction;
+/// The [`ConsensusTime`] used by a [`LeafType`].
+pub type LeafTime<LEAF> = <LeafNode<LEAF> as NodeType>::Time;
 
 /// Additional functions required to use a [`LeafType`] with hotshot-testing.
 pub trait TestableLeaf {
@@ -381,6 +526,14 @@ impl<TYPES: NodeType> LeafType for ValidatingLeaf<TYPES> {
         self.deltas.clone()
     }
 
+    fn get_deltas_commitment(&self) -> Commitment<<Self::NodeType as NodeType>::BlockType> {
+        self.deltas.block_commitment()
+    }
+
+    fn fill_deltas(&mut self, block: LeafBlock<Self>) -> Result<(), LeafDeltasError<Self>> {
+        self.deltas.fill(block)
+    }
+
     fn get_state(&self) -> Self::StateCommitmentType {
         self.state.clone()
     }
@@ -477,6 +630,14 @@ impl<TYPES: NodeType> LeafType for SequencingLeaf<TYPES> {
 
     fn get_deltas(&self) -> Self::DeltasType {
         self.deltas.clone()
+    }
+
+    fn get_deltas_commitment(&self) -> Commitment<<Self::NodeType as NodeType>::BlockType> {
+        self.deltas.block_commitment()
+    }
+
+    fn fill_deltas(&mut self, block: LeafBlock<Self>) -> Result<(), LeafDeltasError<Self>> {
+        self.deltas.fill(block)
     }
 
     // The Sequencing Leaf doesn't have a state.


### PR DESCRIPTION
With this change, `test_skeleton_instantiation` in the sequencer repo finally passes!