### PR TITLE
Create CommunicationChannel for WebServer + Libp2p

### DIFF
--- a/justfile
+++ b/justfile
@@ -24,7 +24,7 @@ test_async_std_all:
 
 test_pkg := "hotshot"
 
-test_name := "sequencing_libp2p_test"
+test_name := "webserver_libp2p_network"
 
 test_async_std_pkg_all pkg=test_pkg:
   cargo test --verbose --release --features=async-std-executor,demo,channel-async-std --lib --bins --tests --benches --package={{pkg}} --no-fail-fast -- --test-threads=1 --nocapture

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -17,6 +17,7 @@ pub mod implementations {
             libp2p_network::{Libp2pCommChannel, Libp2pNetwork, PeerInfoVec},
             memory_network::{DummyReliability, MasterMap, MemoryCommChannel, MemoryNetwork},
             web_server_network::{WebCommChannel, WebServerNetwork},
+            web_sever_libp2p_fallback::WebServerWithFallbackCommChannel,
         },
         storage::memory_storage::MemoryStorage, // atomic_storage::AtomicStorage,
     };

--- a/src/traits/networking.rs
+++ b/src/traits/networking.rs
@@ -9,6 +9,7 @@ pub mod centralized_server_network;
 pub mod libp2p_network;
 pub mod memory_network;
 pub mod web_server_network;
+pub mod web_sever_libp2p_fallback;
 
 pub use hotshot_types::traits::network::{
     ChannelSendSnafu, CouldNotDeliverSnafu, FailedToDeserializeSnafu, FailedToSerializeSnafu,

--- a/src/traits/networking/web_sever_libp2p_fallback.rs
+++ b/src/traits/networking/web_sever_libp2p_fallback.rs
@@ -1,7 +1,6 @@
-use super::{
-    memory_network::MemoryNetwork, FailedToSerializeSnafu, NetworkError, NetworkReliability,
-    NetworkingMetrics,
-};
+use super::NetworkError;
+use crate::traits::implementations::Libp2pNetwork;
+use crate::traits::implementations::WebServerNetwork;
 use crate::NodeImplementation;
 use async_compatibility_layer::{
     art::{async_sleep, async_spawn},
@@ -11,6 +10,7 @@ use async_lock::{Mutex, RwLock};
 use async_trait::async_trait;
 use bincode::Options;
 use dashmap::DashMap;
+use futures::join;
 use futures::StreamExt;
 use hotshot_types::traits::network::TestableChannelImplementation;
 use hotshot_types::traits::network::ViewMessage;
@@ -41,10 +41,7 @@ use std::{
         Arc,
     },
 };
-use crate::traits::implementations::WebServerNetwork;
-use crate::traits::implementations::Libp2pNetwork;
 use tracing::{debug, error, info, info_span, instrument, trace, warn, Instrument};
-
 /// A communication channel with 2 networks, where we can fall back to the slower network if the
 /// primary fails
 #[derive(Clone)]
@@ -99,7 +96,7 @@ impl<
 
     pub fn network(
         &self,
-    ) -> WebServerNetwork<
+    ) -> &WebServerNetwork<
         Message<TYPES, I>,
         TYPES::SignatureKey,
         TYPES::ElectionConfigType,
@@ -107,10 +104,10 @@ impl<
         PROPOSAL,
         VOTE,
     > {
-        self.networks.0
+        &self.networks.0
     }
-    pub fn fallback(&self) -> Libp2pNetwork<Message<TYPES, I>, TYPES::SignatureKey> {
-        self.networks.1
+    pub fn fallback(&self) -> &Libp2pNetwork<Message<TYPES, I>, TYPES::SignatureKey> {
+        &self.networks.1
     }
 }
 
@@ -157,9 +154,14 @@ impl<
     ) -> Result<(), NetworkError> {
         let recipients =
             <MEMBERSHIP as Membership<TYPES>>::get_committee(election, message.get_view_number());
-        /// TODO return no error if either succeeds
-        self.fallback().broadcast_message(message, recipients).await;
-        self.network().broadcast_message(message, recipients).await
+        let fallback = self
+            .fallback()
+            .broadcast_message(message.clone(), recipients.clone());
+        let network = self.network().broadcast_message(message, recipients);
+        match join!(fallback, network) {
+            (Err(e), Err(_)) => Err(e),
+            _ => Ok(()),
+        }
     }
 
     async fn direct_message(
@@ -167,7 +169,11 @@ impl<
         message: Message<TYPES, I>,
         recipient: TYPES::SignatureKey,
     ) -> Result<(), NetworkError> {
-        match self.network().direct_message(message, recipient).await {
+        match self
+            .network()
+            .direct_message(message.clone(), recipient.clone())
+            .await
+        {
             Ok(_) => Ok(()),
             Err(e) => {
                 // TODO log e
@@ -180,7 +186,7 @@ impl<
         &self,
         transmit_type: TransmitType,
     ) -> Result<Vec<Message<TYPES, I>>, NetworkError> {
-        match self.network().recv_msgs(transmit_type).await {
+        match self.network().recv_msgs(transmit_type.clone()).await {
             Ok(msgs) => Ok(msgs),
             Err(e) => {
                 // TODO log e
@@ -190,7 +196,7 @@ impl<
     }
 
     async fn lookup_node(&self, pk: TYPES::SignatureKey) -> Result<(), NetworkError> {
-        match self.network().lookup_node(pk).await {
+        match self.network().lookup_node(pk.clone()).await {
             Ok(msgs) => Ok(msgs),
             Err(e) => {
                 // TODO log e
@@ -199,9 +205,12 @@ impl<
         }
     }
 
-    async fn inject_consensus_info(&self, _tuple: (u64, bool, bool)) -> Result<(), NetworkError> {
-        // Not required
-        Ok(())
+    async fn inject_consensus_info(&self, tuple: (u64, bool, bool)) -> Result<(), NetworkError> {
+        <WebServerNetwork<_, _, _, _, _, _> as ConnectedNetwork<
+            Message<TYPES, I>,
+            TYPES::SignatureKey,
+        >>::inject_consensus_info(self.network(), tuple)
+        .await
     }
 }
 
@@ -211,8 +220,6 @@ impl<
         PROPOSAL: ProposalType<NodeType = TYPES>,
         VOTE: VoteType<TYPES>,
         MEMBERSHIP: Membership<TYPES>,
-        PRIMARY: ConnectedNetwork<Message<TYPES, I>, TYPES::SignatureKey>,
-        FALLBACK: ConnectedNetwork<Message<TYPES, I>, TYPES::SignatureKey>,
     >
     TestableChannelImplementation<
         TYPES,
@@ -220,7 +227,17 @@ impl<
         PROPOSAL,
         VOTE,
         MEMBERSHIP,
-        (PRIMARY, FALLBACK),
+        (
+            WebServerNetwork<
+                Message<TYPES, I>,
+                TYPES::SignatureKey,
+                TYPES::ElectionConfigType,
+                TYPES,
+                PROPOSAL,
+                VOTE,
+            >,
+            Libp2pNetwork<Message<TYPES, I>, TYPES::SignatureKey>,
+        ),
     > for WebServerWithFallbackCommChannel<TYPES, I, PROPOSAL, VOTE, MEMBERSHIP>
 where
     TYPES::SignatureKey: TestableSignatureKey,
@@ -229,205 +246,3 @@ where
         Box::new(move |network| WebServerWithFallbackCommChannel::new(network))
     }
 }
-
-// #[cfg(test)]
-// // panic in tests
-// #[allow(clippy::panic)]
-// mod tests {
-//     use super::*;
-//     use crate::{
-//         demos::vdemo::{Addition, Subtraction, VDemoBlock, VDemoState, VDemoTransaction},
-//         traits::{
-//             election::static_committee::{
-//                 GeneralStaticCommittee, StaticElectionConfig, StaticVoteToken,
-//             },
-//             networking::memory_network::MemoryNetwork,
-//         },
-//     };
-
-//     use crate::traits::implementations::MasterMap;
-//     use crate::traits::implementations::MemoryCommChannel;
-//     use crate::traits::implementations::MemoryStorage;
-//     use async_compatibility_layer::logging::setup_logging;
-//     use hotshot_types::traits::election::QuorumExchange;
-//     use hotshot_types::{
-//         data::ViewNumber,
-//         message::{DataMessage, MessageKind},
-//         traits::{
-//             signature_key::ed25519::{Ed25519Priv, Ed25519Pub},
-//             state::ConsensusTime,
-//         },
-//         vote::QuorumVote,
-//     };
-//     use hotshot_types::{
-//         data::{ValidatingLeaf, ValidatingProposal},
-//         traits::state::ValidatingConsensus,
-//     };
-//     #[derive(
-//         Copy,
-//         Clone,
-//         Debug,
-//         Default,
-//         Hash,
-//         PartialEq,
-//         Eq,
-//         PartialOrd,
-//         Ord,
-//         serde::Serialize,
-//         serde::Deserialize,
-//     )]
-//     struct Test {}
-//     #[derive(Clone, Debug)]
-//     struct TestImpl {}
-
-//     // impl NetworkMsg for Test {}
-
-//     impl NodeType for Test {
-//         // TODO (da) can this be SequencingConsensus?
-//         type ConsensusType = ValidatingConsensus;
-//         type Time = ViewNumber;
-//         type BlockType = VDemoBlock;
-//         type SignatureKey = Ed25519Pub;
-//         type VoteTokenType = StaticVoteToken<Ed25519Pub>;
-//         type Transaction = VDemoTransaction;
-//         type ElectionConfigType = StaticElectionConfig;
-//         type StateType = VDemoState;
-//     }
-
-//     type TestMembership = GeneralStaticCommittee<Test, TestLeaf, Ed25519Pub>;
-//     type TestNetwork =
-//         WebServerWithFallbackCommChannel<Test, TestImpl, TestProposal, TestVote, TestMembership>;
-
-//     impl NodeImplementation<Test> for TestImpl {
-//         type QuorumExchange = QuorumExchange<
-//             Test,
-//             TestLeaf,
-//             TestProposal,
-//             TestMembership,
-//             TestNetwork,
-//             Message<Test, Self>,
-//         >;
-//         type CommitteeExchange = Self::QuorumExchange;
-//         type Leaf = TestLeaf;
-//         type Storage = MemoryStorage<Test, TestLeaf>;
-//     }
-
-//     type TestLeaf = ValidatingLeaf<Test>;
-//     type TestVote = QuorumVote<Test, TestLeaf>;
-//     type TestProposal = ValidatingProposal<Test, TestLeaf>;
-
-//     /// fake Eq
-//     /// we can't compare the votetokentype for equality, so we can't
-//     /// derive EQ on `VoteType<TYPES>` and thereby message
-//     /// we are only sending data messages, though so we compare key and
-//     /// data message
-//     fn fake_message_eq(message_1: Message<Test, TestImpl>, message_2: Message<Test, TestImpl>) {
-//         assert_eq!(message_1.sender, message_2.sender);
-//         if let MessageKind::Data(DataMessage::SubmitTransaction(d_1, _)) = message_1.kind {
-//             if let MessageKind::Data(DataMessage::SubmitTransaction(d_2, _)) = message_2.kind {
-//                 assert_eq!(d_1, d_2);
-//             }
-//         } else {
-//             panic!("Got unexpected message type in memory test!");
-//         }
-//     }
-
-//     #[instrument]
-//     fn get_pubkey() -> Ed25519Pub {
-//         let priv_key = Ed25519Priv::generate();
-//         Ed25519Pub::from_private(&priv_key)
-//     }
-
-//     /// create a message
-//     fn gen_messages(num_messages: u64, seed: u64, pk: Ed25519Pub) -> Vec<Message<Test, TestImpl>> {
-//         let mut messages = Vec::new();
-//         for i in 0..num_messages {
-//             let message = Message {
-//                 sender: pk,
-//                 kind: MessageKind::Data(DataMessage::SubmitTransaction(
-//                     VDemoTransaction {
-//                         add: Addition {
-//                             account: "A".to_string(),
-//                             amount: 50 + i + seed,
-//                         },
-//                         sub: Subtraction {
-//                             account: "B".to_string(),
-//                             amount: 50 + i + seed,
-//                         },
-//                         nonce: seed + i,
-//                         padding: vec![50; 0],
-//                     },
-//                     <ViewNumber as ConsensusTime>::new(0),
-//                 )),
-//             };
-//             messages.push(message);
-//         }
-//         messages
-//     }
-//     // Check to make sure direct queue works
-//     #[cfg_attr(
-//         feature = "tokio-executor",
-//         tokio::test(flavor = "multi_thread", worker_threads = 2)
-//     )]
-//     #[cfg_attr(feature = "async-std-executor", async_std::test)]
-//     #[allow(deprecated)]
-//     #[instrument]
-//     async fn direct_queue() {
-//         setup_logging();
-//         // Create some dummy messages
-
-//         // Make and connect the networking instances
-//         let group: Arc<MasterMap<Message<Test, TestImpl>, <Test as NodeType>::SignatureKey>> =
-//             MasterMap::new();
-//         let group2: Arc<MasterMap<Message<Test, TestImpl>, <Test as NodeType>::SignatureKey>> =
-//             MasterMap::new();
-//         trace!(?group);
-//         let pub_key_1 = get_pubkey();
-//         let network1 =
-//             MemoryNetwork::new(pub_key_1, NoMetrics::boxed(), group.clone(), Option::None);
-//         let pub_key_2 = get_pubkey();
-//         let network2 = MemoryNetwork::new(pub_key_2, NoMetrics::boxed(), group, Option::None);
-//         let fallback1 =
-//             MemoryNetwork::new(pub_key_1, NoMetrics::boxed(), group2.clone(), Option::None);
-//         let fallback2 = MemoryNetwork::new(pub_key_2, NoMetrics::boxed(), group2, Option::None);
-
-//         let comm1 = CommunicationChannelWithFallback::new((network1, fallback1));
-//         let comm2 = CommunicationChannelWithFallback::new((network2, fallback2));
-
-//         let first_messages: Vec<Message<Test, TestImpl>> = gen_messages(5, 100, pub_key_1);
-
-//         // Test 1 -> 2
-//         // Send messages
-//         for sent_message in first_messages {
-//             comm1
-//                 .direct_message(sent_message.clone(), pub_key_2)
-//                 .await
-//                 .expect("Failed to message node");
-//             let mut recv_messages = comm2
-//                 .recv_msgs(TransmitType::Direct)
-//                 .await
-//                 .expect("Failed to receive message");
-//             let recv_message = recv_messages.pop().unwrap();
-//             assert!(recv_messages.is_empty());
-//             fake_message_eq(sent_message, recv_message);
-//         }
-
-//         let second_messages: Vec<Message<Test, TestImpl>> = gen_messages(5, 200, pub_key_2);
-
-//         // Test 2 -> 1
-//         // Send messages
-//         for sent_message in second_messages {
-//             comm2
-//                 .direct_message(sent_message.clone(), pub_key_1)
-//                 .await
-//                 .expect("Failed to message node");
-//             let mut recv_messages = comm1
-//                 .recv_msgs(TransmitType::Direct)
-//                 .await
-//                 .expect("Failed to receive message");
-//             let recv_message = recv_messages.pop().unwrap();
-//             assert!(recv_messages.is_empty());
-//             fake_message_eq(sent_message, recv_message);
-//         }
-//     }
-// }

--- a/src/traits/networking/web_sever_libp2p_fallback.rs
+++ b/src/traits/networking/web_sever_libp2p_fallback.rs
@@ -1,0 +1,433 @@
+use super::{
+    memory_network::MemoryNetwork, FailedToSerializeSnafu, NetworkError, NetworkReliability,
+    NetworkingMetrics,
+};
+use crate::NodeImplementation;
+use async_compatibility_layer::{
+    art::{async_sleep, async_spawn},
+    channel::{bounded, Receiver, SendError, Sender},
+};
+use async_lock::{Mutex, RwLock};
+use async_trait::async_trait;
+use bincode::Options;
+use dashmap::DashMap;
+use futures::StreamExt;
+use hotshot_types::traits::network::TestableChannelImplementation;
+use hotshot_types::traits::network::ViewMessage;
+use hotshot_types::{
+    data::ProposalType,
+    message::Message,
+    traits::{
+        election::Membership,
+        metrics::{Metrics, NoMetrics},
+        network::{
+            CommunicationChannel, ConnectedNetwork, NetworkMsg, TestableNetworkingImplementation,
+            TransmitType,
+        },
+        node_implementation::NodeType,
+        signature_key::{SignatureKey, TestableSignatureKey},
+    },
+    vote::VoteType,
+};
+use hotshot_utils::bincode::bincode_opts;
+use rand::Rng;
+use snafu::ResultExt;
+use std::{
+    collections::BTreeSet,
+    fmt::Debug,
+    marker::PhantomData,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+};
+use crate::traits::implementations::WebServerNetwork;
+use crate::traits::implementations::Libp2pNetwork;
+use tracing::{debug, error, info, info_span, instrument, trace, warn, Instrument};
+
+/// A communication channel with 2 networks, where we can fall back to the slower network if the
+/// primary fails
+#[derive(Clone)]
+pub struct WebServerWithFallbackCommChannel<
+    TYPES: NodeType,
+    I: NodeImplementation<TYPES>,
+    PROPOSAL: ProposalType<NodeType = TYPES>,
+    VOTE: VoteType<TYPES>,
+    MEMBERSHIP: Membership<TYPES>,
+> {
+    networks: Arc<(
+        WebServerNetwork<
+            Message<TYPES, I>,
+            TYPES::SignatureKey,
+            TYPES::ElectionConfigType,
+            TYPES,
+            PROPOSAL,
+            VOTE,
+        >,
+        Libp2pNetwork<Message<TYPES, I>, TYPES::SignatureKey>,
+    )>,
+    _pd: PhantomData<(I, PROPOSAL, VOTE, MEMBERSHIP)>,
+}
+
+impl<
+        TYPES: NodeType,
+        I: NodeImplementation<TYPES>,
+        PROPOSAL: ProposalType<NodeType = TYPES>,
+        VOTE: VoteType<TYPES>,
+        MEMBERSHIP: Membership<TYPES>,
+    > WebServerWithFallbackCommChannel<TYPES, I, PROPOSAL, VOTE, MEMBERSHIP>
+{
+    #[must_use]
+    pub fn new(
+        networks: Arc<(
+            WebServerNetwork<
+                Message<TYPES, I>,
+                TYPES::SignatureKey,
+                TYPES::ElectionConfigType,
+                TYPES,
+                PROPOSAL,
+                VOTE,
+            >,
+            Libp2pNetwork<Message<TYPES, I>, TYPES::SignatureKey>,
+        )>,
+    ) -> Self {
+        Self {
+            networks,
+            _pd: PhantomData::default(),
+        }
+    }
+
+    pub fn network(
+        &self,
+    ) -> WebServerNetwork<
+        Message<TYPES, I>,
+        TYPES::SignatureKey,
+        TYPES::ElectionConfigType,
+        TYPES,
+        PROPOSAL,
+        VOTE,
+    > {
+        self.networks.0
+    }
+    pub fn fallback(&self) -> Libp2pNetwork<Message<TYPES, I>, TYPES::SignatureKey> {
+        self.networks.1
+    }
+}
+
+#[async_trait]
+impl<
+        TYPES: NodeType,
+        I: NodeImplementation<TYPES>,
+        PROPOSAL: ProposalType<NodeType = TYPES>,
+        VOTE: VoteType<TYPES>,
+        MEMBERSHIP: Membership<TYPES>,
+    > CommunicationChannel<TYPES, Message<TYPES, I>, PROPOSAL, VOTE, MEMBERSHIP>
+    for WebServerWithFallbackCommChannel<TYPES, I, PROPOSAL, VOTE, MEMBERSHIP>
+{
+    type NETWORK = (
+        WebServerNetwork<
+            Message<TYPES, I>,
+            TYPES::SignatureKey,
+            TYPES::ElectionConfigType,
+            TYPES,
+            PROPOSAL,
+            VOTE,
+        >,
+        Libp2pNetwork<Message<TYPES, I>, TYPES::SignatureKey>,
+    );
+
+    async fn wait_for_ready(&self) {
+        self.network().wait_for_ready().await;
+        self.fallback().wait_for_ready().await
+    }
+
+    async fn is_ready(&self) -> bool {
+        self.network().is_ready().await && self.fallback().is_ready().await
+    }
+
+    async fn shut_down(&self) -> () {
+        self.network().shut_down().await;
+        self.fallback().shut_down().await;
+    }
+
+    async fn broadcast_message(
+        &self,
+        message: Message<TYPES, I>,
+        election: &MEMBERSHIP,
+    ) -> Result<(), NetworkError> {
+        let recipients =
+            <MEMBERSHIP as Membership<TYPES>>::get_committee(election, message.get_view_number());
+        /// TODO return no error if either succeeds
+        self.fallback().broadcast_message(message, recipients).await;
+        self.network().broadcast_message(message, recipients).await
+    }
+
+    async fn direct_message(
+        &self,
+        message: Message<TYPES, I>,
+        recipient: TYPES::SignatureKey,
+    ) -> Result<(), NetworkError> {
+        match self.network().direct_message(message, recipient).await {
+            Ok(_) => Ok(()),
+            Err(e) => {
+                // TODO log e
+                self.fallback().direct_message(message, recipient).await
+            }
+        }
+    }
+
+    async fn recv_msgs(
+        &self,
+        transmit_type: TransmitType,
+    ) -> Result<Vec<Message<TYPES, I>>, NetworkError> {
+        match self.network().recv_msgs(transmit_type).await {
+            Ok(msgs) => Ok(msgs),
+            Err(e) => {
+                // TODO log e
+                self.fallback().recv_msgs(transmit_type).await
+            }
+        }
+    }
+
+    async fn lookup_node(&self, pk: TYPES::SignatureKey) -> Result<(), NetworkError> {
+        match self.network().lookup_node(pk).await {
+            Ok(msgs) => Ok(msgs),
+            Err(e) => {
+                // TODO log e
+                self.fallback().lookup_node(pk).await
+            }
+        }
+    }
+
+    async fn inject_consensus_info(&self, _tuple: (u64, bool, bool)) -> Result<(), NetworkError> {
+        // Not required
+        Ok(())
+    }
+}
+
+impl<
+        TYPES: NodeType,
+        I: NodeImplementation<TYPES>,
+        PROPOSAL: ProposalType<NodeType = TYPES>,
+        VOTE: VoteType<TYPES>,
+        MEMBERSHIP: Membership<TYPES>,
+        PRIMARY: ConnectedNetwork<Message<TYPES, I>, TYPES::SignatureKey>,
+        FALLBACK: ConnectedNetwork<Message<TYPES, I>, TYPES::SignatureKey>,
+    >
+    TestableChannelImplementation<
+        TYPES,
+        Message<TYPES, I>,
+        PROPOSAL,
+        VOTE,
+        MEMBERSHIP,
+        (PRIMARY, FALLBACK),
+    > for WebServerWithFallbackCommChannel<TYPES, I, PROPOSAL, VOTE, MEMBERSHIP>
+where
+    TYPES::SignatureKey: TestableSignatureKey,
+{
+    fn generate_network() -> Box<dyn Fn(Arc<Self::NETWORK>) -> Self + 'static> {
+        Box::new(move |network| WebServerWithFallbackCommChannel::new(network))
+    }
+}
+
+// #[cfg(test)]
+// // panic in tests
+// #[allow(clippy::panic)]
+// mod tests {
+//     use super::*;
+//     use crate::{
+//         demos::vdemo::{Addition, Subtraction, VDemoBlock, VDemoState, VDemoTransaction},
+//         traits::{
+//             election::static_committee::{
+//                 GeneralStaticCommittee, StaticElectionConfig, StaticVoteToken,
+//             },
+//             networking::memory_network::MemoryNetwork,
+//         },
+//     };
+
+//     use crate::traits::implementations::MasterMap;
+//     use crate::traits::implementations::MemoryCommChannel;
+//     use crate::traits::implementations::MemoryStorage;
+//     use async_compatibility_layer::logging::setup_logging;
+//     use hotshot_types::traits::election::QuorumExchange;
+//     use hotshot_types::{
+//         data::ViewNumber,
+//         message::{DataMessage, MessageKind},
+//         traits::{
+//             signature_key::ed25519::{Ed25519Priv, Ed25519Pub},
+//             state::ConsensusTime,
+//         },
+//         vote::QuorumVote,
+//     };
+//     use hotshot_types::{
+//         data::{ValidatingLeaf, ValidatingProposal},
+//         traits::state::ValidatingConsensus,
+//     };
+//     #[derive(
+//         Copy,
+//         Clone,
+//         Debug,
+//         Default,
+//         Hash,
+//         PartialEq,
+//         Eq,
+//         PartialOrd,
+//         Ord,
+//         serde::Serialize,
+//         serde::Deserialize,
+//     )]
+//     struct Test {}
+//     #[derive(Clone, Debug)]
+//     struct TestImpl {}
+
+//     // impl NetworkMsg for Test {}
+
+//     impl NodeType for Test {
+//         // TODO (da) can this be SequencingConsensus?
+//         type ConsensusType = ValidatingConsensus;
+//         type Time = ViewNumber;
+//         type BlockType = VDemoBlock;
+//         type SignatureKey = Ed25519Pub;
+//         type VoteTokenType = StaticVoteToken<Ed25519Pub>;
+//         type Transaction = VDemoTransaction;
+//         type ElectionConfigType = StaticElectionConfig;
+//         type StateType = VDemoState;
+//     }
+
+//     type TestMembership = GeneralStaticCommittee<Test, TestLeaf, Ed25519Pub>;
+//     type TestNetwork =
+//         WebServerWithFallbackCommChannel<Test, TestImpl, TestProposal, TestVote, TestMembership>;
+
+//     impl NodeImplementation<Test> for TestImpl {
+//         type QuorumExchange = QuorumExchange<
+//             Test,
+//             TestLeaf,
+//             TestProposal,
+//             TestMembership,
+//             TestNetwork,
+//             Message<Test, Self>,
+//         >;
+//         type CommitteeExchange = Self::QuorumExchange;
+//         type Leaf = TestLeaf;
+//         type Storage = MemoryStorage<Test, TestLeaf>;
+//     }
+
+//     type TestLeaf = ValidatingLeaf<Test>;
+//     type TestVote = QuorumVote<Test, TestLeaf>;
+//     type TestProposal = ValidatingProposal<Test, TestLeaf>;
+
+//     /// fake Eq
+//     /// we can't compare the votetokentype for equality, so we can't
+//     /// derive EQ on `VoteType<TYPES>` and thereby message
+//     /// we are only sending data messages, though so we compare key and
+//     /// data message
+//     fn fake_message_eq(message_1: Message<Test, TestImpl>, message_2: Message<Test, TestImpl>) {
+//         assert_eq!(message_1.sender, message_2.sender);
+//         if let MessageKind::Data(DataMessage::SubmitTransaction(d_1, _)) = message_1.kind {
+//             if let MessageKind::Data(DataMessage::SubmitTransaction(d_2, _)) = message_2.kind {
+//                 assert_eq!(d_1, d_2);
+//             }
+//         } else {
+//             panic!("Got unexpected message type in memory test!");
+//         }
+//     }
+
+//     #[instrument]
+//     fn get_pubkey() -> Ed25519Pub {
+//         let priv_key = Ed25519Priv::generate();
+//         Ed25519Pub::from_private(&priv_key)
+//     }
+
+//     /// create a message
+//     fn gen_messages(num_messages: u64, seed: u64, pk: Ed25519Pub) -> Vec<Message<Test, TestImpl>> {
+//         let mut messages = Vec::new();
+//         for i in 0..num_messages {
+//             let message = Message {
+//                 sender: pk,
+//                 kind: MessageKind::Data(DataMessage::SubmitTransaction(
+//                     VDemoTransaction {
+//                         add: Addition {
+//                             account: "A".to_string(),
+//                             amount: 50 + i + seed,
+//                         },
+//                         sub: Subtraction {
+//                             account: "B".to_string(),
+//                             amount: 50 + i + seed,
+//                         },
+//                         nonce: seed + i,
+//                         padding: vec![50; 0],
+//                     },
+//                     <ViewNumber as ConsensusTime>::new(0),
+//                 )),
+//             };
+//             messages.push(message);
+//         }
+//         messages
+//     }
+//     // Check to make sure direct queue works
+//     #[cfg_attr(
+//         feature = "tokio-executor",
+//         tokio::test(flavor = "multi_thread", worker_threads = 2)
+//     )]
+//     #[cfg_attr(feature = "async-std-executor", async_std::test)]
+//     #[allow(deprecated)]
+//     #[instrument]
+//     async fn direct_queue() {
+//         setup_logging();
+//         // Create some dummy messages
+
+//         // Make and connect the networking instances
+//         let group: Arc<MasterMap<Message<Test, TestImpl>, <Test as NodeType>::SignatureKey>> =
+//             MasterMap::new();
+//         let group2: Arc<MasterMap<Message<Test, TestImpl>, <Test as NodeType>::SignatureKey>> =
+//             MasterMap::new();
+//         trace!(?group);
+//         let pub_key_1 = get_pubkey();
+//         let network1 =
+//             MemoryNetwork::new(pub_key_1, NoMetrics::boxed(), group.clone(), Option::None);
+//         let pub_key_2 = get_pubkey();
+//         let network2 = MemoryNetwork::new(pub_key_2, NoMetrics::boxed(), group, Option::None);
+//         let fallback1 =
+//             MemoryNetwork::new(pub_key_1, NoMetrics::boxed(), group2.clone(), Option::None);
+//         let fallback2 = MemoryNetwork::new(pub_key_2, NoMetrics::boxed(), group2, Option::None);
+
+//         let comm1 = CommunicationChannelWithFallback::new((network1, fallback1));
+//         let comm2 = CommunicationChannelWithFallback::new((network2, fallback2));
+
+//         let first_messages: Vec<Message<Test, TestImpl>> = gen_messages(5, 100, pub_key_1);
+
+//         // Test 1 -> 2
+//         // Send messages
+//         for sent_message in first_messages {
+//             comm1
+//                 .direct_message(sent_message.clone(), pub_key_2)
+//                 .await
+//                 .expect("Failed to message node");
+//             let mut recv_messages = comm2
+//                 .recv_msgs(TransmitType::Direct)
+//                 .await
+//                 .expect("Failed to receive message");
+//             let recv_message = recv_messages.pop().unwrap();
+//             assert!(recv_messages.is_empty());
+//             fake_message_eq(sent_message, recv_message);
+//         }
+
+//         let second_messages: Vec<Message<Test, TestImpl>> = gen_messages(5, 200, pub_key_2);
+
+//         // Test 2 -> 1
+//         // Send messages
+//         for sent_message in second_messages {
+//             comm2
+//                 .direct_message(sent_message.clone(), pub_key_1)
+//                 .await
+//                 .expect("Failed to message node");
+//             let mut recv_messages = comm1
+//                 .recv_msgs(TransmitType::Direct)
+//                 .await
+//                 .expect("Failed to receive message");
+//             let recv_message = recv_messages.pop().unwrap();
+//             assert!(recv_messages.is_empty());
+//             fake_message_eq(sent_message, recv_message);
+//         }
+//     }
+// }

--- a/src/traits/networking/web_sever_libp2p_fallback.rs
+++ b/src/traits/networking/web_sever_libp2p_fallback.rs
@@ -1,3 +1,5 @@
+//! Networking Implementation that has a primary and a fallback newtork.  If the primary 
+//! Errors we will use the backup to send or receive
 use super::NetworkError;
 use crate::traits::implementations::Libp2pNetwork;
 use crate::traits::implementations::WebServerNetwork;

--- a/testing/tests/fallback_network.rs
+++ b/testing/tests/fallback_network.rs
@@ -1,0 +1,82 @@
+use hotshot::{
+    traits::{
+        election::static_committee::StaticCommittee,
+        implementations::{MemoryStorage, WebServerWithFallbackCommChannel},
+    },
+    types::Message,
+};
+use hotshot_testing::{
+    test_description::GeneralTestDescriptionBuilder, test_types::StaticCommitteeTestTypes,
+};
+use hotshot_types::traits::election::QuorumExchange;
+
+use hotshot_types::traits::node_implementation::NodeImplementation;
+use hotshot_types::{
+    data::{ValidatingLeaf, ValidatingProposal},
+    vote::QuorumVote,
+};
+use tracing::instrument;
+
+#[derive(Clone, Debug)]
+struct FallbackImpl {}
+
+type StaticMembership =
+    StaticCommittee<StaticCommitteeTestTypes, ValidatingLeaf<StaticCommitteeTestTypes>>;
+
+type StaticCommunication = WebServerWithFallbackCommChannel<
+    StaticCommitteeTestTypes,
+    FallbackImpl,
+    ValidatingProposal<StaticCommitteeTestTypes, ValidatingLeaf<StaticCommitteeTestTypes>>,
+    QuorumVote<StaticCommitteeTestTypes, ValidatingLeaf<StaticCommitteeTestTypes>>,
+    StaticCommittee<StaticCommitteeTestTypes, ValidatingLeaf<StaticCommitteeTestTypes>>,
+>;
+
+impl NodeImplementation<StaticCommitteeTestTypes> for FallbackImpl {
+    type Storage =
+        MemoryStorage<StaticCommitteeTestTypes, ValidatingLeaf<StaticCommitteeTestTypes>>;
+    type Leaf = ValidatingLeaf<StaticCommitteeTestTypes>;
+    type QuorumExchange = QuorumExchange<
+        StaticCommitteeTestTypes,
+        ValidatingLeaf<StaticCommitteeTestTypes>,
+        ValidatingProposal<StaticCommitteeTestTypes, ValidatingLeaf<StaticCommitteeTestTypes>>,
+        StaticMembership,
+        StaticCommunication,
+        Message<StaticCommitteeTestTypes, FallbackImpl>,
+    >;
+    type CommitteeExchange = Self::QuorumExchange;
+}
+
+/// web server with libp2p network test
+#[cfg_attr(
+    feature = "tokio-executor",
+    tokio::test(flavor = "multi_thread", worker_threads = 2)
+)]
+#[cfg_attr(feature = "async-std-executor", async_std::test)]
+#[instrument]
+async fn webserver_libp2p_network() {
+    let description = GeneralTestDescriptionBuilder::default_multiple_rounds();
+
+    description
+        .build::<StaticCommitteeTestTypes, FallbackImpl>()
+        .execute()
+        .await
+        .unwrap();
+}
+
+// stress test for web server with libp2p
+#[cfg_attr(
+    feature = "tokio-executor",
+    tokio::test(flavor = "multi_thread", worker_threads = 2)
+)]
+#[cfg_attr(feature = "async-std-executor", async_std::test)]
+#[instrument]
+#[ignore]
+async fn test_stress_webserver_libp2p_network() {
+    let description = GeneralTestDescriptionBuilder::default_stress();
+
+    description
+        .build::<StaticCommitteeTestTypes, FallbackImpl>()
+        .execute()
+        .await
+        .unwrap();
+}

--- a/types/src/traits/network.rs
+++ b/types/src/traits/network.rs
@@ -155,7 +155,7 @@ pub trait CommunicationChannel<
 >: Clone + Send + Sync + 'static
 {
     /// Underlying Network implementation's type
-    type NETWORK: ConnectedNetwork<M, TYPES::SignatureKey>;
+    type NETWORK;
     /// Blocks until node is successfully initialized
     /// into the network
     async fn wait_for_ready(&self);
@@ -270,7 +270,7 @@ pub trait TestableChannelImplementation<
     PROPOSAL: ProposalType<NodeType = TYPES>,
     VOTE: VoteType<TYPES>,
     MEMBERSHIP: Membership<TYPES>,
-    NETWORK: ConnectedNetwork<M, TYPES::SignatureKey>,
+    NETWORK,
 >: CommunicationChannel<TYPES, M, PROPOSAL, VOTE, MEMBERSHIP>
 {
     /// generates the `CommunicationChannel` given it's associated network type

--- a/types/src/traits/network.rs
+++ b/types/src/traits/network.rs
@@ -248,9 +248,7 @@ pub trait ConnectedNetwork<M: NetworkMsg, K: SignatureKey + 'static>:
 }
 
 /// Describes additional functionality needed by the test network implementation
-pub trait TestableNetworkingImplementation<TYPES: NodeType, M: NetworkMsg>:
-    ConnectedNetwork<M, TYPES::SignatureKey>
-{
+pub trait TestableNetworkingImplementation<TYPES: NodeType, M: NetworkMsg> {
     /// generates a network given an expected node count
     fn generator(
         expected_node_count: usize,


### PR DESCRIPTION
Very basic implementation with the webserver being the primary and the libp2p being the backup.

Most of the work was getting this all to play nicely with the testing stuff.  Because I couldn't implement it generically means I can't use MemoryNetworks to force certain failure modes.  This means the test is more or less testing that things work with the webserver as there should not be any errors/fallback happening.

There are for sure improvements to the logic that we can make, specifically around cancelling broadcasts, and handling duplicated messages.  I want to try to get some more failure tests so I can really make sure the logic works

Closes: #1066