### PR TITLE
Add Debug trait bound

### DIFF
--- a/libp2p-networking/src/network/mod.rs
+++ b/libp2p-networking/src/network/mod.rs
@@ -239,7 +239,7 @@ pub async fn gen_transport(
 /// a single node, connects them to each other
 /// and waits for connections to propagate to all nodes.
 #[instrument]
-pub async fn spin_up_swarm<S: std::fmt::Debug + Default>(
+pub async fn spin_up_swarm<S: Debug + Default>(
     timeout_len: Duration,
     known_nodes: Vec<(Option<PeerId>, Multiaddr)>,
     config: NetworkNodeConfig,

--- a/libp2p-networking/tests/common/mod.rs
+++ b/libp2p-networking/tests/common/mod.rs
@@ -99,7 +99,7 @@ pub async fn print_connections<S>(handles: &[Arc<NetworkNodeHandle<S>>]) {
 /// Spins up `num_of_nodes` nodes, connects them to each other
 /// and waits for connections to propagate to all nodes.
 #[instrument]
-pub async fn spin_up_swarms<S: std::fmt::Debug + Default>(
+pub async fn spin_up_swarms<S: Debug + Default>(
     num_of_nodes: usize,
     timeout_len: Duration,
     num_bootstrap: usize,

--- a/src/demos/vdemo.rs
+++ b/src/demos/vdemo.rs
@@ -538,11 +538,11 @@ impl NodeType for VDemoTypes {
 #[derivative(Clone(bound = ""))]
 pub struct VDemoNode<MEMBERSHIP>(PhantomData<MEMBERSHIP>)
 where
-    MEMBERSHIP: Membership<VDemoTypes> + std::fmt::Debug;
+    MEMBERSHIP: Membership<VDemoTypes> + Debug;
 
 impl<MEMBERSHIP> VDemoNode<MEMBERSHIP>
 where
-    MEMBERSHIP: Membership<VDemoTypes> + std::fmt::Debug,
+    MEMBERSHIP: Membership<VDemoTypes> + Debug,
 {
     /// Create a new `VDemoNode`
     #[must_use]
@@ -553,7 +553,7 @@ where
 
 impl<MEMBERSHIP> Debug for VDemoNode<MEMBERSHIP>
 where
-    MEMBERSHIP: Membership<VDemoTypes> + std::fmt::Debug,
+    MEMBERSHIP: Membership<VDemoTypes> + Debug,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("VDemoNode")
@@ -564,7 +564,7 @@ where
 
 impl<MEMBERSHIP> Default for VDemoNode<MEMBERSHIP>
 where
-    MEMBERSHIP: Membership<VDemoTypes> + std::fmt::Debug,
+    MEMBERSHIP: Membership<VDemoTypes> + Debug,
 {
     fn default() -> Self {
         Self::new()

--- a/src/traits/networking/libp2p_network.rs
+++ b/src/traits/networking/libp2p_network.rs
@@ -44,6 +44,7 @@ use serde::Serialize;
 use snafu::ResultExt;
 use std::{
     collections::{BTreeSet, HashSet},
+    fmt::Debug,
     marker::PhantomData,
     num::NonZeroUsize,
     str::FromStr,
@@ -62,7 +63,7 @@ pub enum Empty {
     Empty,
 }
 
-impl<M: NetworkMsg, K: SignatureKey + 'static> std::fmt::Debug for Libp2pNetwork<M, K> {
+impl<M: NetworkMsg, K: SignatureKey + 'static> Debug for Libp2pNetwork<M, K> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Libp2p").field("inner", &"inner").finish()
     }

--- a/task/src/task.rs
+++ b/task/src/task.rs
@@ -1,4 +1,4 @@
-use std::fmt::Formatter;
+use std::fmt::{Debug, Formatter};
 use std::ops::Deref;
 use std::task::Poll;
 
@@ -14,11 +14,11 @@ use crate::{event_stream::EventStream, global_registry::ShutdownFn, task_state::
 
 /// restrictions on types we wish to pass around.
 /// Includes messages and events
-pub trait PassType: Clone + std::fmt::Debug + Sync + Send + 'static {}
+pub trait PassType: Clone + Debug + Sync + Send + 'static {}
 impl PassType for () {}
 
 /// the task state
-pub trait TS: std::fmt::Debug + Sync + Send + 'static {}
+pub trait TS: Debug + Sync + Send + 'static {}
 
 /// group of types needed for a hotshot task
 pub trait HotShotTaskTypes {
@@ -319,7 +319,7 @@ pub enum HotShotTaskCompleted<HSTT: HotShotTaskTypes> {
     LostReturnValue,
 }
 
-impl<HSTT: HotShotTaskTypes> std::fmt::Debug for HotShotTaskCompleted<HSTT> {
+impl<HSTT: HotShotTaskTypes> Debug for HotShotTaskCompleted<HSTT> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             HotShotTaskCompleted::ShutDown => f.write_str("HotShotTaskCompleted::ShutDown"),

--- a/task/src/task_state.rs
+++ b/task/src/task_state.rs
@@ -1,4 +1,5 @@
 use std::{
+    fmt::Debug,
     sync::{atomic::Ordering, Arc, Mutex},
     task::Waker,
 };
@@ -37,7 +38,7 @@ pub struct TaskState {
     wakers: Arc<Mutex<Vec<Waker>>>,
 }
 
-impl std::fmt::Debug for TaskState {
+impl Debug for TaskState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("TaskState")
             .field("status", &self.get_status())

--- a/types/src/traits/election.rs
+++ b/types/src/traits/election.rs
@@ -171,7 +171,9 @@ where
 }
 
 /// A protocol for determining membership in and participating in a ccommittee.
-pub trait Membership<TYPES: NodeType>: Clone + Eq + PartialEq + Send + Sync + 'static {
+pub trait Membership<TYPES: NodeType>:
+    Clone + std::fmt::Debug + Eq + PartialEq + Send + Sync + 'static
+{
     /// Data used to determine the weight (voting power) of participants.
     type StakeTable: Send + Sync;
 

--- a/types/src/traits/election.rs
+++ b/types/src/traits/election.rs
@@ -172,7 +172,7 @@ where
 
 /// A protocol for determining membership in and participating in a ccommittee.
 pub trait Membership<TYPES: NodeType>:
-    Clone + std::fmt::Debug + Eq + PartialEq + Send + Sync + 'static
+    Clone + Debug + Eq + PartialEq + Send + Sync + 'static
 {
     /// Data used to determine the weight (voting power) of participants.
     type StakeTable: Send + Sync;

--- a/types/src/traits/network.rs
+++ b/types/src/traits/network.rs
@@ -15,8 +15,7 @@ use crate::{data::ProposalType, message::MessagePurpose, vote::VoteType};
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use snafu::Snafu;
-use std::sync::Arc;
-use std::{collections::BTreeSet, time::Duration};
+use std::{collections::BTreeSet, fmt::Debug, sync::Arc, time::Duration};
 
 impl From<NetworkNodeHandleError> for NetworkError {
     fn from(error: NetworkNodeHandleError) -> Self {
@@ -130,7 +129,7 @@ pub enum NetworkError {
 
 /// common traits we would like our network messages to implement
 pub trait NetworkMsg:
-    Serialize + for<'a> Deserialize<'a> + Clone + Sync + Send + std::fmt::Debug + 'static
+    Serialize + for<'a> Deserialize<'a> + Clone + Sync + Send + Debug + 'static
 {
 }
 
@@ -152,7 +151,7 @@ pub trait CommunicationChannel<
     PROPOSAL: ProposalType<NodeType = TYPES>,
     VOTE: VoteType<TYPES>,
     MEMBERSHIP: Membership<TYPES>,
->: Clone + std::fmt::Debug + Send + Sync + 'static
+>: Clone + Debug + Send + Sync + 'static
 {
     /// Underlying Network implementation's type
     type NETWORK;
@@ -287,7 +286,7 @@ pub enum NetworkChange<P: SignatureKey> {
 }
 
 /// interface describing how reliable the network is
-pub trait NetworkReliability: std::fmt::Debug + Sync + std::marker::Send {
+pub trait NetworkReliability: Debug + Sync + std::marker::Send {
     /// Sample from bernoulli distribution to decide whether
     /// or not to keep a packet
     /// # Panics

--- a/types/src/traits/network.rs
+++ b/types/src/traits/network.rs
@@ -152,7 +152,7 @@ pub trait CommunicationChannel<
     PROPOSAL: ProposalType<NodeType = TYPES>,
     VOTE: VoteType<TYPES>,
     MEMBERSHIP: Membership<TYPES>,
->: Clone + Send + Sync + 'static
+>: Clone + std::fmt::Debug + Send + Sync + 'static
 {
     /// Underlying Network implementation's type
     type NETWORK;

--- a/types/src/traits/signature_key/ed25519/ed25519_pub.rs
+++ b/types/src/traits/signature_key/ed25519/ed25519_pub.rs
@@ -2,7 +2,11 @@ use super::{Ed25519Priv, EncodedPublicKey, EncodedSignature, SignatureKey, Testa
 use ed25519_compact::{PublicKey, Signature};
 use espresso_systems_common::hotshot::tag::PEER_ID;
 use serde::{de::Error, Deserialize, Serialize};
-use std::{cmp::Ordering, fmt, str::FromStr};
+use std::{
+    cmp::Ordering,
+    fmt::{self, Debug},
+    str::FromStr,
+};
 use tagged_base64::TaggedBase64;
 use tracing::{debug, instrument, warn};
 
@@ -15,7 +19,7 @@ pub struct Ed25519Pub {
     pub_key: PublicKey,
 }
 
-impl std::fmt::Debug for Ed25519Pub {
+impl Debug for Ed25519Pub {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_tuple("Ed25519Pub")
             .field(&tagged_base64::to_string(&self.to_tagged_base64()))

--- a/types/src/traits/state.rs
+++ b/types/src/traits/state.rs
@@ -105,7 +105,7 @@ where
 }
 
 /// extra functions required on block to be usable by hotshot-testing
-pub trait TestableBlock: Block + std::fmt::Debug {
+pub trait TestableBlock: Block + Debug {
     /// generate a genesis block
     fn genesis() -> Self;
 


### PR DESCRIPTION
This avoids having to specify this bound in the sequencer repo. If we
specify the bounds manually we get a trait requirement overflow (E0275).

Pending some discussion if this is really required / the right approach.