### PR TITLE
Debugging

### DIFF
--- a/consensus/src/sequencing_replica.rs
+++ b/consensus/src/sequencing_replica.rs
@@ -534,7 +534,6 @@ where
                 self.api.send_view_error(self.cur_view, Arc::new(e)).await;
             }
         }
-        let high_qc = leaf.justify_qc.clone();
 
         let included_txns_set: HashSet<_> = if new_decide_reached {
             included_txns
@@ -648,6 +647,6 @@ where
 
             decide_sent.await;
         }
-        high_qc
+        self.high_qc
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -878,6 +878,7 @@ where
             task_runner,
             internal_event_stream.clone(),
             committee_exchange.clone(),
+            handle.clone()
         )
         .await;
         let task_runner = add_view_sync_task::<TYPES, I>(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -282,7 +282,15 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> SystemContext<TYPES::Consens
         })
     }
 
+    /// "Starts" consensus by sending a QCFormed event on the genesis block
+    /// Should only need to be called on the leader node of the first view
     pub async fn start_consensus(&self) {
+        // self.inner
+        // .internal_event_stream
+        // .publish(SequencingHotShotEvent::ViewChange(
+        //     ViewNumber::new(1),
+        // ))
+        // .await;
         self.inner
         .internal_event_stream
         .publish(SequencingHotShotEvent::QCFormed(
@@ -837,23 +845,8 @@ where
     }
 
     async fn run_tasks(self) -> SystemContextHandle<TYPES, I> {
-        // let SystemContextInner {
-        //     public_key,
-        //     private_key,
-        //     config,
-        //     storage,
-        //     exchanges,
-        //     event_sender,
-        //     _metrics,
-        //     transactions,
-        //     consensus,
-        //     channel_maps,
-        //     send_network_lookup,
-        //     recv_network_lookup,
-        //     output_event_stream,
-        //     internal_event_stream,
-        //     id,
-        // } = self.inner.clone();
+
+        // ED Need to set first first number to 1, or properly trigger the change upon start
         let task_runner = TaskRunner::new();
         let registry = task_runner.registry.clone();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -893,7 +893,7 @@ where
         });
 
         // Start HotShot by changing the view to 1 and sending other needed events
-        internal_event_stream.publish(SequencingHotShotEvent::ViewChange(ViewNumber::new(1))).await; 
+        // internal_event_stream.publish(SequencingHotShotEvent::ViewChange(ViewNumber::new(1))).await; 
         internal_event_stream.publish(SequencingHotShotEvent::QCFormed(QuorumCertificate::genesis())).await; 
 
         handle

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -424,6 +424,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> SystemContext<TYPES::Consens
         let inner = self.inner.clone();
         let pk = self.inner.public_key.clone();
         let kind = kind.into();
+        
         async_spawn_local(async move {
             if inner
                 .exchanges

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@ pub mod types;
 
 pub mod tasks;
 
-use crate::tasks::da_filter;
+use crate::tasks::committee_filter;
 use crate::tasks::view_sync_filter;
 use hotshot_task::task::FilterEvent;
 
@@ -877,7 +877,7 @@ where
             task_runner,
             internal_event_stream.clone(),
             committee_exchange.clone(),
-            FilterEvent(Arc::new(da_filter)),
+            FilterEvent(Arc::new(committee_filter)),
         )
         .await;
         let task_runner = add_network_task(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -282,19 +282,22 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> SystemContext<TYPES::Consens
         })
     }
 
-    /// "Starts" consensus by sending a QCFormed event on the genesis block
-    /// Should only need to be called on the leader node of the first view
+    /// "Starts" consensus by sending a ViewChange event
     pub async fn start_consensus(&self) {
-        self.inner
-            .internal_event_stream
-            .publish(SequencingHotShotEvent::QCFormed(
-                QuorumCertificate::genesis(),
-            ))
-            .await;
         self.inner
             .internal_event_stream
             .publish(SequencingHotShotEvent::ViewChange(ViewNumber::new(1)))
             .await;
+
+        // ED This isn't ideal...
+        // async_sleep(Duration::new(1, 0)).await;
+
+        // self.inner
+        //     .internal_event_stream
+        //     .publish(SequencingHotShotEvent::QCFormed(
+        //         QuorumCertificate::genesis(),
+        //     ))
+        //     .await;
     }
 
     /// Marks a given view number as timed out. This should be called a fixed period after a round is started.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -285,18 +285,16 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> SystemContext<TYPES::Consens
     /// "Starts" consensus by sending a QCFormed event on the genesis block
     /// Should only need to be called on the leader node of the first view
     pub async fn start_consensus(&self) {
-        // self.inner
-        // .internal_event_stream
-        // .publish(SequencingHotShotEvent::ViewChange(
-        //     ViewNumber::new(1),
-        // ))
-        // .await;
         self.inner
-        .internal_event_stream
-        .publish(SequencingHotShotEvent::QCFormed(
-            QuorumCertificate::genesis(),
-        ))
-        .await;
+            .internal_event_stream
+            .publish(SequencingHotShotEvent::QCFormed(
+                QuorumCertificate::genesis(),
+            ))
+            .await;
+        self.inner
+            .internal_event_stream
+            .publish(SequencingHotShotEvent::ViewChange(ViewNumber::new(1)))
+            .await;
     }
 
     /// Marks a given view number as timed out. This should be called a fixed period after a round is started.
@@ -845,7 +843,6 @@ where
     }
 
     async fn run_tasks(self) -> SystemContextHandle<TYPES, I> {
-
         // ED Need to set first first number to 1, or properly trigger the change upon start
         let task_runner = TaskRunner::new();
         let registry = task_runner.registry.clone();
@@ -905,14 +902,6 @@ where
         async_spawn(async move {
             task_runner.launch().await;
         });
-
-        // // Start HotShot by changing the view to 1 and sending other needed events
-        // // internal_event_stream.publish(SequencingHotShotEvent::ViewChange(ViewNumber::new(1))).await;
-        // internal_event_stream
-        //     .publish(SequencingHotShotEvent::QCFormed(
-        //         QuorumCertificate::genesis(),
-        //     ))
-        //     .await;
 
         handle
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -892,8 +892,9 @@ where
             task_runner.launch().await;
         });
 
-        // Start HotShot by changing the view to 1
+        // Start HotShot by changing the view to 1 and sending other needed events
         internal_event_stream.publish(SequencingHotShotEvent::ViewChange(ViewNumber::new(1))).await; 
+        internal_event_stream.publish(SequencingHotShotEvent::QCFormed(QuorumCertificate::genesis())).await; 
 
         handle
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,7 @@ use crate::{
     traits::{NodeImplementation, Storage},
     types::{Event, SystemContextHandle},
 };
+use hotshot_task::event_stream::EventStream;
 use async_compatibility_layer::{
     art::{async_sleep, async_spawn, async_spawn_local},
     async_primitives::{broadcast::BroadcastSender, subscribable_rwlock::SubscribableRwLock},
@@ -890,6 +891,9 @@ where
         async_spawn(async move {
             task_runner.launch().await;
         });
+
+        // Start HotShot by changing the view to 1
+        internal_event_stream.publish(SequencingHotShotEvent::ViewChange(ViewNumber::new(1))).await; 
 
         handle
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -282,6 +282,15 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> SystemContext<TYPES::Consens
         })
     }
 
+    pub async fn start_consensus(&self) {
+        self.inner
+        .internal_event_stream
+        .publish(SequencingHotShotEvent::QCFormed(
+            QuorumCertificate::genesis(),
+        ))
+        .await;
+    }
+
     /// Marks a given view number as timed out. This should be called a fixed period after a round is started.
     ///
     /// If the round has already ended then this function will essentially be a no-op. Otherwise `run_round` will return shortly after this function is called.
@@ -904,13 +913,13 @@ where
             task_runner.launch().await;
         });
 
-        // Start HotShot by changing the view to 1 and sending other needed events
-        // internal_event_stream.publish(SequencingHotShotEvent::ViewChange(ViewNumber::new(1))).await;
-        internal_event_stream
-            .publish(SequencingHotShotEvent::QCFormed(
-                QuorumCertificate::genesis(),
-            ))
-            .await;
+        // // Start HotShot by changing the view to 1 and sending other needed events
+        // // internal_event_stream.publish(SequencingHotShotEvent::ViewChange(ViewNumber::new(1))).await;
+        // internal_event_stream
+        //     .publish(SequencingHotShotEvent::QCFormed(
+        //         QuorumCertificate::genesis(),
+        //     ))
+        //     .await;
 
         handle
 

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -551,6 +551,7 @@ pub async fn add_da_task<
     task_runner: TaskRunner,
     event_stream: ChannelStream<SequencingHotShotEvent<TYPES, I>>,
     committee_exchange: CommitteeEx<TYPES, I>,
+    handle: SystemContextHandle<TYPES, I>,
 ) -> TaskRunner
 where
     I::Exchanges: SequencingExchangesType<TYPES, Message<TYPES, I>>,
@@ -565,6 +566,8 @@ where
     let registry = task_runner.registry.clone();
     let da_state = DATaskState {
         registry: registry.clone(),
+        consensus: handle.hotshot.get_consensus(),
+        high_qc: QuorumCertificate::<TYPES, I::Leaf>::genesis(),
         cur_view: TYPES::Time::new(0),
         committee_exchange: committee_exchange.into(),
         vote_collector: None,

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -323,7 +323,7 @@ pub fn quorum_filter<
     match event {
         SequencingHotShotEvent::QuorumProposalSend(_, _)
         | SequencingHotShotEvent::QuorumVoteSend(_)
-        | SequencingHotShotEvent::DACRecv(_)
+        | SequencingHotShotEvent::SendDABlockData(_)
         | SequencingHotShotEvent::Shutdown
         | SequencingHotShotEvent::ViewChange(_)=> true,
 

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -332,7 +332,7 @@ pub fn quorum_filter<
     }
 }
 
-pub fn da_filter<
+pub fn committee_filter<
     TYPES: NodeType<ConsensusType = SequencingConsensus>,
     I: NodeImplementation<
         TYPES,

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -345,6 +345,7 @@ pub fn da_filter<
     match event {
         | SequencingHotShotEvent::DAProposalSend(_, _)
         | SequencingHotShotEvent::DAVoteSend(_)
+        | SequencingHotShotEvent::DACSend(_, _)
         | SequencingHotShotEvent::Shutdown
         | SequencingHotShotEvent::ViewChange(_)
         | SequencingHotShotEvent::TransactionSend(_) => true,

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -323,7 +323,7 @@ pub fn quorum_filter<
     match event {
         SequencingHotShotEvent::QuorumProposalSend(_, _)
         | SequencingHotShotEvent::QuorumVoteSend(_)
-
+        | SequencingHotShotEvent::DACRecv(_)
         | SequencingHotShotEvent::Shutdown
         | SequencingHotShotEvent::ViewChange(_)=> true,
 

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -351,7 +351,7 @@ where
                     .expect("Failed to receive broadcast messages"),
             );
             async_sleep(Duration::new(0, 500)).await;
-            network.shut_down().await;
+            // network.shut_down().await;
             msgs
         };
         boxed_sync(closure)
@@ -367,7 +367,7 @@ where
                     .expect("Failed to receive direct messages"),
             );
             async_sleep(Duration::new(0, 500)).await;
-            network.shut_down().await;
+            // network.shut_down().await;
             msgs
         };
         boxed_sync(closure)

--- a/src/traits/election/static_committee.rs
+++ b/src/traits/election/static_committee.rs
@@ -10,6 +10,7 @@ use hotshot_types::{
         signature_key::{EncodedSignature, SignatureKey},
     },
 };
+use tracing::error;
 use jf_primitives::signatures::BLSSignatureScheme;
 #[allow(deprecated)]
 use serde::{Deserialize, Serialize};

--- a/task-impls/src/consensus.rs
+++ b/task-impls/src/consensus.rs
@@ -184,6 +184,8 @@ where
     match event {
         SequencingHotShotEvent::QuorumVoteRecv(vote) => match vote {
             QuorumVote::Yes(vote) => {
+                error!("In vote handle");
+
                 let accumulator = state.accumulator.left().unwrap();
                 match state.quorum_exchange.accumulate_vote(
                     &vote.signature.0,
@@ -271,7 +273,6 @@ where
         Some(leaf.clone())
     }
     async fn vote_if_able(&self) {
-        error!("In vote if able function");
         if let Some(proposal) = &self.current_proposal {
             // ED Need to account for the genesis DA cert
             if proposal.justify_qc.is_genesis() {
@@ -367,7 +368,6 @@ where
                 if view < self.cur_view {
                     return;
                 }
-                
 
                 let view_leader_key = self.quorum_exchange.get_leader(view);
                 if view_leader_key != sender {
@@ -375,7 +375,6 @@ where
                 }
                 // error!("After {:?}  sender: {:?}", *view, sender);
 
-                
                 self.current_proposal = Some(proposal.data.clone());
 
                 let vote_token = self.quorum_exchange.make_vote_token(view);
@@ -566,6 +565,7 @@ where
                         } else {
                             ViewNumber::new(0)
                         };
+
                         let acc = VoteAccumulator {
                             total_vote_outcomes: HashMap::new(),
                             yes_vote_outcomes: HashMap::new(),
@@ -587,6 +587,7 @@ where
                             None,
                         );
                         if vote.current_view > collection_view {
+                            error!("HERE");
                             let state = VoteCollectionTaskState {
                                 quorum_exchange: self.quorum_exchange.clone(),
                                 accumulator,
@@ -618,10 +619,9 @@ where
                 }
             }
             SequencingHotShotEvent::QCFormed(qc) => {
-
                 // So we don't create a QC on the first view unless we are the leader
                 if !self.quorum_exchange.is_leader(self.cur_view) {
-                    return
+                    return;
                 }
 
                 // update our high qc to the qc we just formed

--- a/task-impls/src/consensus.rs
+++ b/task-impls/src/consensus.rs
@@ -948,6 +948,7 @@ where
                     .await;
             }
             SequencingHotShotEvent::DACRecv(cert) => {
+                panic!("Received DAC!");
                 let view = cert.view_number;
                 self.certs.insert(view, cert);
                 if view == self.cur_view {

--- a/task-impls/src/consensus.rs
+++ b/task-impls/src/consensus.rs
@@ -293,7 +293,7 @@ where
                         );
 
                         if let GeneralConsensusMessage::Vote(vote) = message {
-                            info!("Sending vote to next leader {:?}", vote);
+                            error!("Sending vote to next leader {:?}", vote);
                             self.event_stream
                                 .publish(SequencingHotShotEvent::QuorumVoteSend(vote))
                                 .await;
@@ -304,8 +304,6 @@ where
             }
 
             if let Some(cert) = self.certs.get(&proposal.get_view_number()) {
-                error!("In vote if able");
-
                 let view = cert.view_number;
                 let vote_token = self.quorum_exchange.make_vote_token(view);
                 // TODO: do some of this logic without the vote token check, only do that when voting.
@@ -342,7 +340,7 @@ where
                         }
 
                         if let GeneralConsensusMessage::Vote(vote) = message {
-                            info!("Sending vote to next leader {:?}", vote);
+                            // error!("Sending vote to next leader {:?}", vote);
                             self.event_stream
                                 .publish(SequencingHotShotEvent::QuorumVoteSend(vote))
                                 .await;

--- a/task-impls/src/consensus.rs
+++ b/task-impls/src/consensus.rs
@@ -248,6 +248,7 @@ where
 {
     async fn send_da(&self) {
         // TODO bf we need to send a DA proposal as soon as we are chosen as the leader
+        // ED: Added this in the DA task ^ 
     }
     async fn genesis_leaf(&self) -> Option<SequencingLeaf<TYPES>> {
         let consensus = self.consensus.read().await;

--- a/task-impls/src/consensus.rs
+++ b/task-impls/src/consensus.rs
@@ -184,11 +184,11 @@ where
     match event {
         SequencingHotShotEvent::QuorumVoteRecv(vote) => match vote {
             QuorumVote::Yes(vote) => {
-                error!("In vote handle");
+                // error!("In vote handle");
 
                 // For the case where we receive votes after we've made a certificate
                 if state.accumulator.is_right() {
-                    return (None, state)
+                    return (None, state);
                 }
 
                 let accumulator = state.accumulator.left().unwrap();
@@ -207,6 +207,11 @@ where
                         return (None, state);
                     }
                     Either::Right(qc) => {
+                        // state
+                        //     .event_stream
+                        //     .publish(SequencingHotShotEvent::ViewChange(ViewNumber::new(*state.cur_view + 1)))
+                        //     .await;
+                        error!("QCFormed!");
                         state
                             .event_stream
                             .publish(SequencingHotShotEvent::QCFormed(qc.clone()))
@@ -378,6 +383,8 @@ where
                 if view_leader_key != sender {
                     return;
                 }
+
+                // self.update_view(view).await;
                 // error!("After {:?}  sender: {:?}", *view, sender);
 
                 self.current_proposal = Some(proposal.data.clone());
@@ -591,9 +598,11 @@ where
                             acc,
                             None,
                         );
-                        
-                        if vote.current_view > collection_view || vote.current_view == ViewNumber::new(0) {
-                            error!("HERE");
+
+                        if vote.current_view > collection_view
+                            || vote.current_view == ViewNumber::new(0)
+                        {
+                            // error!("HERE");
                             let state = VoteCollectionTaskState {
                                 quorum_exchange: self.quorum_exchange.clone(),
                                 accumulator,
@@ -625,9 +634,8 @@ where
                 }
             }
             SequencingHotShotEvent::QCFormed(qc) => {
-
-                // ED Need to update the view here?  What does otherwise? 
-                // self.update_view(self.cur_view + 1).await;
+                
+                // ED Need to update the view here?  What does otherwise?
                 // So we don't create a QC on the first view unless we are the leader
                 if !self.quorum_exchange.is_leader(self.cur_view) {
                     return;

--- a/task-impls/src/consensus.rs
+++ b/task-impls/src/consensus.rs
@@ -452,10 +452,16 @@ where
                     }
                 }
             }
-            error!("Couldn't find DAC cert in certs, meaning we haven't received it yet for view {}", *self.cur_view);
+            error!(
+                "Couldn't find DAC cert in certs, meaning we haven't received it yet for view {}",
+                *self.cur_view
+            );
             return false;
         }
-        error!("Could not vote because we don't have a proposal yet for view {}", *self.cur_view);
+        error!(
+            "Could not vote because we don't have a proposal yet for view {}",
+            *self.cur_view
+        );
         return false;
     }
 
@@ -754,15 +760,14 @@ where
                             }
                         });
 
-                        // Because we call the vote if able function above
-                        // if let GeneralConsensusMessage::Vote(vote) = message {
-                        //     info!("Sending vote to next leader {:?}", vote);
-                        //     error!("Vote is {:?}", vote.current_view());
+                        if let GeneralConsensusMessage::Vote(vote) = message {
+                            info!("Sending vote to next leader {:?}", vote);
+                            error!("Vote is {:?}", vote.current_view());
 
-                        //     self.event_stream
-                        //         .publish(SequencingHotShotEvent::QuorumVoteSend(vote))
-                        //         .await;
-                        // };
+                            self.event_stream
+                                .publish(SequencingHotShotEvent::QuorumVoteSend(vote))
+                                .await;
+                        };
                     }
                 }
             }

--- a/task-impls/src/consensus.rs
+++ b/task-impls/src/consensus.rs
@@ -948,7 +948,6 @@ where
                     .await;
             }
             SequencingHotShotEvent::DACRecv(cert) => {
-                panic!("Received DAC!");
                 let view = cert.view_number;
                 self.certs.insert(view, cert);
                 if view == self.cur_view {

--- a/task-impls/src/consensus.rs
+++ b/task-impls/src/consensus.rs
@@ -452,10 +452,10 @@ where
                     }
                 }
             }
-            error!("Couldn't find DAC cert in certs, meaning we haven't received it yet");
+            error!("Couldn't find DAC cert in certs, meaning we haven't received it yet for view {}", *self.cur_view);
             return false;
         }
-        error!("Could not vote because we don't have a proposal yet");
+        error!("Could not vote because we don't have a proposal yet for view {}", *self.cur_view);
         return false;
     }
 
@@ -968,7 +968,7 @@ where
                     .await;
             }
             SequencingHotShotEvent::DACRecv(cert) => {
-                error!("DAC Recved! ");
+                error!("DAC Recved for view ! {}", *cert.view_number);
 
                 let view = cert.view_number;
                 self.certs.insert(view, cert);

--- a/task-impls/src/da.rs
+++ b/task-impls/src/da.rs
@@ -409,6 +409,7 @@ where
                 // TODO ED We should send an event to do this, but just getting it to work for now
 
                 error!("Sending DA proposal for view {}", *self.cur_view);
+                self.event_stream.publish(SequencingHotShotEvent::SendDABlockData(block.clone())).await;
                 if let Err(e) = self.api.send_da_broadcast(message.clone()).await {
                     consensus.metrics.failed_to_send_messages.add(1);
                     warn!(?message, ?e, "Could not broadcast leader proposal");

--- a/task-impls/src/da.rs
+++ b/task-impls/src/da.rs
@@ -337,8 +337,6 @@ where
                 self.cur_view = view;
 
                 // TODO ED Make this a new task so it doesn't block main DA task
-                error!("Here2");
-                // panic!("HERE");
 
                 // If we are not the next leader (DA leader for this view) immediately exit
                 if self.committee_exchange.get_leader(self.cur_view + 1)

--- a/task-impls/src/da.rs
+++ b/task-impls/src/da.rs
@@ -179,6 +179,7 @@ where
         event: SequencingHotShotEvent<TYPES, I>,
     ) -> Option<HotShotTaskCompleted> {
         match event {
+            // TODO ED Add transaction handling logic, looks like there isn't anywhere where DA proposals are created (e.g. create_da_proposal())
             SequencingHotShotEvent::DAProposalRecv(proposal, sender) => {
                 let view = proposal.data.get_view_number();
                 if view < self.cur_view {

--- a/task-impls/src/da.rs
+++ b/task-impls/src/da.rs
@@ -216,7 +216,7 @@ where
 
             */
             SequencingHotShotEvent::TransactionRecv(transaction) => {
-                error!("Received tx in DA task!");
+                // error!("Received tx in DA task!");
                 // TODO ED Add validation checks
                 self.consensus.read().await.get_transactions()
                     .modify(|txns| {
@@ -337,7 +337,8 @@ where
                 self.cur_view = view;
 
                 // TODO ED Make this a new task so it doesn't block main DA task
-                panic!("HERE");
+                error!("Here2");
+                // panic!("HERE");
 
                 // If we are not the next leader (DA leader for this view) immediately exit
                 if self.committee_exchange.get_leader(self.cur_view + 1)

--- a/task-impls/src/da.rs
+++ b/task-impls/src/da.rs
@@ -267,7 +267,7 @@ where
                         // self.cur_view = view;
 
                         if let CommitteeConsensusMessage::DAVote(vote) = message {
-                            // error!("Sending vote to the DA leader {:?}", vote);
+                            error!("Sending vote to the DA leader {:?}", vote.current_view);
                             self.event_stream
                                 .publish(SequencingHotShotEvent::DAVoteSend(vote))
                                 .await;
@@ -402,6 +402,7 @@ where
                 ));
                 // Brodcast DA proposal
                 // TODO ED We should send an event to do this, but just getting it to work for now
+                error!("Sending DA proposal for view {}", *self.cur_view);
                 if let Err(e) = self.api.send_da_broadcast(message.clone()).await {
                     consensus.metrics.failed_to_send_messages.add(1);
                     warn!(?message, ?e, "Could not broadcast leader proposal");

--- a/task-impls/src/da.rs
+++ b/task-impls/src/da.rs
@@ -180,6 +180,14 @@ where
     ) -> Option<HotShotTaskCompleted> {
         match event {
             // TODO ED Add transaction handling logic, looks like there isn't anywhere where DA proposals are created (e.g. create_da_proposal())
+            /* What should that logic look like? 
+            
+            Want the DA proposer to propose once they have enough transactions or a certain amount of time has passed
+            How to translate that into events? --> Will assume view number is associated
+            
+            See QuorumProposalRecv(view n) --> start building new DA Proposal (view n + 1) (with transactions you already have or wait for more) 
+            
+            */
             SequencingHotShotEvent::DAProposalRecv(proposal, sender) => {
                 let view = proposal.data.get_view_number();
                 if view < self.cur_view {

--- a/task-impls/src/da.rs
+++ b/task-impls/src/da.rs
@@ -341,6 +341,9 @@ where
             }
             // TODO ED Update high QC through QCFormed event
             SequencingHotShotEvent::ViewChange(view) => {
+                if *self.cur_view >= *view {
+                    return None
+                }
                 self.cur_view = view;
 
                 // TODO ED Make this a new task so it doesn't block main DA task
@@ -380,6 +383,8 @@ where
                 //     return None;
                 // };
 
+                drop(consensus);
+
                 let mut block = <TYPES as NodeType>::StateType::next_block(None);
                 let txns = self.wait_for_transactions(parent_leaf).await?;
 
@@ -402,6 +407,7 @@ where
                 ));
                 // Brodcast DA proposal
                 // TODO ED We should send an event to do this, but just getting it to work for now
+
                 error!("Sending DA proposal for view {}", *self.cur_view);
                 if let Err(e) = self.api.send_da_broadcast(message.clone()).await {
                     consensus.metrics.failed_to_send_messages.add(1);

--- a/task-impls/src/da.rs
+++ b/task-impls/src/da.rs
@@ -188,6 +188,10 @@ where
             See QuorumProposalRecv(view n) --> start building new DA Proposal (view n + 1) (with transactions you already have or wait for more) 
             
             */
+            SequencingHotShotEvent::TransactionRecv(transaction) => {
+                panic!("Received tx in DA task!");
+                return None
+            }
             SequencingHotShotEvent::DAProposalRecv(proposal, sender) => {
                 let view = proposal.data.get_view_number();
                 if view < self.cur_view {
@@ -313,6 +317,7 @@ where
             SequencingHotShotEvent::DAProposalRecv(_, _)
             | SequencingHotShotEvent::DAVoteRecv(_)
             | SequencingHotShotEvent::Shutdown
+            | SequencingHotShotEvent::TransactionRecv(_)
             | SequencingHotShotEvent::ViewChange(_) => true,
             _ => false,
         }

--- a/task-impls/src/events.rs
+++ b/task-impls/src/events.rs
@@ -1,7 +1,7 @@
 use hotshot_task::task::PassType;
 use hotshot_types::certificate::{DACertificate, QuorumCertificate, ViewSyncCertificate};
 use hotshot_types::data::{DAProposal, ViewNumber};
-use hotshot_types::message::Proposal;
+use hotshot_types::message::{Proposal, DataMessage};
 use hotshot_types::traits::node_implementation::NodeImplementation;
 use hotshot_types::traits::node_implementation::NodeType;
 use hotshot_types::traits::node_implementation::QuorumProposalType;
@@ -35,5 +35,6 @@ pub enum SequencingHotShotEvent<TYPES: NodeType, I: NodeImplementation<TYPES>> {
     ViewSyncVoteRecv(ViewSyncVote<TYPES>),
     ViewSyncCertificateRecv(Proposal<ViewSyncProposalType<TYPES, I>>),
     Timeout(ViewNumber),
+    TransactionRecv(DataMessage<TYPES>),
 }
 impl<TYPES: NodeType, I: NodeImplementation<TYPES>> PassType for SequencingHotShotEvent<TYPES, I> {}

--- a/task-impls/src/events.rs
+++ b/task-impls/src/events.rs
@@ -36,5 +36,7 @@ pub enum SequencingHotShotEvent<TYPES: NodeType, I: NodeImplementation<TYPES>> {
     ViewSyncCertificateRecv(Proposal<ViewSyncProposalType<TYPES, I>>),
     Timeout(ViewNumber),
     TransactionRecv(TYPES::Transaction),
+    TransactionSend(TYPES::Transaction),
+
 }
 impl<TYPES: NodeType, I: NodeImplementation<TYPES>> PassType for SequencingHotShotEvent<TYPES, I> {}

--- a/task-impls/src/events.rs
+++ b/task-impls/src/events.rs
@@ -35,6 +35,6 @@ pub enum SequencingHotShotEvent<TYPES: NodeType, I: NodeImplementation<TYPES>> {
     ViewSyncVoteRecv(ViewSyncVote<TYPES>),
     ViewSyncCertificateRecv(Proposal<ViewSyncProposalType<TYPES, I>>),
     Timeout(ViewNumber),
-    TransactionRecv(DataMessage<TYPES>),
+    TransactionRecv(TYPES::Transaction),
 }
 impl<TYPES: NodeType, I: NodeImplementation<TYPES>> PassType for SequencingHotShotEvent<TYPES, I> {}

--- a/task-impls/src/events.rs
+++ b/task-impls/src/events.rs
@@ -38,5 +38,8 @@ pub enum SequencingHotShotEvent<TYPES: NodeType, I: NodeImplementation<TYPES>> {
     TransactionRecv(TYPES::Transaction),
     TransactionSend(TYPES::Transaction),
 
+    // Event to send DA block data from DA leader to next quorum leader (which should always be the same node)
+    SendDABlockData(TYPES::BlockType)
+
 }
 impl<TYPES: NodeType, I: NodeImplementation<TYPES>> PassType for SequencingHotShotEvent<TYPES, I> {}

--- a/task-impls/src/events.rs
+++ b/task-impls/src/events.rs
@@ -24,7 +24,7 @@ pub enum SequencingHotShotEvent<TYPES: NodeType, I: NodeImplementation<TYPES>> {
     DAProposalSend(Proposal<DAProposal<TYPES>>, TYPES::SignatureKey),
     DAVoteSend(DAVote<TYPES>),
     QCFormed(QuorumCertificate<TYPES, I::Leaf>),
-    DACSend(DACertificate<TYPES>),
+    DACSend(DACertificate<TYPES>, TYPES::SignatureKey),
     ViewChange(ViewNumber),
     ViewSyncTimeout(ViewNumber, u64, ViewSyncPhase),
     ViewSyncVoteSend(ViewSyncVote<TYPES>),

--- a/task-impls/src/network.rs
+++ b/task-impls/src/network.rs
@@ -86,10 +86,12 @@ impl<
             MessageKind::Consensus(consensus_message) => match consensus_message.0 {
                 Either::Left(general_message) => match general_message {
                     GeneralConsensusMessage::Proposal(proposal) => {
-                        error!("Recved quorum proposal");
+                        // error!("Recved quorum proposal");
                         SequencingHotShotEvent::QuorumProposalRecv(proposal.clone(), sender)
                     }
                     GeneralConsensusMessage::Vote(vote) => {
+                        // error!("Recved quorum vote");
+
                         SequencingHotShotEvent::QuorumVoteRecv(vote.clone())
                     }
                     GeneralConsensusMessage::ViewSyncVote(view_sync_message) => {
@@ -151,17 +153,14 @@ impl<
             ),
 
             // ED Each network task is subscribed to all these message types.  Need filters per network task
-            SequencingHotShotEvent::QuorumVoteSend(vote) => {
-                error!("HERE {:?}", vote.current_view());
-                (
-                    vote.signature_key(),
-                    MessageKind::<SequencingConsensus, TYPES, I>::from_consensus_message(
-                        SequencingMessage(Left(GeneralConsensusMessage::Vote(vote.clone()))),
-                    ),
-                    TransmitType::Direct,
-                    Some(membership.get_leader(vote.current_view() + 1)),
-                )
-            }
+            SequencingHotShotEvent::QuorumVoteSend(vote) => (
+                vote.signature_key(),
+                MessageKind::<SequencingConsensus, TYPES, I>::from_consensus_message(
+                    SequencingMessage(Left(GeneralConsensusMessage::Vote(vote.clone()))),
+                ),
+                TransmitType::Direct,
+                Some(membership.get_leader(vote.current_view() + 1)),
+            ),
 
             SequencingHotShotEvent::DAProposalSend(proposal, sender) => (
                 sender,

--- a/task-impls/src/network.rs
+++ b/task-impls/src/network.rs
@@ -147,6 +147,8 @@ impl<
                 TransmitType::Broadcast,
                 None,
             ),
+
+            // ED Each network task is subscribed to all these message types.  Need filters per network task
             SequencingHotShotEvent::QuorumVoteSend(vote) => {
                 error!("HERE {:?}", vote.current_view());
                 (

--- a/task-impls/src/network.rs
+++ b/task-impls/src/network.rs
@@ -219,7 +219,6 @@ impl<
             _phantom: PhantomData,
         };
         match transmit_type {
-            // TODO ED We do not always want to send to the leader, update
             TransmitType::Direct => self
                 .channel
                 .direct_message(message, recipient.unwrap())

--- a/task-impls/src/network.rs
+++ b/task-impls/src/network.rs
@@ -107,8 +107,9 @@ impl<
                     }
                 },
             },
-            MessageKind::Data(_) => {
-                warn!("Got unexpected message type in network task!");
+            MessageKind::Data(message) => {
+                // TODO ED Need to handle TX messages here
+                panic!("Got unexpected message type in network task! {:?}", message);
                 return;
             }
             MessageKind::_Unreachable(_) => unimplemented!(),

--- a/task-impls/src/network.rs
+++ b/task-impls/src/network.rs
@@ -254,22 +254,6 @@ impl<
         return None;
     }
 
-    /// Filter network event.
-    pub fn filter(event: &SequencingHotShotEvent<TYPES, I>) -> bool {
-        match event {
-            SequencingHotShotEvent::QuorumProposalSend(_, _)
-            | SequencingHotShotEvent::QuorumVoteSend(_)
-            | SequencingHotShotEvent::DAProposalSend(_, _)
-            | SequencingHotShotEvent::DAVoteSend(_)
-            | SequencingHotShotEvent::ViewSyncVoteSend(_)
-            | SequencingHotShotEvent::ViewSyncCertificateSend(_, _)
-            | SequencingHotShotEvent::Shutdown
-            | SequencingHotShotEvent::ViewChange(_)
-            | SequencingHotShotEvent::TransactionSend(_) => true,
-
-            _ => false,
-        }
-    }
 }
 
 #[derive(Snafu, Debug)]

--- a/task-impls/src/network.rs
+++ b/task-impls/src/network.rs
@@ -108,9 +108,10 @@ impl<
                 },
             },
             MessageKind::Data(message) => {
-                // TODO ED Need to handle TX messages here
-                panic!("Got unexpected message type in network task! {:?}", message);
-                return;
+                match message {
+                    // ED Why do we need the view number in the transaction? 
+                    hotshot_types::message::DataMessage::SubmitTransaction(transaction, view_number) => SequencingHotShotEvent::TransactionRecv(transaction),
+                }
             }
             MessageKind::_Unreachable(_) => unimplemented!(),
         };

--- a/task-impls/src/network.rs
+++ b/task-impls/src/network.rs
@@ -6,6 +6,7 @@ use hotshot_task::{
     task_impls::HSTWithEventAndMessage,
     GeneratedStream, Merge,
 };
+use tracing::error;
 use hotshot_types::{message::{CommitteeConsensusMessage, SequencingMessage}, traits::election::SignedCertificate};
 use hotshot_types::message::{DataMessage, Message};
 use hotshot_types::traits::state::ConsensusTime;
@@ -116,7 +117,7 @@ impl<
                         transaction,
                         view_number,
                     ) => {
-                        panic!("Tx received");
+                        // panic!("Tx received");
                         SequencingHotShotEvent::TransactionRecv(transaction)},
                 }
             }

--- a/task-impls/src/network.rs
+++ b/task-impls/src/network.rs
@@ -79,12 +79,14 @@ impl<
     > NetworkTaskState<TYPES, I, PROPOSAL, VOTE, MEMBERSHIP, COMMCHANNEL>
 {
     /// Handle the given message.
+    // ED NOTE: Perhaps we should have a different handle event function for each exchange?  Otherwise we are duplicating events like QuorumProposalRecv
     pub async fn handle_message(&mut self, message: Message<TYPES, I>) {
         let sender = message.sender;
         let event = match message.kind {
             MessageKind::Consensus(consensus_message) => match consensus_message.0 {
                 Either::Left(general_message) => match general_message {
                     GeneralConsensusMessage::Proposal(proposal) => {
+                        error!("Recved quorum proposal");
                         SequencingHotShotEvent::QuorumProposalRecv(proposal.clone(), sender)
                     }
                     GeneralConsensusMessage::Vote(vote) => {
@@ -216,6 +218,7 @@ impl<
                 return Some(HotShotTaskCompleted::ShutDown);
             }
             _ => {
+                panic!("Receieved unexpected message in network task");
                 return None;
             }
         };

--- a/testing/src/app_tasks/test_builder.rs
+++ b/testing/src/app_tasks/test_builder.rs
@@ -69,7 +69,8 @@ impl Default for TestMetadata {
             txn_description: TxnTaskDescription::RoundRobinTimeBased(Duration::from_millis(10)),
             completion_task_description: CompletionTaskDescription::TimeBasedCompletionTaskBuilder(
                 TimeBasedCompletionTaskDescription {
-                    duration: Duration::from_millis(10),
+                    // TODO ED Put a configurable time here
+                    duration: Duration::from_millis(100000000),
                 },
             ),
         }

--- a/testing/src/app_tasks/test_builder.rs
+++ b/testing/src/app_tasks/test_builder.rs
@@ -69,8 +69,8 @@ impl Default for TestMetadata {
             txn_description: TxnTaskDescription::RoundRobinTimeBased(Duration::from_millis(10)),
             completion_task_description: CompletionTaskDescription::TimeBasedCompletionTaskBuilder(
                 TimeBasedCompletionTaskDescription {
-                    // TODO ED Put a configurable time here
-                    duration: Duration::from_millis(100000000),
+                    // TODO ED Put a configurable time here - 10 seconds for now
+                    duration: Duration::from_millis(10000),
                 },
             ),
         }

--- a/testing/src/app_tasks/test_runner.rs
+++ b/testing/src/app_tasks/test_runner.rs
@@ -88,6 +88,7 @@ where
         >,
     {
         self.add_nodes(self.launcher.metadata.start_nodes).await;
+
         let TestRunner {
             launcher,
             nodes,
@@ -137,11 +138,13 @@ where
                 stream,
             )
             .await;
+            task_runner = task_runner.add_task(id, id.to_string(), task);
         }
 
+        // TODO ED Here
         task_runner.launch().await;
         // TODO turn errors into something sensible
-        nll_todo()
+        Ok(())
     }
 
     pub async fn add_nodes(&mut self, count: usize) -> Vec<u64>

--- a/testing/src/app_tasks/test_runner.rs
+++ b/testing/src/app_tasks/test_runner.rs
@@ -145,6 +145,7 @@ where
         }
 
         // Start hotshot
+        // Goes through all nodes, but really only needs to call this on the leader node of the first view
         for node in nodes {
             node.handle.hotshot.start_consensus().await;
         }

--- a/testing/src/test_runner.rs
+++ b/testing/src/test_runner.rs
@@ -623,6 +623,8 @@ pub mod test {
     )]
     #[cfg_attr(feature = "async-std-executor", async_std::test)]
     async fn test_basic() {
+        async_compatibility_layer::logging::setup_logging();
+        async_compatibility_layer::logging::setup_backtrace();
         let metadata = crate::app_tasks::test_builder::TestMetadata::default();
         metadata
             .gen_launcher::<SequencingTestTypes, SequencingMemoryImpl>()

--- a/types/src/certificate.rs
+++ b/types/src/certificate.rs
@@ -10,6 +10,7 @@ use crate::{
         state::ConsensusTime,
     },
 };
+use tracing::error;
 use bincode::Options;
 use commit::{Commitment, Committable};
 use espresso_systems_common::hotshot::tag;
@@ -145,12 +146,14 @@ impl<TYPES: NodeType, LEAF: LeafType<NodeType = TYPES>>
         commit: Commitment<LEAF>,
         relay: Option<u64>,
     ) -> Self {
-        QuorumCertificate {
+        let qc = QuorumCertificate {
             leaf_commitment: commit,
             view_number,
             signatures,
             is_genesis: false,
-        }
+        }; 
+        error!("QC commitment when formed is {:?}", qc.leaf_commitment);
+        qc
     }
 
     fn view_number(&self) -> TYPES::Time {

--- a/types/src/message.rs
+++ b/types/src/message.rs
@@ -467,7 +467,7 @@ impl<
                         InternalTrigger::Timeout(time) => *time,
                     },
                     GeneralConsensusMessage::ViewSyncVote(_)
-                    | GeneralConsensusMessage::ViewSyncCertificate(_) => todo!(),
+                    | GeneralConsensusMessage::ViewSyncCertificate(_) => unimplemented!(),
                 }
             }
             Right(committee_message) => {

--- a/types/src/message.rs
+++ b/types/src/message.rs
@@ -512,7 +512,7 @@ impl<
     type CommitteeConsensusMessage = CommitteeConsensusMessage<TYPES>;
 }
 
-#[derive(Serialize, Deserialize, Derivative, Clone, Debug, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Derivative, Clone, Debug, PartialEq, Eq, Hash)]
 #[serde(bound(deserialize = ""))]
 /// Messages related to sending data between nodes
 pub enum DataMessage<TYPES: NodeType> {

--- a/types/src/traits/election.rs
+++ b/types/src/traits/election.rs
@@ -318,10 +318,10 @@ pub trait ConsensusExchange<TYPES: NodeType, M: NetworkMsg>: Send + Sync {
                     })
                     .fold(0, |acc, x| (acc + u64::from(x.1 .2.vote_count())));
 
-                error!(
-                    "Yes votes are: {}",
-                    self.success_threshold()
-                );
+                // error!(
+                //     "Yes votes are: {}",
+                //     self.success_threshold()
+                // );
                 yes_votes >= u64::from(self.success_threshold())
             }
 

--- a/types/src/traits/election.rs
+++ b/types/src/traits/election.rs
@@ -301,6 +301,7 @@ pub trait ConsensusExchange<TYPES: NodeType, M: NetworkMsg>: Send + Sync {
         if leaf_commitment != commit {
             return false;
         }
+
         // TODO ED Write a test to check this fails if leaf_commitment != what commit was signed over
         match qc.signatures() {
             YesNoSignature::Yes(raw_signatures) => {
@@ -317,6 +318,10 @@ pub trait ConsensusExchange<TYPES: NodeType, M: NetworkMsg>: Send + Sync {
                     })
                     .fold(0, |acc, x| (acc + u64::from(x.1 .2.vote_count())));
 
+                error!(
+                    "Yes votes are: {}",
+                    self.success_threshold()
+                );
                 yes_votes >= u64::from(self.success_threshold())
             }
 
@@ -339,6 +344,12 @@ pub trait ConsensusExchange<TYPES: NodeType, M: NetworkMsg>: Send + Sync {
                             no_votes += u64::from(signature.1 .2.vote_count());
                         }
                     }
+                }
+
+                if no_votes > 0 {
+                    error!(
+                        "Too many no votes"
+                    );
                 }
 
                 no_votes >= u64::from(self.failure_threshold())
@@ -392,6 +403,7 @@ pub trait ConsensusExchange<TYPES: NodeType, M: NetworkMsg>: Send + Sync {
             // Ignoring deserialization errors below since we are getting rid of it soon
             Checked::Unchecked(vota_meta.vote_token.clone()),
         ) {
+            error!("Invalid vote!");
             return Either::Left(accumulator);
         }
 

--- a/types/src/vote.rs
+++ b/types/src/vote.rs
@@ -151,6 +151,22 @@ impl<TYPES: NodeType> ViewSyncVote<TYPES> {
         };
         <TYPES::SignatureKey as SignatureKey>::from_bytes(&encoded).unwrap()
     }
+
+    pub fn relay(&self) -> u64 {
+        match &self {
+            ViewSyncVote::PreCommit(vote_internal)
+            | ViewSyncVote::Commit(vote_internal)
+            | ViewSyncVote::Finalize(vote_internal) => vote_internal.relay,
+        }
+    }
+
+    pub fn round(&self) -> TYPES::Time {
+        match &self {
+            ViewSyncVote::PreCommit(vote_internal)
+            | ViewSyncVote::Commit(vote_internal)
+            | ViewSyncVote::Finalize(vote_internal) => vote_internal.round,
+        }
+    }
 }
 
 /// Votes on validating or commitment proposal.


### PR DESCRIPTION
Just a debugging branch; we likely won't commit all these changes.  

This PR: 
* Added a TransactionRecv event that the network task properly handles
* Added a TransactionSend event, but it is not currently used (api.broadcast is used instead)
* Updated network task to handle direct messages (seems like it was only handling broadcast messages before)
* Extended the CompletionTask time to 10 seconds
* Added logic in the DA task to handle the TransactionRecv event and create a DA proposals
* Added a ViewChange(1) event to "start" HotShot
* Updated logic to handle genesis block and DAC in consensus task
* Made separate network filters for each exchange to avoid sending duplicate messages to the network
  * ^ It might be good to do the same for receiving messages as well, since each network task receives all the messages and therefore sends out too many events, but all event handlers should be idempotent anyway (need to check if they actually are)
* Add logic to consensus task to store leaves from proposals
* Debugged consensus task
* Updates self.block in consensus task with the DA block using a new event


Current state: 
* A race condition where events come in before a task is launched, and therefore the task misses those events.  (Currently seen in the consensus task, but will show up in other tasks once we get to them)
* Lots of logging statements
* I think we still need to add logic to emit decide events, update locked_view, etc. I copied it over from the old consensus run_view but it is commented out

This is a messy branch, but I vote to merge it so we can all work on debugging.  We can remove comments and logging at a later date.  