### PR TITLE
Fix shutdown call, modify consensus state construction, and remove todos

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -882,7 +882,7 @@ where
         let task_runner = add_view_sync_task::<TYPES, I>(
             task_runner,
             internal_event_stream.clone(),
-            handle.clone()
+            handle.clone(),
         )
         .await;
         async_spawn(async move {

--- a/task-impls/src/consensus.rs
+++ b/task-impls/src/consensus.rs
@@ -43,7 +43,6 @@ use hotshot_types::{
     },
     vote::{QuorumVote, VoteAccumulator},
 };
-use nll::nll_todo::nll_todo;
 use snafu::Snafu;
 use std::alloc::GlobalAlloc;
 use std::collections::HashMap;

--- a/task-impls/src/network.rs
+++ b/task-impls/src/network.rs
@@ -24,8 +24,6 @@ use snafu::Snafu;
 use std::marker::PhantomData;
 use tracing::warn;
 
-use nll::nll_todo::nll_todo;
-
 pub struct NetworkTaskState<
     TYPES: NodeType<ConsensusType = SequencingConsensus>,
     I: NodeImplementation<

--- a/task-impls/src/network.rs
+++ b/task-impls/src/network.rs
@@ -157,7 +157,6 @@ impl<
                 return None;
             }
             SequencingHotShotEvent::Shutdown => {
-                self.channel.shut_down().await;
                 return Some(HotShotTaskCompleted::ShutDown);
             }
             _ => {

--- a/task-impls/src/view_sync.rs
+++ b/task-impls/src/view_sync.rs
@@ -492,7 +492,6 @@ where
             _ => false,
         }
     }
-
 }
 
 impl<

--- a/task/src/lib.rs
+++ b/task/src/lib.rs
@@ -15,7 +15,6 @@ use either::Either;
 use event_stream::{EventStream, SendableStream};
 // The spawner of the task should be able to fire and forget the task if it makes sense.
 use futures::{future::BoxFuture, stream::Fuse, Future, Stream, StreamExt};
-use nll::nll_todo::nll_todo;
 use std::{
     marker::PhantomData,
     pin::Pin,

--- a/testing/src/app_tasks/completion_task.rs
+++ b/testing/src/app_tasks/completion_task.rs
@@ -21,7 +21,6 @@ use hotshot_types::{
         consensus_type::sequencing_consensus::SequencingConsensus, node_implementation::NodeType,
     },
 };
-use nll::nll_todo::nll_todo;
 use snafu::Snafu;
 
 use crate::test_runner::Node;

--- a/testing/src/app_tasks/test_builder.rs
+++ b/testing/src/app_tasks/test_builder.rs
@@ -8,7 +8,6 @@ use hotshot_types::message::Message;
 use hotshot_types::traits::network::CommunicationChannel;
 use hotshot_types::traits::node_implementation::{NodeType, QuorumCommChannel, QuorumEx};
 use hotshot_types::{ExecutionType, HotShotConfig};
-use nll::nll_todo::nll_todo;
 
 use crate::test_builder::TimingData;
 use crate::test_launcher::ResourceGenerators;

--- a/testing/src/app_tasks/txn_task.rs
+++ b/testing/src/app_tasks/txn_task.rs
@@ -16,7 +16,6 @@ use hotshot_task::{
     GeneratedStream, Merge,
 };
 use hotshot_types::{event::Event, traits::node_implementation::NodeType};
-use nll::nll_todo::nll_todo;
 use rand::thread_rng;
 use snafu::Snafu;
 

--- a/testing/tests/consensus_task.rs
+++ b/testing/tests/consensus_task.rs
@@ -81,7 +81,6 @@ use hotshot_types::{
     },
 };
 use jf_primitives::signatures::BLSSignatureScheme;
-use nll::nll_todo::nll_todo;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::marker::PhantomData;
@@ -303,26 +302,23 @@ where
     let committee_exchange = c_api.inner.exchanges.committee_exchange().clone();
 
     let registry = task_runner.registry.clone();
-    let consensus_state = SequencingConsensusTaskState::<
-        TYPES,
-        I,
-        HotShotSequencingConsensusApi<TYPES, I>,
-    > {
-        registry: registry.clone(),
-        consensus,
-        cur_view: TYPES::Time::new(0),
-        high_qc: QuorumCertificate::<TYPES, I::Leaf>::genesis(),
-        block: TYPES::BlockType::new(),
-        quorum_exchange: c_api.inner.exchanges.quorum_exchange().clone().into(),
-        api: c_api.clone(),
-        committee_exchange: committee_exchange.clone().into(),
-        _pd: PhantomData,
-        vote_collector: Some((TYPES::Time::new(0), nll_todo())), /* async_spawn(async move {})), */
-        timeout_task: async_spawn(async move {}),
-        event_stream: event_stream.clone(),
-        certs: HashMap::new(),
-        current_proposal: None,
-    };
+    let consensus_state =
+        SequencingConsensusTaskState::<TYPES, I, HotShotSequencingConsensusApi<TYPES, I>> {
+            registry: registry.clone(),
+            consensus,
+            cur_view: TYPES::Time::new(0),
+            high_qc: QuorumCertificate::<TYPES, I::Leaf>::genesis(),
+            block: TYPES::BlockType::new(),
+            quorum_exchange: c_api.inner.exchanges.quorum_exchange().clone().into(),
+            api: c_api.clone(),
+            committee_exchange: committee_exchange.clone().into(),
+            _pd: PhantomData,
+            vote_collector: None,
+            timeout_task: async_spawn(async move {}),
+            event_stream: event_stream.clone(),
+            certs: HashMap::new(),
+            current_proposal: None,
+        };
     let consensus_event_handler = HandleEvent(Arc::new(
         move |event,
               mut state: SequencingConsensusTaskState<


### PR DESCRIPTION
- Removes incorrect `shut_down` call for the networking task.
- Changes the vote collector to `None` in testing/tests/consensus_task.rs.
- Removes unused `nll_todo` imports.
- Formats files.