### PR TITLE
Downgrade tracing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -189,7 +189,7 @@ tokio = { version = "1", optional = true, features = [
         "time",
         "tracing",
 ] }
-tracing = "0.1.38"
+tracing = "0.1.37"
 tracing-unwrap = { version = "0.10.0", features = ["log-location"] }
 
 [dev-dependencies]

--- a/centralized_server/Cargo.toml
+++ b/centralized_server/Cargo.toml
@@ -51,7 +51,7 @@ tokio = { version = "1", optional = true, features = [
     "time",
     "tracing",
 ] }
-tracing = "0.1.38"
+tracing = "0.1.37"
 serde = { version = "1.0.163", features = ["derive"] }
 serde_json = "1.0.96"
 snafu = "0.7.4"

--- a/centralized_server/benchmark_client/Cargo.toml
+++ b/centralized_server/benchmark_client/Cargo.toml
@@ -36,4 +36,4 @@ futures = "0.3.28"
 hotshot-centralized-server = { path = ".." }
 hotshot-utils = { path = "../../utils" }
 hotshot-types = { path = "../../types" }
-tracing = "0.1.38"
+tracing = "0.1.37"

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -56,5 +56,5 @@ tokio = { version = "1", optional = true, features = [
     "time",
     "tracing",
 ] }
-tracing = "0.1.38"
+tracing = "0.1.37"
 time = "0.3.21"

--- a/libp2p-networking/Cargo.toml
+++ b/libp2p-networking/Cargo.toml
@@ -107,7 +107,7 @@ tide = { version = "0.16", optional = true, default-features = false, features =
     "h1-server",
 ] }
 tokio-stream = "0.1.14"
-tracing = "0.1.38"
+tracing = "0.1.37"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 ## lossy_network dependencies

--- a/testing-macros/Cargo.toml
+++ b/testing-macros/Cargo.toml
@@ -84,7 +84,7 @@ tokio = { version = "1", optional = true, features = [
   "time",
   "tracing",
 ] }
-tracing = "0.1.38"
+tracing = "0.1.37"
 serde = { version = "1.0.163", features = ["derive"] }
 # proc macro stuff
 quote = "1.0.27"

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -84,7 +84,7 @@ tokio = { version = "1", optional = true, features = [
   "time",
   "tracing",
 ] }
-tracing = "0.1.38"
+tracing = "0.1.37"
 nll = { git = "https://github.com/EspressoSystems/nll.git" }
 serde = { version = "1.0.163", features = ["derive"] }
 

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -84,7 +84,7 @@ tokio = { version = "1", optional = true, features = [
     "time",
     "tracing",
 ] }
-tracing = "0.1.38"
+tracing = "0.1.37"
 
 [dev-dependencies]
 serde_json = "1.0.96"


### PR DESCRIPTION
https://crates.io/crates/tracing/versions 0.1.38 got yanked, so downgrade everything to 0.1.37