### PR TITLE
Replace channels with event stream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3030,6 +3030,7 @@ dependencies = [
  "futures",
  "hotshot",
  "hotshot-consensus",
+ "hotshot-task",
  "hotshot-types",
  "hotshot-utils",
  "jf-primitives",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2981,7 +2981,6 @@ dependencies = [
  "commit",
  "either",
  "futures",
- "hotshot-types",
  "nll",
  "pin-project",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3088,6 +3088,7 @@ dependencies = [
  "espresso-systems-common 0.4.1",
  "futures",
  "hex_fmt",
+ "hotshot-task",
  "hotshot-utils",
  "jf-primitives",
  "libp2p-networking",

--- a/examples/infra/mod.rs
+++ b/examples/infra/mod.rs
@@ -2,6 +2,9 @@ use async_compatibility_layer::{
     art::async_sleep,
     logging::{setup_backtrace, setup_logging},
 };
+use hotshot_types::data::ViewNumber;
+use hotshot_types::traits::state::ConsensusTime;
+use hotshot_types::event::{Event, EventType};
 use futures::StreamExt;
 use nll::nll_todo::nll_todo;
 use async_lock::RwLock;
@@ -286,7 +289,7 @@ pub trait Run<
     }
 
     /// Starts HotShot consensus, returns when consensus has finished
-    async fn run_hotshot(&self, mut hotshot: SystemContextHandle<TYPES, NODE>) {
+    async fn run_hotshot(&self, mut context: SystemContextHandle<TYPES, NODE>) {
         let NetworkConfig {
             padding,
             rounds,
@@ -299,7 +302,7 @@ pub trait Run<
         let size = mem::size_of::<TYPES::Transaction>();
         let adjusted_padding = if padding < size { 0 } else { padding - size };
         let mut txns: VecDeque<TYPES::Transaction> = VecDeque::new();
-        let state = hotshot.get_state().await;
+        let state = context.get_state().await;
 
         // This assumes that no node will be a leader more than 5x the expected number of times they should be the leader
         // FIXME  is this a reasonable assumption when we start doing DA?
@@ -327,18 +330,68 @@ pub trait Run<
         let start = Instant::now();
 
         error!("Starting hotshot!");
-        hotshot.start_consensus().await;
-        let (mut event_stream, _streamid) = hotshot.get_event_stream(FilterEvent::default()).await;
+        context.start_consensus().await;
+        let (mut event_stream, _streamid) = context.get_event_stream(FilterEvent::default()).await;
+        let mut anchor_view : TYPES::Time = <TYPES::Time as ConsensusTime>::genesis();
+        let mut num_successful_commits = 0;
+
+        let total_nodes_u64 = total_nodes.get() as u64;
+
+        let mut should_submit_txns = node_index == (*anchor_view % total_nodes_u64);
 
         loop {
+            if should_submit_txns {
+                for _ in 0..transactions_per_round {
+                    let txn = txns.pop_front().unwrap();
+                    tracing::info!("Submitting txn on round {}", round);
+                    context.submit_transaction(txn).await.unwrap();
+                }
+                should_submit_txns = false;
+            }
+
             match event_stream.next().await {
                 None => {
                     panic!("Error! Event stream completed before consensus ended.");
                 },
-                Some(event) => {
-                    // TODO some processing of the event
+                Some(Event { view_number, event} ) => {
+                    match event {
+                        EventType::Error { error } => {
+                            error!("Error in consensus: {:?}", error);
+                            // TODO what to do here
+
+                        },
+                        EventType::Decide { leaf_chain, qc} => {
+                            // this might be a obob
+                            if let Some(leaf) = leaf_chain.get(0) {
+                                let new_anchor = leaf.view_number;
+                                if new_anchor >= anchor_view {
+                                    anchor_view = leaf.view_number;
+                                }
+                                if (*anchor_view % total_nodes_u64) == node_index {
+                                    should_submit_txns = true;
+                                }
+                            }
+                            num_successful_commits += leaf_chain.len();
+                            if num_successful_commits >= rounds {
+                                break;
+                            }
+                            // when we make progress, submit new events
+                        },
+                        EventType::ReplicaViewTimeout { view_number } => {
+                            error!("Timed out as a replicas in view {:?}", view_number);
+
+                        },
+                        EventType::NextLeaderViewTimeout { view_number } => {
+                            error!("Timed out as the next leader in view {:?}", view_number);
+
+                        },
+                        EventType::ViewFinished { view_number } => {
+                            tracing::info!("view finished: {:?}", view_number);
+                        },
+                        _ => unimplemented!(),
 
 
+                    }
                 }
             }
         }
@@ -349,7 +402,8 @@ pub trait Run<
         // while round <= rounds {
         //     error!("Round {}:", round);
         //
-        //     let num_submitted = if node_index == ((round % total_nodes) as u64) {
+        //     let num_submitted =
+        //     if node_index == ((round % total_nodes) as u64) {
         //         for _ in 0..transactions_per_round {
         //             let txn = txns.pop_front().unwrap();
         //             tracing::info!("Submitting txn on round {}", round);
@@ -384,11 +438,11 @@ pub trait Run<
         //     round += 1;
         // }
         //
-        // let total_time_elapsed = start.elapsed();
-        // let total_size = total_transactions * (padding as u64);
+        let total_time_elapsed = start.elapsed();
+        let total_size = total_transactions * (padding as u64);
         //
         // // This assumes all transactions that were submitted made it through consensus, and does not account for the genesis block
-        // error!("All {rounds} rounds completed in {total_time_elapsed:?}. {timed_out_views} rounds timed out. {total_size} total bytes submitted");
+        error!("All {rounds} rounds completed in {total_time_elapsed:?}. {timed_out_views} rounds timed out. {total_size} total bytes submitted");
     }
 
     /// Returns the network for this run

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,8 @@ use crate::{
     traits::{NodeImplementation, Storage},
     types::{Event, SystemContextHandle},
 };
+use hotshot_task::{event_stream::ChannelStream, global_registry};
+use hotshot_task::task_launcher::TaskRunner;
 use async_compatibility_layer::{
     art::{async_sleep, async_spawn, async_spawn_local},
     async_primitives::{
@@ -57,6 +59,7 @@ use hotshot_consensus::{
     ConsensusSharedApi, DALeader, DAMember, NextValidatingLeader, Replica, SequencingReplica,
     ValidatingLeader, View, ViewInner, ViewQueue,
 };
+use hotshot_task::global_registry::GlobalRegistry;
 use hotshot_types::data::QuorumProposal;
 use hotshot_types::data::{DeltasType, SequencingLeaf};
 use hotshot_types::traits::network::CommunicationChannel;
@@ -94,6 +97,7 @@ use hotshot_types::{
 use hotshot_utils::bincode::bincode_opts;
 use nll::nll_todo::nll_todo;
 use snafu::ResultExt;
+use tasks::GlobalEvent;
 use std::sync::atomic::AtomicBool;
 use std::{
     collections::{BTreeMap, HashMap},
@@ -163,6 +167,10 @@ pub struct SystemContextInner<TYPES: NodeType, I: NodeImplementation<TYPES>> {
     /// for receiving messages in the network lookup task
     recv_network_lookup: Arc<Mutex<UnboundedReceiver<Option<TYPES::Time>>>>,
 
+    global_registry: GlobalRegistry,
+
+    event_stream: ChannelStream<GlobalEvent>,
+
     /// uid for instrumentation
     id: u64,
 }
@@ -192,12 +200,13 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> SystemContext<TYPES::Consens
         initializer: HotShotInitializer<TYPES, I::Leaf>,
         metrics: Box<dyn Metrics>,
     ) -> Result<Self, HotShotError<TYPES>> {
+        let global_registry = GlobalRegistry::new();
+
         info!("Creating a new hotshot");
 
         let consensus_metrics = Arc::new(ConsensusMetrics::new(
             &*metrics.subgroup("consensus".to_string()),
         ));
-
         let anchored_leaf = initializer.inner;
 
         // insert to storage
@@ -260,6 +269,9 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> SystemContext<TYPES::Consens
             event_sender: RwLock::default(),
             background_task_handle: tasks::TaskHandle::default(),
             _metrics: metrics,
+            global_registry: nll_todo(),
+            event_stream: nll_todo()
+
         });
 
         Ok(Self {
@@ -392,7 +404,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> SystemContext<TYPES::Consens
             metrics,
         )
         .await?;
-        let handle = hotshot.spawn_all().await;
+        let handle = hotshot.run_tasks().await;
 
         Ok(handle)
     }
@@ -518,95 +530,95 @@ pub trait HotShotType<TYPES: NodeType, I: NodeImplementation<TYPES>> {
     /// Spawn all tasks that operate on the given [`HotShot`].
     ///
     /// For a list of which tasks are being spawned, see this module's documentation.
-    async fn spawn_all(&self) -> SystemContextHandle<TYPES, I>;
+    async fn run_tasks(&self) -> SystemContextHandle<TYPES, I>;
 
-    /// decide which handler to call based on the message variant and `transmit_type`
-    async fn handle_message(&self, item: Message<TYPES, I>, transmit_type: TransmitType) {
-        match (item.kind, transmit_type) {
-            (MessageKind::Consensus(msg), TransmitType::Broadcast) => {
-                self.handle_broadcast_consensus_message(msg, item.sender)
-                    .await;
-            }
-            (MessageKind::Consensus(msg), TransmitType::Direct) => {
-                self.handle_direct_consensus_message(msg, item.sender).await;
-            }
-            (MessageKind::Data(msg), TransmitType::Broadcast) => {
-                self.handle_broadcast_data_message(msg, item.sender).await;
-            }
-            (MessageKind::Data(msg), TransmitType::Direct) => {
-                self.handle_direct_data_message(msg, item.sender).await;
-            }
-            (MessageKind::_Unreachable(_), _) => unimplemented!(),
-        };
-    }
+    // decide which handler to call based on the message variant and `transmit_type`
+    // async fn handle_message(&self, item: Message<TYPES, I>, transmit_type: TransmitType) {
+    //     match (item.kind, transmit_type) {
+    //         (MessageKind::Consensus(msg), TransmitType::Broadcast) => {
+    //             self.handle_broadcast_consensus_message(msg, item.sender)
+    //                 .await;
+    //         }
+    //         (MessageKind::Consensus(msg), TransmitType::Direct) => {
+    //             self.handle_direct_consensus_message(msg, item.sender).await;
+    //         }
+    //         (MessageKind::Data(msg), TransmitType::Broadcast) => {
+    //             self.handle_broadcast_data_message(msg, item.sender).await;
+    //         }
+    //         (MessageKind::Data(msg), TransmitType::Direct) => {
+    //             self.handle_direct_data_message(msg, item.sender).await;
+    //         }
+    //         (MessageKind::_Unreachable(_), _) => unimplemented!(),
+    //     };
+    // }
 
-    /// Handle an incoming [`ConsensusMessage`] that was broadcasted on the network.
-    async fn handle_broadcast_consensus_message(
-        &self,
-        msg: I::ConsensusMessage,
-        sender: TYPES::SignatureKey,
-    );
+    // Handle an incoming [`ConsensusMessage`] that was broadcasted on the network.
+    // async fn handle_broadcast_consensus_message(
+    //     &self,
+    //     msg: I::ConsensusMessage,
+    //     sender: TYPES::SignatureKey,
+    // );
 
-    /// Handle an incoming [`ConsensusMessage`] directed at this node.
-    async fn handle_direct_consensus_message(
-        &self,
-        msg: I::ConsensusMessage,
-        sender: TYPES::SignatureKey,
-    );
+    // Handle an incoming [`ConsensusMessage`] directed at this node.
+    // async fn handle_direct_consensus_message(
+    //     &self,
+    //     msg: I::ConsensusMessage,
+    //     sender: TYPES::SignatureKey,
+    // );
 
-    /// Handle an incoming [`DataMessage`] that was broadcasted on the network
-    async fn handle_broadcast_data_message(
-        &self,
-        msg: DataMessage<TYPES>,
-        _sender: TYPES::SignatureKey,
-    ) {
-        // TODO validate incoming broadcast message based on sender signature key
-        match msg {
-            DataMessage::SubmitTransaction(transaction, _view_number) => {
-                let size = bincode_opts().serialized_size(&transaction).unwrap_or(0);
+    // Handle an incoming [`DataMessage`] that was broadcasted on the network
+    // async fn handle_broadcast_data_message(
+    //     &self,
+    //     msg: DataMessage<TYPES>,
+    //     _sender: TYPES::SignatureKey,
+    // ) {
+    //     // TODO validate incoming broadcast message based on sender signature key
+    //     match msg {
+    //         DataMessage::SubmitTransaction(transaction, _view_number) => {
+    //             let size = bincode_opts().serialized_size(&transaction).unwrap_or(0);
+    //
+    //             // The API contract requires the hash to be unique
+    //             // so we can assume entry == incoming txn
+    //             // even if eq not satisfied
+    //             // so insert is an idempotent operation
+    //             let mut new = false;
+    //             self.transactions()
+    //                 .modify(|txns| {
+    //                     new = txns.insert(transaction.commit(), transaction).is_none();
+    //                 })
+    //                 .await;
+    //
+    //             if new {
+    //                 // If this is a new transaction, update metrics.
+    //                 let consensus = self.consensus().read().await;
+    //                 consensus.metrics.outstanding_transactions.update(1);
+    //                 consensus
+    //                     .metrics
+    //                     .outstanding_transactions_memory_size
+    //                     .update(i64::try_from(size).unwrap_or_else(|e| {
+    //                         warn!("Conversion failed: {e}. Using the max value.");
+    //                         i64::MAX
+    //                     }));
+    //             }
+    //         }
+    //     }
+    // }
 
-                // The API contract requires the hash to be unique
-                // so we can assume entry == incoming txn
-                // even if eq not satisfied
-                // so insert is an idempotent operation
-                let mut new = false;
-                self.transactions()
-                    .modify(|txns| {
-                        new = txns.insert(transaction.commit(), transaction).is_none();
-                    })
-                    .await;
-
-                if new {
-                    // If this is a new transaction, update metrics.
-                    let consensus = self.consensus().read().await;
-                    consensus.metrics.outstanding_transactions.update(1);
-                    consensus
-                        .metrics
-                        .outstanding_transactions_memory_size
-                        .update(i64::try_from(size).unwrap_or_else(|e| {
-                            warn!("Conversion failed: {e}. Using the max value.");
-                            i64::MAX
-                        }));
-                }
-            }
-        }
-    }
-
-    /// Handle an incoming [`DataMessage`] that directed at this node
-    #[allow(clippy::unused_async)] // async for API compatibility reasons
-    async fn handle_direct_data_message(
-        &self,
-        msg: DataMessage<TYPES>,
-        _sender: TYPES::SignatureKey,
-    ) {
-        debug!(?msg, "Incoming direct data message");
-        match msg {
-            DataMessage::SubmitTransaction(_, _) => {
-                // Log exceptional situation and proceed
-                warn!(?msg, "Broadcast message received over direct channel");
-            }
-        }
-    }
+    // Handle an incoming [`DataMessage`] that directed at this node
+    // #[allow(clippy::unused_async)] // async for API compatibility reasons
+    // async fn handle_direct_data_message(
+    //     &self,
+    //     msg: DataMessage<TYPES>,
+    //     _sender: TYPES::SignatureKey,
+    // ) {
+    //     debug!(?msg, "Incoming direct data message");
+    //     match msg {
+    //         DataMessage::SubmitTransaction(_, _) => {
+    //             // Log exceptional situation and proceed
+    //             warn!(?msg, "Broadcast message received over direct channel");
+    //         }
+    //     }
+    // }
 }
 
 #[async_trait]
@@ -638,195 +650,182 @@ where
         &self.inner.consensus
     }
 
-    async fn spawn_all(&self) -> SystemContextHandle<TYPES, I> {
-        let shut_down = Arc::new(AtomicBool::new(false));
-        let started = Arc::new(AtomicBool::new(false));
+    async fn run_tasks(&self) -> SystemContextHandle<TYPES, I> {
+        unimplemented!()
 
-        let exchange = self.inner.exchanges.quorum_exchange();
+        // let network_broadcast_task_handle = async_spawn(
+        //     tasks::network_task(
+        //         self.clone(),
+        //         shut_down.clone(),
+        //         TransmitType::Broadcast,
+        //         exchange.clone().into(),
+        //     )
+        //     .instrument(info_span!("HotShot Broadcast Task",)),
+        // );
+        // let network_direct_task_handle = async_spawn(
+        //     tasks::network_task(
+        //         self.clone(),
+        //         shut_down.clone(),
+        //         TransmitType::Direct,
+        //         exchange.clone().into(),
+        //     )
+        //     .instrument(info_span!("HotShot Direct Task",)),
+        // );
 
-        let network_broadcast_task_handle = async_spawn(
-            tasks::network_task(
-                self.clone(),
-                shut_down.clone(),
-                TransmitType::Broadcast,
-                exchange.clone().into(),
-            )
-            .instrument(info_span!("HotShot Broadcast Task",)),
-        );
-        let network_direct_task_handle = async_spawn(
-            tasks::network_task(
-                self.clone(),
-                shut_down.clone(),
-                TransmitType::Direct,
-                exchange.clone().into(),
-            )
-            .instrument(info_span!("HotShot Direct Task",)),
-        );
+        // async_spawn(
+        //     tasks::network_lookup_task(self.clone(), shut_down.clone())
+        //         .instrument(info_span!("HotShot Network Lookup Task",)),
+        // );
 
-        async_spawn(
-            tasks::network_lookup_task(self.clone(), shut_down.clone())
-                .instrument(info_span!("HotShot Network Lookup Task",)),
-        );
+        // let (handle_channels, task_channels) = match self.inner.config.execution_type {
+        //     ExecutionType::Continuous => (None, None),
+        //     ExecutionType::Incremental => {
+        //         let (send_consensus_start, recv_consensus_start) = unbounded();
+        //         (Some(send_consensus_start), Some(recv_consensus_start))
+        //     }
+        // };
 
-        let (handle_channels, task_channels) = match self.inner.config.execution_type {
-            ExecutionType::Continuous => (None, None),
-            ExecutionType::Incremental => {
-                let (send_consensus_start, recv_consensus_start) = unbounded();
-                (Some(send_consensus_start), Some(recv_consensus_start))
-            }
-        };
 
-        let consensus_task_handle = async_spawn(
-            tasks::view_runner(
-                self.clone(),
-                started.clone(),
-                shut_down.clone(),
-                task_channels,
-            )
-            .instrument(info_span!("Consensus Task Handle",)),
-        );
+        // let (broadcast_sender, broadcast_receiver) = channel();
+        //
+        // let handle = HotShotHandle {
+        //     sender_handle: Arc::new(broadcast_sender.clone()),
+        //     hotshot: self.clone(),
+        //     stream_output: broadcast_receiver,
+        //     storage: self.inner.storage.clone(),
+        //     shut_down,
+        // };
+        // *self.inner.event_sender.write().await = Some(broadcast_sender);
+        //
+        // let mut background_task_handle = self.inner.background_task_handle.inner.write().await;
+        // *background_task_handle = Some(TaskHandleInner {
+        //     network_broadcast_task_handle,
+        //     network_direct_task_handle,
+        //     committee_network_broadcast_task_handle: None,
+        //     committee_network_direct_task_handle: None,
+        //     consensus_task_handle: nll_todo(),
+        //     shutdown_timeout: Duration::from_millis(self.inner.config.next_view_timeout),
+        //     run_view_channels: handle_channels,
+        //     started,
+        // });
 
-        let (broadcast_sender, broadcast_receiver) = channel();
-
-        let handle = SystemContextHandle {
-            sender_handle: Arc::new(broadcast_sender.clone()),
-            hotshot: self.clone(),
-            stream_output: broadcast_receiver,
-            storage: self.inner.storage.clone(),
-            shut_down,
-        };
-        *self.inner.event_sender.write().await = Some(broadcast_sender);
-
-        let mut background_task_handle = self.inner.background_task_handle.inner.write().await;
-        *background_task_handle = Some(TaskHandleInner {
-            network_broadcast_task_handle,
-            network_direct_task_handle,
-            committee_network_broadcast_task_handle: None,
-            committee_network_direct_task_handle: None,
-            consensus_task_handle: nll_todo(),
-            shutdown_timeout: Duration::from_millis(self.inner.config.next_view_timeout),
-            run_view_channels: handle_channels,
-            started,
-        });
-
-        handle
     }
 
-    #[instrument(
-        skip(self),
-        name = "Handle broadcast consensus message",
-        level = "error"
-    )]
-    async fn handle_broadcast_consensus_message(
-        &self,
-        msg: ValidatingMessage<TYPES, I>,
-        sender: TYPES::SignatureKey,
-    ) {
-        let msg_time = msg.view_number();
+    // #[instrument(
+    //     skip(self),
+    //     name = "Handle broadcast consensus message",
+    //     level = "error"
+    // )]
+    // async fn handle_broadcast_consensus_message(
+    //     &self,
+    //     msg: ValidatingMessage<TYPES, I>,
+    //     sender: TYPES::SignatureKey,
+    // ) {
+    //     let msg_time = msg.view_number();
+    //
+    //     match msg.0 {
+    //         // this is ONLY intended for replica
+    //         GeneralConsensusMessage::Proposal(_) => {
+    //             let channel_map = self
+    //                 .inner
+    //                 .channel_maps
+    //                 .0
+    //                 .vote_channel
+    //                 .upgradable_read()
+    //                 .await;
+    //
+    //             // skip if the proposal is stale
+    //             if msg_time < channel_map.cur_view {
+    //                 warn!(
+    //                     "Throwing away {} for view number: {:?}",
+    //                     std::any::type_name::<Proposal<QuorumProposalType<TYPES, I>>>(),
+    //                     msg_time
+    //                 );
+    //                 return;
+    //             }
+    //
+    //             let chan: ViewQueue<TYPES, I> =
+    //                 Self::create_or_obtain_chan_from_read(msg_time, channel_map).await;
+    //
+    //             if !chan.has_received_proposal.swap(true, Ordering::Relaxed)
+    //                 && chan
+    //                     .sender_chan
+    //                     .send(ProcessedGeneralConsensusMessage::new(msg.0, sender))
+    //                     .await
+    //                     .is_err()
+    //             {
+    //                 warn!("Failed to send to next leader!");
+    //             }
+    //         }
+    //         GeneralConsensusMessage::InternalTrigger(_) => {
+    //             warn!("Received an internal trigger. This shouldn't be possible.");
+    //         }
+    //         GeneralConsensusMessage::Vote(_) => {
+    //             warn!("Received a broadcast for a vote message. This shouldn't be possible.");
+    //         }
+    //         GeneralConsensusMessage::ViewSync(_) => todo!(),
+    //     };
+    // }
 
-        match msg.0 {
-            // this is ONLY intended for replica
-            GeneralConsensusMessage::Proposal(_) => {
-                let channel_map = self
-                    .inner
-                    .channel_maps
-                    .0
-                    .vote_channel
-                    .upgradable_read()
-                    .await;
-
-                // skip if the proposal is stale
-                if msg_time < channel_map.cur_view {
-                    warn!(
-                        "Throwing away {} for view number: {:?}",
-                        std::any::type_name::<Proposal<QuorumProposalType<TYPES, I>>>(),
-                        msg_time
-                    );
-                    return;
-                }
-
-                let chan: ViewQueue<TYPES, I> =
-                    Self::create_or_obtain_chan_from_read(msg_time, channel_map).await;
-
-                if !chan.has_received_proposal.swap(true, Ordering::Relaxed)
-                    && chan
-                        .sender_chan
-                        .send(ProcessedGeneralConsensusMessage::new(msg.0, sender))
-                        .await
-                        .is_err()
-                {
-                    warn!("Failed to send to next leader!");
-                }
-            }
-            GeneralConsensusMessage::InternalTrigger(_) => {
-                warn!("Received an internal trigger. This shouldn't be possible.");
-            }
-            GeneralConsensusMessage::Vote(_) => {
-                warn!("Received a broadcast for a vote message. This shouldn't be possible.");
-            }
-            GeneralConsensusMessage::ViewSync(_) => todo!(),
-        };
-    }
-
-    /// Handle an incoming [`ValidatingMessage`] directed at this node.
-    #[instrument(skip(self), name = "Handle direct consensus message", level = "error")]
-    async fn handle_direct_consensus_message(
-        &self,
-        msg: ValidatingMessage<TYPES, I>,
-        sender: TYPES::SignatureKey,
-    ) {
-        // We can only recv from a replicas
-        // replicas should only send votes or if they timed out, timeouts
-        match msg {
-            ValidatingMessage(
-                GeneralConsensusMessage::Proposal(_) | GeneralConsensusMessage::InternalTrigger(_),
-            ) => {
-                warn!("Received a direct message for a proposal. This shouldn't be possible.");
-            }
-            // this is ONLY intended for next leader
-            c @ ValidatingMessage(GeneralConsensusMessage::Vote(_)) => {
-                let msg_time = c.view_number();
-
-                let channel_map = self
-                    .inner
-                    .channel_maps
-                    .0
-                    .proposal_channel
-                    .upgradable_read()
-                    .await;
-
-                // check if
-                // - is in fact, actually is the next leader
-                // - the message is not stale
-                let is_leader = self
-                    .inner
-                    .clone()
-                    .exchanges
-                    .quorum_exchange()
-                    .is_leader(msg_time + 1);
-                if !is_leader || msg_time < channel_map.cur_view {
-                    warn!(
-                        "Throwing away {} message for view number: {:?}",
-                        std::any::type_name::<QuorumVote<TYPES, I::Leaf>>(),
-                        msg_time
-                    );
-                    return;
-                }
-
-                let chan = Self::create_or_obtain_chan_from_read(msg_time, channel_map).await;
-
-                if chan
-                    .sender_chan
-                    .send(ProcessedGeneralConsensusMessage::new(c.0, sender))
-                    .await
-                    .is_err()
-                {
-                    error!("Failed to send to next leader!");
-                }
-            }
-            ValidatingMessage(GeneralConsensusMessage::ViewSync(_)) => todo!(),
-        }
-    }
+    // Handle an incoming [`ValidatingMessage`] directed at this node.
+//     #[instrument(skip(self), name = "Handle direct consensus message", level = "error")]
+//     async fn handle_direct_consensus_message(
+//         &self,
+//         msg: ValidatingMessage<TYPES, I>,
+//         sender: TYPES::SignatureKey,
+//     ) {
+//         // We can only recv from a replicas
+//         // replicas should only send votes or if they timed out, timeouts
+//         match msg {
+//             ValidatingMessage(
+//                 GeneralConsensusMessage::Proposal(_) | GeneralConsensusMessage::InternalTrigger(_),
+//             ) => {
+//                 warn!("Received a direct message for a proposal. This shouldn't be possible.");
+//             }
+//             // this is ONLY intended for next leader
+//             c @ ValidatingMessage(GeneralConsensusMessage::Vote(_)) => {
+//                 let msg_time = c.view_number();
+//
+//                 let channel_map = self
+//                     .inner
+//                     .channel_maps
+//                     .0
+//                     .proposal_channel
+//                     .upgradable_read()
+//                     .await;
+//
+//                 // check if
+//                 // - is in fact, actually is the next leader
+//                 // - the message is not stale
+//                 let is_leader = self
+//                     .inner
+//                     .clone()
+//                     .exchanges
+//                     .quorum_exchange()
+//                     .is_leader(msg_time + 1);
+//                 if !is_leader || msg_time < channel_map.cur_view {
+//                     warn!(
+//                         "Throwing away {} message for view number: {:?}",
+//                         std::any::type_name::<QuorumVote<TYPES, I::Leaf>>(),
+//                         msg_time
+//                     );
+//                     return;
+//                 }
+//
+//                 let chan = Self::create_or_obtain_chan_from_read(msg_time, channel_map).await;
+//
+//                 if chan
+//                     .sender_chan
+//                     .send(ProcessedGeneralConsensusMessage::new(c.0, sender))
+//                     .await
+//                     .is_err()
+//                 {
+//                     error!("Failed to send to next leader!");
+//                 }
+//             }
+//             ValidatingMessage(GeneralConsensusMessage::ViewSync(_)) => todo!(),
+//         }
+//     }
 }
 
 #[async_trait]
@@ -864,317 +863,351 @@ where
         &self.inner.consensus
     }
 
-    async fn spawn_all(&self) -> SystemContextHandle<TYPES, I> {
-        let shut_down = Arc::new(AtomicBool::new(false));
-        let started = Arc::new(AtomicBool::new(false));
+    async fn run_tasks(&self) -> SystemContextHandle<TYPES, I> {
+        let task_runner = TaskRunner::new();
+        let registry = task_runner.registry.clone();
+        let internal_event_stream = ChannelStream::new();
+        // TODO this will need to go in the consensus task state
+        let output_event_stream = ChannelStream::new();
 
-        let exchange = self.inner.exchanges.quorum_exchange();
-        let committee_exchange = self.inner.exchanges.committee_exchange();
 
-        let network_broadcast_task_handle = async_spawn(
-            tasks::network_task(
-                self.clone(),
-                shut_down.clone(),
-                TransmitType::Broadcast,
-                exchange.clone().into(),
-            )
-            .instrument(info_span!("HotShot Broadcast Task",)),
-        );
-        let network_direct_task_handle = async_spawn(
-            tasks::network_task(
-                self.clone(),
-                shut_down.clone(),
-                TransmitType::Direct,
-                exchange.clone().into(),
-            )
-            .instrument(info_span!("HotShot Direct Task",)),
-        );
-
-        let committee_network_broadcast_task_handle = async_spawn(
-            tasks::network_task(
-                self.clone(),
-                shut_down.clone(),
-                TransmitType::Broadcast,
-                committee_exchange.clone().into(),
-            )
-            .instrument(info_span!("HotShot DA Broadcast Task",)),
-        );
-        let committee_network_direct_task_handle = async_spawn(
-            tasks::network_task(
-                self.clone(),
-                shut_down.clone(),
-                TransmitType::Direct,
-                committee_exchange.clone().into(),
-            )
-            .instrument(info_span!("HotShot DA Direct Task",)),
-        );
-
-        async_spawn(
-            tasks::network_lookup_task(self.clone(), shut_down.clone())
-                .instrument(info_span!("HotShot Network Lookup Task",)),
-        );
-
-        let (handle_channels, task_channels) = match self.inner.config.execution_type {
-            ExecutionType::Continuous => (None, None),
-            ExecutionType::Incremental => {
-                let (send_consensus_start, recv_consensus_start) = unbounded();
-                (Some(send_consensus_start), Some(recv_consensus_start))
-            }
-        };
-
-        let consensus_task_handle = async_spawn(
-            tasks::view_runner(
-                self.clone(),
-                started.clone(),
-                shut_down.clone(),
-                task_channels,
-            )
-            .instrument(info_span!("Consensus Task Handle",)),
-        );
-
-        let (broadcast_sender, broadcast_receiver) = channel();
-
-        let handle = SystemContextHandle {
-            sender_handle: Arc::new(broadcast_sender.clone()),
-            hotshot: self.clone(),
-            stream_output: broadcast_receiver,
-            storage: self.inner.storage.clone(),
-            shut_down,
-        };
-        *self.inner.event_sender.write().await = Some(broadcast_sender);
-
-        let mut background_task_handle = self.inner.background_task_handle.inner.write().await;
-        *background_task_handle = Some(TaskHandleInner {
-            network_broadcast_task_handle,
-            network_direct_task_handle,
-            committee_network_broadcast_task_handle: Some(committee_network_broadcast_task_handle),
-            committee_network_direct_task_handle: Some(committee_network_direct_task_handle),
-            consensus_task_handle: nll_todo(),
-            shutdown_timeout: Duration::from_millis(self.inner.config.next_view_timeout),
-            run_view_channels: handle_channels,
-            started,
+        // TODO it may make sense to move this up a level
+        let task_runner = tasks::add_networking_task(task_runner, internal_event_stream.clone()).await;
+        let task_runner = tasks::add_consensus_task(task_runner, internal_event_stream.clone()).await;
+        let task_runner = tasks::add_da_task(task_runner, internal_event_stream.clone()).await;
+        let task_runner = tasks::add_view_sync_task(task_runner, internal_event_stream.clone()).await;
+        async_spawn(async move {
+            task_runner.launch().await;
         });
 
-        handle
-    }
+        let exchange = self.inner.exchanges.quorum_exchange();
 
-    #[instrument(
-        skip(self),
-        name = "Handle broadcast consensus message",
-        level = "error"
-    )]
-    async fn handle_broadcast_consensus_message(
-        &self,
-        msg: SequencingMessage<TYPES, I>,
-        sender: TYPES::SignatureKey,
-    ) {
-        let msg_time = msg.view_number();
 
-        match msg.0 {
-            Left(general_message) => {
-                match general_message {
-                    // this is ONLY intended for replica
-                    GeneralConsensusMessage::Proposal(_) => {
-                        let channel_map = self
-                            .inner
-                            .channel_maps
-                            .0
-                            .vote_channel
-                            .upgradable_read()
-                            .await;
 
-                        // skip if the proposal is stale
-                        if msg_time < channel_map.cur_view {
-                            warn!(
-                                "Throwing away {} for view number: {:?}",
-                                std::any::type_name::<Proposal<QuorumProposalType<TYPES, I>>>(),
-                                msg_time
-                            );
-                            return;
-                        }
 
-                        let chan: ViewQueue<TYPES, I> =
-                            Self::create_or_obtain_chan_from_read(msg_time, channel_map).await;
-
-                        if !chan.has_received_proposal.swap(true, Ordering::Relaxed)
-                            && chan
-                                .sender_chan
-                                .send(Left(ProcessedGeneralConsensusMessage::new(
-                                    general_message,
-                                    sender,
-                                )))
-                                .await
-                                .is_err()
-                        {
-                            warn!("Failed to send to next leader!");
-                        }
-                    }
-                    GeneralConsensusMessage::InternalTrigger(_) => {
-                        warn!("Received an internal trigger. This shouldn't be possible.");
-                    }
-                    GeneralConsensusMessage::Vote(_) => {
-                        warn!(
-                            "Received a broadcast for a vote message. This shouldn't be possible."
-                        );
-                    }
-                    GeneralConsensusMessage::ViewSync(_) => todo!(),
-                }
-            }
-            Right(committee_message) => {
-                match committee_message {
-                    CommitteeConsensusMessage::DAVote(_) => {
-                        warn!(
-                            "Received a broadcast for a vote message. This shouldn't be possible."
-                        );
-                    }
-                    CommitteeConsensusMessage::DAProposal(_) => {
-                        let channel_map = match &self.inner.channel_maps.1 {
-                            Some(committee_channels) => {
-                                committee_channels.vote_channel.upgradable_read().await
-                            }
-                            None => {
-                                warn!("Committee channels not found.");
-                                return;
-                            }
-                        };
-
-                        // skip if the proposal is stale
-                        if msg_time < channel_map.cur_view {
-                            warn!(
-                                "Throwing away {} for view number: {:?}",
-                                std::any::type_name::<Proposal<DAProposal<TYPES>>>(),
-                                msg_time
-                            );
-                            return;
-                        }
-
-                        let chan: ViewQueue<TYPES, I> =
-                            Self::create_or_obtain_chan_from_read(msg_time, channel_map).await;
-
-                        if !chan.has_received_proposal.swap(true, Ordering::Relaxed)
-                            && chan
-                                .sender_chan
-                                .send(Right(ProcessedCommitteeConsensusMessage::new(
-                                    committee_message,
-                                    sender,
-                                )))
-                                .await
-                                .is_err()
-                        {
-                            warn!("Failed to send to next leader!");
-                        }
-                    }
-                }
-            }
+        let handle = SystemContextHandle {
+            registry,
+            output_event_stream,
+            internal_event_stream,
+            hotshot: self.clone(),
+            storage: self.inner.storage.clone(),
         };
+
+        handle
+
+
+
+
+
+
+        // let shut_down = Arc::new(AtomicBool::new(false));
+        // let started = Arc::new(AtomicBool::new(false));
+        //
+        // let exchange = self.inner.exchanges.quorum_exchange();
+        // let committee_exchange = self.inner.exchanges.committee_exchange();
+        //
+        // let network_broadcast_task_handle = async_spawn(
+        //     tasks::network_task(
+        //         self.clone(),
+        //         shut_down.clone(),
+        //         TransmitType::Broadcast,
+        //         exchange.clone().into(),
+        //     )
+        //     .instrument(info_span!("HotShot Broadcast Task",)),
+        // );
+        // let network_direct_task_handle = async_spawn(
+        //     tasks::network_task(
+        //         self.clone(),
+        //         shut_down.clone(),
+        //         TransmitType::Direct,
+        //         exchange.clone().into(),
+        //     )
+        //     .instrument(info_span!("HotShot Direct Task",)),
+        // );
+        //
+        // let committee_network_broadcast_task_handle = async_spawn(
+        //     tasks::network_task(
+        //         self.clone(),
+        //         shut_down.clone(),
+        //         TransmitType::Broadcast,
+        //         committee_exchange.clone().into(),
+        //     )
+        //     .instrument(info_span!("HotShot DA Broadcast Task",)),
+        // );
+        // let committee_network_direct_task_handle = async_spawn(
+        //     tasks::network_task(
+        //         self.clone(),
+        //         shut_down.clone(),
+        //         TransmitType::Direct,
+        //         committee_exchange.clone().into(),
+        //     )
+        //     .instrument(info_span!("HotShot DA Direct Task",)),
+        // );
+        //
+        // async_spawn(
+        //     tasks::network_lookup_task(self.clone(), shut_down.clone())
+        //         .instrument(info_span!("HotShot Network Lookup Task",)),
+        // );
+        //
+        // let (handle_channels, task_channels) = match self.inner.config.execution_type {
+        //     ExecutionType::Continuous => (None, None),
+        //     ExecutionType::Incremental => {
+        //         let (send_consensus_start, recv_consensus_start) = unbounded();
+        //         (Some(send_consensus_start), Some(recv_consensus_start))
+        //     }
+        // };
+        //
+        // let consensus_task_handle = async_spawn(
+        //     tasks::view_runner(
+        //         self.clone(),
+        //     )
+        //     .instrument(info_span!("Consensus Task Handle",)),
+        // );
+        //
+        // let (broadcast_sender, broadcast_receiver) = channel();
+        //
+        // let handle = SystemContextHandle {
+        //     sender_handle: Arc::new(broadcast_sender.clone()),
+        //     hotshot: self.clone(),
+        //     stream_output: broadcast_receiver,
+        //     storage: self.inner.storage.clone(),
+        //     shut_down,
+        // };
+        // *self.inner.event_sender.write().await = Some(broadcast_sender);
+        //
+        // let mut background_task_handle = self.inner.background_task_handle.inner.write().await;
+        // *background_task_handle = Some(TaskHandleInner {
+        //     network_broadcast_task_handle,
+        //     network_direct_task_handle,
+        //     committee_network_broadcast_task_handle: Some(committee_network_broadcast_task_handle),
+        //     committee_network_direct_task_handle: Some(committee_network_direct_task_handle),
+        //     consensus_task_handle: nll_todo(),
+        //     shutdown_timeout: Duration::from_millis(self.inner.config.next_view_timeout),
+        //     run_view_channels: handle_channels,
+        //     started,
+        // });
+        //
+        // handle
+
     }
 
-    #[instrument(skip(self), name = "Handle direct consensus message", level = "error")]
-    async fn handle_direct_consensus_message(
-        &self,
-        msg: SequencingMessage<TYPES, I>,
-        sender: TYPES::SignatureKey,
-    ) {
-        let msg_time = msg.view_number();
+    // #[instrument(
+    //     skip(self),
+    //     name = "Handle broadcast consensus message",
+    //     level = "error"
+    // )]
+    // async fn handle_broadcast_consensus_message(
+    //     &self,
+    //     msg: SequencingMessage<TYPES, I>,
+    //     sender: TYPES::SignatureKey,
+    // ) {
+    //     let msg_time = msg.view_number();
+    //
+    //     match msg.0 {
+    //         Left(general_message) => {
+    //             match general_message {
+    //                 // this is ONLY intended for replica
+    //                 GeneralConsensusMessage::Proposal(_) => {
+    //                     let channel_map = self
+    //                         .inner
+    //                         .channel_maps
+    //                         .0
+    //                         .vote_channel
+    //                         .upgradable_read()
+    //                         .await;
+    //
+    //                     // skip if the proposal is stale
+    //                     if msg_time < channel_map.cur_view {
+    //                         warn!(
+    //                             "Throwing away {} for view number: {:?}",
+    //                             std::any::type_name::<Proposal<QuorumProposalType<TYPES, I>>>(),
+    //                             msg_time
+    //                         );
+    //                         return;
+    //                     }
+    //
+    //                     let chan: ViewQueue<TYPES, I> =
+    //                         Self::create_or_obtain_chan_from_read(msg_time, channel_map).await;
+    //
+    //                     if !chan.has_received_proposal.swap(true, Ordering::Relaxed)
+    //                         && chan
+    //                             .sender_chan
+    //                             .send(Left(ProcessedGeneralConsensusMessage::new(
+    //                                 general_message,
+    //                                 sender,
+    //                             )))
+    //                             .await
+    //                             .is_err()
+    //                     {
+    //                         warn!("Failed to send to next leader!");
+    //                     }
+    //                 }
+    //                 GeneralConsensusMessage::InternalTrigger(_) => {
+    //                     warn!("Received an internal trigger. This shouldn't be possible.");
+    //                 }
+    //                 GeneralConsensusMessage::Vote(_) => {
+    //                     warn!(
+    //                         "Received a broadcast for a vote message. This shouldn't be possible."
+    //                     );
+    //                 }
+    //                 GeneralConsensusMessage::ViewSync(_) => todo!(),
+    //             }
+    //         }
+    //         Right(committee_message) => {
+    //             match committee_message {
+    //                 CommitteeConsensusMessage::DAVote(_) => {
+    //                     warn!(
+    //                         "Received a broadcast for a vote message. This shouldn't be possible."
+    //                     );
+    //                 }
+    //                 CommitteeConsensusMessage::DAProposal(_) => {
+    //                     let channel_map = match &self.inner.channel_maps.1 {
+    //                         Some(committee_channels) => {
+    //                             committee_channels.vote_channel.upgradable_read().await
+    //                         }
+    //                         None => {
+    //                             warn!("Committee channels not found.");
+    //                             return;
+    //                         }
+    //                     };
+    //
+    //                     // skip if the proposal is stale
+    //                     if msg_time < channel_map.cur_view {
+    //                         warn!(
+    //                             "Throwing away {} for view number: {:?}",
+    //                             std::any::type_name::<Proposal<DAProposal<TYPES>>>(),
+    //                             msg_time
+    //                         );
+    //                         return;
+    //                     }
+    //
+    //                     let chan: ViewQueue<TYPES, I> =
+    //                         Self::create_or_obtain_chan_from_read(msg_time, channel_map).await;
+    //
+    //                     if !chan.has_received_proposal.swap(true, Ordering::Relaxed)
+    //                         && chan
+    //                             .sender_chan
+    //                             .send(Right(ProcessedCommitteeConsensusMessage::new(
+    //                                 committee_message,
+    //                                 sender,
+    //                             )))
+    //                             .await
+    //                             .is_err()
+    //                     {
+    //                         warn!("Failed to send to next leader!");
+    //                     }
+    //                 }
+    //             }
+    //         }
+    //     };
+    // }
 
-        // We can only recv from a replicas
-        // replicas should only send votes or if they timed out, timeouts
-        match msg.0 {
-            Left(general_message) => match general_message {
-                GeneralConsensusMessage::Proposal(_)
-                | GeneralConsensusMessage::InternalTrigger(_) => {
-                    warn!("Received a direct message for a proposal. This shouldn't be possible.");
-                }
-                // this is ONLY intended for next leader
-                c @ GeneralConsensusMessage::Vote(_) => {
-                    let channel_map = self
-                        .inner
-                        .channel_maps
-                        .0
-                        .proposal_channel
-                        .upgradable_read()
-                        .await;
-
-                    // check if
-                    // - is in fact, actually is the next leader
-                    // - the message is not stale
-                    let is_leader = self
-                        .inner
-                        .clone()
-                        .exchanges
-                        .quorum_exchange()
-                        .is_leader(msg_time + 1);
-                    if !is_leader || msg_time < channel_map.cur_view {
-                        warn!(
-                            "Throwing away {} message for view number: {:?}",
-                            std::any::type_name::<QuorumVote<TYPES, I::Leaf>>(),
-                            msg_time
-                        );
-                        return;
-                    }
-
-                    let chan = Self::create_or_obtain_chan_from_read(msg_time, channel_map).await;
-
-                    if chan
-                        .sender_chan
-                        .send(Left(ProcessedGeneralConsensusMessage::new(c, sender)))
-                        .await
-                        .is_err()
-                    {
-                        error!("Failed to send to next leader!");
-                    }
-                }
-                GeneralConsensusMessage::ViewSync(_) => todo!(),
-            },
-            Right(committee_message) => {
-                match committee_message {
-                    c @ CommitteeConsensusMessage::DAVote(_) => {
-                        let channel_map = match &self.inner.channel_maps.1 {
-                            Some(committee_channels) => {
-                                committee_channels.proposal_channel.upgradable_read().await
-                            }
-                            None => {
-                                warn!("Committee channels not found.");
-                                return;
-                            }
-                        };
-
-                        // check if
-                        // - is in fact, actually is the next leader
-                        // - the message is not stale
-                        let is_leader = self
-                            .inner
-                            .clone()
-                            .exchanges
-                            .committee_exchange()
-                            .is_leader(msg_time);
-                        if !is_leader || msg_time < channel_map.cur_view {
-                            warn!(
-                                "Throwing away {} message for view number: {:?}, Channel cur view: {:?}",
-                                std::any::type_name::<DAVote<TYPES, I::Leaf>>(),
-                                msg_time,
-                                channel_map.cur_view,
-                            );
-                            return;
-                        }
-
-                        let chan =
-                            Self::create_or_obtain_chan_from_read(msg_time, channel_map).await;
-
-                        if chan
-                            .sender_chan
-                            .send(Right(ProcessedCommitteeConsensusMessage::new(c, sender)))
-                            .await
-                            .is_err()
-                        {
-                            error!("Failed to send to next leader!");
-                        }
-                    }
-                    CommitteeConsensusMessage::DAProposal(_) => todo!(),
-                }
-            }
-        }
-    }
+    // #[instrument(skip(self), name = "Handle direct consensus message", level = "error")]
+    // async fn handle_direct_consensus_message(
+    //     &self,
+    //     msg: SequencingMessage<TYPES, I>,
+    //     sender: TYPES::SignatureKey,
+    // ) {
+    //     let msg_time = msg.view_number();
+    //
+    //     // We can only recv from a replicas
+    //     // replicas should only send votes or if they timed out, timeouts
+    //     match msg.0 {
+    //         Left(general_message) => match general_message {
+    //             GeneralConsensusMessage::Proposal(_)
+    //             | GeneralConsensusMessage::InternalTrigger(_) => {
+    //                 warn!("Received a direct message for a proposal. This shouldn't be possible.");
+    //             }
+    //             // this is ONLY intended for next leader
+    //             c @ GeneralConsensusMessage::Vote(_) => {
+    //                 let channel_map = self
+    //                     .inner
+    //                     .channel_maps
+    //                     .0
+    //                     .proposal_channel
+    //                     .upgradable_read()
+    //                     .await;
+    //
+    //                 // check if
+    //                 // - is in fact, actually is the next leader
+    //                 // - the message is not stale
+    //                 let is_leader = self
+    //                     .inner
+    //                     .clone()
+    //                     .exchanges
+    //                     .quorum_exchange()
+    //                     .is_leader(msg_time + 1);
+    //                 if !is_leader || msg_time < channel_map.cur_view {
+    //                     warn!(
+    //                         "Throwing away {} message for view number: {:?}",
+    //                         std::any::type_name::<QuorumVote<TYPES, I::Leaf>>(),
+    //                         msg_time
+    //                     );
+    //                     return;
+    //                 }
+    //
+    //                 let chan = Self::create_or_obtain_chan_from_read(msg_time, channel_map).await;
+    //
+    //                 if chan
+    //                     .sender_chan
+    //                     .send(Left(ProcessedGeneralConsensusMessage::new(c, sender)))
+    //                     .await
+    //                     .is_err()
+    //                 {
+    //                     error!("Failed to send to next leader!");
+    //                 }
+    //             }
+    //             GeneralConsensusMessage::ViewSync(_) => todo!(),
+    //         },
+    //         Right(committee_message) => {
+    //             match committee_message {
+    //                 c @ CommitteeConsensusMessage::DAVote(_) => {
+    //                     let channel_map = match &self.inner.channel_maps.1 {
+    //                         Some(committee_channels) => {
+    //                             committee_channels.proposal_channel.upgradable_read().await
+    //                         }
+    //                         None => {
+    //                             warn!("Committee channels not found.");
+    //                             return;
+    //                         }
+    //                     };
+    //
+    //                     // check if
+    //                     // - is in fact, actually is the next leader
+    //                     // - the message is not stale
+    //                     let is_leader = self
+    //                         .inner
+    //                         .clone()
+    //                         .exchanges
+    //                         .committee_exchange()
+    //                         .is_leader(msg_time);
+    //                     if !is_leader || msg_time < channel_map.cur_view {
+    //                         warn!(
+    //                             "Throwing away {} message for view number: {:?}, Channel cur view: {:?}",
+    //                             std::any::type_name::<DAVote<TYPES, I::Leaf>>(),
+    //                             msg_time,
+    //                             channel_map.cur_view,
+    //                         );
+    //                         return;
+    //                     }
+    //
+    //                     let chan =
+    //                         Self::create_or_obtain_chan_from_read(msg_time, channel_map).await;
+    //
+    //                     if chan
+    //                         .sender_chan
+    //                         .send(Right(ProcessedCommitteeConsensusMessage::new(c, sender)))
+    //                         .await
+    //                         .is_err()
+    //                     {
+    //                         error!("Failed to send to next leader!");
+    //                     }
+    //                 }
+    //                 CommitteeConsensusMessage::DAProposal(_) => todo!(),
+    //             }
+    //         }
+    //     }
+    // }
 }
 
 /// A view runner implemented by [HotShot] for different types of consensus.

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -265,53 +265,53 @@ pub async fn network_lookup_task<TYPES: NodeType, I: NodeImplementation<TYPES>>(
 }
 
 /// Continually processes the incoming broadcast messages received on `hotshot.inner.networking`, redirecting them to their relevant handler
-pub async fn network_task<
-    TYPES: NodeType,
-    I: NodeImplementation<TYPES>,
-    EXCHANGE: ConsensusExchange<TYPES, Message<TYPES, I>>,
->(
-    hotshot: SystemContext<TYPES::ConsensusType, TYPES, I>,
-    shut_down: Arc<AtomicBool>,
-    transmit_type: TransmitType,
-    exchange: Arc<EXCHANGE>,
-) where
-    SystemContext<TYPES::ConsensusType, TYPES, I>: HotShotType<TYPES, I>,
-{
-    info!(
-        "Launching network processing task for {:?} messages",
-        transmit_type
-    );
-    let networking = &exchange.network();
-    let mut incremental_backoff_ms = 10;
-    while !shut_down.load(Ordering::Relaxed) {
-        let queue = match networking.recv_msgs(transmit_type).await {
-            Ok(queue) => queue,
-            Err(e) => {
-                if !shut_down.load(Ordering::Relaxed) {
-                    error!(?e, "did not shut down gracefully.");
-                }
-                return;
-            }
-        };
-        if queue.is_empty() {
-            trace!("No message, sleeping for {} ms", incremental_backoff_ms);
-            async_sleep(Duration::from_millis(incremental_backoff_ms)).await;
-            incremental_backoff_ms = (incremental_backoff_ms * 2).min(1000);
-            continue;
-        }
-        // Make sure to reset the backoff time
-        incremental_backoff_ms = 10;
-        for item in queue {
-            let _metrics = Arc::clone(&hotshot.inner.consensus.read().await.metrics);
-            trace!(?item, "Processing item");
-            hotshot.handle_message(item, transmit_type).await;
-        }
-        trace!(
-            "Items processed in network {:?} task, querying for more",
-            transmit_type
-        );
-    }
-}
+// pub async fn network_task<
+//     TYPES: NodeType,
+//     I: NodeImplementation<TYPES>,
+//     EXCHANGE: ConsensusExchange<TYPES, Message<TYPES, I>>,
+// >(
+//     hotshot: SystemContext<TYPES::ConsensusType, TYPES, I>,
+//     shut_down: Arc<AtomicBool>,
+//     transmit_type: TransmitType,
+//     exchange: Arc<EXCHANGE>,
+// ) where
+//     SystemContext<TYPES::ConsensusType, TYPES, I>: HotShotType<TYPES, I>,
+// {
+//     info!(
+//         "Launching network processing task for {:?} messages",
+//         transmit_type
+//     );
+//     let networking = &exchange.network();
+//     let mut incremental_backoff_ms = 10;
+//     while !shut_down.load(Ordering::Relaxed) {
+//         let queue = match networking.recv_msgs(transmit_type).await {
+//             Ok(queue) => queue,
+//             Err(e) => {
+//                 if !shut_down.load(Ordering::Relaxed) {
+//                     error!(?e, "did not shut down gracefully.");
+//                 }
+//                 return;
+//             }
+//         };
+//         if queue.is_empty() {
+//             trace!("No message, sleeping for {} ms", incremental_backoff_ms);
+//             async_sleep(Duration::from_millis(incremental_backoff_ms)).await;
+//             incremental_backoff_ms = (incremental_backoff_ms * 2).min(1000);
+//             continue;
+//         }
+//         // Make sure to reset the backoff time
+//         incremental_backoff_ms = 10;
+//         for item in queue {
+//             let _metrics = Arc::clone(&hotshot.inner.consensus.read().await.metrics);
+//             trace!(?item, "Processing item");
+//             hotshot.handle_message(item, transmit_type).await;
+//         }
+//         trace!(
+//             "Items processed in network {:?} task, querying for more",
+//             transmit_type
+//         );
+//     }
+// }
 
 /// networking task error type
 #[derive(Snafu, Debug)]
@@ -547,14 +547,12 @@ pub async fn add_view_sync_task(
 /// the view runner
 pub async fn view_runner<TYPES: NodeType, I: NodeImplementation<TYPES>>(
     _hotshot: SystemContext<TYPES::ConsensusType, TYPES, I>,
-    _started: Arc<AtomicBool>,
-    _shut_down: Arc<AtomicBool>,
-    _run_once: Option<UnboundedReceiver<()>>,
 ) -> (GlobalRegistry, ChannelStream<GlobalEvent>) {
     let task_runner = TaskRunner::new();
     let registry = task_runner.registry.clone();
     let event_stream = event_stream::ChannelStream::new();
 
+    // TODO it may make sense to move this up a level
     let task_runner = add_networking_task(task_runner, event_stream.clone()).await;
     let task_runner = add_consensus_task(task_runner, event_stream.clone()).await;
     let task_runner = add_da_task(task_runner, event_stream.clone()).await;

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -544,21 +544,21 @@ pub async fn add_view_sync_task(
     )
 }
 
-/// the view runner
-pub async fn view_runner<TYPES: NodeType, I: NodeImplementation<TYPES>>(
-    _hotshot: SystemContext<TYPES::ConsensusType, TYPES, I>,
-) -> (GlobalRegistry, ChannelStream<GlobalEvent>) {
-    let task_runner = TaskRunner::new();
-    let registry = task_runner.registry.clone();
-    let event_stream = event_stream::ChannelStream::new();
-
-    // TODO it may make sense to move this up a level
-    let task_runner = add_networking_task(task_runner, event_stream.clone()).await;
-    let task_runner = add_consensus_task(task_runner, event_stream.clone()).await;
-    let task_runner = add_da_task(task_runner, event_stream.clone()).await;
-    let task_runner = add_view_sync_task(task_runner, event_stream.clone()).await;
-    async_spawn(async move {
-        task_runner.launch().await;
-    });
-    (registry, event_stream)
-}
+// the view runner
+// pub async fn view_runner<TYPES: NodeType, I: NodeImplementation<TYPES>>(
+//     _hotshot: SystemContext<TYPES::ConsensusType, TYPES, I>,
+// ) -> (GlobalRegistry, ChannelStream<GlobalEvent>) {
+//     let task_runner = TaskRunner::new();
+//     let registry = task_runner.registry.clone();
+//     let event_stream = event_stream::ChannelStream::new();
+//
+//     // TODO it may make sense to move this up a level
+//     let task_runner = add_networking_task(task_runner, event_stream.clone()).await;
+//     let task_runner = add_consensus_task(task_runner, event_stream.clone()).await;
+//     let task_runner = add_da_task(task_runner, event_stream.clone()).await;
+//     let task_runner = add_view_sync_task(task_runner, event_stream.clone()).await;
+//     async_spawn(async move {
+//         task_runner.launch().await;
+//     });
+//     (registry, event_stream)
+// }

--- a/src/types/handle.rs
+++ b/src/types/handle.rs
@@ -130,7 +130,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static> SystemContextHandl
     //     nll_todo()
     // }
 
-    /// obtains a straem to expose to the user
+    /// obtains a stream to expose to the user
     pub async fn get_event_stream(&mut self, filter: FilterEvent<Event<TYPES, I::Leaf>>) -> (impl Stream<Item = Event<TYPES, I::Leaf>>, StreamId) {
         self.output_event_stream.subscribe(filter).await
     }
@@ -189,6 +189,11 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static> SystemContextHandl
             error!("Hotshot storage has no anchor leaf!");
         }
 
+    }
+
+    /// begin consensus by sending a genesis event
+    pub async fn start_consensus(&self) {
+        self.maybe_do_genesis_init().await;
     }
 
     /// iterate through all events on a [`NodeImplementation`] and determine if the node finished

--- a/src/types/handle.rs
+++ b/src/types/handle.rs
@@ -2,6 +2,7 @@
 
 use crate::Message;
 use crate::QuorumCertificate;
+use crate::tasks::GlobalEvent;
 use crate::{
     traits::{NetworkError::ShutDown, NodeImplementation},
     types::{Event, HotShotError::NetworkFault},
@@ -9,6 +10,15 @@ use crate::{
 };
 use async_compatibility_layer::async_primitives::broadcast::{BroadcastReceiver, BroadcastSender};
 use commit::Committable;
+use futures::FutureExt;
+use futures::Stream;
+use futures::StreamExt;
+use hotshot_task::event_stream::ChannelStream;
+use hotshot_task::event_stream::EventStream;
+use hotshot_task::event_stream::SendableStream;
+use hotshot_task::event_stream::StreamId;
+use hotshot_task::global_registry::GlobalRegistry;
+use hotshot_task::task::FilterEvent;
 use hotshot_types::traits::election::QuorumExchangeType;
 use hotshot_types::{
     data::LeafType,
@@ -23,6 +33,7 @@ use hotshot_types::{
         storage::Storage,
     },
 };
+use nll::nll_todo::nll_todo;
 use std::sync::{
     atomic::{AtomicBool, Ordering},
     Arc,
@@ -43,14 +54,15 @@ pub struct SystemContextHandle<TYPES: NodeType, I: NodeImplementation<TYPES>> {
     /// The [sender](BroadcastSender) for the output stream from the background process
     ///
     /// This is kept around as an implementation detail, as the [`BroadcastSender::handle_async`]
-    /// method is needed to generate new receivers for cloning the handle.
-    pub(crate) sender_handle: Arc<BroadcastSender<Event<TYPES, I::Leaf>>>,
+    /// method is needed to generate new receivers to expose to the user
+    pub(crate) output_event_stream: ChannelStream<Event<TYPES, I::Leaf>>,
+    /// access to the internal ev ent stream, in case we need to, say, shut something down
+    pub(crate) internal_event_stream: ChannelStream<GlobalEvent>,
+    /// registry for controlling tasks
+    pub(crate) registry: GlobalRegistry,
+
     /// Internal reference to the underlying [`HotShot`]
     pub(crate) hotshot: SystemContext<TYPES::ConsensusType, TYPES, I>,
-    /// The [`BroadcastReceiver`] we get the events from
-    pub(crate) stream_output: BroadcastReceiver<Event<TYPES, I::Leaf>>,
-    /// Global to signify the `SystemContext` should be closed after completing the next round
-    pub(crate) shut_down: Arc<AtomicBool>,
     /// Our copy of the `Storage` view for a hotshot
     pub(crate) storage: I::Storage,
 }
@@ -60,37 +72,38 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static> Clone
 {
     fn clone(&self) -> Self {
         Self {
-            sender_handle: self.sender_handle.clone(),
-            stream_output: self.sender_handle.handle_sync(),
+            registry: self.registry.clone(),
+            output_event_stream: self.output_event_stream.clone(),
+            internal_event_stream: self.internal_event_stream.clone(),
             hotshot: self.hotshot.clone(),
-            shut_down: self.shut_down.clone(),
             storage: self.storage.clone(),
         }
     }
 }
 
 impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static> SystemContextHandle<TYPES, I> {
-    /// Will return the next event in the queue
-    ///
-    /// # Errors
-    ///
-    /// Will return [`HotShotError::NetworkFault`] if the underlying [`SystemContext`] has been closed.
-    pub async fn next_event(&mut self) -> Result<Event<TYPES, I::Leaf>, HotShotError<TYPES>> {
-        let result = self.stream_output.recv_async().await;
-        match result {
-            Ok(result) => Ok(result),
-            Err(_) => Err(NetworkFault { source: ShutDown }),
-        }
-    }
-    /// Will attempt to immediately pull an event out of the queue
-    ///
-    /// # Errors
-    ///
-    /// Will return [`HotShotError::NetworkFault`] if the underlying [`HotShot`] instance has shut down
-    pub fn try_next_event(&mut self) -> Result<Option<Event<TYPES, I::Leaf>>, HotShotError<TYPES>> {
-        let result = self.stream_output.try_recv();
-        Ok(result)
-    }
+    // /// Will return the next event in the queue
+    // ///
+    // /// # Errors
+    // ///
+    // /// Will return [`HotShotError::NetworkFault`] if the underlying [`SystemContext`] has been closed.
+    // pub async fn next_event(&mut self) -> Result<Event<TYPES, I::Leaf>, HotShotError<TYPES>> {
+    //     let result = self.stream_output.recv_async().await;
+    //     match result {
+    //         Ok(result) => Ok(result),
+    //         Err(_) => Err(NetworkFault { source: ShutDown }),
+    //     }
+    // }
+    // /// Will attempt to immediately pull an event out of the queue
+    // ///
+    // /// # Errors
+    // ///
+    // /// Will return [`HotShotError::NetworkFault`] if the underlying [`HotShot`] instance has shut down
+    // pub fn try_next_event(&mut self) -> Result<Option<Event<TYPES, I::Leaf>>, HotShotError<TYPES>> {
+    //     self.stream.await
+    //     // let result = self.stream_output.try_recv();
+    //     // Ok(result)
+    // }
 
     /// Will pull all the currently available events out of the event queue.
     ///
@@ -98,18 +111,28 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static> SystemContextHandl
     ///
     /// Will return [`HotShotError::NetworkFault`] if the underlying [`HotShot`] instance has been shut
     /// down.
-    pub fn available_events(&mut self) -> Result<Vec<Event<TYPES, I::Leaf>>, HotShotError<TYPES>> {
-        let mut output = vec![];
+    // pub async fn available_events(&mut self) -> Result<Vec<Event<TYPES, I::Leaf>>, HotShotError<TYPES>> {
+        // let mut stream = self.output_stream;
+        // let _ = <dyn SendableStream<Item = Event<TYPES, I::Leaf>> as StreamExt/* ::<Output = Self::Event> */>::next(&mut *stream);
+        // let mut output = vec![];
         // Loop to pull out all the outputs
-        loop {
-            match self.try_next_event() {
-                Ok(Some(x)) => output.push(x),
-                Ok(None) => break,
+        // loop {
+        //     let _ = <dyn SendableStream<Item = Event<TYPES, I::Leaf>> as StreamExt/* ::<Output = Self::Event> */>::next(stream);
+            // let _ = FutureExt::<Output = Self::Event>::next(*self.output_stream).await;
+            // match FutureExt<Output = {
+                // Ok(Some(x)) => output.push(x),
+                // Ok(None) => break,
                 // // try_next event can only return HotShotError { source: NetworkError::ShutDown }
-                Err(x) => return Err(x),
-            }
-        }
-        Ok(output)
+                // Err(x) => return Err(x),
+            // }
+        // }
+        // Ok(output)
+    //     nll_todo()
+    // }
+
+    /// obtains a straem to expose to the user
+    pub async fn get_event_stream(&mut self, filter: FilterEvent<Event<TYPES, I::Leaf>>) -> (impl Stream<Item = Event<TYPES, I::Leaf>>, StreamId) {
+        self.output_event_stream.subscribe(filter).await
     }
 
     /// Gets the current committed state of the [`HotShot`] instance
@@ -144,12 +167,8 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static> SystemContextHandl
         self.hotshot.publish_transaction_async(tx).await
     }
 
-    /// Signals to the underlying [`SystemContext`] to unpause
-    ///
-    /// This will cause the background task to start running consensus again.
-    pub async fn start(&self) {
-        self.hotshot.inner.background_task_handle.start().await;
-        // if is genesis
+    /// performs the genesis initializaiton
+    pub async fn maybe_do_genesis_init(&self){
         let _anchor = self.storage();
         if let Ok(anchor_leaf) = self.storage().get_anchored_view().await {
             if anchor_leaf.view_number == TYPES::Time::genesis() {
@@ -163,24 +182,13 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static> SystemContextHandl
                         qc: Arc::new(qc),
                     },
                 };
-                if self.sender_handle.send_async(event).await.is_err() {
-                    error!("Error sending genesis storage event upstream!");
-                }
+                self.output_event_stream.publish(event).await;
             }
         } else {
+            // TODO (justin) this seems bad. I think we should hard error in this case??
             error!("Hotshot storage has no anchor leaf!");
         }
-    }
 
-    /// Signals the underlying [`SystemContext`] to run one round, if paused.
-    ///
-    /// Do not call this function if [`SystemContext`] has been unpaused by [`SystemContextHandle::start`].
-    pub async fn start_one_round(&self) {
-        self.hotshot
-            .inner
-            .background_task_handle
-            .start_one_round()
-            .await;
     }
 
     /// iterate through all events on a [`NodeImplementation`] and determine if the node finished
@@ -189,42 +197,42 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static> SystemContextHandl
     /// Errors if unable to obtain storage
     /// # Panics
     /// Panics if the event stream is shut down while this is running
-    pub async fn collect_round_events(
-        &mut self,
-    ) -> Result<
-        (
-            Vec<<I as NodeImplementation<TYPES>>::Leaf>,
-            QuorumCertificate<TYPES, <I as NodeImplementation<TYPES>>::Leaf>,
-        ),
-        HotShotError<TYPES>,
-    > {
-        // TODO we should probably do a view check
-        // but we can do that later. It's non-obvious how to get the view number out
-        // to check against
-
-        // drain all events from this node
-        let mut results = Ok((vec![], QuorumCertificate::genesis()));
-        loop {
-            // unwrap is fine here since the thing hasn't been shut down
-            let event = self.next_event().await.unwrap();
-            match event.event {
-                EventType::ReplicaViewTimeout { view_number: time } => {
-                    error!(?event, "Replica timed out!");
-                    results = Err(HotShotError::ViewTimeoutError {
-                        view_number: time,
-                        state: RoundTimedoutState::TestCollectRoundEventsTimedOut,
-                    });
-                }
-                EventType::Decide { leaf_chain, qc } => {
-                    results = Ok((leaf_chain.to_vec(), (*qc).clone()));
-                }
-                EventType::ViewFinished { view_number: _ } => return results,
-                event => {
-                    debug!("recv-ed event {:?}", event);
-                }
-            }
-        }
-    }
+    // pub async fn collect_round_events(
+    //     &mut self,
+    // ) -> Result<
+    //     (
+    //         Vec<<I as NodeImplementation<TYPES>>::Leaf>,
+    //         QuorumCertificate<TYPES, <I as NodeImplementation<TYPES>>::Leaf>,
+    //     ),
+    //     HotShotError<TYPES>,
+    // > {
+    //     // TODO we should probably do a view check
+    //     // but we can do that later. It's non-obvious how to get the view number out
+    //     // to check against
+    //
+    //     // drain all events from this node
+    //     let mut results = Ok((vec![], QuorumCertificate::genesis()));
+    //     loop {
+    //         // unwrap is fine here since the thing hasn't been shut down
+    //         let event = self.next_event().await.unwrap();
+    //         match event.event {
+    //             EventType::ReplicaViewTimeout { view_number: time } => {
+    //                 error!(?event, "Replica timed out!");
+    //                 results = Err(HotShotError::ViewTimeoutError {
+    //                     view_number: time,
+    //                     state: RoundTimedoutState::TestCollectRoundEventsTimedOut,
+    //                 });
+    //             }
+    //             EventType::Decide { leaf_chain, qc } => {
+    //                 results = Ok((leaf_chain.to_vec(), (*qc).clone()));
+    //             }
+    //             EventType::ViewFinished { view_number: _ } => return results,
+    //             event => {
+    //                 debug!("recv-ed event {:?}", event);
+    //             }
+    //         }
+    //     }
+    // }
 
     /// Provides a reference to the underlying storage for this [`SystemContext`], allowing access to
     /// historical data
@@ -240,13 +248,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static> SystemContextHandl
 
     /// Shut down the the inner hotshot and wait until all background threads are closed.
     pub async fn shut_down(self) {
-        self.shut_down.store(true, Ordering::Relaxed);
-        self.hotshot.inner.exchanges.shut_down_networks().await;
-        self.hotshot
-            .inner
-            .background_task_handle
-            .wait_shutdown(self.hotshot.inner.send_network_lookup.clone())
-            .await;
+
     }
 
     /// return the timeout for a view of the underlying `SystemContext`

--- a/task/Cargo.toml
+++ b/task/Cargo.toml
@@ -35,7 +35,6 @@ async-std = { version = "1.12.0", optional = true, features = ["unstable"] }
 async-trait = "0.1.68"
 either = { version = "1.8.1", features = [ "serde" ] }
 futures = "0.3.28"
-hotshot-types = { path = "../types", default-features = false }
 nll = { git = "https://github.com/EspressoSystems/nll.git" }
 serde = { version = "1.0.164", features = ["derive"] }
 snafu = "0.7.4"

--- a/task/src/event_stream.rs
+++ b/task/src/event_stream.rs
@@ -66,6 +66,8 @@ pub trait EventStream: Clone + 'static + Sync + Send {
 
     /// subscribe to a particular set of events
     /// specified by `filter`. Filter returns true if the event should be propagated
+    /// TODO (justin) rethink API, we might be able just to use `StreamExt::filter` and `Filter`
+    /// That would certainly be cleaner
     async fn subscribe(&self, filter: FilterEvent<Self::EventType>)
         -> (Self::StreamType, StreamId);
 

--- a/task/src/global_registry.rs
+++ b/task/src/global_registry.rs
@@ -164,4 +164,16 @@ impl GlobalRegistry {
             Either::Right(b) => b,
         }
     }
+
+    /// checks if all registered tasks have completed
+    pub async fn is_shutdown(&mut self) -> bool {
+        let task_list = self.state_list.read().await;
+        for task in task_list.iter() {
+            if task.0.get_status() != TaskStatus::Completed {
+                return false;
+            }
+        }
+        true
+    }
+
 }

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -21,28 +21,33 @@ tokio-executor = [
   "hotshot-consensus/tokio-executor",
   "hotshot-types/tokio-executor",
   "async-compatibility-layer/tokio-executor",
+  "hotshot-task/tokio-executor",
 ]
 async-std-executor = [
   "dep:async-std",
   "hotshot/async-std-executor",
   "hotshot-consensus/async-std-executor",
   "hotshot-types/async-std-executor",
+  "hotshot-task/async-std-executor",
   "async-compatibility-layer/async-std-executor",
 ]
 channel-flume = [
   "hotshot-consensus/channel-flume",
   "hotshot-types/channel-flume",
   "async-compatibility-layer/channel-flume",
+  "hotshot-task/channel-flume",
 ]
 channel-tokio = [
   "hotshot-consensus/channel-tokio",
   "hotshot-types/channel-tokio",
   "async-compatibility-layer/channel-tokio",
+  "hotshot-task/channel-tokio",
 ]
 channel-async-std = [
   "hotshot-consensus/channel-async-std",
   "hotshot-types/channel-async-std",
   "async-compatibility-layer/channel-async-std",
+  "hotshot-task/channel-async-std",
 ]
 
 [dependencies]
@@ -87,6 +92,7 @@ tokio = { version = "1", optional = true, features = [
 tracing = "0.1.37"
 nll = { git = "https://github.com/EspressoSystems/nll.git" }
 serde = { version = "1.0.164", features = ["derive"] }
+hotshot-task = { path = "../task", default-features = false }
 
 [dev-dependencies]
 nll = { git = "https://github.com/EspressoSystems/nll.git" }

--- a/testing/src/app_tasks/mod.rs
+++ b/testing/src/app_tasks/mod.rs
@@ -1,0 +1,8 @@
+/// task periodically checking for soundness task
+pub mod soundness_task;
+
+/// task determining when to timeout
+pub mod timeout_task;
+
+/// task determining when to submit transactions
+ pub mod txn_task;

--- a/testing/src/app_tasks/txn_task.rs
+++ b/testing/src/app_tasks/txn_task.rs
@@ -1,0 +1,17 @@
+use hotshot::tasks::DATaskState;
+use snafu::Snafu;
+use hotshot_task::task::{TaskErr, TS};
+
+/// Data Availability task error
+#[derive(Snafu, Debug)]
+pub struct TimeoutTaskErr {}
+impl TaskErr for TimeoutTaskErr {}
+
+/// Data availability task state
+#[derive(Debug)]
+pub struct TimeoutTask {}
+impl TS for TimeoutTask {}
+
+// /// Data Availability task types
+// pub type DATaskTypes =
+//     HSTWithEvent<TimeoutTaskErr, GlobalEvent, ChannelStream<GlobalEvent>, DATaskState>;

--- a/testing/src/lib.rs
+++ b/testing/src/lib.rs
@@ -31,3 +31,6 @@ pub mod round;
 
 /// helper functions to build a round
 pub mod round_builder;
+
+/// tasks for view
+pub mod app_tasks;

--- a/testing/src/test_builder.rs
+++ b/testing/src/test_builder.rs
@@ -36,7 +36,7 @@ pub struct TestMetadata {
     /// number of txn per round
     /// TODO in the future we should make this sample from a distribution
     /// much like how network reliability is implemented
-    pub num_txns_per_round: usize,
+    pub num_txns_per_view: usize,
     /// Description of the network reliability
     /// `None` == perfect network
     pub network_reliability: Option<Arc<dyn NetworkReliability>>,
@@ -63,7 +63,7 @@ impl Default for TestMetadata {
             max_transactions: NonZeroUsize::new(999999).unwrap(),
             min_transactions: 0,
             timing_data: TimingData::default(),
-            num_txns_per_round: 20,
+            num_txns_per_view: 20,
             da_committee_size: 0,
         }
     }
@@ -96,7 +96,7 @@ impl TestMetadata {
     {
         Round {
             setup_round: RoundSetupBuilder {
-                num_txns_per_round: metadata.num_txns_per_round,
+                num_txns_per_round: metadata.num_txns_per_view,
                 ..RoundSetupBuilder::default()
             }
             .build(),

--- a/testing/src/test_runner.rs
+++ b/testing/src/test_runner.rs
@@ -1,3 +1,4 @@
+use nll::nll_todo::nll_todo;
 use rand::SeedableRng;
 use std::{collections::HashMap, sync::Arc};
 
@@ -331,13 +332,17 @@ where
         info!("EXECUTOR: running one round");
         for handle in self.nodes() {
             info!("STARTING ONE ROUND");
-            handle.start_one_round().await;
+            // TODO (justin) fix this. we need long running tasks
+            let _ : () = nll_todo();
+            // handle.start_one_round().await;
         }
         info!("EXECUTOR: done running one round");
         let mut failures = HashMap::new();
         for node in &mut self.nodes {
             info!("EXECUTOR: COLLECTING NODE {:?}", node.node_id.clone());
-            let result = node.handle.collect_round_events().await;
+            // let result = node.handle.collect_round_events().await;
+            // TODO (justin) fix this. we need long running tasks
+            let result = nll_todo();
             info!(
                 "EXECUTOR: collected node {:?} results: {}",
                 node.node_id.clone(),

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -15,24 +15,29 @@ profiling = ["async-compatibility-layer/profiling"]
 async-std-executor = [
     "dep:async-std",
     "async-compatibility-layer/async-std-executor",
+    "hotshot-task/async-std-executor",
     "libp2p-networking/async-std-executor",
 ]
 tokio-executor = [
     "dep:tokio",
     "async-compatibility-layer/tokio-executor",
+    "hotshot-task/tokio-executor",
     "libp2p-networking/tokio-executor",
 ]
 demo = ["ed25519-compact"]
 channel-flume = [
     "async-compatibility-layer/channel-flume",
+    "hotshot-task/channel-flume",
     "libp2p-networking/channel-flume",
 ]
 channel-tokio = [
     "async-compatibility-layer/channel-tokio",
+    "hotshot-task/channel-tokio",
     "libp2p-networking/channel-tokio",
 ]
 channel-async-std = [
     "async-compatibility-layer/channel-async-std",
+    "hotshot-task/channel-async-std",
     "libp2p-networking/channel-async-std",
 ]
 
@@ -55,6 +60,7 @@ espresso-systems-common = { git = "https://github.com/espressosystems/espresso-s
 futures = "0.3.28"
 hex_fmt = "0.3.0"
 hotshot-utils = { path = "../utils" }
+hotshot-task = { path = "../task", default-features = false }
 jf-primitives = { git = "https://github.com/EspressoSystems/jellyfish", tag = "0.1.2-patch.1", features = [
   "std",
 ] }

--- a/types/src/data.rs
+++ b/types/src/data.rs
@@ -26,7 +26,7 @@ use serde::{Deserialize, Serialize};
 use snafu::{ensure, Snafu};
 use std::{
     fmt::{Debug, Display},
-    hash::Hash,
+    hash::Hash, ops::{Add, Rem, Div},
 };
 
 /// Type-safe wrapper around `u64` so we know the thing we're talking about is a view number.
@@ -40,6 +40,9 @@ use std::{
     Ord,
     Hash,
     Serialize,
+    // std::ops::Add,
+    // std::ops::Div,
+    // std::ops::Rem,
     Deserialize,
     CanonicalSerialize,
     CanonicalDeserialize,

--- a/types/src/event.rs
+++ b/types/src/event.rs
@@ -1,6 +1,7 @@
 //! Events that a `HotShot` instance can emit
 
 use crate::certificate::QuorumCertificate;
+use hotshot_task::task::PassType;
 use crate::{data::LeafType, error::HotShotError, traits::node_implementation::NodeType};
 use std::sync::Arc;
 /// A status event emitted by a `HotShot` instance
@@ -14,6 +15,8 @@ pub struct Event<TYPES: NodeType, LEAF: LeafType<NodeType = TYPES>> {
     /// The underlying event
     pub event: EventType<TYPES, LEAF>,
 }
+
+impl<TYPES: NodeType, LEAF: LeafType<NodeType = TYPES>> PassType for Event<TYPES, LEAF> {}
 
 /// The type and contents of a status event emitted by a `HotShot` instance
 ///

--- a/types/src/traits/state.rs
+++ b/types/src/traits/state.rs
@@ -7,7 +7,7 @@ use crate::traits::Block;
 use commit::Committable;
 use espresso_systems_common::hotshot::tag;
 use serde::{de::DeserializeOwned, Serialize};
-use std::{error::Error, fmt::Debug, hash::Hash, ops, ops::Deref};
+use std::{error::Error, fmt::Debug, hash::Hash, ops, ops::{Deref, Add, Div, Rem}};
 
 /// Abstraction over the state that blocks modify
 ///


### PR DESCRIPTION
Replaces the internal channels with two event streams. Note, I'm running into a compile error where the first compile (fresh from empty) errors (and doesn't specify the error), but the second compiles successfully. This should be fixed before merging.