### PR TITLE
Update vote collector

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -770,10 +770,7 @@ where
 
 #[async_trait]
 impl<
-        TYPES: NodeType<
-            ConsensusType = SequencingConsensus,
-            Time = ViewNumber,
-        >,
+        TYPES: NodeType<ConsensusType = SequencingConsensus, Time = ViewNumber>,
         I: NodeImplementation<
             TYPES,
             Leaf = SequencingLeaf<TYPES>,

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -564,11 +564,7 @@ where
         registry: registry.clone(),
         cur_view: TYPES::Time::new(0),
         committee_exchange: committee_exchange.into(),
-        vote_collector: (
-            TYPES::Time::new(0),
-            0,
-            async_spawn(async move { HotShotTaskCompleted::ShutDown }),
-        ),
+        vote_collector: None,
         event_stream: event_stream.clone(),
     };
     let da_event_handler = HandleEvent(Arc::new(move |event, mut state: DATaskState<TYPES, I>| {

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -335,6 +335,7 @@ pub async fn add_network_task<
     event_stream: ChannelStream<SequencingHotShotEvent<TYPES, I>>,
     exchange: EXCHANGE,
 ) -> TaskRunner
+// This bound is required so that we can call the `recv_msgs` function of `CommunicationChannel`.
 where
     EXCHANGE::Networking:
         CommunicationChannel<TYPES, Message<TYPES, I>, PROPOSAL, VOTE, MEMBERSHIP>,

--- a/task-impls/src/da.rs
+++ b/task-impls/src/da.rs
@@ -63,8 +63,8 @@ pub struct DATaskState<
     /// the committee exchange
     pub committee_exchange: Arc<CommitteeEx<TYPES, I>>,
 
-    /// Current Vote collection task, with it's view and ID.
-    pub vote_collector: (ViewNumber, usize, JoinHandle<HotShotTaskCompleted>),
+    /// The view and ID of the current vote collection task, if there is one.
+    pub vote_collector: Option<(ViewNumber, usize)>,
 
     /// Global events stream to publish events
     pub event_stream: ChannelStream<SequencingHotShotEvent<TYPES, I>>,
@@ -235,10 +235,15 @@ where
                 let handle_event = HandleEvent(Arc::new(move |event, state| {
                     async move { vote_handle(state, event).await }.boxed()
                 }));
-                let (collection_view, collection_id, _collection_task) = &self.vote_collector;
-                if view > *collection_view {
-                    self.registry.shutdown_task(*collection_id).await;
-                }
+                let collection_view =
+                    if let Some((collection_view, collection_id)) = &self.vote_collector {
+                        if view > *collection_view {
+                            self.registry.shutdown_task(*collection_id).await;
+                        }
+                        collection_view.clone()
+                    } else {
+                        ViewNumber::new(0)
+                    };
                 let acc = VoteAccumulator {
                     total_vote_outcomes: HashMap::new(),
                     yes_vote_outcomes: HashMap::new(),
@@ -257,7 +262,7 @@ where
                     acc,
                     None,
                 );
-                if view > *collection_view {
+                if view > collection_view {
                     let state = DAVoteCollectionTaskState {
                         committee_exchange: self.committee_exchange.clone(),
                         accumulator,
@@ -279,7 +284,7 @@ where
                         async_spawn(
                             async move { DAVoteCollectionTypes::build(builder).launch().await },
                         );
-                    self.vote_collector = (view, id, task);
+                    self.vote_collector = Some((view, id));
                 }
             }
             SequencingHotShotEvent::ViewChange(view) => {
@@ -287,8 +292,6 @@ where
                 return None;
             }
             SequencingHotShotEvent::Shutdown => {
-                let (_, collection_id, _) = &self.vote_collector;
-                self.registry.shutdown_task(*collection_id);
                 return Some(HotShotTaskCompleted::ShutDown);
             }
             _ => {}

--- a/task-impls/src/network.rs
+++ b/task-impls/src/network.rs
@@ -79,10 +79,7 @@ impl<
             MessageKind::Consensus(consensus_message) => match consensus_message.0 {
                 Either::Left(general_message) => match general_message {
                     GeneralConsensusMessage::Proposal(proposal) => {
-                        SequencingHotShotEvent::QuorumProposalRecv(
-                            proposal.clone(),
-                            sender,
-                        )
+                        SequencingHotShotEvent::QuorumProposalRecv(proposal.clone(), sender)
                     }
                     GeneralConsensusMessage::Vote(vote) => {
                         SequencingHotShotEvent::QuorumVoteRecv(vote.clone())


### PR DESCRIPTION
This is a follow-up PR for https://github.com/EspressoSystems/HotShot/issues/1179 and the run view integration.

- Makes the vote collector optional for the DA task.
- Removes the task handle from the collector field.
- Adds a comment to the where clause for the `CommunicationChannel` bound.