### PR TITLE
Fix errors due to Exchanges type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -805,7 +805,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.13",
+ "syn 2.0.14",
 ]
 
 [[package]]
@@ -822,7 +822,7 @@ checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.13",
+ "syn 2.0.14",
 ]
 
 [[package]]
@@ -854,9 +854,9 @@ dependencies = [
 
 [[package]]
 name = "async-tungstenite"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0388bb7a400072bbb41ceb75d65c3baefb2ea99672fa22e85278452cd9b58b"
+checksum = "b6d2c69d237cf761215175f390021344f5530101cca8164d69878b8a1779e80c"
 dependencies = [
  "async-std",
  "futures-io",
@@ -864,7 +864,7 @@ dependencies = [
  "log",
  "pin-project-lite 0.2.9",
  "tokio",
- "tungstenite 0.18.0",
+ "tungstenite 0.19.0",
 ]
 
 [[package]]
@@ -1340,7 +1340,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.13",
+ "syn 2.0.14",
 ]
 
 [[package]]
@@ -1895,7 +1895,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn 2.0.13",
+ "syn 2.0.14",
 ]
 
 [[package]]
@@ -1912,7 +1912,7 @@ checksum = "2345488264226bf682893e25de0769f3360aac9957980ec49361b083ddaa5bc5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.13",
+ "syn 2.0.14",
 ]
 
 [[package]]
@@ -2548,7 +2548,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.13",
+ "syn 2.0.14",
 ]
 
 [[package]]
@@ -2700,9 +2700,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be7b54589b581f624f566bf5d8eb2bab1db736c51528720b6bd36b96b55924d"
+checksum = "66b91535aa35fea1523ad1b86cb6b53c28e0ae566ba4a460f4457e936cad7c6f"
 dependencies = [
  "bytes 1.4.0",
  "fnv",
@@ -2925,7 +2925,7 @@ dependencies = [
  "async-lock",
  "async-std",
  "async-trait",
- "async-tungstenite 0.20.0",
+ "async-tungstenite 0.21.0",
  "atomic_store",
  "bimap",
  "bincode",
@@ -3003,6 +3003,7 @@ dependencies = [
  "bincode",
  "commit 0.2.2",
  "custom_debug",
+ "derivative",
  "either",
  "futures",
  "hotshot-types",
@@ -3096,7 +3097,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "snafu",
- "syn 2.0.13",
+ "syn 2.0.14",
  "tempfile",
  "tokio",
  "tracing",
@@ -3112,7 +3113,7 @@ dependencies = [
  "async-compatibility-layer",
  "async-std",
  "async-trait",
- "async-tungstenite 0.20.0",
+ "async-tungstenite 0.21.0",
  "atomic_store",
  "bincode",
  "blake3",
@@ -3164,6 +3165,7 @@ dependencies = [
  "libp2p-core 0.37.0",
  "nll",
  "portpicker",
+ "rand 0.8.5",
  "serde",
  "serde_json",
  "snafu",
@@ -3793,9 +3795,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p"
-version = "0.51.2"
+version = "0.51.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab78d6d2201578bb3a33dff33c540af6b8f0bdcd751b4028e798e868c2ca0722"
+checksum = "f210d259724eae82005b5c48078619b7745edb7b76de370b03f8ba59ea103097"
 dependencies = [
  "bytes 1.4.0",
  "futures",
@@ -5277,7 +5279,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.13",
+ "syn 2.0.14",
 ]
 
 [[package]]
@@ -5635,7 +5637,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.13",
+ "syn 2.0.14",
 ]
 
 [[package]]
@@ -6726,9 +6728,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.159"
+version = "1.0.160"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c04e8343c3daeec41f58990b9d77068df31209f2af111e059e9fe9646693065"
+checksum = "bb2f3770c8bce3bcda7e149193a069a0f4365bda1fa5cd88e03bca26afc1216c"
 dependencies = [
  "serde_derive",
 ]
@@ -6753,20 +6755,20 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.159"
+version = "1.0.160"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c614d17805b093df4b147b51339e7e44bf05ef59fba1e45d83500bcfb4d8585"
+checksum = "291a097c63d8497e00160b166a967a4a79c64f3facdd01cbd7502231688d77df"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.13",
+ "syn 2.0.14",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.95"
+version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d721eca97ac802aa7777b701877c8004d950fc142651367300d21c1cc0194744"
+checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
 dependencies = [
  "itoa 1.0.6",
  "ryu",
@@ -7367,9 +7369,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.13"
+version = "2.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c9da457c5285ac1f936ebd076af6dac17a61cfe7826f2076b4d015cf47bc8ec"
+checksum = "fcf316d5356ed6847742d036f8a39c3b8435cac10bd528a4bd461928a6ab34d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7509,7 +7511,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.13",
+ "syn 2.0.14",
 ]
 
 [[package]]
@@ -7757,7 +7759,7 @@ checksum = "61a573bdc87985e9d6ddeed1b3d864e8a302c847e40d647746df2f1de209d1ce"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.13",
+ "syn 2.0.14",
 ]
 
 [[package]]
@@ -8183,13 +8185,13 @@ dependencies = [
 
 [[package]]
 name = "tungstenite"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30ee6ab729cd4cf0fd55218530c4522ed30b7b6081752839b68fcec8d0960788"
+checksum = "15fba1a6d6bb030745759a9a2a588bfe8490fc8b4751a277db3a0be1c9ebbf67"
 dependencies = [
- "base64 0.13.1",
  "byteorder",
  "bytes 1.4.0",
+ "data-encoding",
  "http",
  "httparse",
  "log",
@@ -9184,5 +9186,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.13",
+ "syn 2.0.14",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,7 +113,7 @@ async-compatibility-layer = { git = "https://github.com/EspressoSystems/async-co
 async-lock = "2.7"
 async-std = { version = "1.12", optional = true }
 async-trait = "0.1.68"
-async-tungstenite = "0.20.0"
+async-tungstenite = "0.21.0"
 atomic_store = { git = "https://github.com/EspressoSystems/atomicstore", tag = "0.1.3" }
 bimap = "0.6.3"
 bincode = "1.3.3"
@@ -141,7 +141,7 @@ jf-primitives = { git = "https://github.com/EspressoSystems/jellyfish", tag = "0
 libp2p-swarm-derive = { version = "=0.32.0" }
 libp2p-networking = { path = "./libp2p-networking", version = "0.1.0", default-features = false }
 libp2p-identity = "0.1.1"
-libp2p = { version = "0.51.2", default-features = false, features = [
+libp2p = { version = "0.51.3", default-features = false, features = [
         "macros",
         "autonat",
         "deflate",
@@ -168,7 +168,7 @@ nll = { git = "https://github.com/EspressoSystems/nll.git" }
 num = "0.4.0"
 rand = "0.8.5"
 rand_chacha = "0.3.1"
-serde = { version = "1.0.159", features = ["derive", "rc"] }
+serde = { version = "1.0.160", features = ["derive", "rc"] }
 snafu = "0.7.4"
 surf-disco = { git = "https://github.com/EspressoSystems/surf-disco.git", branch = "main" }
 tempfile = "3.5.0"
@@ -196,7 +196,7 @@ tracing-unwrap = { version = "0.10.0", features = ["log-location"] }
 async-std = { version = "1.12.0", features = ["attributes"] }
 clap = { version = "4.2", features = ["derive", "env"] }
 rand_xoshiro = "0.6.0"
-serde_json = "1.0.95"
+serde_json = "1.0.96"
 sha2 = { version = "0.10.1" }
 toml = "0.7.3"
 

--- a/centralized_server/Cargo.toml
+++ b/centralized_server/Cargo.toml
@@ -52,7 +52,7 @@ tokio = { version = "1", optional = true, features = [
     "tracing",
 ] }
 tracing = "0.1.37"
-serde = { version = "1.0.159", features = ["derive"] }
-serde_json = "1.0.95"
+serde = { version = "1.0.160", features = ["derive"] }
+serde_json = "1.0.96"
 snafu = "0.7.4"
 toml = "0.7.3"

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -35,6 +35,7 @@ async-trait = "0.1.68"
 bincode = "1.3.3"
 commit = { git = "https://github.com/EspressoSystems/commit", tag = "0.2.2" }
 custom_debug = "0.5"
+derivative = "2.2"
 either = { version = "1.8.1" }
 futures = "0.3.28"
 hotshot-types = { path = "../types", default-features = false }

--- a/consensus/src/da_member.rs
+++ b/consensus/src/da_member.rs
@@ -6,16 +6,15 @@ use crate::{
     Consensus, SequencingConsensusApi,
 };
 use async_compatibility_layer::channel::UnboundedReceiver;
-use async_lock::{Mutex, RwLock, RwLockUpgradableReadGuard};
+use async_lock::{Mutex, RwLock};
 use commit::Committable;
-use either::Left;
 use hotshot_types::message::Message;
 use hotshot_types::{
     certificate::QuorumCertificate,
     data::{DAProposal, SequencingLeaf},
     message::{ConsensusMessage, ProcessedConsensusMessage},
     traits::{
-        election::{CommitteeExchangeType, ConsensusExchange, SignedCertificate},
+        election::{CommitteeExchangeType, ConsensusExchange},
         node_implementation::{CommitteeProposal, CommitteeVote, NodeImplementation, NodeType},
         signature_key::SignatureKey,
     },
@@ -68,32 +67,6 @@ where
             Vote = DAVote<TYPES, SequencingLeaf<TYPES>>,
         > + CommitteeExchangeType<TYPES, I::Leaf, Message<TYPES, I>>,
 {
-    /// Returns the parent leaf of the proposal we are voting on
-    async fn parent_leaf(&self) -> Option<SequencingLeaf<TYPES>> {
-        let parent_view_number = &self.high_qc.view_number();
-        let consensus = self.consensus.read().await;
-        let parent_leaf = if let Some(parent_view) = consensus.state_map.get(parent_view_number) {
-            match &parent_view.view_inner {
-                ViewInner::Leaf { leaf } => {
-                    if let Some(leaf) = consensus.saved_leaves.get(leaf) {
-                        leaf
-                    } else {
-                        warn!("Failed to find high QC parent.");
-                        return None;
-                    }
-                }
-                ViewInner::Failed => {
-                    warn!("Parent of high QC points to a failed QC");
-                    return None;
-                }
-            }
-        } else {
-            warn!("Couldn't find high QC parent in state map.");
-            return None;
-        };
-        Some(parent_leaf.clone())
-    }
-
     /// DA committee member task that spins until a valid DA proposal can be signed or timeout is
     /// hit.
     #[instrument(skip_all, fields(id = self.id, view = *self.cur_view), name = "DA Member Task", level = "error")]
@@ -101,7 +74,7 @@ where
     async fn find_valid_msg<'a>(
         &self,
         view_leader_key: TYPES::SignatureKey,
-    ) -> Option<SequencingLeaf<TYPES>> {
+    ) -> Option<TYPES::BlockType> {
         let lock = self.proposal_collection_chan.lock().await;
         let leaf = loop {
             let msg = lock.recv().await;
@@ -117,17 +90,6 @@ where
                         if view_leader_key != sender {
                             continue;
                         }
-                        let parent = self.parent_leaf().await?;
-                        let leaf = SequencingLeaf {
-                            view_number: self.cur_view,
-                            height: parent.height + 1,
-                            justify_qc: self.high_qc.clone(),
-                            parent_commitment: parent.commit(),
-                            deltas: Left(p.data.deltas.clone()),
-                            rejected: Vec::new(),
-                            timestamp: time::OffsetDateTime::now_utc().unix_timestamp_nanos(),
-                            proposer_id: sender.to_bytes(),
-                        };
 
                         let block_commitment = p.data.deltas.commit();
                         if !view_leader_key.validate(&p.signature, block_commitment.as_ref()) {
@@ -168,7 +130,7 @@ where
                                 }
                             }
                         }
-                        break leaf;
+                        break p.data.deltas;
                     }
                     ProcessedConsensusMessage::InternalTrigger(_trigger) => {
                         warn!("DA committee member receieved an internal trigger message. This is not what the member expects. Skipping.");
@@ -203,30 +165,24 @@ where
         info!("DA Committee Member task started!");
         let view_leader_key = self.exchange.get_leader(self.cur_view);
 
-        let maybe_leaf = self.find_valid_msg(view_leader_key).await;
+        let maybe_block = self.find_valid_msg(view_leader_key).await;
 
-        let Some(leaf) = maybe_leaf else {
-            // We either timed out or for some reason could not accept a proposal.
-            return self.high_qc;
+        if let Some(block) = maybe_block {
+            let mut consensus = self.consensus.write().await;
+
+            // Ensure this view is in the view map for garbage collection, but do not overwrite if
+            // there is already a view there: the replica task may have inserted a `Leaf` view which
+            // contains strictly more information.
+            consensus.state_map.entry(self.cur_view).or_insert(View {
+                view_inner: ViewInner::DA {
+                    block: block.commit(),
+                },
+            });
+
+            // Record the block we have promised to make available.
+            consensus.saved_blocks.insert(block);
         };
 
-        // Update state map and leaves.
-        let consensus = self.consensus.upgradable_read().await;
-        let mut consensus = RwLockUpgradableReadGuard::upgrade(consensus).await;
-        consensus.state_map.insert(
-            self.cur_view,
-            View {
-                view_inner: ViewInner::Leaf {
-                    leaf: leaf.commit(),
-                },
-            },
-        );
-        consensus.saved_leaves.insert(leaf.commit(), leaf.clone());
-
-        // We're only storing the last QC. We could store more but we're realistically only going to retrieve the last one.
-        if let Err(e) = self.api.store_leaf(self.cur_view, leaf).await {
-            error!("Could not insert new anchor into the storage API: {:?}", e);
-        }
         self.high_qc
     }
 }

--- a/consensus/src/leader.rs
+++ b/consensus/src/leader.rs
@@ -1,6 +1,6 @@
 //! Contains the [`ValidatingLeader`] struct used for the leader step in the hotstuff consensus algorithm.
 
-use crate::{utils::ViewInner, CommitmentMap, Consensus, ValidatingConsensusApi};
+use crate::{CommitmentMap, Consensus, ValidatingConsensusApi};
 use async_compatibility_layer::{
     art::{async_sleep, async_timeout},
     async_primitives::subscribable_rwlock::{ReadView, SubscribableRwLock},
@@ -75,28 +75,26 @@ where
         let consensus = self.consensus.read().await;
         let mut reached_decided = false;
 
-        let parent_leaf = if let Some(parent_view) = consensus.state_map.get(parent_view_number) {
-            match &parent_view.view_inner {
-                ViewInner::Leaf { leaf } => {
-                    if let Some(leaf) = consensus.saved_leaves.get(leaf) {
-                        if leaf.view_number == consensus.last_decided_view {
-                            reached_decided = true;
-                        }
-                        leaf
-                    } else {
-                        warn!("Failed to find high QC parent.");
-                        return self.high_qc;
-                    }
-                }
-                ViewInner::Failed => {
-                    warn!("Parent of high QC points to a failed QC");
-                    return self.high_qc;
-                }
-            }
-        } else {
+        let Some(parent_view) = consensus.state_map.get(parent_view_number) else {
             warn!("Couldn't find high QC parent in state map.");
             return self.high_qc;
         };
+        let Some(leaf) = parent_view.get_leaf_commitment() else {
+            warn!(
+                ?parent_view_number,
+                ?parent_view,
+                "Parent of high QC points to a view without a proposal"
+            );
+            return self.high_qc;
+        };
+        let Some(leaf) = consensus.saved_leaves.get(&leaf) else {
+            warn!("Failed to find high QC parent.");
+            return self.high_qc;
+        };
+        if leaf.view_number == consensus.last_decided_view {
+            reached_decided = true;
+        }
+        let parent_leaf = leaf.clone();
 
         let original_parent_hash = parent_leaf.commit();
         let starting_state = &parent_leaf.state;

--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -30,7 +30,8 @@ pub use sequencing_replica::SequencingReplica;
 pub use traits::{ConsensusSharedApi, SequencingConsensusApi, ValidatingConsensusApi};
 pub use utils::{SendToTasks, View, ViewInner, ViewQueue};
 
-use commit::Commitment;
+use commit::{Commitment, Committable};
+use derivative::Derivative;
 use hotshot_types::certificate::QuorumCertificate;
 use hotshot_types::traits::metrics::Counter;
 use hotshot_types::{
@@ -42,7 +43,7 @@ use hotshot_types::{
     },
 };
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::{hash_map::Entry, BTreeMap, HashMap},
     sync::Arc,
 };
 use tracing::{error, warn};
@@ -114,6 +115,11 @@ pub struct Consensus<TYPES: NodeType, LEAF: LeafType<NodeType = TYPES>> {
     /// - contains undecided leaves
     /// - includes the MOST RECENT decided leaf
     pub saved_leaves: CommitmentMap<LEAF>,
+
+    /// Saved blocks
+    ///
+    /// Contains the full block for every leaf in `saved_leaves` if that block is available.
+    pub saved_blocks: BlockStore<TYPES::BlockType>,
 
     /// The `locked_qc` view number
     pub locked_view: TYPES::Time,
@@ -245,8 +251,7 @@ impl<TYPES: NodeType, LEAF: LeafType<NodeType = TYPES>> Consensus<TYPES, LEAF> {
         F: FnMut(&LEAF) -> bool,
     {
         let mut next_leaf = if let Some(view) = self.state_map.get(&start_from) {
-            *view
-                .get_leaf_commitment()
+            view.get_leaf_commitment()
                 .ok_or_else(|| HotShotError::InvalidState {
                     context: format!(
                         "Visited failed view {start_from:?} leaf. Expected successfuil leaf"
@@ -306,9 +311,17 @@ impl<TYPES: NodeType, LEAF: LeafType<NodeType = TYPES>> Consensus<TYPES, LEAF> {
         // perform gc
         self.state_map
             .range(old_anchor_view..new_anchor_view)
+            .filter_map(|(_view_number, view)| view.get_block_commitment())
+            .for_each(|block| {
+                self.saved_blocks.remove(block);
+            });
+        self.state_map
+            .range(old_anchor_view..new_anchor_view)
             .filter_map(|(_view_number, view)| view.get_leaf_commitment())
             .for_each(|leaf| {
-                let _removed = self.saved_leaves.remove(leaf);
+                if let Some(removed) = self.saved_leaves.remove(&leaf) {
+                    self.saved_blocks.remove(removed.get_deltas_commitment());
+                }
             });
         self.state_map = self.state_map.split_off(&new_anchor_view);
     }
@@ -330,6 +343,60 @@ impl<TYPES: NodeType, LEAF: LeafType<NodeType = TYPES>> Consensus<TYPES, LEAF> {
         let leaf = view
             .get_leaf_commitment()
             .expect("Decided state not found! Consensus internally inconsistent");
-        self.saved_leaves.get(leaf).unwrap().clone()
+        self.saved_leaves.get(&leaf).unwrap().clone()
+    }
+}
+
+/// Mapping from block commitments to full blocks.
+///
+/// Entries in this mapping are reference-counted, so multiple consensus objects can refer to the
+/// same block, and the block will only be deleted after _all_ such objects are garbage collected.
+/// For example, multiple leaves may temporarily reference the same block on different branches,
+/// before all but one branch are ultimately garbage collected.
+#[derive(Clone, Debug, Derivative)]
+#[derivative(Default(bound = ""))]
+pub struct BlockStore<BLOCK: Committable>(HashMap<Commitment<BLOCK>, (BLOCK, u64)>);
+
+impl<BLOCK: Committable> BlockStore<BLOCK> {
+    /// Save `block` for later retrieval.
+    ///
+    /// After calling this function, and before the corresponding call to [`remove`](Self::remove),
+    /// `self.get(block.commit())` will return `Some(block)`.
+    ///
+    /// This function will increment a reference count on the saved block, so that multiple calls to
+    /// [`insert`](Self::insert) for the same block result in multiple owning references to the
+    /// block. [`remove`](Self::remove) must be called once for each reference before the block will
+    /// be deallocated.
+    pub fn insert(&mut self, block: BLOCK) {
+        self.0
+            .entry(block.commit())
+            .and_modify(|(_, refcount)| *refcount += 1)
+            .or_insert((block, 1));
+    }
+
+    /// Get a saved block, if available.
+    ///
+    /// If a block has been saved with [`insert`](Self::insert), this function will retrieve it. It
+    /// may return [`None`] if a block with the given commitment has not been saved or if the block
+    /// has been dropped with [`remove`](Self::remove).
+    #[must_use]
+    pub fn get(&self, block: Commitment<BLOCK>) -> Option<&BLOCK> {
+        self.0.get(&block).map(|(block, _)| block)
+    }
+
+    /// Drop a reference to a saved block.
+    ///
+    /// If the block exists and this call drops the last reference to it, the block will be
+    /// returned. Otherwise, the return value is [`None`].
+    pub fn remove(&mut self, block: Commitment<BLOCK>) -> Option<BLOCK> {
+        if let Entry::Occupied(mut e) = self.0.entry(block) {
+            let (_, refcount) = e.get_mut();
+            *refcount -= 1;
+            if *refcount == 0 {
+                let (block, _) = e.remove();
+                return Some(block);
+            }
+        }
+        None
     }
 }

--- a/examples/libp2p/types.rs
+++ b/examples/libp2p/types.rs
@@ -7,9 +7,11 @@ use hotshot::{
     },
 };
 use hotshot_types::message::Message;
-use hotshot_types::traits::consensus_type::validating_consensus::ValidatingConsensus;
-use hotshot_types::traits::election::QuorumExchange;
-use hotshot_types::traits::node_implementation::NodeImplementation;
+use hotshot_types::traits::{
+    consensus_type::validating_consensus::ValidatingConsensus,
+    election::QuorumExchange,
+    node_implementation::{NodeImplementation, ValidatingExchanges},
+};
 use hotshot_types::{
     data::{ValidatingLeaf, ValidatingProposal},
     traits::node_implementation::NodeType,

--- a/examples/libp2p/types.rs
+++ b/examples/libp2p/types.rs
@@ -7,6 +7,7 @@ use hotshot::{
     },
 };
 use hotshot_types::message::Message;
+use hotshot_types::traits::consensus_type::validating_consensus::ValidatingConsensus;
 use hotshot_types::traits::election::QuorumExchange;
 use hotshot_types::traits::node_implementation::NodeImplementation;
 use hotshot_types::{
@@ -31,6 +32,13 @@ pub type ThisVote = QuorumVote<VDemoTypes, ThisLeaf>;
 impl NodeImplementation<VDemoTypes> for NodeImpl {
     type Storage = MemoryStorage<VDemoTypes, Self::Leaf>;
     type Leaf = ValidatingLeaf<VDemoTypes>;
+    type Exchanges = ValidatingExchanges<
+        ValidatingConsensus,
+        VDemoTypes,
+        ValidatingLeaf<VDemoTypes>,
+        Message<VDemoTypes, Self>,
+        Self::QuorumExchange,
+    >;
     type QuorumExchange = QuorumExchange<
         VDemoTypes,
         Self::Leaf,

--- a/examples/web-server/types.rs
+++ b/examples/web-server/types.rs
@@ -5,8 +5,11 @@ use hotshot::{
     traits::{election::static_committee::GeneralStaticCommittee, implementations::WebCommChannel},
 };
 use hotshot_types::message::Message;
-use hotshot_types::traits::election::QuorumExchange;
-use hotshot_types::traits::node_implementation::NodeImplementation;
+use hotshot_types::traits::{
+    consensus_type::validating_consensus::ValidatingConsensus,
+    election::QuorumExchange,
+    node_implementation::{NodeImplementation, ValidatingExchanges},
+};
 use hotshot_types::{
     data::{ValidatingLeaf, ValidatingProposal},
     traits::node_implementation::NodeType,

--- a/examples/web-server/types.rs
+++ b/examples/web-server/types.rs
@@ -27,6 +27,13 @@ pub type ThisVote = QuorumVote<VDemoTypes, ThisLeaf>;
 impl NodeImplementation<VDemoTypes> for NodeImpl {
     type Storage = MemoryStorage<VDemoTypes, Self::Leaf>;
     type Leaf = ValidatingLeaf<VDemoTypes>;
+    type Exchanges = ValidatingExchanges<
+        ValidatingConsensus,
+        VDemoTypes,
+        ValidatingLeaf<VDemoTypes>,
+        Message<VDemoTypes, Self>,
+        Self::QuorumExchange,
+    >;
     type QuorumExchange = QuorumExchange<
         VDemoTypes,
         Self::Leaf,

--- a/libp2p-networking/Cargo.toml
+++ b/libp2p-networking/Cargo.toml
@@ -56,7 +56,7 @@ futures = "0.3.28"
 hotshot-utils = { path = "../utils"}
 libp2p-swarm-derive = { version = "=0.32.0" }
 libp2p-identity = "0.1.1"
-libp2p = { version = "0.51.2", default-features = false, features = [
+libp2p = { version = "0.51.3", default-features = false, features = [
     "macros",
     "autonat",
     "deflate",
@@ -84,8 +84,8 @@ libp2p = { version = "0.51.2", default-features = false, features = [
 ] }
 parking_lot = "0.12.0"
 rand = "0.8.5"
-serde = { version = "1.0.159", features = ["derive"] }
-serde_json = "1.0.95"
+serde = { version = "1.0.160", features = ["derive"] }
+serde_json = "1.0.96"
 snafu = "0.7.4"
 tokio = { version = "1", optional = true, features = [
     "fs",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,8 +49,8 @@ use commit::{Commitment, Committable};
 
 use hotshot_consensus::{
     Consensus, ConsensusLeader, ConsensusMetrics, ConsensusNextLeader, ConsensusSharedApi,
-    DALeader, DAMember, NextValidatingLeader, Replica, SendToTasks, SequencingConsensusApi,
-    SequencingReplica, ValidatingConsensusApi, ValidatingLeader, View, ViewInner, ViewQueue,
+    DALeader, DAMember, NextValidatingLeader, Replica, SendToTasks, SequencingReplica,
+    ValidatingLeader, View, ViewInner, ViewQueue,
 };
 use hotshot_types::certificate::DACertificate;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,14 +48,14 @@ use bincode::Options;
 use commit::{Commitment, Committable};
 
 use hotshot_consensus::{
-    Consensus, ConsensusLeader, ConsensusMetrics, ConsensusNextLeader, ConsensusSharedApi,
-    DALeader, DAMember, NextValidatingLeader, Replica, SendToTasks, SequencingReplica,
-    ValidatingLeader, View, ViewInner, ViewQueue,
+    BlockStore, Consensus, ConsensusLeader, ConsensusMetrics, ConsensusNextLeader,
+    ConsensusSharedApi, DALeader, DAMember, NextValidatingLeader, Replica, SendToTasks,
+    SequencingReplica, ValidatingLeader, View, ViewInner, ViewQueue,
 };
 use hotshot_types::certificate::DACertificate;
 
 use hotshot_types::data::CommitmentProposal;
-use hotshot_types::data::{DAProposal, SequencingLeaf};
+use hotshot_types::data::{DAProposal, DeltasType, SequencingLeaf};
 use hotshot_types::traits::election::CommitteeExchangeType;
 use hotshot_types::traits::election::QuorumExchangeType;
 use hotshot_types::traits::network::CommunicationChannel;
@@ -246,7 +246,11 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> HotShot<TYPES::ConsensusType
         );
 
         let mut saved_leaves = HashMap::new();
+        let mut saved_blocks = BlockStore::default();
         saved_leaves.insert(anchored_leaf.commit(), anchored_leaf.clone());
+        if let Ok(block) = anchored_leaf.get_deltas().try_resolve() {
+            saved_blocks.insert(block);
+        }
 
         let start_view = anchored_leaf.get_view_number();
 
@@ -256,6 +260,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> HotShot<TYPES::ConsensusType
             last_decided_view: anchored_leaf.get_view_number(),
             transactions: Arc::default(),
             saved_leaves,
+            saved_blocks,
             // TODO this is incorrect
             // https://github.com/EspressoSystems/HotShot/issues/560
             locked_view: anchored_leaf.get_view_number(),

--- a/testing-macros/Cargo.toml
+++ b/testing-macros/Cargo.toml
@@ -85,10 +85,10 @@ tokio = { version = "1", optional = true, features = [
   "tracing",
 ] }
 tracing = "0.1.37"
-serde = { version = "1.0.159", features = ["derive"] }
+serde = { version = "1.0.160", features = ["derive"] }
 # proc macro stuff
 quote = "1.0.26"
-syn = { version = "2.0.13", features = ["full", "extra-traits"] }
+syn = { version = "2.0.14", features = ["full", "extra-traits"] }
 proc-macro2 = "1.0.56"
 derive_builder = "0.12.0"
 

--- a/testing-macros/src/lib.rs
+++ b/testing-macros/src/lib.rs
@@ -188,7 +188,7 @@ impl TestData {
             quote! {}
         };
 
-        let (consensus_type, leaf, vote, proposal, committee_exchange) =
+        let (consensus_type, leaf, vote, proposal, exchanges, committee_exchange) =
             match supported_consensus_type {
                 SupportedConsensusTypes::SequencingConsensus => {
                     let consensus_type = quote! {
@@ -218,8 +218,25 @@ impl TestData {
                             hotshot_types::message::Message<TestTypes, TestNodeImpl>,
                         >
                     };
+                    let exchanges = quote! {
+                        hotshot_types::traits::node_implementation::SequencingExchanges<
+                            hotshot_types::traits::consensus_type::sequencing_consensus::SequencingConsensus,
+                            TestTypes,
+                            #leaf,
+                            hotshot_types::message::Message<TestTypes, TestNodeImpl>,
+                            TestQuorumExchange,
+                            #committee_exchange
+                        >
+                    };
 
-                    (consensus_type, leaf, vote, proposal, committee_exchange)
+                    (
+                        consensus_type,
+                        leaf,
+                        vote,
+                        proposal,
+                        exchanges,
+                        committee_exchange,
+                    )
                 }
                 SupportedConsensusTypes::ValidatingConsensus => {
                     let consensus_type = quote! {
@@ -237,7 +254,23 @@ impl TestData {
                     let committee_exchange = quote! {
                         TestQuorumExchange
                     };
-                    (consensus_type, leaf, vote, proposal, committee_exchange)
+                    let exchanges = quote! {
+                        hotshot_types::traits::node_implementation::ValidatingExchanges<
+                            hotshot_types::traits::consensus_type::validating_consensus::ValidatingConsensus,
+                            TestTypes,
+                            #leaf,
+                            hotshot_types::message::Message<TestTypes, TestNodeImpl>,
+                            TestQuorumExchange
+                        >
+                    };
+                    (
+                        consensus_type,
+                        leaf,
+                        vote,
+                        proposal,
+                        exchanges,
+                        committee_exchange,
+                    )
                 }
             };
 
@@ -308,6 +341,7 @@ impl TestData {
                 impl hotshot_types::traits::node_implementation::NodeImplementation<TestTypes> for TestNodeImpl {
                     type Leaf = #leaf;
                     type Storage = #storage<TestTypes, #leaf>;
+                    type Exchanges = #exchanges;
                     type QuorumExchange = TestQuorumExchange;
                     type CommitteeExchange = TestCommitteeExchange;
                 }

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -84,7 +84,7 @@ tokio = { version = "1", optional = true, features = [
   "tracing",
 ] }
 tracing = "0.1.37"
-serde = { version = "1.0.159", features = ["derive"] }
+serde = { version = "1.0.160", features = ["derive"] }
 
 [dev-dependencies]
 async-lock = "2.7"

--- a/testing/src/test_types.rs
+++ b/testing/src/test_types.rs
@@ -13,7 +13,6 @@ use hotshot::{
         NodeImplementation,
     },
 };
-use hotshot_types::message::Message;
 use hotshot_types::{
     data::{ValidatingLeaf, ValidatingProposal, ViewNumber},
     traits::{
@@ -24,6 +23,7 @@ use hotshot_types::{
     },
     vote::QuorumVote,
 };
+use hotshot_types::{message::Message, traits::node_implementation::ValidatingExchanges};
 use jf_primitives::{
     signatures::{
         bls::{BLSSignature, BLSVerKey},
@@ -126,6 +126,13 @@ type StaticCommunication = MemoryCommChannel<
 impl NodeImplementation<VrfTestTypes> for StandardNodeImplType {
     type Storage = MemoryStorage<VrfTestTypes, ValidatingLeaf<VrfTestTypes>>;
     type Leaf = ValidatingLeaf<VrfTestTypes>;
+    type Exchanges = ValidatingExchanges<
+        ValidatingConsensus,
+        VrfTestTypes,
+        ValidatingLeaf<VrfTestTypes>,
+        Message<VrfTestTypes, Self>,
+        Self::QuorumExchange,
+    >;
     type QuorumExchange = QuorumExchange<
         VrfTestTypes,
         ValidatingLeaf<VrfTestTypes>,
@@ -141,6 +148,13 @@ impl NodeImplementation<StaticCommitteeTestTypes> for StaticNodeImplType {
     type Storage =
         MemoryStorage<StaticCommitteeTestTypes, ValidatingLeaf<StaticCommitteeTestTypes>>;
     type Leaf = ValidatingLeaf<StaticCommitteeTestTypes>;
+    type Exchanges = ValidatingExchanges<
+        ValidatingConsensus,
+        StaticCommitteeTestTypes,
+        ValidatingLeaf<StaticCommitteeTestTypes>,
+        Message<StaticCommitteeTestTypes, Self>,
+        Self::QuorumExchange,
+    >;
     type QuorumExchange = QuorumExchange<
         StaticCommitteeTestTypes,
         ValidatingLeaf<StaticCommitteeTestTypes>,

--- a/testing/tests/centralized_server.rs
+++ b/testing/tests/centralized_server.rs
@@ -15,8 +15,11 @@ use hotshot_types::{
 };
 // use hotshot_utils::test_util::shutdown_logging;
 use hotshot_types::message::Message;
-use hotshot_types::traits::election::QuorumExchange;
-use hotshot_types::traits::node_implementation::NodeImplementation;
+use hotshot_types::traits::{
+    consensus_type::validating_consensus::ValidatingConsensus,
+    election::QuorumExchange,
+    node_implementation::{NodeImplementation, ValidatingExchanges},
+};
 use jf_primitives::{signatures::BLSSignatureScheme, vrf::blsvrf::BLSVRFScheme};
 use tracing::instrument;
 
@@ -43,6 +46,13 @@ type VrfCommunication = CentralizedCommChannel<
 impl NodeImplementation<VrfTestTypes> for VrfCentralizedImp {
     type Storage = MemoryStorage<VrfTestTypes, ValidatingLeaf<VrfTestTypes>>;
     type Leaf = ValidatingLeaf<VrfTestTypes>;
+    type Exchanges = ValidatingExchanges<
+        ValidatingConsensus,
+        VrfTestTypes,
+        ValidatingLeaf<VrfTestTypes>,
+        Message<VrfTestTypes, Self>,
+        Self::QuorumExchange,
+    >;
     type QuorumExchange = QuorumExchange<
         VrfTestTypes,
         ValidatingLeaf<VrfTestTypes>,
@@ -90,6 +100,13 @@ impl NodeImplementation<StaticCommitteeTestTypes> for StaticCentralizedImp {
     type Storage =
         MemoryStorage<StaticCommitteeTestTypes, ValidatingLeaf<StaticCommitteeTestTypes>>;
     type Leaf = ValidatingLeaf<StaticCommitteeTestTypes>;
+    type Exchanges = ValidatingExchanges<
+        ValidatingConsensus,
+        StaticCommitteeTestTypes,
+        ValidatingLeaf<StaticCommitteeTestTypes>,
+        Message<StaticCommitteeTestTypes, Self>,
+        Self::QuorumExchange,
+    >;
     type QuorumExchange = QuorumExchange<
         StaticCommitteeTestTypes,
         ValidatingLeaf<StaticCommitteeTestTypes>,

--- a/testing/tests/libp2p.rs
+++ b/testing/tests/libp2p.rs
@@ -8,9 +8,11 @@ use hotshot::{
 use hotshot_testing::{
     test_description::GeneralTestDescriptionBuilder, test_types::StaticCommitteeTestTypes,
 };
-use hotshot_types::traits::election::QuorumExchange;
-
-use hotshot_types::traits::node_implementation::NodeImplementation;
+use hotshot_types::traits::{
+    consensus_type::validating_consensus::ValidatingConsensus,
+    election::QuorumExchange,
+    node_implementation::{NodeImplementation, ValidatingExchanges},
+};
 use hotshot_types::{
     data::{ValidatingLeaf, ValidatingProposal},
     vote::QuorumVote,
@@ -35,6 +37,13 @@ impl NodeImplementation<StaticCommitteeTestTypes> for Libp2pImpl {
     type Storage =
         MemoryStorage<StaticCommitteeTestTypes, ValidatingLeaf<StaticCommitteeTestTypes>>;
     type Leaf = ValidatingLeaf<StaticCommitteeTestTypes>;
+    type Exchanges = ValidatingExchanges<
+        ValidatingConsensus,
+        StaticCommitteeTestTypes,
+        ValidatingLeaf<StaticCommitteeTestTypes>,
+        Message<StaticCommitteeTestTypes, Self>,
+        Self::QuorumExchange,
+    >;
     type QuorumExchange = QuorumExchange<
         StaticCommitteeTestTypes,
         ValidatingLeaf<StaticCommitteeTestTypes>,

--- a/testing/tests/sequencing_tests.rs
+++ b/testing/tests/sequencing_tests.rs
@@ -22,7 +22,7 @@ use hotshot_types::{
     traits::{
         consensus_type::sequencing_consensus::SequencingConsensus,
         election::{CommitteeExchange, QuorumExchange},
-        node_implementation::NodeType,
+        node_implementation::{NodeType, SequencingExchanges},
     },
     vote::DAVote,
 };
@@ -78,6 +78,14 @@ type StaticQuroumComm = MemoryCommChannel<
 impl NodeImplementation<SequencingTestTypes> for SequencingMemoryImpl {
     type Storage = MemoryStorage<SequencingTestTypes, SequencingLeaf<SequencingTestTypes>>;
     type Leaf = SequencingLeaf<SequencingTestTypes>;
+    type Exchanges = SequencingExchanges<
+        SequencingConsensus,
+        SequencingTestTypes,
+        SequencingLeaf<SequencingTestTypes>,
+        Message<SequencingTestTypes, Self>,
+        Self::QuorumExchange,
+        Self::CommitteeExchange,
+    >;
     type QuorumExchange = QuorumExchange<
         SequencingTestTypes,
         Self::Leaf,
@@ -134,6 +142,14 @@ type StaticQuroumCommP2p = Libp2pCommChannel<
 impl NodeImplementation<SequencingTestTypes> for SequencingLibP2PImpl {
     type Storage = MemoryStorage<SequencingTestTypes, SequencingLeaf<SequencingTestTypes>>;
     type Leaf = SequencingLeaf<SequencingTestTypes>;
+    type Exchanges = SequencingExchanges<
+        SequencingConsensus,
+        SequencingTestTypes,
+        SequencingLeaf<SequencingTestTypes>,
+        Message<SequencingTestTypes, Self>,
+        Self::QuorumExchange,
+        Self::CommitteeExchange,
+    >;
     type QuorumExchange = QuorumExchange<
         SequencingTestTypes,
         Self::Leaf,
@@ -190,6 +206,14 @@ type StaticQuroumCommCentral = CentralizedCommChannel<
 impl NodeImplementation<SequencingTestTypes> for SequencingCentralImpl {
     type Storage = MemoryStorage<SequencingTestTypes, SequencingLeaf<SequencingTestTypes>>;
     type Leaf = SequencingLeaf<SequencingTestTypes>;
+    type Exchanges = SequencingExchanges<
+        SequencingConsensus,
+        SequencingTestTypes,
+        SequencingLeaf<SequencingTestTypes>,
+        Message<SequencingTestTypes, Self>,
+        Self::QuorumExchange,
+        Self::CommitteeExchange,
+    >;
     type QuorumExchange = QuorumExchange<
         SequencingTestTypes,
         Self::Leaf,

--- a/testing/tests/web_server.rs
+++ b/testing/tests/web_server.rs
@@ -9,8 +9,11 @@ use hotshot_testing::{
     test_description::GeneralTestDescriptionBuilder, test_types::StaticCommitteeTestTypes,
 };
 use hotshot_types::message::Message;
-use hotshot_types::traits::election::QuorumExchange;
-use hotshot_types::traits::node_implementation::NodeImplementation;
+use hotshot_types::traits::{
+    consensus_type::validating_consensus::ValidatingConsensus,
+    election::QuorumExchange,
+    node_implementation::{NodeImplementation, ValidatingExchanges},
+};
 use hotshot_types::{
     data::{ValidatingLeaf, ValidatingProposal},
     vote::QuorumVote,
@@ -35,6 +38,13 @@ impl NodeImplementation<StaticCommitteeTestTypes> for StaticCentralizedImp {
     type Storage =
         MemoryStorage<StaticCommitteeTestTypes, ValidatingLeaf<StaticCommitteeTestTypes>>;
     type Leaf = ValidatingLeaf<StaticCommitteeTestTypes>;
+    type Exchanges = ValidatingExchanges<
+        ValidatingConsensus,
+        StaticCommitteeTestTypes,
+        ValidatingLeaf<StaticCommitteeTestTypes>,
+        Message<StaticCommitteeTestTypes, Self>,
+        Self::QuorumExchange,
+    >;
     type QuorumExchange = QuorumExchange<
         StaticCommitteeTestTypes,
         ValidatingLeaf<StaticCommitteeTestTypes>,

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -43,7 +43,7 @@ arbitrary = { version = "1.3", features = ["derive"] }
 async-compatibility-layer = { git = "https://github.com/EspressoSystems/async-compatibility-layer.git", tag = "1.0.1", default-features = false, features = [ "logging-utils" ] }
 async-std = { version = "1.12.0", optional = true, features = ["unstable"] }
 async-trait = "0.1.68"
-async-tungstenite = "0.20.0"
+async-tungstenite = "0.21.0"
 atomic_store = { git = "https://github.com/EspressoSystems/atomicstore", tag = "0.1.3" }
 ark-serialize = { version = "0.3", features = ["derive"] }
 ark-std = "0.4"
@@ -61,7 +61,7 @@ hotshot-utils = { path = "../utils" }
 nll = { git = "https://github.com/EspressoSystems/nll.git" }
 libp2p-networking = { path = "../libp2p-networking", version = "0.1.0", default-features = false }
 rand = "0.8.5"
-serde = { version = "1.0.159", features = ["derive"] }
+serde = { version = "1.0.160", features = ["derive"] }
 serde_bytes = "0.11.9"
 snafu = "0.7.4"
 tagged-base64 = { git = "https://github.com/EspressoSystems/tagged-base64", tag = "0.2.4" }
@@ -84,4 +84,4 @@ tokio = { version = "1", optional = true, features = [
 tracing = "0.1.37"
 
 [dev-dependencies]
-serde_json = "1.0.95"
+serde_json = "1.0.96"

--- a/types/src/data.rs
+++ b/types/src/data.rs
@@ -23,6 +23,7 @@ use either::Either;
 use espresso_systems_common::hotshot::tag;
 use rand::Rng;
 use serde::{Deserialize, Serialize};
+use snafu::{ensure, Snafu};
 use std::{fmt::Debug, hash::Hash};
 
 /// Type-safe wrapper around `u64` so we know the thing we're talking about is a view number.
@@ -187,6 +188,120 @@ pub trait ProposalType:
     fn get_view_number(&self) -> <Self::NodeType as NodeType>::Time;
 }
 
+/// A state change encoded in a leaf.
+///
+/// [`DeltasType`] represents a [block](NodeType::BlockType), but it may not contain the block in
+/// full. It is guaranteed to contain, at least, a cryptographic commitment to the block, and it
+/// provides an interface for resolving the commitment to a full block if the full block is
+/// available.
+pub trait DeltasType<Block: Committable>:
+    Clone + Debug + for<'a> Deserialize<'a> + PartialEq + Send + Serialize + Sync
+{
+    /// Errors reported by this type.
+    type Error: std::error::Error;
+
+    /// Get a cryptographic commitment to the block represented by this delta.
+    fn block_commitment(&self) -> Commitment<Block>;
+
+    /// Get the full block if it is available, otherwise return this object unchanged.
+    ///
+    /// # Errors
+    ///
+    /// Returns the original [`DeltasType`], unchanged, in an [`Err`] variant in the case where the
+    /// full block is not currently available.
+    fn try_resolve(self) -> Result<Block, Self>;
+
+    /// Fill this [`DeltasType`] by providing a complete block.
+    ///
+    /// After this function succeeds, [`try_resolve`](Self::try_resolve) is guaranteed to return
+    /// `Ok(block)`.
+    ///
+    /// # Errors
+    ///
+    /// Fails if `block` does not match `self.block_commitment()`, or if the block is not able to be
+    /// stored for some implementation-defined reason.
+    fn fill(&mut self, block: Block) -> Result<(), Self::Error>;
+}
+
+/// Error which occurs when [`DeltasType::fill`] is called with a block that does not match the
+/// deltas' internal block commitment.
+#[derive(Clone, Copy, Debug, Snafu)]
+#[snafu(display("the block {:?} has commitment {} (expected {})", block, block.commit(), commitment))]
+pub struct InconsistentDeltasError<BLOCK: Committable + Debug> {
+    /// The block with the wrong commitment.
+    block: BLOCK,
+    /// The expected commitment.
+    commitment: Commitment<BLOCK>,
+}
+
+impl<BLOCK> DeltasType<BLOCK> for BLOCK
+where
+    BLOCK:
+        Committable + Clone + Debug + for<'a> Deserialize<'a> + PartialEq + Send + Serialize + Sync,
+{
+    type Error = InconsistentDeltasError<BLOCK>;
+
+    fn block_commitment(&self) -> Commitment<BLOCK> {
+        self.commit()
+    }
+
+    fn try_resolve(self) -> Result<BLOCK, Self> {
+        Ok(self)
+    }
+
+    fn fill(&mut self, block: BLOCK) -> Result<(), Self::Error> {
+        ensure!(
+            block.commit() == self.commit(),
+            InconsistentDeltasSnafu {
+                block,
+                commitment: self.commit()
+            }
+        );
+        // If the commitments are equal the blocks are equal, and we already have the block, so we
+        // don't have to do anything.
+        Ok(())
+    }
+}
+
+impl<BLOCK> DeltasType<BLOCK> for Either<BLOCK, Commitment<BLOCK>>
+where
+    BLOCK:
+        Committable + Clone + Debug + for<'a> Deserialize<'a> + PartialEq + Send + Serialize + Sync,
+{
+    type Error = InconsistentDeltasError<BLOCK>;
+
+    fn block_commitment(&self) -> Commitment<BLOCK> {
+        match self {
+            Either::Left(block) => block.commit(),
+            Either::Right(comm) => *comm,
+        }
+    }
+
+    fn try_resolve(self) -> Result<BLOCK, Self> {
+        match self {
+            Either::Left(block) => Ok(block),
+            Either::Right(_) => Err(self),
+        }
+    }
+
+    fn fill(&mut self, block: BLOCK) -> Result<(), Self::Error> {
+        match self {
+            Either::Left(curr) => curr.fill(block),
+            Either::Right(comm) => {
+                ensure!(
+                    *comm == block.commit(),
+                    InconsistentDeltasSnafu {
+                        block,
+                        commitment: *comm
+                    }
+                );
+                *self = Either::Left(block);
+                Ok(())
+            }
+        }
+    }
+}
+
 /// An item which is appended to a blockchain.
 pub trait LeafType:
     Debug
@@ -203,7 +318,7 @@ pub trait LeafType:
     /// Type of nodes participating in the network.
     type NodeType: NodeType;
     /// Type of block contained by this leaf.
-    type DeltasType: Clone + Debug + for<'a> Deserialize<'a> + PartialEq + Send + Serialize + Sync;
+    type DeltasType: DeltasType<LeafBlock<Self>>;
     /// Commitment to the blockchain state.
     type StateCommitmentType: Clone
         + Debug
@@ -215,13 +330,13 @@ pub trait LeafType:
 
     /// Create a new leaf from its components.
     fn new(
-        view_number: <Self::NodeType as NodeType>::Time,
+        view_number: LeafTime<Self>,
         justify_qc: QuorumCertificate<Self::NodeType, Self>,
-        deltas: <Self::NodeType as NodeType>::BlockType,
-        state: <Self::NodeType as NodeType>::StateType,
+        deltas: LeafBlock<Self>,
+        state: LeafState<Self>,
     ) -> Self;
     /// Time when this leaf was created.
-    fn get_view_number(&self) -> <Self::NodeType as NodeType>::Time;
+    fn get_view_number(&self) -> LeafTime<Self>;
     /// Height of this leaf in the chain.
     ///
     /// Equivalently, this is the number of leaves before this one in the chain.
@@ -234,17 +349,47 @@ pub trait LeafType:
     fn get_parent_commitment(&self) -> Commitment<Self>;
     /// The block contained in this leaf.
     fn get_deltas(&self) -> Self::DeltasType;
+    /// Fill this leaf with the entire corresponding block.
+    ///
+    /// After this function succeeds, `self.get_deltas().try_resolve()` is guaranteed to return
+    /// `Ok(block)`.
+    ///
+    /// # Errors
+    ///
+    /// Fails if `block` does not match `self.get_deltas_commitment()`, or if the block is not able
+    /// to be stored for some implementation-defined reason.
+    fn fill_deltas(&mut self, block: LeafBlock<Self>) -> Result<(), LeafDeltasError<Self>>;
     /// The blockchain state after appending this leaf.
     fn get_state(&self) -> Self::StateCommitmentType;
     /// Transactions rejected or invalidated by the application of this leaf.
-    fn get_rejected(&self) -> Vec<<<Self::NodeType as NodeType>::BlockType as Block>::Transaction>;
+    fn get_rejected(&self) -> Vec<LeafTransaction<Self>>;
     /// Real-world time when this leaf was created.
     fn get_timestamp(&self) -> i128;
     /// Identity of the network participant who proposed this leaf.
     fn get_proposer_id(&self) -> EncodedPublicKey;
     /// Create a leaf from information stored about a view.
     fn from_stored_view(stored_view: StoredView<Self::NodeType, Self>) -> Self;
+
+    /// A commitment to the block contained in this leaf.
+    fn get_deltas_commitment(&self) -> Commitment<LeafBlock<Self>> {
+        self.get_deltas().block_commitment()
+    }
 }
+
+/// The [`DeltasType`] in a [`LeafType`].
+pub type LeafDeltas<LEAF> = <LEAF as LeafType>::DeltasType;
+/// Errors reported by the [`DeltasType`] in a [`LeafType`].
+pub type LeafDeltasError<LEAF> = <LeafDeltas<LEAF> as DeltasType<LeafBlock<LEAF>>>::Error;
+/// The [`NodeType`] in a [`LeafType`].
+pub type LeafNode<LEAF> = <LEAF as LeafType>::NodeType;
+/// The [`StateType`] in a [`LeafType`].
+pub type LeafState<LEAF> = <LeafNode<LEAF> as NodeType>::StateType;
+/// The [`Block`] in a [`LeafType`].
+pub type LeafBlock<LEAF> = <LeafNode<LEAF> as NodeType>::BlockType;
+/// The [`Transaction`] in a [`LeafType`].
+pub type LeafTransaction<LEAF> = <LeafBlock<LEAF> as Block>::Transaction;
+/// The [`ConsensusTime`] used by a [`LeafType`].
+pub type LeafTime<LEAF> = <LeafNode<LEAF> as NodeType>::Time;
 
 /// Additional functions required to use a [`LeafType`] with hotshot-testing.
 pub trait TestableLeaf {
@@ -382,6 +527,14 @@ impl<TYPES: NodeType> LeafType for ValidatingLeaf<TYPES> {
         self.deltas.clone()
     }
 
+    fn get_deltas_commitment(&self) -> Commitment<<Self::NodeType as NodeType>::BlockType> {
+        self.deltas.block_commitment()
+    }
+
+    fn fill_deltas(&mut self, block: LeafBlock<Self>) -> Result<(), LeafDeltasError<Self>> {
+        self.deltas.fill(block)
+    }
+
     fn get_state(&self) -> Self::StateCommitmentType {
         self.state.clone()
     }
@@ -478,6 +631,14 @@ impl<TYPES: NodeType> LeafType for SequencingLeaf<TYPES> {
 
     fn get_deltas(&self) -> Self::DeltasType {
         self.deltas.clone()
+    }
+
+    fn get_deltas_commitment(&self) -> Commitment<<Self::NodeType as NodeType>::BlockType> {
+        self.deltas.block_commitment()
+    }
+
+    fn fill_deltas(&mut self, block: LeafBlock<Self>) -> Result<(), LeafDeltasError<Self>> {
+        self.deltas.fill(block)
     }
 
     // The Sequencing Leaf doesn't have a state.

--- a/types/src/traits/consensus_type.rs
+++ b/types/src/traits/consensus_type.rs
@@ -3,5 +3,5 @@
 pub mod sequencing_consensus;
 pub mod validating_consensus;
 
-/// ConsensusType generalized trait
+/// [`ConsensusType`] generalized trait
 pub trait ConsensusType: Clone + Send + Sync {}

--- a/types/src/traits/consensus_type.rs
+++ b/types/src/traits/consensus_type.rs
@@ -4,5 +4,4 @@ pub mod sequencing_consensus;
 pub mod validating_consensus;
 
 /// ConsensusType generalized trait
-pub trait ConsensusType: Clone + Send + Sync {
-}
+pub trait ConsensusType: Clone + Send + Sync {}

--- a/types/src/traits/node_implementation.rs
+++ b/types/src/traits/node_implementation.rs
@@ -56,6 +56,7 @@ pub trait NodeImplementation<TYPES: NodeType>: Send + Sync + Debug + Clone + 'st
     type CommitteeExchange: ConsensusExchange<TYPES, Self::Leaf, Message<TYPES, Self>>;
 }
 
+// TODO (Keyao) move exchange types to election.rs?
 pub trait ExchangesType<
     CONSENSUS: ConsensusType,
     TYPES: NodeType<ConsensusType = CONSENSUS>,

--- a/types/src/traits/node_implementation.rs
+++ b/types/src/traits/node_implementation.rs
@@ -10,8 +10,7 @@ use super::{
     block_contents::Transaction,
     consensus_type::{
         sequencing_consensus::SequencingConsensusType,
-        validating_consensus::{ValidatingConsensus, ValidatingConsensusType},
-        ConsensusType,
+        validating_consensus::ValidatingConsensusType, ConsensusType,
     },
     election::{ConsensusExchange, ElectionConfig, VoteToken},
     network::{NetworkMsg, TestableNetworkingImplementation},
@@ -57,6 +56,7 @@ pub trait NodeImplementation<TYPES: NodeType>: Send + Sync + Debug + Clone + 'st
 }
 
 // TODO (Keyao) move exchange types to election.rs?
+/// Contains the protocols for exchanging proposals and votes.
 pub trait ExchangesType<
     CONSENSUS: ConsensusType,
     TYPES: NodeType<ConsensusType = CONSENSUS>,
@@ -66,6 +66,7 @@ pub trait ExchangesType<
 {
 }
 
+/// An [`ExchangesType`] for validating consensus.
 pub trait ValidatingExchangesType<
     CONSENSUS: ValidatingConsensusType,
     TYPES: NodeType<ConsensusType = CONSENSUS>,
@@ -77,6 +78,7 @@ pub trait ValidatingExchangesType<
     type QuorumExchange: ConsensusExchange<TYPES, LEAF, MESSAGE>;
 }
 
+/// An [`ExchangesType`] for sequencing consensus.
 pub trait SequencingExchangesType<
     CONSENSUS: SequencingConsensusType,
     TYPES: NodeType<ConsensusType = CONSENSUS>,
@@ -100,10 +102,7 @@ pub struct ValidatingExchanges<
     MESSAGE: NetworkMsg,
     QUORUMEXCHANGE: ConsensusExchange<TYPES, LEAF, MESSAGE>,
 > {
-    quorum_exchange: QUORUMEXCHANGE,
-    _phantom1: PhantomData<TYPES>,
-    _phantom2: PhantomData<LEAF>,
-    _phantom3: PhantomData<MESSAGE>,
+    _phantom: PhantomData<(TYPES, LEAF, MESSAGE, QUORUMEXCHANGE)>,
 }
 
 impl<CONSENSUS, TYPES, LEAF, MESSAGE, QUORUMEXCHANGE>
@@ -140,11 +139,7 @@ pub struct SequencingExchanges<
     QUORUMEXCHANGE: ConsensusExchange<TYPES, LEAF, MESSAGE>,
     COMMITTEEEXCHANGE: ConsensusExchange<TYPES, LEAF, MESSAGE>,
 > {
-    quorum_exchange: QUORUMEXCHANGE,
-    committee_exchange: COMMITTEEEXCHANGE,
-    _phantom1: PhantomData<TYPES>,
-    _phantom2: PhantomData<LEAF>,
-    _phantom3: PhantomData<MESSAGE>,
+    _phantom: PhantomData<(TYPES, LEAF, MESSAGE, QUORUMEXCHANGE, COMMITTEEEXCHANGE)>,
 }
 
 impl<CONSENSUS, TYPES, LEAF, MESSAGE, QUORUMEXCHANGE, COMMITTEEEXCHANGE>

--- a/types/src/traits/node_implementation.rs
+++ b/types/src/traits/node_implementation.rs
@@ -93,7 +93,7 @@ pub trait SequencingExchangesType<
     type CommitteeExchange: ConsensusExchange<TYPES, LEAF, MESSAGE>;
 }
 
-/// ExchangesType ValidatingExchanges
+/// Implements [`ValidatingExchangesType`].
 #[derive(Clone, Debug)]
 pub struct ValidatingExchanges<
     CONSENSUS: ValidatingConsensusType,
@@ -102,6 +102,7 @@ pub struct ValidatingExchanges<
     MESSAGE: NetworkMsg,
     QUORUMEXCHANGE: ConsensusExchange<TYPES, LEAF, MESSAGE>,
 > {
+    /// Phantom data.
     _phantom: PhantomData<(TYPES, LEAF, MESSAGE, QUORUMEXCHANGE)>,
 }
 
@@ -129,7 +130,7 @@ where
 {
 }
 
-/// ExchangesType SequencingExchanges
+/// Implementes [`SequencingExchangesType`].
 #[derive(Clone, Debug)]
 pub struct SequencingExchanges<
     CONSENSUS: SequencingConsensusType,
@@ -139,6 +140,7 @@ pub struct SequencingExchanges<
     QUORUMEXCHANGE: ConsensusExchange<TYPES, LEAF, MESSAGE>,
     COMMITTEEEXCHANGE: ConsensusExchange<TYPES, LEAF, MESSAGE>,
 > {
+    /// Phantom data.
     _phantom: PhantomData<(TYPES, LEAF, MESSAGE, QUORUMEXCHANGE, COMMITTEEEXCHANGE)>,
 }
 

--- a/web_server/Cargo.toml
+++ b/web_server/Cargo.toml
@@ -46,6 +46,7 @@ jf-primitives = { git = "https://github.com/EspressoSystems/jellyfish", tag = "0
 tide-disco = { git = "https://github.com/EspressoSystems/tide-disco.git", tag = "v0.4.1" }
 nll = { git = "https://github.com/EspressoSystems/nll.git" }
 tracing = "0.1.37"
+rand = "0.8.5"
 serde = { version = "1.0.147", features = ["derive"] }
 serde_json = "1.0.87"
 snafu = "0.7.3"


### PR DESCRIPTION
- Fixes errors in `examples`, `testing` and `testing-macros` directories caused by missing the `Exchanges` types.
- Fixes warnings and merges with main.

Part of https://github.com/EspressoSystems/HotShot/issues/1071.

To be merged into `nfy/refactoring_node_implementation` branch.