### PR TITLE
Commit blocks besides genesis

### DIFF
--- a/consensus/src/leader.rs
+++ b/consensus/src/leader.rs
@@ -117,7 +117,7 @@ where
         async_sleep(self.api.propose_min_round_time() - passed_time).await;
 
         let receiver = self.transactions.subscribe().await;
-        let mut block = starting_state.next_block();
+        let mut block = <TYPES as NodeType>::StateType::next_block(Some(starting_state.clone()));
 
         // Wait until we have min_transactions for the block or we hit propose_max_round_time
         while task_start_time.elapsed() < self.api.propose_max_round_time() {

--- a/consensus/src/sequencing_leader.rs
+++ b/consensus/src/sequencing_leader.rs
@@ -16,6 +16,7 @@ use hotshot_types::message::Message;
 use hotshot_types::traits::election::CommitteeExchangeType;
 use hotshot_types::traits::election::ConsensusExchange;
 use hotshot_types::traits::election::QuorumExchangeType;
+use hotshot_types::traits::state::State;
 
 use hotshot_types::traits::node_implementation::{
     NodeImplementation, QuorumProposal, QuorumVoteType,
@@ -238,7 +239,7 @@ where
              return None;
          };
 
-        let mut block = TYPES::BlockType::new();
+        let mut block = <TYPES as NodeType>::StateType::next_block(None);
         let txns = self.wait_for_transactions().await?;
 
         for txn in txns {

--- a/src/demos/sdemo.rs
+++ b/src/demos/sdemo.rs
@@ -70,7 +70,7 @@ pub struct SDemoGenesisBlock {}
 #[derive(PartialEq, Eq, Hash, Serialize, Deserialize, Clone, Debug)]
 pub struct SDemoNormalBlock {
     /// Block state commitment
-    pub previous_state: Commitment<SDemoState>,
+    pub previous_state: (),
     /// Transaction vector
     pub transactions: Vec<SDemoTransaction>,
 }
@@ -91,8 +91,7 @@ impl Committable for SDemoBlock {
                 commit::RawCommitmentBuilder::new("SDemo Genesis Comm").finalize()
             }
             SDemoBlock::Normal(block) => {
-                let mut builder = commit::RawCommitmentBuilder::new("SDemo Normal Comm")
-                    .var_size_field("Previous State", block.previous_state.as_ref());
+                let mut builder = commit::RawCommitmentBuilder::new("SDemo Normal Comm");
                 for txn in &block.transactions {
                     builder = builder.u64_field("transaction", **txn);
                 }
@@ -213,9 +212,9 @@ impl State for SDemoState {
 
     type Time = ViewNumber;
 
-    fn next_block(&self) -> Self::BlockType {
+    fn next_block(_state: Option<Self>) -> Self::BlockType {
         SDemoBlock::Normal(SDemoNormalBlock {
-            previous_state: self.commit(),
+            previous_state: (),
             transactions: Vec::new(),
         })
     }
@@ -225,9 +224,7 @@ impl State for SDemoState {
             SDemoBlock::Genesis(_) => {
                 view_number == &ViewNumber::genesis() && view_number == &self.view_number
             }
-            SDemoBlock::Normal(n) => {
-                n.previous_state == self.commit() && self.view_number < *view_number
-            }
+            SDemoBlock::Normal(_n) => self.view_number < *view_number,
         }
     }
 

--- a/src/demos/vdemo.rs
+++ b/src/demos/vdemo.rs
@@ -231,11 +231,14 @@ impl State for VDemoState {
 
     type Time = ViewNumber;
 
-    fn next_block(&self) -> Self::BlockType {
-        VDemoBlock::Normal(VDemoNormalBlock {
-            previous_state: self.commit(),
-            transactions: Vec::new(),
-        })
+    fn next_block(state: Option<Self>) -> Self::BlockType {
+        match state {
+            Some(state) => VDemoBlock::Normal(VDemoNormalBlock {
+                previous_state: state.commit(),
+                transactions: Vec::new(),
+            }),
+            None => panic!("State is required for the next block"),
+        }
     }
 
     // Note: validate_block is actually somewhat redundant, its meant to be a quick and dirty check

--- a/src/demos/vdemo.rs
+++ b/src/demos/vdemo.rs
@@ -231,6 +231,7 @@ impl State for VDemoState {
 
     type Time = ViewNumber;
 
+    #[allow(clippy::panic)]
     fn next_block(state: Option<Self>) -> Self::BlockType {
         match state {
             Some(state) => VDemoBlock::Normal(VDemoNormalBlock {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -366,7 +366,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> HotShot<TYPES::ConsensusType
     /// # Panics
     ///
     /// Panics if internal state for consensus is inconsistent
-    pub async fn get_state(&self) -> <I::Leaf as LeafType>::StateCommitmentType {
+    pub async fn get_state(&self) -> <I::Leaf as LeafType>::MaybeState {
         self.hotstuff.read().await.get_decided_leaf().get_state()
     }
 

--- a/src/types/handle.rs
+++ b/src/types/handle.rs
@@ -116,7 +116,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static> HotShotHandle<TYPE
     /// # Errors
     ///
     /// Returns an error if the underlying `Storage` returns an error
-    pub async fn get_state(&self) -> <I::Leaf as LeafType>::StateCommitmentType {
+    pub async fn get_state(&self) -> <I::Leaf as LeafType>::MaybeState {
         self.hotshot.get_state().await
     }
 
@@ -192,7 +192,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static> HotShotHandle<TYPE
         &mut self,
     ) -> Result<
         (
-            Vec<<I::Leaf as LeafType>::StateCommitmentType>,
+            Vec<<I::Leaf as LeafType>::MaybeState>,
             Vec<<I::Leaf as LeafType>::DeltasType>,
         ),
         HotShotError<TYPES>,

--- a/testing/src/lib.rs
+++ b/testing/src/lib.rs
@@ -59,7 +59,7 @@ pub struct RoundResult<TYPES: NodeType, LEAF: LeafType<NodeType = TYPES>> {
     /// Transactions that were submitted
     pub txns: Vec<TYPES::Transaction>,
     /// Nodes that committed this round
-    pub results: HashMap<u64, StateAndBlock<LEAF::StateCommitmentType, LEAF::DeltasType>>,
+    pub results: HashMap<u64, StateAndBlock<LEAF::MaybeState, LEAF::DeltasType>>,
     /// Nodes that failed to commit this round
     pub failures: HashMap<u64, HotShotError<TYPES>>,
 }

--- a/types/src/data.rs
+++ b/types/src/data.rs
@@ -325,14 +325,8 @@ pub trait LeafType:
     type NodeType: NodeType;
     /// Type of block contained by this leaf.
     type DeltasType: DeltasType<LeafBlock<Self>>;
-    /// Commitment to the blockchain state.
-    type StateCommitmentType: Clone
-        + Debug
-        + for<'a> Deserialize<'a>
-        + PartialEq
-        + Send
-        + Serialize
-        + Sync;
+    /// Either state or empty
+    type MaybeState: Clone + Debug + for<'a> Deserialize<'a> + PartialEq + Send + Serialize + Sync;
 
     /// Create a new leaf from its components.
     fn new(
@@ -366,7 +360,7 @@ pub trait LeafType:
     /// to be stored for some implementation-defined reason.
     fn fill_deltas(&mut self, block: LeafBlock<Self>) -> Result<(), LeafDeltasError<Self>>;
     /// The blockchain state after appending this leaf.
-    fn get_state(&self) -> Self::StateCommitmentType;
+    fn get_state(&self) -> Self::MaybeState;
     /// Transactions rejected or invalidated by the application of this leaf.
     fn get_rejected(&self) -> Vec<LeafTransaction<Self>>;
     /// Real-world time when this leaf was created.
@@ -488,7 +482,7 @@ pub struct SequencingLeaf<TYPES: NodeType> {
 impl<TYPES: NodeType> LeafType for ValidatingLeaf<TYPES> {
     type NodeType = TYPES;
     type DeltasType = TYPES::BlockType;
-    type StateCommitmentType = TYPES::StateType;
+    type MaybeState = TYPES::StateType;
 
     fn new(
         view_number: <Self::NodeType as NodeType>::Time,
@@ -541,7 +535,7 @@ impl<TYPES: NodeType> LeafType for ValidatingLeaf<TYPES> {
         self.deltas.fill(block)
     }
 
-    fn get_state(&self) -> Self::StateCommitmentType {
+    fn get_state(&self) -> Self::MaybeState {
         self.state.clone()
     }
 
@@ -595,7 +589,7 @@ where
 impl<TYPES: NodeType> LeafType for SequencingLeaf<TYPES> {
     type NodeType = TYPES;
     type DeltasType = Either<TYPES::BlockType, Commitment<TYPES::BlockType>>;
-    type StateCommitmentType = ();
+    type MaybeState = ();
 
     fn new(
         view_number: <Self::NodeType as NodeType>::Time,
@@ -648,7 +642,7 @@ impl<TYPES: NodeType> LeafType for SequencingLeaf<TYPES> {
     }
 
     // The Sequencing Leaf doesn't have a state.
-    fn get_state(&self) -> Self::StateCommitmentType {}
+    fn get_state(&self) -> Self::MaybeState {}
 
     fn get_rejected(&self) -> Vec<<TYPES::BlockType as Block>::Transaction> {
         self.rejected.clone()

--- a/types/src/traits/state.rs
+++ b/types/src/traits/state.rs
@@ -41,7 +41,7 @@ pub trait State:
     type Time: ConsensusTime;
 
     /// Returns an empty, template next block given this current state
-    fn next_block(&self) -> Self::BlockType;
+    fn next_block(prev_commitment: Option<Self>) -> Self::BlockType;
 
     /// Returns true if and only if the provided block is valid and can extend this state
     fn validate_block(&self, block: &Self::BlockType, view_number: &Self::Time) -> bool;
@@ -186,8 +186,11 @@ pub mod dummy {
         type BlockType = DummyBlock;
         type Time = ViewNumber;
 
-        fn next_block(&self) -> Self::BlockType {
-            DummyBlock { nonce: self.nonce }
+        fn next_block(state: Option<Self>) -> Self::BlockType {
+            match state {
+                Some(state) => DummyBlock { nonce: state.nonce },
+                None => unimplemented!(),
+            }
         }
 
         fn validate_block(&self, _block: &Self::BlockType, _view_number: &Self::Time) -> bool {

--- a/types/src/traits/storage.rs
+++ b/types/src/traits/storage.rs
@@ -134,7 +134,7 @@ pub struct StoredView<TYPES: NodeType, LEAF: LeafType<NodeType = TYPES>> {
     /// The justify QC of this view. See the hotstuff paper for more information on this.
     pub justify_qc: QuorumCertificate<TYPES, LEAF>,
     /// The state of this view
-    pub state: LEAF::StateCommitmentType,
+    pub state: LEAF::MaybeState,
     /// The deltas of this view
     pub deltas: LEAF::DeltasType,
     /// transactions rejected in this view
@@ -158,7 +158,7 @@ where
     pub fn from_qc_block_and_state(
         qc: QuorumCertificate<TYPES, LEAF>,
         deltas: LEAF::DeltasType,
-        state: LEAF::StateCommitmentType,
+        state: LEAF::MaybeState,
         height: u64,
         parent_commitment: Commitment<LEAF>,
         rejected: Vec<<TYPES::BlockType as Block>::Transaction>,


### PR DESCRIPTION
This changes the signature on `next_block` such that it may be called without a previous state. This lets us commit blocks besides genesis. I also renamed `StateCommitmentType` since it either `State` or `()`, but never actually a commitment.