### PR TITLE
Simplify poll

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,7 @@ use async_compatibility_layer::{
 };
 use async_lock::{Mutex, RwLock, RwLockUpgradableReadGuard, RwLockWriteGuard};
 use async_trait::async_trait;
+use nll::nll_todo::nll_todo;
 use bincode::Options;
 use commit::{Commitment, Committable};
 use either::{Left, Right};
@@ -708,7 +709,7 @@ where
             network_direct_task_handle,
             committee_network_broadcast_task_handle: None,
             committee_network_direct_task_handle: None,
-            consensus_task_handle,
+            consensus_task_handle: nll_todo(),
             shutdown_timeout: Duration::from_millis(self.inner.config.next_view_timeout),
             run_view_channels: handle_channels,
             started,
@@ -942,7 +943,7 @@ where
             network_direct_task_handle,
             committee_network_broadcast_task_handle: Some(committee_network_broadcast_task_handle),
             committee_network_direct_task_handle: Some(committee_network_direct_task_handle),
-            consensus_task_handle,
+            consensus_task_handle: nll_todo(),
             shutdown_timeout: Duration::from_millis(self.inner.config.next_view_timeout),
             run_view_channels: handle_channels,
             started,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,6 @@ use async_compatibility_layer::{
 };
 use async_lock::{Mutex, RwLock, RwLockUpgradableReadGuard, RwLockWriteGuard};
 use async_trait::async_trait;
-use nll::nll_todo::nll_todo;
 use bincode::Options;
 use commit::{Commitment, Committable};
 use either::{Left, Right};
@@ -709,7 +708,7 @@ where
             network_direct_task_handle,
             committee_network_broadcast_task_handle: None,
             committee_network_direct_task_handle: None,
-            consensus_task_handle: nll_todo(),
+            consensus_task_handle,
             shutdown_timeout: Duration::from_millis(self.inner.config.next_view_timeout),
             run_view_channels: handle_channels,
             started,
@@ -943,7 +942,7 @@ where
             network_direct_task_handle,
             committee_network_broadcast_task_handle: Some(committee_network_broadcast_task_handle),
             committee_network_direct_task_handle: Some(committee_network_direct_task_handle),
-            consensus_task_handle: nll_todo(),
+            consensus_task_handle,
             shutdown_timeout: Duration::from_millis(self.inner.config.next_view_timeout),
             run_view_channels: handle_channels,
             started,

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -2,7 +2,7 @@
 
 use crate::{HotShot, HotShotType, ViewRunner};
 use async_compatibility_layer::{
-    art::{async_sleep, async_spawn_local, async_timeout},
+    art::{async_sleep, async_spawn, async_spawn_local, async_timeout},
     channel::{UnboundedReceiver, UnboundedSender},
 };
 use async_lock::RwLock;
@@ -13,7 +13,7 @@ use hotshot_task::{
         FilterEvent, HandleEvent, HotShotTaskCompleted, HotShotTaskTypes, PassType, TaskErr, TS,
     },
     task_impls::{HSTWithEvent, TaskBuilder},
-    task_launcher::TaskRunner,
+    task_launcher::TaskRunner, global_registry::GlobalRegistry,
 };
 use hotshot_types::message::Message;
 use hotshot_types::traits::election::ConsensusExchange;
@@ -174,6 +174,7 @@ pub(crate) struct TaskHandleInner {
 }
 
 /// main thread driving consensus
+/// TODO run_view refactor: delete
 pub async fn view_runner_old<TYPES: NodeType, I: NodeImplementation<TYPES>>(
     hotshot: HotShot<TYPES::ConsensusType, TYPES, I>,
     started: Arc<AtomicBool>,
@@ -548,13 +549,19 @@ pub async fn view_runner<TYPES: NodeType, I: NodeImplementation<TYPES>>(
     _started: Arc<AtomicBool>,
     _shut_down: Arc<AtomicBool>,
     _run_once: Option<UnboundedReceiver<()>>,
-) {
+) -> (GlobalRegistry, ChannelStream<GlobalEvent>) {
     let task_runner = TaskRunner::new();
+    let registry = task_runner.registry.clone();
     let event_stream = event_stream::ChannelStream::new();
 
     let task_runner = add_networking_task(task_runner, event_stream.clone()).await;
     let task_runner = add_consensus_task(task_runner, event_stream.clone()).await;
     let task_runner = add_da_task(task_runner, event_stream.clone()).await;
-    let task_runner = add_view_sync_task(task_runner, event_stream).await;
-    task_runner.launch().await;
+    let task_runner = add_view_sync_task(task_runner, event_stream.clone()).await;
+    async_spawn(async move {
+        task_runner.launch().await;
+        }
+    );
+    (registry, event_stream)
+
 }

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -9,11 +9,12 @@ use async_lock::RwLock;
 use futures::FutureExt;
 use hotshot_task::{
     event_stream::{self, ChannelStream},
+    global_registry::GlobalRegistry,
     task::{
         FilterEvent, HandleEvent, HotShotTaskCompleted, HotShotTaskTypes, PassType, TaskErr, TS,
     },
     task_impls::{HSTWithEvent, TaskBuilder},
-    task_launcher::TaskRunner, global_registry::GlobalRegistry,
+    task_launcher::TaskRunner,
 };
 use hotshot_types::message::Message;
 use hotshot_types::traits::election::ConsensusExchange;
@@ -560,8 +561,6 @@ pub async fn view_runner<TYPES: NodeType, I: NodeImplementation<TYPES>>(
     let task_runner = add_view_sync_task(task_runner, event_stream.clone()).await;
     async_spawn(async move {
         task_runner.launch().await;
-        }
-    );
+    });
     (registry, event_stream)
-
 }


### PR DESCRIPTION
Utilize pin project to simplify the Future::poll implementation of the hotshot task. It's still not *great* because the logic for the message stream vs event stream is identical, but it's definitely easier than before to grokk. I also caught a few bugs while doing this (there was a mismatched if-else statement in a couple places).

Closes #1211 