### PR TITLE
Share `ConnectedNetwork` b/t `CommunicationChannel`s

### DIFF
--- a/src/traits/networking/libp2p_network.rs
+++ b/src/traits/networking/libp2p_network.rs
@@ -117,11 +117,8 @@ pub struct Libp2pNetwork<M: NetworkMsg, K: SignatureKey + 'static> {
 impl<
         TYPES: NodeType,
         I: NodeImplementation<TYPES>,
-        PROPOSAL: ProposalType<NodeType = TYPES>,
-        VOTE: VoteType<TYPES>,
-        MEMBERSHIP: Membership<TYPES>,
-    > TestableNetworkingImplementation<TYPES, Message<TYPES, I>, PROPOSAL, VOTE, MEMBERSHIP>
-    for Libp2pCommChannel<TYPES, I, PROPOSAL, VOTE, MEMBERSHIP>
+    > TestableNetworkingImplementation<TYPES, Message<TYPES, I>>
+    for Libp2pNetwork<Message<TYPES, I>, TYPES::SignatureKey>
 where
     TYPES::SignatureKey: TestableSignatureKey,
 {
@@ -202,20 +199,17 @@ where
                 let bootstrap_addrs_ref = bootstrap_addrs.clone();
                 let all_keys = all_keys.clone();
                 async_block_on(async move {
-                    Libp2pCommChannel(
-                        Libp2pNetwork::new(
-                            NoMetrics::boxed(),
-                            config,
-                            pubkey,
-                            bootstrap_addrs_ref,
-                            num_bootstrap,
-                            node_id as usize,
-                            all_keys,
-                        )
-                        .await
-                        .unwrap(),
-                        PhantomData,
+                    Libp2pNetwork::new(
+                        NoMetrics::boxed(),
+                        config,
+                        pubkey,
+                        bootstrap_addrs_ref,
+                        num_bootstrap,
+                        node_id as usize,
+                        all_keys,
                     )
+                    .await
+                    .unwrap()
                 })
             }
         })
@@ -473,7 +467,7 @@ impl<M: NetworkMsg, K: SignatureKey + 'static> Libp2pNetwork<M, K> {
 }
 
 #[async_trait]
-impl<M: NetworkMsg, K: SignatureKey + 'static> ConnectedNetwork<M, M, K> for Libp2pNetwork<M, K> {
+impl<M: NetworkMsg, K: SignatureKey + 'static> ConnectedNetwork<M, K> for Libp2pNetwork<M, K> {
     #[instrument(name = "Libp2pNetwork::ready_blocking", skip_all)]
     async fn wait_for_ready(&self) {
         self.wait_for_ready().await;
@@ -716,6 +710,8 @@ impl<
     > CommunicationChannel<TYPES, Message<TYPES, I>, PROPOSAL, VOTE, MEMBERSHIP>
     for Libp2pCommChannel<TYPES, I, PROPOSAL, VOTE, MEMBERSHIP>
 {
+    type NETWORK = Libp2pNetwork<Message<TYPES, I>, TYPES::SignatureKey>;
+
     async fn wait_for_ready(&self) {
         self.0.wait_for_ready().await;
     }

--- a/src/traits/networking/web_server_network.rs
+++ b/src/traits/networking/web_server_network.rs
@@ -472,9 +472,9 @@ impl<
         let endpoint = match &message.purpose() {
             MessagePurpose::Proposal => config::post_proposal_route(*view_number),
             MessagePurpose::Vote => config::post_vote_route(*view_number),
-            MessagePurpose::Internal => return Err(WebServerNetworkError::EndpointError),
-            MessagePurpose::Internal => return Err(WebServerNetworkError::EndpointError),
-            MessagePurpose::Data => return Err(WebServerNetworkError::EndpointError),
+            MessagePurpose::Internal | MessagePurpose::Data => {
+                return Err(WebServerNetworkError::EndpointError)
+            }
         };
 
         let network_msg: SendMsg<M> = SendMsg {

--- a/src/traits/networking/web_server_network.rs
+++ b/src/traits/networking/web_server_network.rs
@@ -14,6 +14,7 @@ use async_compatibility_layer::{
     art::{async_sleep, async_spawn},
     channel::{oneshot, OneShotSender},
 };
+use hotshot_types::message::MessagePurpose;
 use hotshot_types::traits::node_implementation::NodeImplementation;
 
 use hotshot_web_server::{self, config};
@@ -27,7 +28,8 @@ use hotshot_types::{
         election::{ElectionConfig, Membership},
         network::{
             CommunicationChannel, ConnectedNetwork, NetworkError, NetworkMsg,
-            TestableNetworkingImplementation, TransmitType, WebServerNetworkError,
+            TestableChannelImplementation, TestableNetworkingImplementation, TransmitType,
+            WebServerNetworkError,
         },
         node_implementation::NodeType,
         signature_key::{SignatureKey, TestableSignatureKey},
@@ -57,13 +59,15 @@ pub struct WebCommChannel<
     VOTE: VoteType<TYPES>,
     MEMBERSHIP: Membership<TYPES>,
 >(
-    WebServerNetwork<
-        Message<TYPES, I>,
-        TYPES::SignatureKey,
-        TYPES::ElectionConfigType,
-        TYPES,
-        PROPOSAL,
-        VOTE,
+    Arc<
+        WebServerNetwork<
+            Message<TYPES, I>,
+            TYPES::SignatureKey,
+            TYPES::ElectionConfigType,
+            TYPES,
+            PROPOSAL,
+            VOTE,
+        >,
     >,
     PhantomData<(MEMBERSHIP, I)>,
 );
@@ -78,51 +82,18 @@ impl<
     /// Create new communication channel
     #[must_use]
     pub fn new(
-        network: WebServerNetwork<
-            Message<TYPES, I>,
-            TYPES::SignatureKey,
-            TYPES::ElectionConfigType,
-            TYPES,
-            PROPOSAL,
-            VOTE,
+        network: Arc<
+            WebServerNetwork<
+                Message<TYPES, I>,
+                TYPES::SignatureKey,
+                TYPES::ElectionConfigType,
+                TYPES,
+                PROPOSAL,
+                VOTE,
+            >,
         >,
     ) -> Self {
         Self(network, PhantomData::default())
-    }
-
-    /// Parses a message to find the appropriate endpoint
-    /// Returns a `SendMsg` containing the endpoint
-    fn parse_post_message(
-        message: Message<TYPES, I>,
-    ) -> Result<SendMsg<Message<TYPES, I>>, WebServerNetworkError> {
-        let view_number: TYPES::Time = message.get_view_number();
-
-        let endpoint = match &message.kind {
-            hotshot_types::message::MessageKind::Consensus(message_kind) => match message_kind {
-                hotshot_types::message::ConsensusMessage::Proposal(_)
-                | hotshot_types::message::ConsensusMessage::DAProposal(_) => {
-                    config::post_proposal_route(*view_number)
-                }
-                hotshot_types::message::ConsensusMessage::Vote(_)
-                | hotshot_types::message::ConsensusMessage::DAVote(_) => {
-                    config::post_vote_route(*view_number)
-                }
-                hotshot_types::message::ConsensusMessage::InternalTrigger(_) => {
-                    return Err(WebServerNetworkError::EndpointError)
-                }
-            },
-            hotshot_types::message::MessageKind::Data(message_kind) => match message_kind {
-                hotshot_types::message::DataMessage::SubmitTransaction(_, _) => {
-                    config::post_transactions_route()
-                }
-            },
-        };
-
-        let network_msg: SendMsg<Message<TYPES, I>> = SendMsg {
-            message: Some(message),
-            endpoint,
-        };
-        Ok(network_msg)
     }
 }
 
@@ -377,7 +348,7 @@ impl<M: NetworkMsg> NetworkMsg for SendMsg<M> {}
 impl<M: NetworkMsg> NetworkMsg for RecvMsg<M> {}
 
 impl<
-        M: NetworkMsg + 'static,
+        M: NetworkMsg + 'static + ViewMessage<TYPES>,
         K: SignatureKey + 'static,
         E: ElectionConfig + 'static,
         TYPES: NodeType + 'static,
@@ -492,6 +463,26 @@ impl<
 
         Ok(())
     }
+
+    /// Parses a message to find the appropriate endpoint
+    /// Returns a `SendMsg` containing the endpoint
+    fn parse_post_message(message: M) -> Result<SendMsg<M>, WebServerNetworkError> {
+        let view_number: TYPES::Time = message.get_view_number();
+
+        let endpoint = match &message.purpose() {
+            MessagePurpose::Proposal => config::post_proposal_route(*view_number),
+            MessagePurpose::Vote => config::post_vote_route(*view_number),
+            MessagePurpose::Internal => return Err(WebServerNetworkError::EndpointError),
+            MessagePurpose::Internal => return Err(WebServerNetworkError::EndpointError),
+            MessagePurpose::Data => return Err(WebServerNetworkError::EndpointError),
+        };
+
+        let network_msg: SendMsg<M> = SendMsg {
+            message: Some(message),
+            endpoint,
+        };
+        Ok(network_msg)
+    }
 }
 
 /// Enum for matching messages to their type
@@ -515,7 +506,14 @@ impl<
     > CommunicationChannel<TYPES, Message<TYPES, I>, PROPOSAL, VOTE, MEMBERSHIP>
     for WebCommChannel<TYPES, I, PROPOSAL, VOTE, MEMBERSHIP>
 {
-    type NETWORK = WebServerNetwork<Message<TYPES, I>, TYPES::SignatureKey, TYPES::ElectionConfigType, TYPES, PROPOSAL, VOTE>;
+    type NETWORK = WebServerNetwork<
+        Message<TYPES, I>,
+        TYPES::SignatureKey,
+        TYPES::ElectionConfigType,
+        TYPES,
+        PROPOSAL,
+        VOTE,
+    >;
     /// Blocks until node is successfully initialized
     /// into the network
     async fn wait_for_ready(&self) {
@@ -554,13 +552,7 @@ impl<
         message: Message<TYPES, I>,
         _election: &MEMBERSHIP,
     ) -> Result<(), NetworkError> {
-        let network_msg = Self::parse_post_message(message);
-        match network_msg {
-            Ok(network_msg) => self.0.broadcast_message(network_msg, BTreeSet::new()).await,
-            Err(network_msg) => Err(NetworkError::WebServer {
-                source: network_msg,
-            }),
-        }
+        self.0.broadcast_message(message, BTreeSet::new()).await
     }
 
     /// Sends a direct message to a specific node
@@ -570,13 +562,7 @@ impl<
         message: Message<TYPES, I>,
         recipient: TYPES::SignatureKey,
     ) -> Result<(), NetworkError> {
-        let network_msg = Self::parse_post_message(message);
-        match network_msg {
-            Ok(network_msg) => self.0.direct_message(network_msg, recipient).await,
-            Err(network_msg) => Err(NetworkError::WebServer {
-                source: network_msg,
-            }),
-        }
+        self.0.direct_message(message, recipient).await
     }
 
     /// Moves out the entire queue of received messages of 'transmit_type`
@@ -587,18 +573,11 @@ impl<
         &self,
         transmit_type: TransmitType,
     ) -> Result<Vec<Message<TYPES, I>>, NetworkError> {
-        let result = <WebServerNetwork<_, _, _, _, _, _> as ConnectedNetwork<
+        <WebServerNetwork<_, _, _, _, _, _> as ConnectedNetwork<
             Message<TYPES, I>,
             TYPES::SignatureKey,
         >>::recv_msgs(&self.0, transmit_type)
-        .await;
-
-        match result {
-            Ok(messages) => Ok(messages.iter().map(|x| x.get_message().unwrap()).collect()),
-            _ => Err(NetworkError::WebServer {
-                source: WebServerNetworkError::ClientError,
-            }),
-        }
+        .await
     }
 
     /// look up a node
@@ -618,14 +597,13 @@ impl<
 
 #[async_trait]
 impl<
-        M: NetworkMsg + 'static,
+        M: NetworkMsg + 'static + ViewMessage<TYPES>,
         K: SignatureKey + 'static,
         E: ElectionConfig + 'static,
         TYPES: NodeType + 'static,
         PROPOSAL: ProposalType<NodeType = TYPES> + 'static,
         VOTE: VoteType<TYPES> + 'static,
-    > ConnectedNetwork<M, K>
-    for WebServerNetwork<M, K, E, TYPES, PROPOSAL, VOTE>
+    > ConnectedNetwork<M, K> for WebServerNetwork<M, K, E, TYPES, PROPOSAL, VOTE>
 {
     /// Blocks until the network is successfully initialized
     async fn wait_for_ready(&self) {
@@ -653,31 +631,50 @@ impl<
         message: M,
         _recipients: BTreeSet<K>,
     ) -> Result<(), NetworkError> {
-        self.post_message_to_web_server(message).await
+        let network_msg = Self::parse_post_message(message);
+        match network_msg {
+            Ok(network_msg) => self.post_message_to_web_server(network_msg).await,
+            Err(network_msg) => Err(NetworkError::WebServer {
+                source: network_msg,
+            }),
+        }
     }
 
     /// Sends a direct message to a specific node
     /// blocking
     async fn direct_message(&self, message: M, _recipient: K) -> Result<(), NetworkError> {
-        self.post_message_to_web_server(message).await
+        let network_msg = Self::parse_post_message(message);
+        match network_msg {
+            Ok(network_msg) => self.post_message_to_web_server(network_msg).await,
+            Err(network_msg) => Err(NetworkError::WebServer {
+                source: network_msg,
+            }),
+        }
     }
 
     /// Moves out the entire queue of received messages of 'transmit_type`
     ///
     /// Will unwrap the underlying `NetworkMessage`
     /// blocking
-    async fn recv_msgs(
-        &self,
-        transmit_type: TransmitType,
-    ) -> Result<Vec<M>, NetworkError> {
+    async fn recv_msgs(&self, transmit_type: TransmitType) -> Result<Vec<M>, NetworkError> {
         match transmit_type {
             TransmitType::Direct => {
                 let mut queue = self.inner.direct_poll_queue.write().await;
-                Ok(queue.drain(..).collect())
+                Ok(queue
+                    .drain(..)
+                    .collect::<Vec<_>>()
+                    .iter()
+                    .map(|x| x.get_message().unwrap())
+                    .collect())
             }
             TransmitType::Broadcast => {
                 let mut queue = self.inner.broadcast_poll_queue.write().await;
-                Ok(queue.drain(..).collect())
+                Ok(queue
+                    .drain(..)
+                    .collect::<Vec<_>>()
+                    .iter()
+                    .map(|x| x.get_message().unwrap())
+                    .collect())
             }
         }
     }
@@ -763,5 +760,49 @@ where
 
     fn in_flight_message_count(&self) -> Option<usize> {
         None
+    }
+}
+
+impl<
+        TYPES: NodeType,
+        I: NodeImplementation<TYPES>,
+        PROPOSAL: ProposalType<NodeType = TYPES>,
+        VOTE: VoteType<TYPES>,
+        MEMBERSHIP: Membership<TYPES>,
+    >
+    TestableChannelImplementation<
+        TYPES,
+        Message<TYPES, I>,
+        PROPOSAL,
+        VOTE,
+        MEMBERSHIP,
+        WebServerNetwork<
+            Message<TYPES, I>,
+            TYPES::SignatureKey,
+            TYPES::ElectionConfigType,
+            TYPES,
+            PROPOSAL,
+            VOTE,
+        >,
+    > for WebCommChannel<TYPES, I, PROPOSAL, VOTE, MEMBERSHIP>
+where
+    TYPES::SignatureKey: TestableSignatureKey,
+{
+    fn generate_network() -> Box<
+        dyn Fn(
+                Arc<
+                    WebServerNetwork<
+                        Message<TYPES, I>,
+                        TYPES::SignatureKey,
+                        TYPES::ElectionConfigType,
+                        TYPES,
+                        PROPOSAL,
+                        VOTE,
+                    >,
+                >,
+            ) -> Self
+            + 'static,
+    > {
+        Box::new(move |network| WebCommChannel::new(network))
     }
 }

--- a/testing/src/launcher.rs
+++ b/testing/src/launcher.rs
@@ -1,52 +1,20 @@
-use super::{Generator, TestRunner};
+use super::{Generator, NetworkGenerator, NetworkType, TestRunner};
 
 use hotshot::traits::TestableNodeImplementation;
 use hotshot::types::SignatureKey;
 
-use hotshot_types::traits::election::ConsensusExchange;
-use hotshot_types::traits::network::{
-    CommunicationChannel, ConnectedNetwork, TestableNetworkingImplementation,
-};
 use hotshot_types::traits::node_implementation::{CommitteeNetwork, QuorumNetwork};
 use hotshot_types::{
-    message::Message,
     traits::node_implementation::{NodeImplementation, NodeType},
     ExecutionType, HotShotConfig,
 };
-use std::sync::Arc;
 use std::{num::NonZeroUsize, time::Duration};
 
-type NetworkType<TYPES, I> =
-    <<<I as NodeImplementation<TYPES>>::QuorumExchange as ConsensusExchange<
-        TYPES,
-        <I as NodeImplementation<TYPES>>::Leaf,
-        Message<TYPES, I>,
-    >>::Networking as CommunicationChannel<
-        TYPES,
-        Message<TYPES, I>,
-        <<I as NodeImplementation<TYPES>>::QuorumExchange as ConsensusExchange<
-            TYPES,
-            <I as NodeImplementation<TYPES>>::Leaf,
-            Message<TYPES, I>,
-        >>::Proposal,
-        <<I as NodeImplementation<TYPES>>::QuorumExchange as ConsensusExchange<
-            TYPES,
-            <I as NodeImplementation<TYPES>>::Leaf,
-            Message<TYPES, I>,
-        >>::Vote,
-        <<I as NodeImplementation<TYPES>>::QuorumExchange as ConsensusExchange<
-            TYPES,
-            <I as NodeImplementation<TYPES>>::Leaf,
-            Message<TYPES, I>,
-        >>::Membership,
-    >>::NETWORK;
 /// A launcher for [`TestRunner`], allowing you to customize the network and some default settings for spawning nodes.
 pub struct TestLauncher<TYPES: NodeType, I: TestableNodeImplementation<TYPES>> {
     pub(super) network: Generator<NetworkType<TYPES, I>>,
-    pub(super) quorum_network:
-        Box<dyn Fn(Arc<NetworkType<TYPES, I>>) -> QuorumNetwork<TYPES, I> + 'static>,
-    pub(super) committee_network:
-        Box<dyn Fn(Arc<NetworkType<TYPES, I>>) -> CommitteeNetwork<TYPES, I> + 'static>,
+    pub(super) quorum_network: NetworkGenerator<TYPES, I, QuorumNetwork<TYPES, I>>,
+    pub(super) committee_network: NetworkGenerator<TYPES, I, CommitteeNetwork<TYPES, I>>,
     pub(super) storage: Generator<<I as NodeImplementation<TYPES>>::Storage>,
     pub(super) block: Generator<TYPES::BlockType>,
     pub(super) config: HotShotConfig<TYPES::SignatureKey, TYPES::ElectionConfigType>,

--- a/testing/src/launcher.rs
+++ b/testing/src/launcher.rs
@@ -97,51 +97,7 @@ impl<TYPES: NodeType, I: TestableNodeImplementation<TYPES>> TestLauncher<TYPES, 
 // TODO make these functions generic over the target networking/storage/other generics
 // so we can hotswap out
 impl<TYPES: NodeType, I: TestableNodeImplementation<TYPES>> TestLauncher<TYPES, I> {
-    //     /// Set a custom quorum network generator. Note that this can also be overwritten per-node in the [`TestLauncher`].
-    //     pub fn with_quorum_network(
-    //         self,
-    //         quorum_network: impl Fn(u64, TYPES::SignatureKey) -> QuorumNetwork<TYPES, I> + 'static,
-    //     ) -> TestLauncher<TYPES, I> {
-    //         TestLauncher {
-    //             quorum_network: Box::new({
-    //                 move |node_id| {
-    //                     // FIXME perhaps this pk generation is a separate function
-    //                     // to add as an input
-    //                     // that way we don't rely on threshold crypto
-    //                     let priv_key = I::generate_test_key(node_id);
-    //                     let pubkey = TYPES::SignatureKey::from_private(&priv_key);
-    //                     quorum_network(node_id, pubkey)
-    //                 }
-    //             }),
-    //             committee_network: self.committee_network,
-    //             storage: self.storage,
-    //             block: self.block,
-    //             config: self.config,
-    //         }
-    //     }
-
-    //     /// Set a custom committee network generator. Note that this can also be overwritten per-node in the [`TestLauncher`].
-    //     pub fn with_committee_network(
-    //         self,
-    //         committee_network: impl Fn(u64, TYPES::SignatureKey) -> CommitteeNetwork<TYPES, I> + 'static,
-    //     ) -> TestLauncher<TYPES, I> {
-    //         TestLauncher {
-    //             quorum_network: self.quorum_network,
-    //             committee_network: Box::new({
-    //                 move |node_id| {
-    //                     // FIXME perhaps this pk generation is a separate function
-    //                     // to add as an input
-    //                     // that way we don't rely on threshold crypto
-    //                     let priv_key = I::generate_test_key(node_id);
-    //                     let pubkey = TYPES::SignatureKey::from_private(&priv_key);
-    //                     committee_network(node_id, pubkey)
-    //                 }
-    //             }),
-    //             storage: self.storage,
-    //             block: self.block,
-    //             config: self.config,
-    //         }
-    //     }
+    /// TODO: Add functions to allow injecting custom networks or communication channels
 
     /// Set a custom storage generator. Note that this can also be overwritten per-node in the [`TestLauncher`].
     pub fn with_storage(

--- a/testing/src/lib.rs
+++ b/testing/src/lib.rs
@@ -28,11 +28,13 @@ use hotshot::{
 use hotshot_types::traits::election::ConsensusExchange;
 
 use hotshot_types::message::Message;
-use hotshot_types::traits::network::CommunicationChannel;
 use hotshot_types::traits::node_implementation::{CommitteeNetwork, QuorumNetwork};
 use hotshot_types::{
     data::LeafType,
-    traits::{election::Membership, metrics::NoMetrics, node_implementation::NodeType},
+    traits::{
+        election::Membership, metrics::NoMetrics, node_implementation::NetworkType,
+        node_implementation::NodeType,
+    },
     HotShotConfig,
 };
 use snafu::Snafu;
@@ -47,33 +49,6 @@ pub const N: usize = H_256;
 
 /// Alias for `(Vec<S>, Vec<B>)`. Used in [`RoundResult`].
 pub type StateAndBlock<S, B> = (Vec<S>, Vec<B>);
-
-// TODO remove this really ugly type once we have `ConsensusExchanges` impl and can use that to do all generation
-/// Type for the underlying `ConnectedNetwork` that will be shared (for now) b/t Communication Channels
-pub type NetworkType<TYPES, I> =
-    <<<I as NodeImplementation<TYPES>>::QuorumExchange as ConsensusExchange<
-        TYPES,
-        <I as NodeImplementation<TYPES>>::Leaf,
-        Message<TYPES, I>,
-    >>::Networking as CommunicationChannel<
-        TYPES,
-        Message<TYPES, I>,
-        <<I as NodeImplementation<TYPES>>::QuorumExchange as ConsensusExchange<
-            TYPES,
-            <I as NodeImplementation<TYPES>>::Leaf,
-            Message<TYPES, I>,
-        >>::Proposal,
-        <<I as NodeImplementation<TYPES>>::QuorumExchange as ConsensusExchange<
-            TYPES,
-            <I as NodeImplementation<TYPES>>::Leaf,
-            Message<TYPES, I>,
-        >>::Vote,
-        <<I as NodeImplementation<TYPES>>::QuorumExchange as ConsensusExchange<
-            TYPES,
-            <I as NodeImplementation<TYPES>>::Leaf,
-            Message<TYPES, I>,
-        >>::Membership,
-    >>::NETWORK;
 
 /// Wrapper Type for function that takes a `ConnectedNetwork` and returns a `CommunicationChannel`
 pub type NetworkGenerator<TYPES, I, T> = Box<dyn Fn(Arc<NetworkType<TYPES, I>>) -> T + 'static>;

--- a/types/src/message.rs
+++ b/types/src/message.rs
@@ -65,10 +65,15 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> ViewMessage<TYPES> for Messa
     }
 }
 
+/// A message type agnostic description of a messages purpose
 pub enum MessagePurpose {
+    /// Message contains a proposal
     Proposal,
+    /// Message contains a vote
     Vote,
+    /// Message for internal use
     Internal,
+    /// Data message
     Data,
 }
 
@@ -157,12 +162,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> ProcessedConsensusMessage<TY
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 #[serde(bound(deserialize = "", serialize = ""))]
 /// Messages related to the consensus protocol
-pub enum ConsensusMessage<
-    TYPES: NodeType,
-    I: NodeImplementation<TYPES>,
-    // PROPOSAL: ProposalType<NodeType = TYPES>,
-    // VOTE: VoteType<TYPES>,
-> {
+pub enum ConsensusMessage<TYPES: NodeType, I: NodeImplementation<TYPES>> {
     /// Leader's proposal for full quorum voting
     Proposal(Proposal<QuorumProposal<TYPES, I>>),
 

--- a/types/src/message.rs
+++ b/types/src/message.rs
@@ -49,6 +49,27 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> ViewMessage<TYPES> for Messa
             MessageKind::Data(DataMessage::SubmitTransaction(_, v)) => *v,
         }
     }
+    fn purpose(&self) -> MessagePurpose {
+        match &self.kind {
+            MessageKind::Consensus(message_kind) => match message_kind {
+                ConsensusMessage::Proposal(_) | ConsensusMessage::DAProposal(_) => {
+                    MessagePurpose::Proposal
+                }
+                ConsensusMessage::Vote(_) | ConsensusMessage::DAVote(_) => MessagePurpose::Vote,
+                ConsensusMessage::InternalTrigger(_) => MessagePurpose::Internal,
+            },
+            MessageKind::Data(message_kind) => match message_kind {
+                DataMessage::SubmitTransaction(_, _) => MessagePurpose::Data,
+            },
+        }
+    }
+}
+
+pub enum MessagePurpose {
+    Proposal,
+    Vote,
+    Internal,
+    Data,
 }
 
 // TODO (da) make it more customized to the consensus layer, maybe separating the specific message

--- a/types/src/traits/network.rs
+++ b/types/src/traits/network.rs
@@ -10,12 +10,7 @@ use tokio::time::error::Elapsed as TimeoutError;
 #[cfg(not(any(feature = "async-std-executor", feature = "tokio-executor")))]
 std::compile_error! {"Either feature \"async-std-executor\" or feature \"tokio-executor\" must be enabled for this crate."}
 
-use super::{
-    election::Membership,
-    node_implementation::{NodeImplementation, NodeType},
-    signature_key::SignatureKey,
-};
-use crate::message::MessageKind;
+use super::{election::Membership, node_implementation::NodeType, signature_key::SignatureKey};
 use crate::{data::ProposalType, message::MessagePurpose, vote::VoteType};
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
@@ -143,7 +138,8 @@ pub trait NetworkMsg:
 pub trait ViewMessage<TYPES: NodeType> {
     /// get the view out of the message
     fn get_view_number(&self) -> TYPES::Time;
-    // TODO don't use this trait.
+    // TODO move out of this trait.
+    /// get the purpose of the message
     fn purpose(&self) -> MessagePurpose;
 }
 
@@ -158,6 +154,7 @@ pub trait CommunicationChannel<
     MEMBERSHIP: Membership<TYPES>,
 >: Clone + Send + Sync + 'static
 {
+    /// Underlying Network implementation's type
     type NETWORK: ConnectedNetwork<M, TYPES::SignatureKey>;
     /// Blocks until node is successfully initialized
     /// into the network
@@ -266,7 +263,7 @@ pub trait TestableNetworkingImplementation<TYPES: NodeType, M: NetworkMsg>:
     /// Some implementations will not be able to tell how many messages there are in-flight. These implementations should return `None`.
     fn in_flight_message_count(&self) -> Option<usize>;
 }
-
+/// Describes additional functionality needed by the test communication channel
 pub trait TestableChannelImplementation<
     TYPES: NodeType,
     M: NetworkMsg,
@@ -276,6 +273,7 @@ pub trait TestableChannelImplementation<
     NETWORK: ConnectedNetwork<M, TYPES::SignatureKey>,
 >: CommunicationChannel<TYPES, M, PROPOSAL, VOTE, MEMBERSHIP>
 {
+    /// generates the `CommunicationChannel` given it's associated network type
     fn generate_network() -> Box<dyn Fn(Arc<NETWORK>) -> Self + 'static>;
 }
 

--- a/types/src/traits/node_implementation.rs
+++ b/types/src/traits/node_implementation.rs
@@ -10,8 +10,7 @@ use super::{
     block_contents::Transaction,
     election::{ConsensusExchange, ElectionConfig, VoteToken},
     network::{
-        CommunicationChannel, ConnectedNetwork, TestableChannelImplementation,
-        TestableNetworkingImplementation,
+        CommunicationChannel, TestableChannelImplementation, TestableNetworkingImplementation,
     },
     signature_key::TestableSignatureKey,
     state::{ConsensusTime, ConsensusType, TestableBlock, TestableState},
@@ -57,6 +56,7 @@ pub trait NodeImplementation<TYPES: NodeType>: Send + Sync + Debug + Clone + 'st
 #[allow(clippy::type_complexity)]
 #[async_trait]
 pub trait TestableNodeImplementation<TYPES: NodeType>: NodeImplementation<TYPES> {
+    /// generates a network given an expected node count
     fn network_generator(expected_node_count: usize, num_bootstrap_nodes: usize) -> Box<dyn Fn(u64) -> <<<Self as NodeImplementation<TYPES>>::QuorumExchange as ConsensusExchange<
     TYPES,
     <Self as NodeImplementation<TYPES>>::Leaf,
@@ -68,7 +68,7 @@ pub trait TestableNodeImplementation<TYPES: NodeType>: NodeImplementation<TYPES>
     <Self::QuorumExchange as ConsensusExchange<TYPES, Self::Leaf, Message<TYPES, Self>>>::Vote,
     <Self::QuorumExchange as ConsensusExchange<TYPES, Self::Leaf, Message<TYPES, Self>>>::Membership,
 >>::NETWORK + 'static>;
-    /// generates a network given an expected node count
+    /// generates a committee communication channel given the network
     fn committee_generator() -> Box<
         dyn Fn(
                 Arc<
@@ -104,7 +104,7 @@ pub trait TestableNodeImplementation<TYPES: NodeType>: NodeImplementation<TYPES>
             + 'static,
     >;
 
-    /// generates a network given an expected node count
+    /// generates a quorum communication channel given the network
     fn quorum_generator() -> Box<
         dyn Fn(
                 Arc<

--- a/types/src/traits/node_implementation.rs
+++ b/types/src/traits/node_implementation.rs
@@ -57,45 +57,14 @@ pub trait NodeImplementation<TYPES: NodeType>: Send + Sync + Debug + Clone + 'st
 #[async_trait]
 pub trait TestableNodeImplementation<TYPES: NodeType>: NodeImplementation<TYPES> {
     /// generates a network given an expected node count
-    fn network_generator(expected_node_count: usize, num_bootstrap_nodes: usize) -> Box<dyn Fn(u64) -> <<<Self as NodeImplementation<TYPES>>::QuorumExchange as ConsensusExchange<
-    TYPES,
-    <Self as NodeImplementation<TYPES>>::Leaf,
-    Message<TYPES, Self>,
->>::Networking as CommunicationChannel<
-    TYPES,
-    Message<TYPES, Self>,
-    <Self::QuorumExchange as ConsensusExchange<TYPES, Self::Leaf, Message<TYPES, Self>>>::Proposal,
-    <Self::QuorumExchange as ConsensusExchange<TYPES, Self::Leaf, Message<TYPES, Self>>>::Vote,
-    <Self::QuorumExchange as ConsensusExchange<TYPES, Self::Leaf, Message<TYPES, Self>>>::Membership,
->>::NETWORK + 'static>;
+    fn network_generator(
+        expected_node_count: usize,
+        num_bootstrap_nodes: usize,
+    ) -> Box<dyn Fn(u64) -> NetworkType<TYPES, Self> + 'static>;
     /// generates a committee communication channel given the network
     fn committee_generator() -> Box<
         dyn Fn(
-                Arc<
-                    <<<Self as NodeImplementation<TYPES>>::QuorumExchange as ConsensusExchange<
-                        TYPES,
-                        <Self as NodeImplementation<TYPES>>::Leaf,
-                        Message<TYPES, Self>,
-                    >>::Networking as CommunicationChannel<
-                        TYPES,
-                        Message<TYPES, Self>,
-                        <Self::QuorumExchange as ConsensusExchange<
-                            TYPES,
-                            Self::Leaf,
-                            Message<TYPES, Self>,
-                        >>::Proposal,
-                        <Self::QuorumExchange as ConsensusExchange<
-                            TYPES,
-                            Self::Leaf,
-                            Message<TYPES, Self>,
-                        >>::Vote,
-                        <Self::QuorumExchange as ConsensusExchange<
-                            TYPES,
-                            Self::Leaf,
-                            Message<TYPES, Self>,
-                        >>::Membership,
-                    >>::NETWORK,
-                >,
+                Arc<NetworkType<TYPES, Self>>,
             ) -> <Self::CommitteeExchange as ConsensusExchange<
                 TYPES,
                 Self::Leaf,
@@ -107,31 +76,7 @@ pub trait TestableNodeImplementation<TYPES: NodeType>: NodeImplementation<TYPES>
     /// generates a quorum communication channel given the network
     fn quorum_generator() -> Box<
         dyn Fn(
-                Arc<
-                    <<<Self as NodeImplementation<TYPES>>::QuorumExchange as ConsensusExchange<
-                        TYPES,
-                        <Self as NodeImplementation<TYPES>>::Leaf,
-                        Message<TYPES, Self>,
-                    >>::Networking as CommunicationChannel<
-                        TYPES,
-                        Message<TYPES, Self>,
-                        <Self::QuorumExchange as ConsensusExchange<
-                            TYPES,
-                            Self::Leaf,
-                            Message<TYPES, Self>,
-                        >>::Proposal,
-                        <Self::QuorumExchange as ConsensusExchange<
-                            TYPES,
-                            Self::Leaf,
-                            Message<TYPES, Self>,
-                        >>::Vote,
-                        <Self::QuorumExchange as ConsensusExchange<
-                            TYPES,
-                            Self::Leaf,
-                            Message<TYPES, Self>,
-                        >>::Membership,
-                    >>::NETWORK,
-                >,
+                Arc<NetworkType<TYPES, Self>>,
             ) -> <Self::QuorumExchange as ConsensusExchange<
                 TYPES,
                 Self::Leaf,
@@ -203,76 +148,45 @@ pub trait TestableNodeImplementation<TYPES: NodeType>: NodeImplementation<TYPES>
 impl<TYPES: NodeType, I: NodeImplementation<TYPES>> TestableNodeImplementation<TYPES>
 for I
 where
-<I::CommitteeExchange as ConsensusExchange<TYPES, I::Leaf, Message<TYPES, I>>>::Networking :
-TestableChannelImplementation<
-    TYPES,
-    Message<TYPES, I>,
-    <I::CommitteeExchange as ConsensusExchange<TYPES, I::Leaf, Message<TYPES, I>>>::Proposal,
-    <I::CommitteeExchange as ConsensusExchange<TYPES, I::Leaf, Message<TYPES, I>>>::Vote,
-    <I::CommitteeExchange as ConsensusExchange<TYPES, I::Leaf, Message<TYPES, I>>>::Membership,
-    <<<I as NodeImplementation<TYPES>>::QuorumExchange as ConsensusExchange<TYPES, <I as NodeImplementation<TYPES>>::Leaf, Message<TYPES, I>>>::Networking as CommunicationChannel<TYPES, Message<TYPES, I>, <I::QuorumExchange as ConsensusExchange<TYPES, I::Leaf, Message<TYPES, I>>>::Proposal,
-<I::QuorumExchange as ConsensusExchange<TYPES, I::Leaf, Message<TYPES, I>>>::Vote,
-<I::QuorumExchange as ConsensusExchange<TYPES, I::Leaf, Message<TYPES, I>>>::Membership,>>::NETWORK
->,
-<I::QuorumExchange as ConsensusExchange<TYPES, I::Leaf, Message<TYPES, I>>>::Networking :
-TestableChannelImplementation<
-    TYPES,
-    Message<TYPES, I>,
-    <I::QuorumExchange as ConsensusExchange<TYPES, I::Leaf, Message<TYPES, I>>>::Proposal,
-    <I::QuorumExchange as ConsensusExchange<TYPES, I::Leaf, Message<TYPES, I>>>::Vote,
-    <I::QuorumExchange as ConsensusExchange<TYPES, I::Leaf, Message<TYPES, I>>>::Membership,
-    <<<I as NodeImplementation<TYPES>>::QuorumExchange as ConsensusExchange<TYPES, <I as NodeImplementation<TYPES>>::Leaf, Message<TYPES, I>>>::Networking as CommunicationChannel<TYPES, Message<TYPES, I>, <I::QuorumExchange as ConsensusExchange<TYPES, I::Leaf, Message<TYPES, I>>>::Proposal,
-<I::QuorumExchange as ConsensusExchange<TYPES, I::Leaf, Message<TYPES, I>>>::Vote,
-<I::QuorumExchange as ConsensusExchange<TYPES, I::Leaf, Message<TYPES, I>>>::Membership,>>::NETWORK
->,
-<<<I as NodeImplementation<TYPES>>::QuorumExchange as ConsensusExchange<TYPES, <I as NodeImplementation<TYPES>>::Leaf, Message<TYPES, I>>>::Networking as CommunicationChannel<TYPES, Message<TYPES, I>, <I::QuorumExchange as ConsensusExchange<TYPES, I::Leaf, Message<TYPES, I>>>::Proposal,
-<I::QuorumExchange as ConsensusExchange<TYPES, I::Leaf, Message<TYPES, I>>>::Vote,
-<I::QuorumExchange as ConsensusExchange<TYPES, I::Leaf, Message<TYPES, I>>>::Membership,>>::NETWORK :
-TestableNetworkingImplementation<TYPES, Message<TYPES, I>>,
-TYPES::StateType : TestableState,
-TYPES::BlockType : TestableBlock,
-I::Storage : TestableStorage<TYPES, I::Leaf>,
-TYPES::SignatureKey : TestableSignatureKey,
-I::Leaf : TestableLeaf<NodeType = TYPES>,
-// <I::QuorumExchange as ConsensusExchange<TYPES, I::Leaf, Message<TYPES, I>>>::Membership : TestableElection<TYPES>,
-// <I::CommitteeExchange as ConsensusExchange<TYPES, I::Leaf, Message<TYPES, I>>>::Membership : TestableElection<TYPES>,
-{
-    fn network_generator(expected_node_count: usize, num_bootstrap_nodes: usize) -> Box<dyn Fn(u64) -> <<<I as NodeImplementation<TYPES>>::QuorumExchange as ConsensusExchange<
-    TYPES,
-    <I as NodeImplementation<TYPES>>::Leaf,
-    Message<TYPES, I>,
->>::Networking as CommunicationChannel<
-    TYPES,
-    Message<TYPES, I>,
-    <I::QuorumExchange as ConsensusExchange<TYPES, I::Leaf, Message<TYPES, I>>>::Proposal,
-    <I::QuorumExchange as ConsensusExchange<TYPES, I::Leaf, Message<TYPES, I>>>::Vote,
-    <I::QuorumExchange as ConsensusExchange<TYPES, I::Leaf, Message<TYPES, I>>>::Membership,
->>::NETWORK + 'static> {
-        <<<<I as NodeImplementation<TYPES>>::QuorumExchange as ConsensusExchange<
+    <I::CommitteeExchange as ConsensusExchange<TYPES, I::Leaf, Message<TYPES, I>>>::Networking :
+    TestableChannelImplementation<
         TYPES,
-        <I as NodeImplementation<TYPES>>::Leaf,
         Message<TYPES, I>,
-    >>::Networking as CommunicationChannel<
+        <I::CommitteeExchange as ConsensusExchange<TYPES, I::Leaf, Message<TYPES, I>>>::Proposal,
+        <I::CommitteeExchange as ConsensusExchange<TYPES, I::Leaf, Message<TYPES, I>>>::Vote,
+        <I::CommitteeExchange as ConsensusExchange<TYPES, I::Leaf, Message<TYPES, I>>>::Membership,
+        NetworkType<TYPES, I>,
+    >,
+    <I::QuorumExchange as ConsensusExchange<TYPES, I::Leaf, Message<TYPES, I>>>::Networking :
+    TestableChannelImplementation<
         TYPES,
         Message<TYPES, I>,
         <I::QuorumExchange as ConsensusExchange<TYPES, I::Leaf, Message<TYPES, I>>>::Proposal,
         <I::QuorumExchange as ConsensusExchange<TYPES, I::Leaf, Message<TYPES, I>>>::Vote,
         <I::QuorumExchange as ConsensusExchange<TYPES, I::Leaf, Message<TYPES, I>>>::Membership,
-    >>::NETWORK as TestableNetworkingImplementation<_, _>>::generator(
+        NetworkType<TYPES, I>,
+    >,
+    NetworkType<TYPES, I> : TestableNetworkingImplementation<TYPES, Message<TYPES, I>>,
+    TYPES::StateType : TestableState,
+    TYPES::BlockType : TestableBlock,
+    I::Storage : TestableStorage<TYPES, I::Leaf>,
+    TYPES::SignatureKey : TestableSignatureKey,
+    I::Leaf : TestableLeaf<NodeType = TYPES>,
+// <I::QuorumExchange as ConsensusExchange<TYPES, I::Leaf, Message<TYPES, I>>>::Membership : TestableElection<TYPES>,
+// <I::CommitteeExchange as ConsensusExchange<TYPES, I::Leaf, Message<TYPES, I>>>::Membership : TestableElection<TYPES>,
+{
+    fn network_generator(expected_node_count: usize, num_bootstrap_nodes: usize) -> Box<dyn Fn(u64) -> NetworkType<TYPES, I> + 'static> {
+        <NetworkType<TYPES, I> as TestableNetworkingImplementation<_, _>>::generator(
         expected_node_count,
         num_bootstrap_nodes,
         1,
     )
     }
-    fn committee_generator () -> Box<dyn Fn(Arc<<<<I as NodeImplementation<TYPES>>::QuorumExchange as ConsensusExchange<TYPES, <I as NodeImplementation<TYPES>>::Leaf, Message<TYPES, I>>>::Networking as CommunicationChannel<TYPES, Message<TYPES, I>, <I::QuorumExchange as ConsensusExchange<TYPES, I::Leaf, Message<TYPES, I>>>::Proposal,
-        <I::QuorumExchange as ConsensusExchange<TYPES, I::Leaf, Message<TYPES, I>>>::Vote,
-        <I::QuorumExchange as ConsensusExchange<TYPES, I::Leaf, Message<TYPES, I>>>::Membership,>>::NETWORK>) -> <I::CommitteeExchange as ConsensusExchange<TYPES, I::Leaf, Message<TYPES, I>>>::Networking + 'static> {
+    fn committee_generator () -> Box<dyn Fn(Arc<NetworkType<TYPES, I>>) -> <I::CommitteeExchange as ConsensusExchange<TYPES, I::Leaf, Message<TYPES, I>>>::Networking + 'static> {
         <<I::CommitteeExchange as ConsensusExchange<TYPES, I::Leaf, Message<TYPES, I>>>::Networking as TestableChannelImplementation<_, _, _, _, _, _>>::generate_network()
     }
 
-    fn quorum_generator() -> Box<dyn Fn(Arc<<<<I as NodeImplementation<TYPES>>::QuorumExchange as ConsensusExchange<TYPES, <I as NodeImplementation<TYPES>>::Leaf, Message<TYPES, I>>>::Networking as CommunicationChannel<TYPES, Message<TYPES, I>, <I::QuorumExchange as ConsensusExchange<TYPES, I::Leaf, Message<TYPES, I>>>::Proposal,
-        <I::QuorumExchange as ConsensusExchange<TYPES, I::Leaf, Message<TYPES, I>>>::Vote,
-        <I::QuorumExchange as ConsensusExchange<TYPES, I::Leaf, Message<TYPES, I>>>::Membership,>>::NETWORK>) -> <I::QuorumExchange as ConsensusExchange<TYPES, I::Leaf, Message<TYPES, I>>>::Networking + 'static> {
+    fn quorum_generator() -> Box<dyn Fn(Arc<NetworkType<TYPES, I>>) -> <I::QuorumExchange as ConsensusExchange<TYPES, I::Leaf, Message<TYPES, I>>>::Networking + 'static> {
         <<I::QuorumExchange as ConsensusExchange<TYPES, I::Leaf, Message<TYPES, I>>>::Networking as TestableChannelImplementation<_, _, _, _, _, _>>::generate_network()
     }
 
@@ -389,7 +303,32 @@ pub type CommitteeMembership<TYPES, I> =
         <I as NodeImplementation<TYPES>>::Leaf,
         Message<TYPES, I>,
     >>::Membership;
-
+// TODO remove this really ugly type once we have `ConsensusExchanges` impl and can use that to do all generation
+/// Type for the underlying `ConnectedNetwork` that will be shared (for now) b/t Communication Channels
+pub type NetworkType<TYPES, I> =
+    <<<I as NodeImplementation<TYPES>>::QuorumExchange as ConsensusExchange<
+        TYPES,
+        <I as NodeImplementation<TYPES>>::Leaf,
+        Message<TYPES, I>,
+    >>::Networking as CommunicationChannel<
+        TYPES,
+        Message<TYPES, I>,
+        <<I as NodeImplementation<TYPES>>::QuorumExchange as ConsensusExchange<
+            TYPES,
+            <I as NodeImplementation<TYPES>>::Leaf,
+            Message<TYPES, I>,
+        >>::Proposal,
+        <<I as NodeImplementation<TYPES>>::QuorumExchange as ConsensusExchange<
+            TYPES,
+            <I as NodeImplementation<TYPES>>::Leaf,
+            Message<TYPES, I>,
+        >>::Vote,
+        <<I as NodeImplementation<TYPES>>::QuorumExchange as ConsensusExchange<
+            TYPES,
+            <I as NodeImplementation<TYPES>>::Leaf,
+            Message<TYPES, I>,
+        >>::Membership,
+    >>::NETWORK;
 /// Trait with all the type definitions that are used in the current hotshot setup.
 pub trait NodeType:
     Clone


### PR DESCRIPTION
 This PR does 3 related things

1. Makes the `CommunicationChannel` accept and `Arc` for the network instead of the object allowing us to share one instance
2. Moves `TestableNetworkImplementation` to be on the `ConnectedNetwork` allowing us to generate a `ConnectedNetwork` Directly from the test launcher
3. Removes the second Message generic from `ConnectedNetwork` and makes it so `WebSeverNetwork` doesn't need two message type generics

The test parts are a bit awkward without having `ConsensusExchanges` completed yet.  Basically the tests have to create one ConnectedNetwork type but that type isn't readily exposed at the `TestableNodeImplementation` level and only gotten through the ConsensusExchange's communication channel type.  This is why we have the super complex type def called `NetworkTypes` in node_implementation.rs.  Also it means we have to introduce the restriction in test that the `QuorumExchange`'s associated `CommunicationChannel`'s associated `ConnectedNetwork` equals the  `CommitteeExchange`'s associated `CommunicationChannel`'s associated `ConnectedNetwork`.  In other words if the Quorum's underlying network is LibP2p the Committee's must also be LibP2p for the test.  This is fine because that's how all the tests were working anyhow and it doesn't matter for the Validating tests (b/c Committee doesn't get used)

This can get fixed once we have `ConsensusExchanges` implemented because we can delegate the `ConnectedNetwork` and `CommunicationChannel` creation to a `TestableConsensusExchanges` trait.

Closes: #1062