### PR TITLE
Bf/consensus cleanup

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -353,12 +353,19 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> SystemContext<TYPES::Consens
         // Wrap up a message
         // TODO place a view number here that makes sense
         // we haven't worked out how this will work yet
-        let message = DataMessage::SubmitTransaction(transaction, TYPES::Time::new(0));
+        // let message = DataMessage::SubmitTransaction(transaction, TYPES::Time::new(0));
 
-        let api = self.clone();
-        async_spawn(async move {
-            let _result = api.send_broadcast_message(message).await.is_err();
-        });
+        // let api = self.clone();
+        self.inner
+            .internal_event_stream
+            .publish(SequencingHotShotEvent::TransactionSend(
+                transaction,
+                self.inner.public_key.clone(),
+            ))
+            .await;
+        // async_spawn(async move {
+        //     let _result = api.send_broadcast_message(message).await.is_err();
+        // });
         Ok(())
     }
 

--- a/src/traits/election/vrf.rs
+++ b/src/traits/election/vrf.rs
@@ -9,22 +9,16 @@ use bincode::Options;
 // use commit::{Commitment, Committable, RawCommitmentBuilder};
 // use derivative::Derivative;
 // use espresso_systems_common::hotshot::tag;
-use hotshot_types::{
-    // data::LeafType,
-    traits::{
-        election::{
-            // Checked, ElectionConfig, ElectionError, Membership, TestableElection, VoteToken,
-        },
-        // node_implementation::NodeType,
-        signature_key::{EncodedPublicKey, EncodedSignature, SignatureKey, TestableSignatureKey},
-    },
+use hotshot_types::traits::signature_key::{
+    EncodedPublicKey, EncodedSignature, SignatureKey, TestableSignatureKey,
 };
 use hotshot_utils::bincode::bincode_opts;
 use jf_primitives::{
     // hash_to_group::TEHashToGroup,
     signatures::{
         // bls_over_bls12381::{BLSSignature, BLSVerKey},
-        BLSSignatureScheme, SignatureScheme,
+        BLSSignatureScheme,
+        SignatureScheme,
     },
     vrf::{blsvrf::BLSVRFScheme, Vrf},
 };
@@ -35,7 +29,7 @@ use rand::SeedableRng;
 // use rand_chacha::ChaChaRng;
 use serde::{de, Deserialize, Serialize};
 use std::{
-    collections::{BTreeMap, /* HashMap */ },
+    collections::BTreeMap,
     fmt::Debug,
     hash::Hash,
     marker::PhantomData,

--- a/src/traits/networking/web_server_network.rs
+++ b/src/traits/networking/web_server_network.rs
@@ -557,7 +557,7 @@ impl<
         Self: 'b,
     {
         let closure = async move {
-            <WebServerNetwork<_, _, _, _,> as ConnectedNetwork<
+            <WebServerNetwork<_, _, _, _> as ConnectedNetwork<
                 Message<TYPES, I>,
                 TYPES::SignatureKey,
             >>::recv_msgs(&self.0, transmit_type)

--- a/task-impls/src/consensus.rs
+++ b/task-impls/src/consensus.rs
@@ -705,13 +705,19 @@ where
                                     }
 
                                     leaf_views.push(leaf.clone());
-                                    if let Left(block) = &leaf.deltas {
+                                    match &leaf.deltas {
+                                        Left(block) => {
                                         let txns = block.contained_transactions();
+                                        error!("removing {} transactions", txns.len());
                                         for txn in txns {
                                             included_txns.insert(txn);
                                         }
                                     }
+                                    Right(commit) => {
+
+                                    }
                                 }
+                            }
                                 true
                             },
                         ) {
@@ -787,6 +793,7 @@ where
                             }
 
                             // warn!("Inserting leaf into storage {:?}", leaf.commit());
+                            error!("Sending Decide for view {:?}", consensus.last_decided_view);
                             decide_sent.await;
                         }
 
@@ -1199,7 +1206,7 @@ where
             SequencingHotShotEvent::Timeout(view) => {
                 // The view sync module will handle updating views in the case of timeout
                 // TODO ED In the future send a timeout vote
-                error!(
+                warn!(
                     "We received a timeout event in the consensus task for view {}!",
                     *view
                 )

--- a/task-impls/src/consensus.rs
+++ b/task-impls/src/consensus.rs
@@ -792,7 +792,10 @@ where
                             }
 
                             // warn!("Inserting leaf into storage {:?}", leaf.commit());
-                            error!("Sending Decide for view {:?}", consensus.last_decided_view);
+                            if *view % 10 == 0 && self.quorum_exchange.is_leader(view){
+                                error!("Sending Decide for view {:?}", consensus.last_decided_view);
+                                error!("Decided txns {:?}", included_txns_set)
+                            }
                             decide_sent.await;
                         }
 

--- a/task-impls/src/consensus.rs
+++ b/task-impls/src/consensus.rs
@@ -708,7 +708,6 @@ where
                                     match &leaf.deltas {
                                         Left(block) => {
                                         let txns = block.contained_transactions();
-                                        error!("removing {} transactions", txns.len());
                                         for txn in txns {
                                             included_txns.insert(txn);
                                         }

--- a/task-impls/src/da.rs
+++ b/task-impls/src/da.rs
@@ -224,7 +224,6 @@ where
     ) -> Option<HotShotTaskCompleted> {
         match event {
             SequencingHotShotEvent::TransactionRecv(transaction) => {
-                // warn!("Received tx in DA task!");
                 // TODO ED Add validation checks
 
                 self.consensus

--- a/task-impls/src/da.rs
+++ b/task-impls/src/da.rs
@@ -11,8 +11,10 @@ use commit::Committable;
 use either::Either;
 use either::{Left, Right};
 use futures::FutureExt;
+use hotshot_consensus::utils::ViewInner;
 use hotshot_consensus::Consensus;
 use hotshot_consensus::SequencingConsensusApi;
+use hotshot_consensus::View;
 use hotshot_task::event_stream::ChannelStream;
 use hotshot_task::event_stream::EventStream;
 use hotshot_task::global_registry::GlobalRegistry;
@@ -272,7 +274,7 @@ where
                         error!("We were not chosen for DA committee on {:?}", view);
                     }
                     Ok(Some(vote_token)) => {
-                        error!("We were chosen for DA committee on {:?}", view);
+                        warn!("We were chosen for DA committee on {:?}", view);
 
                         // Generate and send vote
                         let message = self.committee_exchange.create_da_message(
@@ -290,6 +292,19 @@ where
                                 .publish(SequencingHotShotEvent::DAVoteSend(vote))
                                 .await;
                         }
+                        let mut consensus = self.consensus.write().await;
+
+                        // Ensure this view is in the view map for garbage collection, but do not overwrite if
+                        // there is already a view there: the replica task may have inserted a `Leaf` view which
+                        // contains strictly more information.
+                        consensus.state_map.entry(view).or_insert(View {
+                            view_inner: ViewInner::DA {
+                                block: block_commitment,
+                            },
+                        });
+
+                        // Record the block we have promised to make available.
+                        consensus.saved_blocks.insert(proposal.data.deltas);
                     }
                 }
             }

--- a/task-impls/src/events.rs
+++ b/task-impls/src/events.rs
@@ -37,7 +37,7 @@ pub enum SequencingHotShotEvent<TYPES: NodeType, I: NodeImplementation<TYPES>> {
     ViewSyncTrigger(ViewNumber),
     Timeout(ViewNumber),
     TransactionRecv(TYPES::Transaction),
-    TransactionSend(TYPES::Transaction),
+    TransactionSend(TYPES::Transaction, TYPES::SignatureKey),
 
     // Event to send DA block data from DA leader to next quorum leader (which should always be the same node)
     SendDABlockData(TYPES::BlockType),

--- a/task-impls/src/network.rs
+++ b/task-impls/src/network.rs
@@ -226,9 +226,8 @@ impl<
                     Some(membership.get_leader(vote.round() + vote.relay())),
                 )
             }
-            SequencingHotShotEvent::TransactionSend(transaction) => (
-                // TODO ED Get our own key
-                nll_todo(),
+            SequencingHotShotEvent::TransactionSend(transaction, sender) => (
+                sender,
                 MessageKind::<SequencingConsensus, TYPES, I>::from(DataMessage::SubmitTransaction(
                     transaction,
                     TYPES::Time::new(*self.view),
@@ -296,7 +295,7 @@ impl<
             | SequencingHotShotEvent::DACSend(_, _)
             | SequencingHotShotEvent::Shutdown
             | SequencingHotShotEvent::ViewChange(_)
-            | SequencingHotShotEvent::TransactionSend(_) => true,
+            | SequencingHotShotEvent::TransactionSend(_, _) => true,
 
             _ => false,
         }

--- a/task-impls/src/view_sync.rs
+++ b/task-impls/src/view_sync.rs
@@ -434,13 +434,13 @@ where
             SequencingHotShotEvent::ViewChange(new_view) => {
                 // TODO ED Don't call new twice
                 if self.current_view < TYPES::Time::new(*new_view) {
-                    error!(
+                    warn!(
                         "Change from view {} to view {} in view sync task",
                         *self.current_view, *new_view
                     );
 
                     self.current_view = TYPES::Time::new(*new_view);
-                    self.next_view = self.current_view; 
+                    self.next_view = self.current_view;
                     self.num_timeouts_tracked = 0;
                 }
                 return;
@@ -450,11 +450,7 @@ where
                 if view_number < ViewNumber::new(*self.current_view) {
                     return;
                 }
-                // TODO ED Combine this code with other replica code since some of it is repeated
-                if view_number < ViewNumber::new(*self.current_view) {
-                    error!("Got old timeout");
-                    return;
-                }
+
                 self.num_timeouts_tracked += 1;
                 error!("Num timeouts tracked is {}", self.num_timeouts_tracked);
 

--- a/task/src/event_stream.rs
+++ b/task/src/event_stream.rs
@@ -135,7 +135,7 @@ impl<EVENT: PassType + 'static> EventStream for ChannelStream<EVENT> {
                 }
             }
             None => {
-                tracing::error!("Requested stream id not found");
+                // tracing::error!("Requested stream id not found");
             }
         }
     }

--- a/testing/src/app_tasks/test_builder.rs
+++ b/testing/src/app_tasks/test_builder.rs
@@ -136,9 +136,9 @@ impl TestMetadata {
             )),
         };
         let network_generator =
-        I::network_generator(total_nodes, num_bootstrap_nodes, da_committee_size, false);
-    let secondary_network_generator =
-        I::network_generator(total_nodes, num_bootstrap_nodes, da_committee_size, true);
+            I::network_generator(total_nodes, num_bootstrap_nodes, da_committee_size, false);
+        let secondary_network_generator =
+            I::network_generator(total_nodes, num_bootstrap_nodes, da_committee_size, true);
         let TimingData {
             next_view_timeout,
             timeout_ratio,

--- a/testing/src/test_launcher.rs
+++ b/testing/src/test_launcher.rs
@@ -113,7 +113,7 @@ where
             min_transactions,
             max_transactions: NonZeroUsize::new(99999).unwrap(),
             known_nodes,
-            da_committee_size, 
+            da_committee_size,
             next_view_timeout: 500,
             timeout_ratio: (11, 10),
             round_start_delay: 1,

--- a/testing/src/test_runner.rs
+++ b/testing/src/test_runner.rs
@@ -519,7 +519,8 @@ pub mod test {
                 vrf::JfPubKey,
             },
             implementations::{
-                CentralizedCommChannel, Libp2pCommChannel, MemoryCommChannel, MemoryStorage, WebCommChannel,
+                CentralizedCommChannel, Libp2pCommChannel, MemoryCommChannel, MemoryStorage,
+                WebCommChannel,
             },
             NodeImplementation,
         },
@@ -656,18 +657,6 @@ pub mod test {
             .await
             .unwrap();
     }
-
-
-
-
-
-
-
-
-
-
-
-
 
     #[derive(Clone, Debug, Deserialize, Serialize, Hash, Eq, PartialEq)]
     pub struct SequencingWebImpl {}

--- a/testing/tests/consensus_task.rs
+++ b/testing/tests/consensus_task.rs
@@ -284,10 +284,7 @@ where
     });
     let exchanges = I::Exchanges::create(
         known_nodes.clone(),
-        (
-            quorum_election_config,
-            committee_election_config,
-        ),
+        (quorum_election_config, committee_election_config),
         (quorum_network, view_sync_network, committee_network),
         public_key.clone(),
         private_key.clone(),

--- a/types/src/traits/node_implementation.rs
+++ b/types/src/traits/node_implementation.rs
@@ -16,8 +16,8 @@ use super::{
     storage::{StorageError, StorageState, TestableStorage},
     State,
 };
-use crate::vote::ViewSyncVote;
 use crate::traits::election::Membership;
+use crate::vote::ViewSyncVote;
 use crate::{data::TestableLeaf, message::Message};
 use crate::{
     data::{LeafType, SequencingLeaf, ValidatingLeaf},
@@ -316,8 +316,6 @@ pub struct SequencingExchanges<
 
     /// Committee exchange.
     committee_exchange: COMMITTEEEXCHANGE,
-
-    
 
     /// Phantom data.
     _phantom: PhantomData<(TYPES, MESSAGE)>,


### PR DESCRIPTION
- Update `stored_blocks` so we actually can get the transactions during a decide event.  
- Submit transaction via the Event and Network Task
- Log transactions we have decided and verify they aren't duplicated.