### PR TITLE
Refactor to expose `OrchestratorClient`

### DIFF
--- a/examples/infra/mod.rs
+++ b/examples/infra/mod.rs
@@ -6,7 +6,6 @@ use async_lock::RwLock;
 use async_trait::async_trait;
 use clap::Parser;
 use futures::Future;
-use futures::FutureExt;
 use hotshot::{
     traits::{
         implementations::{
@@ -19,6 +18,7 @@ use hotshot::{
 };
 use hotshot_orchestrator::{
     self,
+    client::{OrchestratorClient, ValidatorArgs},
     config::{NetworkConfig, NetworkConfigFile, WebServerConfig},
 };
 use hotshot_types::traits::election::ConsensusExchange;
@@ -58,10 +58,8 @@ use std::{
     num::NonZeroUsize,
     str::FromStr,
     sync::Arc,
-    time::{Duration, Instant},
+    time::Instant,
 };
-use surf_disco::error::ClientError;
-use surf_disco::Client;
 #[allow(deprecated)]
 use tracing::error;
 
@@ -152,24 +150,6 @@ pub async fn run_orchestrator<
         TYPES::ElectionConfigType,
     >(run_config, host, port)
     .await;
-}
-
-// VALIDATOR
-
-#[derive(Parser, Debug, Clone)]
-#[command(
-    name = "Multi-machine consensus",
-    about = "Simulates consensus among multiple machines"
-)]
-/// Arguments passed to the validator
-pub struct ValidatorArgs {
-    /// The address the orchestrator runs on
-    pub host: IpAddr,
-    /// The port the orchestrator runs on
-    pub port: u16,
-    /// This node's public IP address, for libp2p
-    /// If no IP address is passed in, it will default to 127.0.0.1
-    pub public_ip: Option<IpAddr>,
 }
 
 /// Defines the behavior of a "run" of the network with a given configuration
@@ -760,106 +740,6 @@ where
 
     fn get_config(&self) -> NetworkConfig<TYPES::SignatureKey, TYPES::ElectionConfigType> {
         self.config.clone()
-    }
-}
-
-/// Holds the client connection to the orchestrator
-pub struct OrchestratorClient {
-    client: surf_disco::Client<ClientError>,
-}
-
-impl OrchestratorClient {
-    /// Creates the client that connects to the orchestrator
-    pub async fn connect_to_orchestrator(args: ValidatorArgs) -> Self {
-        let base_url = format!("{0}:{1}", args.host, args.port);
-        let base_url = format!("http://{base_url}").parse().unwrap();
-        let client = surf_disco::Client::<ClientError>::new(base_url);
-        assert!(client.connect(None).await);
-
-        OrchestratorClient { client }
-    }
-
-    /// Sends an identify message to the server
-    /// Returns this validator's node_index in the network
-    pub async fn identify_with_orchestrator(&self, identity: String) -> u16 {
-        let identity = identity.as_str();
-        let f = |client: Client<ClientError>| {
-            async move {
-                let node_index: Result<u16, ClientError> = client
-                    .post(&format!("api/identity/{identity}"))
-                    .send()
-                    .await;
-                node_index
-            }
-            .boxed()
-        };
-        self.wait_for_fn_from_orchestrator(f).await
-    }
-
-    /// Returns the run configuration from the orchestrator
-    /// Will block until the configuration is returned
-    pub async fn get_config_from_orchestrator<TYPES: NodeType>(
-        &self,
-        node_index: u16,
-    ) -> NetworkConfig<TYPES::SignatureKey, TYPES::ElectionConfigType> {
-        let f = |client: Client<ClientError>| {
-            async move {
-                let config: Result<
-                    NetworkConfig<TYPES::SignatureKey, TYPES::ElectionConfigType>,
-                    ClientError,
-                > = client
-                    .post(&format!("api/config/{node_index}"))
-                    .send()
-                    .await;
-                config
-            }
-            .boxed()
-        };
-        self.wait_for_fn_from_orchestrator(f).await
-    }
-
-    /// Tells the orchestrator this validator is ready to start
-    /// Blocks until the orchestrator indicates all nodes are ready to start
-    pub async fn wait_for_all_nodes_ready(&self, node_index: u64) -> bool {
-        let send_ready_f = |client: Client<ClientError>| {
-            async move {
-                let result: Result<_, ClientError> = client
-                    .post("api/ready")
-                    .body_json(&node_index)
-                    .unwrap()
-                    .send()
-                    .await;
-                result
-            }
-            .boxed()
-        };
-        self.wait_for_fn_from_orchestrator::<_, _, ()>(send_ready_f)
-            .await;
-
-        let wait_for_all_nodes_ready_f = |client: Client<ClientError>| {
-            async move { client.get("api/start").send().await }.boxed()
-        };
-        self.wait_for_fn_from_orchestrator(wait_for_all_nodes_ready_f)
-            .await
-    }
-
-    /// Generic function that waits for the orchestrator to return a non-error
-    /// Returns whatever type the given function returns
-    pub async fn wait_for_fn_from_orchestrator<F, Fut, GEN>(&self, f: F) -> GEN
-    where
-        F: Fn(Client<ClientError>) -> Fut,
-        Fut: Future<Output = Result<GEN, ClientError>>,
-    {
-        loop {
-            let client = self.client.clone();
-            let res = f(client).await;
-            match res {
-                Ok(x) => break x,
-                Err(_x) => {
-                    async_sleep(Duration::from_millis(250)).await;
-                }
-            }
-        }
     }
 }
 

--- a/examples/infra/modDA.rs
+++ b/examples/infra/modDA.rs
@@ -1,4 +1,4 @@
-use crate::infra::{load_config_from_file, OrchestratorArgs, OrchestratorClient, ValidatorArgs};
+use crate::infra::{load_config_from_file, OrchestratorArgs};
 
 use async_compatibility_layer::logging::{setup_backtrace, setup_logging};
 use async_trait::async_trait;
@@ -14,6 +14,7 @@ use hotshot::{
 };
 use hotshot_orchestrator::{
     self,
+    client::{OrchestratorClient, ValidatorArgs},
     config::{NetworkConfig, WebServerConfig},
 };
 use hotshot_types::traits::{
@@ -122,7 +123,6 @@ pub async fn run_orchestrator_da<
     >(run_config, host, port)
     .await;
 }
-
 
 /// Defines the behavior of a "run" of the network with a given configuration
 #[async_trait]
@@ -513,7 +513,6 @@ where
         self.config.clone()
     }
 }
-
 
 /// Main entry point for validators
 pub async fn main_entry_point<

--- a/examples/libp2p/validator.rs
+++ b/examples/libp2p/validator.rs
@@ -1,6 +1,7 @@
-use crate::infra::{main_entry_point, ValidatorArgs};
+use crate::infra::main_entry_point;
 use clap::Parser;
 use hotshot::demos::vdemo::VDemoTypes;
+use hotshot_orchestrator::client::ValidatorArgs;
 use tracing::instrument;
 
 use crate::types::{NodeImpl, ThisMembership, ThisNetwork, ThisRun};

--- a/examples/web-server-da/validator.rs
+++ b/examples/web-server-da/validator.rs
@@ -1,11 +1,11 @@
-use async_compatibility_layer::logging::{setup_logging, setup_backtrace};
+use async_compatibility_layer::logging::{setup_backtrace, setup_logging};
 use clap::Parser;
 use hotshot::demos::sdemo::SDemoTypes;
 use tracing::instrument;
 
 use crate::types::{DANetwork, NodeImpl, QuorumNetwork, ThisMembership, ThisRun};
 
-use crate::infra::ValidatorArgs;
+use hotshot_orchestrator::client::ValidatorArgs;
 
 pub mod types;
 

--- a/examples/web-server/validator.rs
+++ b/examples/web-server/validator.rs
@@ -1,9 +1,10 @@
 use clap::Parser;
 use hotshot::demos::vdemo::VDemoTypes;
+use hotshot_orchestrator::client::ValidatorArgs;
 use tracing::instrument;
 
 use crate::{
-    infra::{main_entry_point, ValidatorArgs},
+    infra::main_entry_point,
     types::{NodeImpl, ThisMembership, ThisNetwork, ThisRun},
 };
 

--- a/orchestrator/src/client.rs
+++ b/orchestrator/src/client.rs
@@ -1,0 +1,125 @@
+use std::{net::IpAddr, time::Duration};
+
+use crate::config::NetworkConfig;
+use async_compatibility_layer::art::async_sleep;
+use clap::Parser;
+use futures::{Future, FutureExt};
+
+use hotshot_types::traits::node_implementation::NodeType;
+use surf_disco::{error::ClientError, Client};
+
+pub struct OrchestratorClient {
+    client: surf_disco::Client<ClientError>,
+}
+
+// VALIDATOR
+
+#[derive(Parser, Debug, Clone)]
+#[command(
+    name = "Multi-machine consensus",
+    about = "Simulates consensus among multiple machines"
+)]
+/// Arguments passed to the validator
+pub struct ValidatorArgs {
+    /// The address the orchestrator runs on
+    pub host: String,
+    /// The port the orchestrator runs on
+    pub port: u16,
+    /// This node's public IP address, for libp2p
+    /// If no IP address is passed in, it will default to 127.0.0.1
+    pub public_ip: Option<IpAddr>,
+}
+
+impl OrchestratorClient {
+    /// Creates the client that connects to the orchestrator
+    pub async fn connect_to_orchestrator(args: ValidatorArgs) -> Self {
+        let base_url = format!("{0}:{1}", args.host, args.port);
+        let base_url = format!("http://{base_url}").parse().unwrap();
+        let client = surf_disco::Client::<ClientError>::new(base_url);
+        // TODO ED: Add healthcheck wait here
+        OrchestratorClient { client }
+    }
+
+    /// Sends an identify message to the server
+    /// Returns this validator's node_index in the network
+    pub async fn identify_with_orchestrator(&self, identity: String) -> u16 {
+        let identity = identity.as_str();
+        let f = |client: Client<ClientError>| {
+            async move {
+                let node_index: Result<u16, ClientError> = client
+                    .post(&format!("api/identity/{identity}"))
+                    .send()
+                    .await;
+                node_index
+            }
+            .boxed()
+        };
+        self.wait_for_fn_from_orchestrator(f).await
+    }
+
+    /// Returns the run configuration from the orchestrator
+    /// Will block until the configuration is returned
+    pub async fn get_config_from_orchestrator<TYPES: NodeType>(
+        &self,
+        node_index: u16,
+    ) -> NetworkConfig<TYPES::SignatureKey, TYPES::ElectionConfigType> {
+        let f = |client: Client<ClientError>| {
+            async move {
+                let config: Result<
+                    NetworkConfig<TYPES::SignatureKey, TYPES::ElectionConfigType>,
+                    ClientError,
+                > = client
+                    .post(&format!("api/config/{node_index}"))
+                    .send()
+                    .await;
+                config
+            }
+            .boxed()
+        };
+        self.wait_for_fn_from_orchestrator(f).await
+    }
+
+    /// Tells the orchestrator this validator is ready to start
+    /// Blocks until the orchestrator indicates all nodes are ready to start
+    pub async fn wait_for_all_nodes_ready(&self, node_index: u64) -> bool {
+        let send_ready_f = |client: Client<ClientError>| {
+            async move {
+                let result: Result<_, ClientError> = client
+                    .post("api/ready")
+                    .body_json(&node_index)
+                    .unwrap()
+                    .send()
+                    .await;
+                result
+            }
+            .boxed()
+        };
+        self.wait_for_fn_from_orchestrator::<_, _, ()>(send_ready_f)
+            .await;
+
+        let wait_for_all_nodes_ready_f = |client: Client<ClientError>| {
+            async move { client.get("api/start").send().await }.boxed()
+        };
+        self.wait_for_fn_from_orchestrator(wait_for_all_nodes_ready_f)
+            .await
+    }
+
+    /// Generic function that waits for the orchestrator to return a non-error
+    /// Returns whatever type the given function returns
+    async fn wait_for_fn_from_orchestrator<F, Fut, GEN>(&self, f: F) -> GEN
+    where
+        F: Fn(Client<ClientError>) -> Fut,
+        Fut: Future<Output = Result<GEN, ClientError>>,
+    {
+        loop {
+            let client = self.client.clone();
+            let res = f(client).await;
+            match res {
+                Ok(x) => break x,
+                Err(_x) => {
+                    async_sleep(Duration::from_millis(250)).await;
+                }
+            }
+        }
+    }
+}

--- a/orchestrator/src/lib.rs
+++ b/orchestrator/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod client;
 pub mod config;
 
 use async_lock::RwLock;
@@ -193,8 +194,12 @@ where
     KEY: serde::Serialize,
     ELECTION: serde::Serialize,
 {
-    let mut api = Api::<State, ServerError>::from_file("orchestrator/api.toml")
-        .expect("api.toml file is not found");
+    let api_toml = toml::from_str::<toml::Value>(include_str!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/api.toml"
+    )))
+    .expect("API file is not valid toml");
+    let mut api = Api::<State, ServerError>::new(api_toml)?;
     api.post("postidentity", |req, state| {
         async move {
             let identity = req.string_param("identity")?.parse::<IpAddr>();


### PR DESCRIPTION
- Exposes OrchestratorClient for use in external crates
- Load Orchestrator as TOML value instead of from a file path so that external crates can run the orchestrator