### PR TITLE
Update network task for incoming and outgoing messages

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@ pub mod tasks;
 use crate::{
     certificate::QuorumCertificate,
     tasks::{
-        add_consensus_task, add_da_task, add_network_task_in_msg, add_network_task_out_msg,
+        add_consensus_task, add_da_task, add_network_event_task, add_network_message_task,
         add_view_sync_task,
     },
     traits::{NodeImplementation, Storage},
@@ -873,14 +873,14 @@ where
             storage: self.inner.storage.clone(),
         };
 
-        let task_runner = add_network_task_in_msg(
+        let task_runner = add_network_message_task(
             task_runner,
             internal_event_stream.clone(),
             quorum_exchange.clone(),
             handle.clone(),
         )
         .await;
-        let task_runner = add_network_task_out_msg(
+        let task_runner = add_network_event_task(
             task_runner,
             internal_event_stream.clone(),
             quorum_exchange,
@@ -888,7 +888,7 @@ where
             handle.clone(),
         )
         .await;
-        let task_runner = add_network_task_out_msg(
+        let task_runner = add_network_event_task(
             task_runner,
             internal_event_stream.clone(),
             committee_exchange.clone(),
@@ -896,7 +896,7 @@ where
             handle.clone(),
         )
         .await;
-        let task_runner = add_network_task_out_msg(
+        let task_runner = add_network_event_task(
             task_runner,
             internal_event_stream.clone(),
             view_sync_exchange.clone(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -885,7 +885,6 @@ where
             internal_event_stream.clone(),
             quorum_exchange,
             NetworkTaskKind::Quorum,
-            handle.clone(),
         )
         .await;
         let task_runner = add_network_event_task(
@@ -893,7 +892,6 @@ where
             internal_event_stream.clone(),
             committee_exchange.clone(),
             NetworkTaskKind::Committee,
-            handle.clone(),
         )
         .await;
         let task_runner = add_network_event_task(
@@ -901,7 +899,6 @@ where
             internal_event_stream.clone(),
             view_sync_exchange.clone(),
             NetworkTaskKind::ViewSync,
-            handle.clone(),
         )
         .await;
         let task_runner = add_consensus_task(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,10 @@ pub mod tasks;
 
 use crate::{
     certificate::QuorumCertificate,
-    tasks::{add_consensus_task, add_da_task, add_network_task, add_view_sync_task},
+    tasks::{
+        add_consensus_task, add_da_task, add_network_task_out_msg, add_network_task_in_msg,
+        add_view_sync_task,
+    },
     traits::{NodeImplementation, Storage},
     types::{Event, SystemContextHandle},
 };
@@ -870,8 +873,14 @@ where
             storage: self.inner.storage.clone(),
         };
 
-        // TODO (run_view) Restore the lines below after making all event types consistent.
-        let task_runner = add_network_task(
+        let task_runner = add_network_task_in_msg(
+            task_runner,
+            internal_event_stream.clone(),
+            quorum_exchange.clone(),
+            handle.clone(),
+        )
+        .await;
+        let task_runner = add_network_task_out_msg(
             task_runner,
             internal_event_stream.clone(),
             quorum_exchange,
@@ -879,7 +888,7 @@ where
             handle.clone(),
         )
         .await;
-        let task_runner = add_network_task(
+        let task_runner = add_network_task_out_msg(
             task_runner,
             internal_event_stream.clone(),
             committee_exchange.clone(),
@@ -887,7 +896,7 @@ where
             handle.clone(),
         )
         .await;
-        let task_runner = add_network_task(
+        let task_runner = add_network_task_out_msg(
             task_runner,
             internal_event_stream.clone(),
             view_sync_exchange.clone(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@ pub mod tasks;
 use crate::{
     certificate::QuorumCertificate,
     tasks::{
-        add_consensus_task, add_da_task, add_network_task_out_msg, add_network_task_in_msg,
+        add_consensus_task, add_da_task, add_network_task_in_msg, add_network_task_out_msg,
         add_view_sync_task,
     },
     traits::{NodeImplementation, Storage},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -880,6 +880,20 @@ where
             handle.clone(),
         )
         .await;
+        let task_runner = add_network_message_task(
+            task_runner,
+            internal_event_stream.clone(),
+            committee_exchange.clone(),
+            handle.clone(),
+        )
+        .await;
+        let task_runner = add_network_message_task(
+            task_runner,
+            internal_event_stream.clone(),
+            view_sync_exchange.clone(),
+            handle.clone(),
+        )
+        .await;
         let task_runner = add_network_event_task(
             task_runner,
             internal_event_stream.clone(),

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -311,10 +311,10 @@ pub enum GlobalEvent {
 }
 impl PassType for GlobalEvent {}
 
-/// add the networking task
+/// Add the network task to handle messages and publish events.
 /// # Panics
 /// Is unable to panic. This section here is just to satisfy clippy
-pub async fn add_network_task<
+pub async fn add_network_task_in_msg<
     TYPES: NodeType<ConsensusType = SequencingConsensus>,
     I: NodeImplementation<
         TYPES,
@@ -335,7 +335,6 @@ pub async fn add_network_task<
     task_runner: TaskRunner,
     event_stream: ChannelStream<SequencingHotShotEvent<TYPES, I>>,
     exchange: EXCHANGE,
-    task_kind: NetworkTaskKind,
     handle: SystemContextHandle<TYPES, I>,
 ) -> TaskRunner
 // This bound is required so that we can call the `recv_msgs` function of `CommunicationChannel`.
@@ -344,7 +343,6 @@ where
         CommunicationChannel<TYPES, Message<TYPES, I>, PROPOSAL, VOTE, MEMBERSHIP>,
 {
     let channel = exchange.network().clone();
-
     let broadcast_stream = GeneratedStream::<Messages<TYPES, I>>::new(Arc::new(move || {
         let network = channel.clone();
         let closure = async move {
@@ -377,14 +375,6 @@ where
         boxed_sync(closure)
     }));
     let message_stream = Merge::new(broadcast_stream, direct_stream);
-    let filter = NetworkTaskState::<
-        TYPES,
-        I,
-        PROPOSAL,
-        VOTE,
-        MEMBERSHIP,
-        <EXCHANGE as ConsensusExchange<_, _>>::Networking,
-    >::filter(task_kind);
     let channel = exchange.network().clone();
     let network_state: NetworkTaskState<_, _, _, _, _, _> = NetworkTaskState {
         channel,
@@ -409,13 +399,85 @@ where
             let id = handle.hotshot.inner.id;
             async move {
                 for message in messages.0 {
-                    state.handle_message(task_kind.clone(), message, id).await;
+                    state.handle_message(message, id).await;
                 }
                 (None, state)
             }
             .boxed()
         },
     ));
+    let networking_name = "Networking Task";
+
+    let networking_task_builder =
+        TaskBuilder::<NetworkTaskTypes<_, _, _, _, _, _>>::new(networking_name.to_string())
+            .register_message_stream(message_stream)
+            .register_registry(&mut registry.clone())
+            .await
+            .register_state(network_state)
+            .register_message_handler(network_message_handler);
+
+    // impossible for unwraps to fail
+    // we *just* registered
+    let networking_task_id = networking_task_builder.get_task_id().unwrap();
+    let networking_task = NetworkTaskTypes::build(networking_task_builder).launch();
+
+    let task_runner = task_runner.add_task(
+        networking_task_id,
+        networking_name.to_string(),
+        networking_task,
+    );
+
+    task_runner
+}
+
+/// Add the network task to handle events and send messages.
+/// # Panics
+/// Is unable to panic. This section here is just to satisfy clippy
+pub async fn add_network_task_out_msg<
+    TYPES: NodeType<ConsensusType = SequencingConsensus>,
+    I: NodeImplementation<
+        TYPES,
+        Leaf = SequencingLeaf<TYPES>,
+        ConsensusMessage = SequencingMessage<TYPES, I>,
+    >,
+    PROPOSAL: ProposalType<NodeType = TYPES>,
+    VOTE: VoteType<TYPES>,
+    MEMBERSHIP: Membership<TYPES>,
+    EXCHANGE: ConsensusExchange<
+            TYPES,
+            Message<TYPES, I>,
+            Proposal = PROPOSAL,
+            Vote = VOTE,
+            Membership = MEMBERSHIP,
+        > + 'static,
+>(
+    task_runner: TaskRunner,
+    event_stream: ChannelStream<SequencingHotShotEvent<TYPES, I>>,
+    exchange: EXCHANGE,
+    task_kind: NetworkTaskKind,
+    handle: SystemContextHandle<TYPES, I>,
+) -> TaskRunner
+// This bound is required so that we can call the `recv_msgs` function of `CommunicationChannel`.
+where
+    EXCHANGE::Networking:
+        CommunicationChannel<TYPES, Message<TYPES, I>, PROPOSAL, VOTE, MEMBERSHIP>,
+{
+    let filter = NetworkTaskState::<
+        TYPES,
+        I,
+        PROPOSAL,
+        VOTE,
+        MEMBERSHIP,
+        <EXCHANGE as ConsensusExchange<_, _>>::Networking,
+    >::filter(task_kind);
+    let channel = exchange.network().clone();
+    let network_state: NetworkTaskState<_, _, _, _, _, _> = NetworkTaskState {
+        channel,
+        event_stream: event_stream.clone(),
+        view: ViewNumber::genesis(),
+        phantom: PhantomData,
+    };
+    let registry = task_runner.registry.clone();
     let network_event_handler = HandleEvent(Arc::new(
         move |event, mut state: NetworkTaskState<_, _, _, _, MEMBERSHIP, _>| {
             let membership = exchange.membership().clone();
@@ -430,13 +492,11 @@ where
 
     let networking_task_builder =
         TaskBuilder::<NetworkTaskTypes<_, _, _, _, _, _>>::new(networking_name.to_string())
-            .register_message_stream(message_stream)
             .register_event_stream(event_stream.clone(), filter)
             .await
             .register_registry(&mut registry.clone())
             .await
             .register_state(network_state)
-            .register_message_handler(network_message_handler)
             .register_event_handler(network_event_handler);
 
     // impossible for unwraps to fail

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -355,7 +355,7 @@ where
                     .await
                     .expect("Failed to receive broadcast messages"),
             );
-            async_sleep(Duration::new(0, 50)).await;
+            async_sleep(Duration::new(0, 500)).await;
             msgs
         };
         boxed_sync(closure)
@@ -370,7 +370,7 @@ where
                     .await
                     .expect("Failed to receive direct messages"),
             );
-            async_sleep(Duration::new(0, 50)).await;
+            async_sleep(Duration::new(0, 500)).await;
             msgs
         };
         boxed_sync(closure)
@@ -445,30 +445,12 @@ pub async fn add_network_event_task<
     event_stream: ChannelStream<SequencingHotShotEvent<TYPES, I>>,
     exchange: EXCHANGE,
     task_kind: NetworkTaskKind,
-    handle: SystemContextHandle<TYPES, I>,
 ) -> TaskRunner
 // This bound is required so that we can call the `recv_msgs` function of `CommunicationChannel`.
 where
     EXCHANGE::Networking:
         CommunicationChannel<TYPES, Message<TYPES, I>, PROPOSAL, VOTE, MEMBERSHIP>,
 {
-    let broadcast_stream = GeneratedStream::<Messages<TYPES, I>>::new(Arc::new(move || {
-        let closure = async move {
-            let msgs = Messages(Vec::new());
-            async_sleep(Duration::new(0, 50)).await;
-            msgs
-        };
-        boxed_sync(closure)
-    }));
-    let direct_stream = GeneratedStream::<Messages<TYPES, I>>::new(Arc::new(move || {
-        let closure = async move {
-            let msgs = Messages(Vec::new());
-            async_sleep(Duration::new(0, 50)).await;
-            msgs
-        };
-        boxed_sync(closure)
-    }));
-    let message_stream = Merge::new(broadcast_stream, direct_stream);
     let filter = NetworkEventTaskState::<
         TYPES,
         I,

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -455,7 +455,7 @@ where
     let broadcast_stream = GeneratedStream::<Messages<TYPES, I>>::new(Arc::new(move || {
         let closure = async move {
             let msgs = Messages(Vec::new());
-            async_sleep(Duration::new(0, 500)).await;
+            async_sleep(Duration::new(0, 50)).await;
             msgs
         };
         boxed_sync(closure)
@@ -463,7 +463,7 @@ where
     let direct_stream = GeneratedStream::<Messages<TYPES, I>>::new(Arc::new(move || {
         let closure = async move {
             let msgs = Messages(Vec::new());
-            async_sleep(Duration::new(0, 500)).await;
+            async_sleep(Duration::new(0, 50)).await;
             msgs
         };
         boxed_sync(closure)

--- a/task-impls/src/consensus.rs
+++ b/task-impls/src/consensus.rs
@@ -792,7 +792,7 @@ where
                             }
 
                             // warn!("Inserting leaf into storage {:?}", leaf.commit());
-                            if *view % 10 == 0 && self.quorum_exchange.is_leader(view){
+                            if *view % 10 == 0 && self.quorum_exchange.is_leader(view) {
                                 error!("Sending Decide for view {:?}", consensus.last_decided_view);
                                 error!("Decided txns {:?}", included_txns_set)
                             }

--- a/task-impls/src/network.rs
+++ b/task-impls/src/network.rs
@@ -306,6 +306,9 @@ impl<
 pub struct NetworkTaskError {}
 impl TaskErr for NetworkTaskError {}
 
+// TODO (Keyao run_view) add task types to handle incoming and outgoing messages separately. It
+// should be `HSTWithMessage` for the former and `HSTWithEvent` for the latter. Neither should
+// handle both events and messages.
 pub type NetworkTaskTypes<TYPES, I, PROPOSAL, VOTE, MEMBERSHIP, COMMCHANNEL> =
     HSTWithEventAndMessage<
         NetworkTaskError,

--- a/task-impls/src/network.rs
+++ b/task-impls/src/network.rs
@@ -84,24 +84,13 @@ impl<
         COMMCHANNEL: CommunicationChannel<TYPES, Message<TYPES, I>, PROPOSAL, VOTE, MEMBERSHIP>,
     > NetworkTaskState<TYPES, I, PROPOSAL, VOTE, MEMBERSHIP, COMMCHANNEL>
 {
-    /// Handle the message for the given type of network task.
-    pub async fn handle_message(
-        &mut self,
-        task: NetworkTaskKind,
-        message: Message<TYPES, I>,
-        id: u64,
-    ) {
+    /// Handle the message.
+    pub async fn handle_message(&mut self, message: Message<TYPES, I>, id: u64) {
         let sender = message.sender;
         let event = match message.kind {
             MessageKind::Consensus(consensus_message) => match consensus_message.0 {
                 Either::Left(general_message) => match general_message {
                     GeneralConsensusMessage::Proposal(proposal) => {
-                        warn!(
-                            "ID = {} Recved quorum proposal on {:?} view {:?}",
-                            id,
-                            task,
-                            proposal.data.get_view_number()
-                        );
                         SequencingHotShotEvent::QuorumProposalRecv(proposal.clone(), sender)
                     }
                     GeneralConsensusMessage::Vote(vote) => {

--- a/task/src/task_impls.rs
+++ b/task/src/task_impls.rs
@@ -225,6 +225,8 @@ impl<
         Self: Sized,
     {
         builder.0.base_check();
+        // TODO (Keyao run_view) after refactoring the network task to handle incoming and outgoing
+        // messages separately by different task types, restore the checks below.
         // builder.0.message_check();
         // builder.0.event_check();
         builder.0

--- a/task/src/task_impls.rs
+++ b/task/src/task_impls.rs
@@ -225,8 +225,8 @@ impl<
         Self: Sized,
     {
         builder.0.base_check();
-        builder.0.message_check();
-        builder.0.event_check();
+        // builder.0.message_check();
+        // builder.0.event_check();
         builder.0
     }
 }

--- a/task/src/task_impls.rs
+++ b/task/src/task_impls.rs
@@ -225,10 +225,8 @@ impl<
         Self: Sized,
     {
         builder.0.base_check();
-        // TODO (Keyao run_view) after refactoring the network task to handle incoming and outgoing
-        // messages separately by different task types, restore the checks below.
-        // builder.0.message_check();
-        // builder.0.event_check();
+        builder.0.message_check();
+        builder.0.event_check();
         builder.0
     }
 }


### PR DESCRIPTION
- Splits `NetworkTaskState` and `NetworkTaskTypes` into two parts, so the latter isn't `HSTWithEventAndMessage` anymore, but `HSTWithEvent` and `HSTWithMessage`.
- Adds another network task to handle incoming messages.
- Refactors existing network tasks to handle events only.

Closes https://github.com/EspressoSystems/HotShot/issues/1380.