### PR TITLE
Non-committee nodes do not poll for DA messages

### DIFF
--- a/testing/src/test_types.rs
+++ b/testing/src/test_types.rs
@@ -25,13 +25,7 @@ use hotshot_types::{
     vote::QuorumVote,
 };
 use hotshot_types::{message::Message, traits::node_implementation::ValidatingExchanges};
-use jf_primitives::{
-    signatures::{
-        // bls_over_bls12381::{BLSSignature, BLSVerKey},
-        BLSSignatureScheme,
-    },
-    // vrf::blsvrf::BLSVRFScheme,
-};
+use jf_primitives::signatures::BLSSignatureScheme;
 use serde::{Deserialize, Serialize};
 
 // #[derive(


### PR DESCRIPTION
This PR: 
* Updates web server polling logic so that non-committee nodes do not poll for DA-related messages
* Adds logic in the main run_view loop that only spawns the DA task if a node is on the DA committee