### PR TITLE
s/hotshot/systemcontext

### DIFF
--- a/examples/infra/mod.rs
+++ b/examples/infra/mod.rs
@@ -14,7 +14,7 @@ use hotshot::{
         },
         NodeImplementation, Storage,
     },
-    types::{HotShotHandle, SignatureKey},
+    types::{SignatureKey, SystemContextHandle},
     SystemContext, ViewRunner,
 };
 use hotshot_orchestrator::{
@@ -217,7 +217,9 @@ pub trait Run<
     /// Initializes the genesis state and HotShot instance; does not start HotShot consensus
     /// # Panics if it cannot generate a genesis block, fails to initialize HotShot, or cannot
     /// get the anchored view
-    async fn initialize_state_and_hotshot(&self) -> (TYPES::StateType, HotShotHandle<TYPES, NODE>) {
+    async fn initialize_state_and_hotshot(
+        &self,
+    ) -> (TYPES::StateType, SystemContextHandle<TYPES, NODE>) {
         let genesis_block = TYPES::BlockType::genesis();
         let initializer =
             hotshot::HotShotInitializer::<TYPES, ValidatingLeaf<TYPES>>::from_genesis(
@@ -281,7 +283,7 @@ pub trait Run<
     }
 
     /// Starts HotShot consensus, returns when consensus has finished
-    async fn run_hotshot(&self, mut hotshot: HotShotHandle<TYPES, NODE>) {
+    async fn run_hotshot(&self, mut hotshot: SystemContextHandle<TYPES, NODE>) {
         let NetworkConfig {
             padding,
             rounds,

--- a/examples/infra/mod.rs
+++ b/examples/infra/mod.rs
@@ -15,7 +15,7 @@ use hotshot::{
         NodeImplementation, Storage,
     },
     types::{HotShotHandle, SignatureKey},
-    HotShot, ViewRunner,
+    SystemContext, ViewRunner,
 };
 use hotshot_orchestrator::{
     self,
@@ -206,7 +206,7 @@ pub trait Run<
     <TYPES as NodeType>::StateType: TestableState,
     <TYPES as NodeType>::BlockType: TestableBlock,
     ValidatingLeaf<TYPES>: TestableLeaf,
-    HotShot<TYPES::ConsensusType, TYPES, NODE>: ViewRunner<TYPES, NODE>,
+    SystemContext<TYPES::ConsensusType, TYPES, NODE>: ViewRunner<TYPES, NODE>,
     Self: Sync,
 {
     /// Initializes networking, returns self
@@ -258,7 +258,7 @@ pub trait Run<
             sk.clone(),
             ek.clone(),
         );
-        let hotshot = HotShot::init(
+        let hotshot = SystemContext::init(
             pk,
             sk,
             config.node_index,
@@ -477,7 +477,7 @@ where
     <TYPES as NodeType>::StateType: TestableState,
     <TYPES as NodeType>::BlockType: TestableBlock,
     ValidatingLeaf<TYPES>: TestableLeaf,
-    HotShot<TYPES::ConsensusType, TYPES, NODE>: ViewRunner<TYPES, NODE>,
+    SystemContext<TYPES::ConsensusType, TYPES, NODE>: ViewRunner<TYPES, NODE>,
     Self: Sync,
 {
     async fn initialize_networking(
@@ -710,7 +710,7 @@ where
     <TYPES as NodeType>::StateType: TestableState,
     <TYPES as NodeType>::BlockType: TestableBlock,
     ValidatingLeaf<TYPES>: TestableLeaf,
-    HotShot<TYPES::ConsensusType, TYPES, NODE>: ViewRunner<TYPES, NODE>,
+    SystemContext<TYPES::ConsensusType, TYPES, NODE>: ViewRunner<TYPES, NODE>,
     Self: Sync,
 {
     async fn initialize_networking(
@@ -897,7 +897,7 @@ pub async fn main_entry_point<
     <TYPES as NodeType>::StateType: TestableState,
     <TYPES as NodeType>::BlockType: TestableBlock,
     ValidatingLeaf<TYPES>: TestableLeaf,
-    HotShot<TYPES::ConsensusType, TYPES, NODE>: ViewRunner<TYPES, NODE>,
+    SystemContext<TYPES::ConsensusType, TYPES, NODE>: ViewRunner<TYPES, NODE>,
 {
     setup_logging();
     setup_backtrace();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@ use crate::{
     certificate::QuorumCertificate,
     tasks::TaskHandleInner,
     traits::{NodeImplementation, Storage},
-    types::{Event, HotShotHandle},
+    types::{Event, SystemContextHandle},
 };
 use async_compatibility_layer::{
     art::{async_sleep, async_spawn, async_spawn_local},
@@ -373,7 +373,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> SystemContext<TYPES::Consens
         exchanges: I::Exchanges,
         initializer: HotShotInitializer<TYPES, I::Leaf>,
         metrics: Box<dyn Metrics>,
-    ) -> Result<HotShotHandle<TYPES, I>, HotShotError<TYPES>>
+    ) -> Result<SystemContextHandle<TYPES, I>, HotShotError<TYPES>>
     where
         SystemContext<TYPES::ConsensusType, TYPES, I>: ViewRunner<TYPES, I>,
         SystemContext<TYPES::ConsensusType, TYPES, I>: HotShotType<TYPES, I>,
@@ -516,7 +516,7 @@ pub trait HotShotType<TYPES: NodeType, I: NodeImplementation<TYPES>> {
     /// Spawn all tasks that operate on the given [`HotShot`].
     ///
     /// For a list of which tasks are being spawned, see this module's documentation.
-    async fn spawn_all(&self) -> HotShotHandle<TYPES, I>;
+    async fn spawn_all(&self) -> SystemContextHandle<TYPES, I>;
 
     /// decide which handler to call based on the message variant and `transmit_type`
     async fn handle_message(&self, item: Message<TYPES, I>, transmit_type: TransmitType) {
@@ -636,7 +636,7 @@ where
         &self.inner.consensus
     }
 
-    async fn spawn_all(&self) -> HotShotHandle<TYPES, I> {
+    async fn spawn_all(&self) -> SystemContextHandle<TYPES, I> {
         let shut_down = Arc::new(AtomicBool::new(false));
         let started = Arc::new(AtomicBool::new(false));
 
@@ -686,7 +686,7 @@ where
 
         let (broadcast_sender, broadcast_receiver) = channel();
 
-        let handle = HotShotHandle {
+        let handle = SystemContextHandle {
             sender_handle: Arc::new(broadcast_sender.clone()),
             hotshot: self.clone(),
             stream_output: broadcast_receiver,
@@ -862,7 +862,7 @@ where
         &self.inner.consensus
     }
 
-    async fn spawn_all(&self) -> HotShotHandle<TYPES, I> {
+    async fn spawn_all(&self) -> SystemContextHandle<TYPES, I> {
         let shut_down = Arc::new(AtomicBool::new(false));
         let started = Arc::new(AtomicBool::new(false));
 
@@ -932,7 +932,7 @@ where
 
         let (broadcast_sender, broadcast_receiver) = channel();
 
-        let handle = HotShotHandle {
+        let handle = SystemContextHandle {
             sender_handle: Arc::new(broadcast_sender.clone()),
             hotshot: self.clone(),
             stream_output: broadcast_receiver,

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -1,6 +1,6 @@
 //! Provides a number of tasks that run continuously on a [`HotShot`]
 
-use crate::{SystemContext, HotShotType, ViewRunner};
+use crate::{HotShotType, SystemContext, ViewRunner};
 use async_compatibility_layer::{
     art::{async_sleep, async_spawn_local, async_timeout},
     channel::{UnboundedReceiver, UnboundedSender},
@@ -197,7 +197,7 @@ pub async fn network_lookup_task<TYPES: NodeType, I: NodeImplementation<TYPES>>(
     let mut completion_map: HashMap<TYPES::Time, Arc<AtomicBool>> = HashMap::default();
 
     while !shut_down.load(Ordering::Relaxed) {
-        let lock = hotshot.recv_network_lookup.lock().await;
+        let lock = hotshot.inner.recv_network_lookup.lock().await;
 
         if let Ok(Some(cur_view)) = lock.recv().await {
             // Injecting consensus data into the networking implementation
@@ -290,7 +290,7 @@ pub async fn network_task<
         // Make sure to reset the backoff time
         incremental_backoff_ms = 10;
         for item in queue {
-            let _metrics = Arc::clone(&hotshot.consensus.read().await.metrics);
+            let _metrics = Arc::clone(&hotshot.inner.consensus.read().await.metrics);
             trace!(?item, "Processing item");
             hotshot.handle_message(item, transmit_type).await;
         }

--- a/src/types.rs
+++ b/src/types.rs
@@ -3,7 +3,7 @@ mod handle;
 
 pub use event::{Event, EventType};
 
-pub use handle::HotShotHandle;
+pub use handle::SystemContextHandle;
 
 pub(crate) use hotshot_types::error::HotShotError;
 pub use hotshot_types::{

--- a/src/types/handle.rs
+++ b/src/types/handle.rs
@@ -39,7 +39,7 @@ use hotshot_types::traits::signature_key::EncodedSignature;
 /// This type provides the means to message and interact with a background [`SystemContext`] instance,
 /// allowing the ability to receive [`Event`]s from it, send transactions to it, and interact with
 /// the underlying storage.
-pub struct HotShotHandle<TYPES: NodeType, I: NodeImplementation<TYPES>> {
+pub struct SystemContextHandle<TYPES: NodeType, I: NodeImplementation<TYPES>> {
     /// The [sender](BroadcastSender) for the output stream from the background process
     ///
     /// This is kept around as an implementation detail, as the [`BroadcastSender::handle_async`]
@@ -55,7 +55,9 @@ pub struct HotShotHandle<TYPES: NodeType, I: NodeImplementation<TYPES>> {
     pub(crate) storage: I::Storage,
 }
 
-impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static> Clone for HotShotHandle<TYPES, I> {
+impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static> Clone
+    for SystemContextHandle<TYPES, I>
+{
     fn clone(&self) -> Self {
         Self {
             sender_handle: self.sender_handle.clone(),
@@ -67,7 +69,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static> Clone for HotShotH
     }
 }
 
-impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static> HotShotHandle<TYPES, I> {
+impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static> SystemContextHandle<TYPES, I> {
     /// Will return the next event in the queue
     ///
     /// # Errors
@@ -172,7 +174,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static> HotShotHandle<TYPE
 
     /// Signals the underlying [`SystemContext`] to run one round, if paused.
     ///
-    /// Do not call this function if [`SystemContext`] has been unpaused by [`HotShotHandle::start`].
+    /// Do not call this function if [`SystemContext`] has been unpaused by [`SystemContextHandle::start`].
     pub async fn start_one_round(&self) {
         self.hotshot
             .inner

--- a/src/types/handle.rs
+++ b/src/types/handle.rs
@@ -5,7 +5,7 @@ use crate::QuorumCertificate;
 use crate::{
     traits::{NetworkError::ShutDown, NodeImplementation},
     types::{Event, HotShotError::NetworkFault},
-    HotShot,
+    SystemContext,
 };
 use async_compatibility_layer::async_primitives::broadcast::{BroadcastReceiver, BroadcastSender};
 use commit::Committable;
@@ -34,9 +34,9 @@ use commit::Commitment;
 #[cfg(feature = "hotshot-testing")]
 use hotshot_types::traits::signature_key::EncodedSignature;
 
-/// Event streaming handle for a [`HotShot`] instance running in the background
+/// Event streaming handle for a [`SystemContext`] instance running in the background
 ///
-/// This type provides the means to message and interact with a background [`HotShot`] instance,
+/// This type provides the means to message and interact with a background [`SystemContext`] instance,
 /// allowing the ability to receive [`Event`]s from it, send transactions to it, and interact with
 /// the underlying storage.
 pub struct HotShotHandle<TYPES: NodeType, I: NodeImplementation<TYPES>> {
@@ -46,10 +46,10 @@ pub struct HotShotHandle<TYPES: NodeType, I: NodeImplementation<TYPES>> {
     /// method is needed to generate new receivers for cloning the handle.
     pub(crate) sender_handle: Arc<BroadcastSender<Event<TYPES, I::Leaf>>>,
     /// Internal reference to the underlying [`HotShot`]
-    pub(crate) hotshot: HotShot<TYPES::ConsensusType, TYPES, I>,
+    pub(crate) hotshot: SystemContext<TYPES::ConsensusType, TYPES, I>,
     /// The [`BroadcastReceiver`] we get the events from
     pub(crate) stream_output: BroadcastReceiver<Event<TYPES, I::Leaf>>,
-    /// Global to signify the `HotShot` should be closed after completing the next round
+    /// Global to signify the `SystemContext` should be closed after completing the next round
     pub(crate) shut_down: Arc<AtomicBool>,
     /// Our copy of the `Storage` view for a hotshot
     pub(crate) storage: I::Storage,
@@ -72,7 +72,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static> HotShotHandle<TYPE
     ///
     /// # Errors
     ///
-    /// Will return [`HotShotError::NetworkFault`] if the underlying [`HotShot`] has been closed.
+    /// Will return [`HotShotError::NetworkFault`] if the underlying [`SystemContext`] has been closed.
     pub async fn next_event(&mut self) -> Result<Event<TYPES, I::Leaf>, HotShotError<TYPES>> {
         let result = self.stream_output.recv_async().await;
         match result {
@@ -134,7 +134,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static> HotShotHandle<TYPE
     /// # Errors
     ///
     /// Will return a [`HotShotError`] if some error occurs in the underlying
-    /// [`HotShot`] instance.
+    /// [`SystemContext`] instance.
     pub async fn submit_transaction(
         &self,
         tx: TYPES::Transaction,
@@ -142,7 +142,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static> HotShotHandle<TYPE
         self.hotshot.publish_transaction_async(tx).await
     }
 
-    /// Signals to the underlying [`HotShot`] to unpause
+    /// Signals to the underlying [`SystemContext`] to unpause
     ///
     /// This will cause the background task to start running consensus again.
     pub async fn start(&self) {
@@ -170,9 +170,9 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static> HotShotHandle<TYPE
         }
     }
 
-    /// Signals the underlying [`HotShot`] to run one round, if paused.
+    /// Signals the underlying [`SystemContext`] to run one round, if paused.
     ///
-    /// Do not call this function if [`HotShot`] has been unpaused by [`HotShotHandle::start`].
+    /// Do not call this function if [`SystemContext`] has been unpaused by [`HotShotHandle::start`].
     pub async fn start_one_round(&self) {
         self.hotshot
             .inner
@@ -224,7 +224,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static> HotShotHandle<TYPE
         }
     }
 
-    /// Provides a reference to the underlying storage for this [`HotShot`], allowing access to
+    /// Provides a reference to the underlying storage for this [`SystemContext`], allowing access to
     /// historical data
     pub fn storage(&self) -> &I::Storage {
         &self.storage
@@ -247,7 +247,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static> HotShotHandle<TYPE
             .await;
     }
 
-    /// return the timeout for a view of the underlying `HotShot`
+    /// return the timeout for a view of the underlying `SystemContext`
     pub fn get_next_view_timeout(&self) -> u64 {
         self.hotshot.get_next_view_timeout()
     }
@@ -274,7 +274,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static> HotShotHandle<TYPE
     /// Wrapper to get this node's current view
     #[cfg(feature = "hotshot-testing")]
     pub async fn get_current_view(&self) -> TYPES::Time {
-        self.hotshot.hotstuff.read().await.cur_view
+        self.hotshot.consensus.read().await.cur_view
     }
 
     /// Wrapper around `HotShotConsensusApi`'s `sign_validating_or_commitment_proposal` function

--- a/testing/src/round.rs
+++ b/testing/src/round.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, ops::Deref, sync::Arc};
 use futures::future::LocalBoxFuture;
 use hotshot::{
     traits::{NodeImplementation, TestableNodeImplementation},
-    SystemContext, HotShotError, HotShotType,
+    HotShotError, HotShotType, SystemContext,
 };
 use hotshot_types::certificate::QuorumCertificate;
 use hotshot_types::{

--- a/testing/src/round.rs
+++ b/testing/src/round.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, ops::Deref, sync::Arc};
 use futures::future::LocalBoxFuture;
 use hotshot::{
     traits::{NodeImplementation, TestableNodeImplementation},
-    HotShot, HotShotError, HotShotType,
+    SystemContext, HotShotError, HotShotType,
 };
 use hotshot_types::certificate::QuorumCertificate;
 use hotshot_types::{
@@ -134,7 +134,7 @@ where
 impl<TYPES: NodeType, I: TestableNodeImplementation<TYPES::ConsensusType, TYPES>> Default
     for Round<TYPES, I>
 where
-    HotShot<TYPES::ConsensusType, TYPES, I>: HotShotType<TYPES, I>,
+    SystemContext<TYPES::ConsensusType, TYPES, I>: HotShotType<TYPES, I>,
     I::Exchanges: ExchangesType<
         TYPES::ConsensusType,
         TYPES,

--- a/testing/src/round_builder.rs
+++ b/testing/src/round_builder.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, sync::Arc};
 use futures::{future::LocalBoxFuture, FutureExt};
 use hotshot::{
     traits::{NodeImplementation, TestableNodeImplementation},
-    SystemContext, HotShotType,
+    HotShotType, SystemContext,
 };
 use hotshot_types::{
     data::LeafType,

--- a/testing/src/round_builder.rs
+++ b/testing/src/round_builder.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, sync::Arc};
 use futures::{future::LocalBoxFuture, FutureExt};
 use hotshot::{
     traits::{NodeImplementation, TestableNodeImplementation},
-    HotShot, HotShotType,
+    SystemContext, HotShotType,
 };
 use hotshot_types::{
     data::LeafType,
@@ -67,7 +67,7 @@ impl RoundSetupBuilder {
         &self,
     ) -> RoundSetup<TYPES, I>
     where
-        HotShot<TYPES::ConsensusType, TYPES, I>: HotShotType<TYPES, I>,
+        SystemContext<TYPES::ConsensusType, TYPES, I>: HotShotType<TYPES, I>,
         I::Exchanges: ExchangesType<
             TYPES::ConsensusType,
             TYPES,
@@ -166,7 +166,7 @@ impl RoundSafetyCheckBuilder {
         self,
     ) -> RoundSafetyCheck<TYPES, I>
     where
-        HotShot<TYPES::ConsensusType, TYPES, I>: HotShotType<TYPES, I>,
+        SystemContext<TYPES::ConsensusType, TYPES, I>: HotShotType<TYPES, I>,
         QuorumCommChannel<TYPES, I>: CommunicationChannel<
             TYPES,
             Message<TYPES, I>,

--- a/testing/src/test_builder.rs
+++ b/testing/src/test_builder.rs
@@ -2,7 +2,7 @@ use std::num::NonZeroUsize;
 use std::{sync::Arc, time::Duration};
 
 use hotshot::traits::TestableNodeImplementation;
-use hotshot::{traits::NetworkReliability, HotShot, HotShotError, HotShotType};
+use hotshot::{traits::NetworkReliability, SystemContext, HotShotError, HotShotType};
 use hotshot_types::{
     message::Message,
     traits::{
@@ -78,7 +78,7 @@ impl TestMetadata {
         metadata: &TestMetadata,
     ) -> Round<TYPES, I>
     where
-        HotShot<TYPES::ConsensusType, TYPES, I>: HotShotType<TYPES, I>,
+        SystemContext<TYPES::ConsensusType, TYPES, I>: HotShotType<TYPES, I>,
         I::Exchanges: ExchangesType<
             TYPES::ConsensusType,
             TYPES,
@@ -185,7 +185,7 @@ impl TestBuilder {
 
 #[derive(Debug, Snafu)]
 enum RoundError<TYPES: NodeType> {
-    HotShot { source: HotShotError<TYPES> },
+    SystemContext { source: HotShotError<TYPES> },
 }
 
 /// data describing how a round should be timed.
@@ -222,7 +222,7 @@ impl TestBuilder {
         self,
     ) -> TestLauncher<TYPES, I>
     where
-        HotShot<TYPES::ConsensusType, TYPES, I>: HotShotType<TYPES, I>,
+        SystemContext<TYPES::ConsensusType, TYPES, I>: HotShotType<TYPES, I>,
         I::Exchanges: ExchangesType<
             TYPES::ConsensusType,
             TYPES,

--- a/testing/src/test_builder.rs
+++ b/testing/src/test_builder.rs
@@ -2,7 +2,7 @@ use std::num::NonZeroUsize;
 use std::{sync::Arc, time::Duration};
 
 use hotshot::traits::TestableNodeImplementation;
-use hotshot::{traits::NetworkReliability, SystemContext, HotShotError, HotShotType};
+use hotshot::{traits::NetworkReliability, HotShotError, HotShotType, SystemContext};
 use hotshot_types::{
     message::Message,
     traits::{

--- a/testing/src/test_launcher.rs
+++ b/testing/src/test_launcher.rs
@@ -4,7 +4,7 @@ use crate::test_runner::{
     CommitteeNetworkGenerator, Generator, QuorumNetworkGenerator, TestRunner,
 };
 use hotshot::types::{Message, SignatureKey};
-use hotshot::{traits::TestableNodeImplementation, HotShot, HotShotType};
+use hotshot::{traits::TestableNodeImplementation, SystemContext, HotShotType};
 use hotshot_types::traits::election::{ConsensusExchange, Membership};
 use hotshot_types::traits::node_implementation::{QuorumCommChannel, QuorumEx, QuorumNetwork};
 use hotshot_types::{
@@ -251,7 +251,7 @@ where
 impl<TYPES: NodeType, I: TestableNodeImplementation<TYPES::ConsensusType, TYPES>>
     TestLauncher<TYPES, I>
 where
-    HotShot<TYPES::ConsensusType, TYPES, I>: HotShotType<TYPES, I>,
+    SystemContext<TYPES::ConsensusType, TYPES, I>: HotShotType<TYPES, I>,
     QuorumCommChannel<TYPES, I>: CommunicationChannel<
         TYPES,
         Message<TYPES, I>,

--- a/testing/src/test_launcher.rs
+++ b/testing/src/test_launcher.rs
@@ -4,7 +4,7 @@ use crate::test_runner::{
     CommitteeNetworkGenerator, Generator, QuorumNetworkGenerator, TestRunner,
 };
 use hotshot::types::{Message, SignatureKey};
-use hotshot::{traits::TestableNodeImplementation, SystemContext, HotShotType};
+use hotshot::{traits::TestableNodeImplementation, HotShotType, SystemContext};
 use hotshot_types::traits::election::{ConsensusExchange, Membership};
 use hotshot_types::traits::node_implementation::{QuorumCommChannel, QuorumEx, QuorumNetwork};
 use hotshot_types::{

--- a/testing/src/test_runner.rs
+++ b/testing/src/test_runner.rs
@@ -9,7 +9,7 @@ use crate::{
 use async_compatibility_layer::logging::{setup_backtrace, setup_logging};
 use hotshot::{
     traits::{NodeImplementation, TestableNodeImplementation},
-    types::{HotShotHandle, Message},
+    types::{Message, SystemContextHandle},
     HotShotError, HotShotInitializer, HotShotType, SystemContext, ViewRunner,
 };
 use hotshot_types::{
@@ -57,7 +57,7 @@ where
 
 struct Node<TYPES: NodeType, I: TestableNodeImplementation<TYPES::ConsensusType, TYPES>> {
     pub node_id: u64,
-    pub handle: HotShotHandle<TYPES, I>,
+    pub handle: SystemContextHandle<TYPES, I>,
 }
 
 /// HACK we want a concise and a wordy way to print things
@@ -260,8 +260,8 @@ where
         node_id
     }
 
-    /// Iterate over the [`HotShotHandle`] nodes in this runner.
-    pub fn nodes(&self) -> impl Iterator<Item = &HotShotHandle<TYPES, I>> + '_ {
+    /// Iterate over the [`SystemContextHandle`] nodes in this runner.
+    pub fn nodes(&self) -> impl Iterator<Item = &SystemContextHandle<TYPES, I>> + '_ {
         self.nodes.iter().map(|node| &node.handle)
     }
 
@@ -401,7 +401,7 @@ where
 
     /// returns the requested handle specified by `id` if it exists
     /// else returns `None`
-    pub fn get_handle(&self, id: u64) -> Option<HotShotHandle<TYPES, I>> {
+    pub fn get_handle(&self, id: u64) -> Option<SystemContextHandle<TYPES, I>> {
         self.nodes.iter().find_map(|node| {
             if node.node_id == id {
                 Some(node.handle.clone())

--- a/testing/src/test_runner.rs
+++ b/testing/src/test_runner.rs
@@ -10,7 +10,7 @@ use async_compatibility_layer::logging::{setup_backtrace, setup_logging};
 use hotshot::{
     traits::{NodeImplementation, TestableNodeImplementation},
     types::{HotShotHandle, Message},
-    SystemContext, HotShotError, HotShotInitializer, HotShotType, ViewRunner,
+    HotShotError, HotShotInitializer, HotShotType, SystemContext, ViewRunner,
 };
 use hotshot_types::{
     certificate::QuorumCertificate,

--- a/testing/src/test_runner.rs
+++ b/testing/src/test_runner.rs
@@ -10,7 +10,7 @@ use async_compatibility_layer::logging::{setup_backtrace, setup_logging};
 use hotshot::{
     traits::{NodeImplementation, TestableNodeImplementation},
     types::{HotShotHandle, Message},
-    HotShot, HotShotError, HotShotInitializer, HotShotType, ViewRunner,
+    SystemContext, HotShotError, HotShotInitializer, HotShotType, ViewRunner,
 };
 use hotshot_types::{
     certificate::QuorumCertificate,
@@ -95,7 +95,7 @@ pub fn concise_leaf_and_node<
 impl<TYPES: NodeType, I: TestableNodeImplementation<TYPES::ConsensusType, TYPES>>
     TestRunner<TYPES, I>
 where
-    HotShot<TYPES::ConsensusType, TYPES, I>: HotShotType<TYPES, I>,
+    SystemContext<TYPES::ConsensusType, TYPES, I>: HotShotType<TYPES, I>,
     QuorumCommChannel<TYPES, I>: CommunicationChannel<
         TYPES,
         Message<TYPES, I>,
@@ -120,7 +120,7 @@ where
     /// run the test
     pub async fn run_test(mut self) -> Result<(), ConsensusTestError>
     where
-        HotShot<TYPES::ConsensusType, TYPES, I>: ViewRunner<TYPES, I>,
+        SystemContext<TYPES::ConsensusType, TYPES, I>: ViewRunner<TYPES, I>,
         I::Exchanges: ExchangesType<
             TYPES::ConsensusType,
             TYPES,
@@ -153,7 +153,7 @@ where
     /// Add `count` nodes to the network. These will be spawned with the default node config and state
     pub async fn add_nodes(&mut self, count: usize) -> Vec<u64>
     where
-        HotShot<TYPES::ConsensusType, TYPES, I>: ViewRunner<TYPES, I>,
+        SystemContext<TYPES::ConsensusType, TYPES, I>: ViewRunner<TYPES, I>,
         I::Exchanges: ExchangesType<
             TYPES::ConsensusType,
             TYPES,
@@ -212,7 +212,7 @@ where
         config: HotShotConfig<TYPES::SignatureKey, TYPES::ElectionConfigType>,
     ) -> u64
     where
-        HotShot<TYPES::ConsensusType, TYPES, I>: ViewRunner<TYPES, I>,
+        SystemContext<TYPES::ConsensusType, TYPES, I>: ViewRunner<TYPES, I>,
         I::Exchanges: ExchangesType<
             TYPES::ConsensusType,
             TYPES,
@@ -244,7 +244,7 @@ where
             private_key.clone(),
             ek.clone(),
         );
-        let handle = HotShot::init(
+        let handle = SystemContext::init(
             public_key,
             private_key,
             node_id,

--- a/testing/tests/consensus.rs
+++ b/testing/tests/consensus.rs
@@ -15,7 +15,7 @@ use commit::Committable;
 use futures::{future::LocalBoxFuture, FutureExt};
 use hotshot::{
     certificate::QuorumCertificate, demos::vdemo::random_validating_leaf,
-    traits::TestableNodeImplementation, HotShot, HotShotType,
+    traits::TestableNodeImplementation, SystemContext, HotShotType,
 };
 
 use hotshot_types::message::{GeneralConsensusMessage, Message, ValidatingMessage};
@@ -58,7 +58,7 @@ async fn is_upcoming_validating_leader<
     view_number: TYPES::Time,
 ) -> bool
 where
-    HotShot<ValidatingConsensus, TYPES, I>: HotShotType<TYPES, I>,
+    SystemContext<ValidatingConsensus, TYPES, I>: HotShotType<TYPES, I>,
 {
     let handle = runner.get_handle(node_id).unwrap();
     let leader = handle.get_leader(view_number).await;
@@ -74,7 +74,7 @@ async fn submit_validating_proposal<
     sender_node_id: u64,
     view_number: TYPES::Time,
 ) where
-    HotShot<ValidatingConsensus, TYPES, I>: HotShotType<TYPES, I>,
+    SystemContext<ValidatingConsensus, TYPES, I>: HotShotType<TYPES, I>,
     I: NodeImplementation<TYPES, ConsensusMessage = ValidatingMessage<TYPES, I>>,
     ValidatingQuorumEx<TYPES, I>: ConsensusExchange<
         TYPES,
@@ -114,7 +114,7 @@ async fn submit_validating_vote<
     view_number: TYPES::Time,
     recipient_node_id: u64,
 ) where
-    HotShot<ValidatingConsensus, TYPES, I>: HotShotType<TYPES, I>,
+    SystemContext<ValidatingConsensus, TYPES, I>: HotShotType<TYPES, I>,
     I: NodeImplementation<TYPES, ConsensusMessage = ValidatingMessage<TYPES, I>>,
     ValidatingQuorumEx<TYPES, I>: ConsensusExchange<
         TYPES,
@@ -172,7 +172,7 @@ fn test_validating_vote_queueing_post_safety_check<
     _results: RoundResult<TYPES, ValidatingLeaf<TYPES>>,
 ) -> LocalBoxFuture<'a, Result<(), ConsensusTestError>>
 where
-    HotShot<ValidatingConsensus, TYPES, I>: HotShotType<TYPES, I>,
+    SystemContext<ValidatingConsensus, TYPES, I>: HotShotType<TYPES, I>,
     I: NodeImplementation<TYPES, ConsensusMessage = ValidatingMessage<TYPES, I>>,
     <I as NodeImplementation<TYPES>>::Exchanges: ValidatingExchangesType<TYPES, Message<TYPES, I>>,
 {
@@ -221,7 +221,7 @@ fn test_validating_vote_queueing_round_setup<
     _ctx: &'a RoundCtx<TYPES, I>,
 ) -> LocalBoxFuture<'a, Vec<TYPES::Transaction>>
 where
-    HotShot<ValidatingConsensus, TYPES, I>: HotShotType<TYPES, I>,
+    SystemContext<ValidatingConsensus, TYPES, I>: HotShotType<TYPES, I>,
     I: NodeImplementation<TYPES, ConsensusMessage = ValidatingMessage<TYPES, I>>,
     <I as NodeImplementation<TYPES>>::Exchanges: ValidatingExchangesType<TYPES, Message<TYPES, I>>,
     ValidatingQuorumEx<TYPES, I>: ConsensusExchange<
@@ -257,7 +257,7 @@ fn test_validating_proposal_queueing_post_safety_check<
     _results: RoundResult<TYPES, ValidatingLeaf<TYPES>>,
 ) -> LocalBoxFuture<'a, Result<(), ConsensusTestError>>
 where
-    HotShot<ValidatingConsensus, TYPES, I>: HotShotType<TYPES, I>,
+    SystemContext<ValidatingConsensus, TYPES, I>: HotShotType<TYPES, I>,
     I: NodeImplementation<TYPES, ConsensusMessage = ValidatingMessage<TYPES, I>>,
     <I as NodeImplementation<TYPES>>::Exchanges: ValidatingExchangesType<TYPES, Message<TYPES, I>>,
     ValidatingQuorumEx<TYPES, I>: ConsensusExchange<
@@ -314,7 +314,7 @@ fn test_validating_proposal_queueing_round_setup<
     _ctx: &'a RoundCtx<TYPES, I>,
 ) -> LocalBoxFuture<'a, Vec<TYPES::Transaction>>
 where
-    HotShot<ValidatingConsensus, TYPES, I>: HotShotType<TYPES, I>,
+    SystemContext<ValidatingConsensus, TYPES, I>: HotShotType<TYPES, I>,
     I: NodeImplementation<TYPES, ConsensusMessage = ValidatingMessage<TYPES, I>>,
     <I as NodeImplementation<TYPES>>::Exchanges: ValidatingExchangesType<TYPES, Message<TYPES, I>>,
     ValidatingQuorumEx<TYPES, I>: ConsensusExchange<
@@ -348,7 +348,7 @@ fn test_bad_validating_proposal_round_setup<
     _ctx: &'a RoundCtx<TYPES, I>,
 ) -> LocalBoxFuture<'a, Vec<TYPES::Transaction>>
 where
-    HotShot<ValidatingConsensus, TYPES, I>: HotShotType<TYPES, I>,
+    SystemContext<ValidatingConsensus, TYPES, I>: HotShotType<TYPES, I>,
     I: NodeImplementation<TYPES, ConsensusMessage = ValidatingMessage<TYPES, I>>,
     <I as NodeImplementation<TYPES>>::Exchanges: ValidatingExchangesType<TYPES, Message<TYPES, I>>,
     ValidatingQuorumEx<TYPES, I>: ConsensusExchange<
@@ -385,7 +385,7 @@ fn test_bad_validating_proposal_post_safety_check<
     _results: RoundResult<TYPES, ValidatingLeaf<TYPES>>,
 ) -> LocalBoxFuture<'a, Result<(), ConsensusTestError>>
 where
-    HotShot<ValidatingConsensus, TYPES, I>: HotShotType<TYPES, I>,
+    SystemContext<ValidatingConsensus, TYPES, I>: HotShotType<TYPES, I>,
     I: NodeImplementation<TYPES, ConsensusMessage = ValidatingMessage<TYPES, I>>,
     <I as NodeImplementation<TYPES>>::Exchanges: ValidatingExchangesType<TYPES, Message<TYPES, I>>,
 {

--- a/testing/tests/consensus.rs
+++ b/testing/tests/consensus.rs
@@ -15,7 +15,7 @@ use commit::Committable;
 use futures::{future::LocalBoxFuture, FutureExt};
 use hotshot::{
     certificate::QuorumCertificate, demos::vdemo::random_validating_leaf,
-    traits::TestableNodeImplementation, SystemContext, HotShotType,
+    traits::TestableNodeImplementation, HotShotType, SystemContext,
 };
 
 use hotshot_types::message::{GeneralConsensusMessage, Message, ValidatingMessage};


### PR DESCRIPTION
Performs a bunch of renaming described in #1268 . I left `HotShot` and `HotShotInner`, because AFAICT there is no clean way to merge the two. If we merge, then `CONSENSUS` must be propagated everywhere. I wanted to avoid this, so I left the two separated, but moved all the state from `HotShot` into `HotShotInner` s.t. the reasoning we do is simplified.

Closes #1268 