### PR TITLE
Make the commitment of all VoteData of fixed length

### DIFF
--- a/src/traits/election/static_committee.rs
+++ b/src/traits/election/static_committee.rs
@@ -129,7 +129,8 @@ where
         }
         let mut message: Vec<u8> = vec![];
         message.extend(view_number.to_le_bytes());
-        // let mut message = GenericArray::from_slice(&vec_message); 
+        // Sishan NOTE: change the length from 8 to 32
+        message.extend_from_slice(&[0u8; 32 - 8]);
         let signature = PUBKEY::sign(private_key, key_pair_test.clone(), &message);
         Ok(Some(StaticVoteToken { signature, pub_key }))
     }

--- a/src/traits/election/static_committee.rs
+++ b/src/traits/election/static_committee.rs
@@ -1,6 +1,7 @@
 use super::vrf::JfPubKey;
 // use ark_bls12_381::Parameters as Param381;
 use commit::{Commitment, Committable, RawCommitmentBuilder};
+use digest::generic_array::GenericArray;
 use espresso_systems_common::hotshot::tag;
 use hotshot_types::{
     data::LeafType,
@@ -128,6 +129,7 @@ where
         }
         let mut message: Vec<u8> = vec![];
         message.extend(view_number.to_le_bytes());
+        // let mut message = GenericArray::from_slice(&vec_message); 
         let signature = PUBKEY::sign(private_key, key_pair_test.clone(), &message);
         Ok(Some(StaticVoteToken { signature, pub_key }))
     }

--- a/src/traits/election/static_committee.rs
+++ b/src/traits/election/static_committee.rs
@@ -129,7 +129,7 @@ where
         }
         let mut message: Vec<u8> = vec![];
         message.extend(view_number.to_le_bytes());
-        // Sishan NOTE: change the length from 8 to 32
+        // Sishan NOTE: change the length from 8 to 32, use defined constant? instead of 32.
         message.extend_from_slice(&[0u8; 32 - 8]);
         let signature = PUBKEY::sign(private_key, key_pair_test.clone(), &message);
         Ok(Some(StaticVoteToken { signature, pub_key }))

--- a/src/traits/election/vrf.rs
+++ b/src/traits/election/vrf.rs
@@ -228,14 +228,14 @@ where
         println!("Inside sign() of SignatureKey for JfPubKey.");
         // Sign it
         // Sishan NOTE: for QC Aggregation
-        // Sishan NOTE TODO: change 32 to a defined constant
-        let pointer = data.as_ptr() as *const [u8; 32];
-        let mut msg_test = unsafe { *pointer };
+        let mut generic_msg_test = GenericArray::from_slice(data);
+        println!("generic_msg_test = {:?}", generic_msg_test);
         println!("data = {:?}", data);
         let agg_signature_test =
             BitvectorQuorumCertificate::<BLSOverBN254CurveSignatureScheme>::partial_sign(
                 &(),
-                &msg_test.into(),
+                &generic_msg_test,
+                // &msg_test.into(),
                 key_pair_test.sign_key_ref(),
                 &mut rand::thread_rng());
         let signature: <SIGSCHEME as SignatureScheme>::Signature = SIGSCHEME::sign(&(), &private_key.0, data, &mut rand::thread_rng())

--- a/src/traits/election/vrf.rs
+++ b/src/traits/election/vrf.rs
@@ -5,6 +5,7 @@
 // use ark_bls12_381::Parameters as Param381;
 // use ark_ec::bls12::Bls12Parameters;
 use bincode::Options;
+use digest::generic_array::GenericArray;
 // use blake3::Hasher;
 // use commit::{Commitment, Committable, RawCommitmentBuilder};
 // use derivative::Derivative;
@@ -226,13 +227,10 @@ where
     fn sign(private_key: &Self::PrivateKey, key_pair_test: QCKeyPair, data: &[u8]) -> EncodedSignature {
         println!("Inside sign() of SignatureKey for JfPubKey.");
         // Sign it
-        /* Sishan NOTE: for QC Aggregation, 
-         now the msg is a test message, partial_sign only support msg with [u8] in length 32, cannot support general `data`.*/
-        //<BLSOverBN254CurveSignatureScheme as SignatureScheme>::Signature
-        // let msg_test: [u8; data.len()] = data.clone();
-        let msg_test = [72u8; 32]; // Sishan TODO: change to `data` after hotshot-primitives is updated
-        // msg_test[..data.len()].clone_from_slice(&data); 
-        println!("msg_test = {:?}", msg_test);
+        // Sishan NOTE: for QC Aggregation
+        // Sishan NOTE TODO: change 32 to a defined constant
+        let pointer = data.as_ptr() as *const [u8; 32];
+        let mut msg_test = unsafe { *pointer };
         println!("data = {:?}", data);
         let agg_signature_test =
             BitvectorQuorumCertificate::<BLSOverBN254CurveSignatureScheme>::partial_sign(

--- a/types/src/traits/election.rs
+++ b/types/src/traits/election.rs
@@ -91,6 +91,35 @@ pub enum VoteData<COMMITTABLE: Committable + Serialize + Clone> {
     ViewSync(ViewSyncVoteData<COMMITTABLE>),
 }
 
+impl<COMMITTABLE: Committable + Serialize + Clone> Committable for VoteData<COMMITTABLE> {
+    fn commit(&self) -> Commitment<Self> {
+        match self {
+            VoteData::DA(block_commitment) => 
+                commit::RawCommitmentBuilder::new("DA Block Commit")
+                    .field("block_commitment", block_commitment.clone())
+                    .finalize(),
+            VoteData::Yes(leaf_commitment) => 
+                commit::RawCommitmentBuilder::new("Yes Vote Commit")
+                    .field("leaf_commitment", leaf_commitment.clone())
+                    .finalize(),
+            VoteData::No(leaf_commitment) =>
+                commit::RawCommitmentBuilder::new("No Vote Commit")
+                    .field("leaf_commitment", leaf_commitment.clone())
+                    .finalize(),
+            VoteData::Timeout(view_number_commitment) =>
+                commit::RawCommitmentBuilder::new("Timeout View Number Commit")
+                    .field("view_number_commitment", view_number_commitment.clone())
+                    .finalize(),
+            VoteData::ViewSync(commitment) =>
+                unimplemented!(),
+        }
+    }
+
+    fn tag() -> String {
+            ("VOTE_DATA_COMMIT").to_string()
+    }
+}
+
 /// Data which `ViewSyncVotes` are signed over
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash)]
 #[serde(bound(deserialize = ""))]

--- a/types/src/traits/election.rs
+++ b/types/src/traits/election.rs
@@ -398,7 +398,7 @@ pub trait ConsensusExchange<TYPES: NodeType, M: NetworkMsg>: Send + Sync {
         let mut is_valid_vote_token = false;
         let mut is_valid_signature = false;
         if let Some(key) = <TYPES::SignatureKey as SignatureKey>::from_bytes(encoded_key) {
-            is_valid_signature = key.validate(encoded_signature, &data.as_bytes());
+            is_valid_signature = key.validate(encoded_signature, &data.commit().as_ref());
             let valid_vote_token =
                 self.membership()
                     .validate_vote_token(view_number, key, vote_token);
@@ -579,12 +579,11 @@ impl<
         &self,
         block_commitment: Commitment<TYPES::BlockType>,
     ) -> (EncodedPublicKey, EncodedSignature) {
-        println!("Inside sign_da_vote() of QuorumExchangeType and prepare to call sign(). 
-            &VoteData::<TYPES::BlockType>::DA(block_commitment).as_bytes()");
+        println!("Inside sign_da_vote() of QuorumExchangeType and prepare to call sign().");
         let signature = TYPES::SignatureKey::sign(
             &self.private_key,
             self.key_pair_test.clone(),
-            &VoteData::<TYPES::BlockType>::DA(block_commitment).as_bytes(),
+            &VoteData::<TYPES::BlockType>::DA(block_commitment).commit().as_ref(),
         );
         (self.public_key.to_bytes(), signature)
     }
@@ -864,12 +863,11 @@ impl<
         &self,
         leaf_commitment: Commitment<LEAF>,
     ) -> (EncodedPublicKey, EncodedSignature) {
-        println!("Inside sign_yes_vote() of QuorumExchangeType and prepare to call sign().
-        &VoteData::<LEAF>::Yes(leaf_commitment).as_bytes()");
+        println!("Inside sign_yes_vote() of QuorumExchangeType and prepare to call sign().");
         let signature = TYPES::SignatureKey::sign(
             &self.private_key,
             self.key_pair_test.clone(),
-            &VoteData::<LEAF>::Yes(leaf_commitment).as_bytes(),
+            &VoteData::<LEAF>::Yes(leaf_commitment).commit().as_ref(),
         );
         (self.public_key.to_bytes(), signature)
     }
@@ -883,12 +881,11 @@ impl<
         &self,
         leaf_commitment: Commitment<LEAF>,
     ) -> (EncodedPublicKey, EncodedSignature) {
-        println!("Inside sign_no_vote() of QuorumExchangeType and prepare to call sign().
-        &VoteData::<LEAF>::No(leaf_commitment).as_bytes()");
+        println!("Inside sign_no_vote() of QuorumExchangeType and prepare to call sign().");
         let signature = TYPES::SignatureKey::sign(
             &self.private_key,
             self.key_pair_test.clone(),
-            &VoteData::<LEAF>::No(leaf_commitment).as_bytes(),
+            &VoteData::<LEAF>::No(leaf_commitment).commit().as_ref(),
         );
         (self.public_key.to_bytes(), signature)
     }
@@ -901,12 +898,11 @@ impl<
     /// This also allows for the high QC included with the vote to be spoofed in a MITM scenario,
     /// but it is outside our threat model.
     fn sign_timeout_vote(&self, view_number: TYPES::Time) -> (EncodedPublicKey, EncodedSignature) {
-        println!("Inside sign_timeout_vote() of QuorumExchangeType and prepare to call sign().
-        &VoteData::<TYPES::Time>::Timeout(view_number.commit()).as_bytes()");
+        println!("Inside sign_timeout_vote() of QuorumExchangeType and prepare to call sign().");
         let signature = TYPES::SignatureKey::sign(
             &self.private_key,
             self.key_pair_test.clone(),
-            &VoteData::<TYPES::Time>::Timeout(view_number.commit()).as_bytes(),
+            &VoteData::<TYPES::Time>::Timeout(view_number.commit()).commit().as_ref(),
         );
         (self.public_key.to_bytes(), signature)
     }


### PR DESCRIPTION
This PR

- Implement Commitment<T> for all the kinds of [VoteData](https://github.com/EspressoSystems/HotShot/blob/paper_benchmarking/types/src/traits/election.rs#L76). So that the new commitment (the actual one we'll use) takes in the type and the sub-commitment (like leaf_commitment or block_commitment).
- Change the type of input data so that sign() takes in GenericArray.

This PR can (only?) pass the web server sequencing tests and will be merged to `[sishan/signature_aggregation_with_hsp](https://github.com/EspressoSystems/HotShot/tree/sishan/signature_aggregation_with_hsp)` once it's approved.