### PR TITLE
Doppio benchmarking

### DIFF
--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -17,7 +17,7 @@ mod next_leader;
 mod replica;
 mod sequencing_leader;
 mod sequencing_replica;
-mod traits;
+pub mod traits;
 pub mod utils;
 
 use async_compatibility_layer::async_primitives::subscribable_rwlock::SubscribableRwLock;

--- a/consensus/src/traits.rs
+++ b/consensus/src/traits.rs
@@ -1,8 +1,8 @@
 //! Contains the [`SequencingConsensusApi`] and [`ValidatingConsensusApi`] traits.
 
 use async_trait::async_trait;
-
 use hotshot_types::certificate::QuorumCertificate;
+use hotshot_types::message::DataMessage;
 use hotshot_types::message::{Message, SequencingMessage, ValidatingMessage};
 use hotshot_types::traits::node_implementation::{
     NodeImplementation, NodeType, SequencingExchangesType, ValidatingExchangesType,
@@ -155,6 +155,11 @@ pub trait ValidatingConsensusApi<
         &self,
         message: ValidatingMessage<TYPES, I>,
     ) -> std::result::Result<(), NetworkError>;
+
+    async fn send_transaction(
+        &self,
+        message: DataMessage<TYPES>,
+    ) -> std::result::Result<(), NetworkError>;
 }
 
 /// The API that [`HotStuff`] needs to talk to the system, for sequencing consensus.
@@ -196,5 +201,10 @@ pub trait SequencingConsensusApi<
     async fn send_da_broadcast(
         &self,
         message: SequencingMessage<TYPES, I>,
+    ) -> std::result::Result<(), NetworkError>;
+
+    async fn send_transaction(
+        &self,
+        message: DataMessage<TYPES>,
     ) -> std::result::Result<(), NetworkError>;
 }

--- a/consensus/src/traits.rs
+++ b/consensus/src/traits.rs
@@ -111,6 +111,7 @@ pub trait ConsensusSharedApi<
             event: EventType::Decide {
                 leaf_chain: Arc::new(leaf_views),
                 qc: Arc::new(decide_qc),
+                num_block: None,
             },
         })
         .await;

--- a/deploy/multi-machine-web.Dockerfile
+++ b/deploy/multi-machine-web.Dockerfile
@@ -2,7 +2,7 @@
 FROM ubuntu:jammy
 
 # assuming this is built already
-COPY target/release-lto/examples/multi-machine-web /bin/multi-machine-web
+COPY target/release-lto/examples/web-server-da-validator /bin/web-server-da-validator
 
 # the host to connect to. Must be an IP address
 ENV HOST="0.0.0.0"
@@ -16,4 +16,4 @@ ENV RUST_LOG="warn"
 # log format. JSON no ansi
 ENV RUST_LOG_FORMAT="json"
 
-CMD ["sh", "-c", "/bin/multi-machine-web $HOST $PORT"]
+CMD ["sh", "-c", "/bin/web-server-da-validator $HOST $PORT"]

--- a/examples/infra/mod.rs
+++ b/examples/infra/mod.rs
@@ -388,7 +388,7 @@ pub trait Run<
                             error!("Error in consensus: {:?}", error);
                             // TODO what to do here
                         }
-                        EventType::Decide { leaf_chain, qc } => {
+                        EventType::Decide { leaf_chain, qc, _ } => {
                             // this might be a obob
                             if let Some(leaf) = leaf_chain.get(0) {
                                 let new_anchor = leaf.view_number;

--- a/examples/infra/mod.rs
+++ b/examples/infra/mod.rs
@@ -388,7 +388,7 @@ pub trait Run<
                             error!("Error in consensus: {:?}", error);
                             // TODO what to do here
                         }
-                        EventType::Decide { leaf_chain, qc, _ } => {
+                        EventType::Decide { leaf_chain, qc, num_block } => {
                             // this might be a obob
                             if let Some(leaf) = leaf_chain.get(0) {
                                 let new_anchor = leaf.view_number;

--- a/examples/infra/modDA.rs
+++ b/examples/infra/modDA.rs
@@ -607,7 +607,7 @@ where
                 &host.to_string(),
                 DEFAULT_WEB_SERVER_VIEW_SYNC_PORT,
                 wait_between_polls,
-                pub_key,
+                pub_key.clone(),
                 known_nodes.clone(),
                 false,
             )

--- a/examples/infra/modDA.rs
+++ b/examples/infra/modDA.rs
@@ -365,8 +365,7 @@ pub trait RunDA<
                             error!("Error in consensus: {:?}", error);
                             // TODO what to do here
                         }
-                        EventType::Decide { leaf_chain, qc, _ } => {
-                            error!("In decide handler");
+                        EventType::Decide { leaf_chain, qc, num_block } => {
                             // this might be a obob
                             if let Some(leaf) = leaf_chain.get(0) {
                                 error!("Decide event for leaf: {}", *leaf.view_number);
@@ -377,6 +376,12 @@ pub trait RunDA<
                                 }
     
                             }
+
+                            if num_block.is_some() {
+                                total_transactions += num_block.unwrap();
+                                
+                            }
+
                             num_successful_commits += leaf_chain.len();
                             if num_successful_commits >= rounds {
                                 break;
@@ -451,6 +456,7 @@ pub trait RunDA<
         // This assumes all transactions that were submitted made it through consensus, and does not account for the genesis block
         error!("All {rounds} rounds completed in {total_time_elapsed:?}. {timed_out_views} rounds timed out. {total_size} total bytes submitted");
         error!("Total commitments: {num_successful_commits}");
+        error!("Total transactions committed: {total_transactions}");
     }
 
     /// Returns the da network for this run

--- a/examples/infra/modDA.rs
+++ b/examples/infra/modDA.rs
@@ -386,6 +386,10 @@ pub trait RunDA<
                             if num_successful_commits >= rounds {
                                 break;
                             }
+
+                            if leaf_chain.len() > 1 {
+                                error!("Leaf chain is greater than 1 with len {}", leaf_chain.len());
+                            }
                             // when we make progress, submit new events
                         }
                         EventType::ReplicaViewTimeout { view_number } => {

--- a/examples/infra/modDA.rs
+++ b/examples/infra/modDA.rs
@@ -327,7 +327,7 @@ pub trait RunDA<
 
         error!("Adjusted padding size is {:?} bytes", adjusted_padding);
         let mut timed_out_views: u64 = 0;
-        let mut round = 1;
+        let mut round = 0;
         let mut total_transactions = 0;
         let mut total_commitments = 0;
 
@@ -340,7 +340,7 @@ pub trait RunDA<
 
         let total_nodes_u64 = total_nodes.get() as u64;
 
-        let mut should_submit_txns = node_index == (*anchor_view % total_nodes_u64);
+        let mut should_submit_txns = node_index == (round % total_nodes_u64);
 
         context.hotshot.start_consensus().await;
 
@@ -375,9 +375,7 @@ pub trait RunDA<
                                 if new_anchor >= anchor_view {
                                     anchor_view = leaf.view_number;
                                 }
-                                if (*anchor_view % total_nodes_u64) == node_index {
-                                    should_submit_txns = true;
-                                }
+    
                             }
                             num_successful_commits += leaf_chain.len();
                             if num_successful_commits >= rounds {
@@ -395,6 +393,9 @@ pub trait RunDA<
                             if *view_number > round {
                                 round = *view_number;
                                 tracing::error!("view finished: {:?}", view_number);
+                                if (round % total_nodes_u64) == node_index {
+                                    should_submit_txns = true;
+                                }
 
                             }
                         }

--- a/examples/infra/modDA.rs
+++ b/examples/infra/modDA.rs
@@ -365,7 +365,7 @@ pub trait RunDA<
                             error!("Error in consensus: {:?}", error);
                             // TODO what to do here
                         }
-                        EventType::Decide { leaf_chain, qc } => {
+                        EventType::Decide { leaf_chain, qc, _ } => {
                             error!("In decide handler");
                             // this might be a obob
                             if let Some(leaf) = leaf_chain.get(0) {

--- a/examples/infra/modDA.rs
+++ b/examples/infra/modDA.rs
@@ -572,7 +572,6 @@ where
             wait_between_polls,
         }: WebServerConfig = config.clone().web_server_config.unwrap();
 
-
         let known_nodes = config.config.known_nodes.clone();
 
         let mut _committee_nodes = known_nodes.clone();
@@ -597,6 +596,24 @@ where
             .into(),
         );
 
+        let view_sync_network: WebCommChannel<
+            TYPES,
+            NODE,
+            ViewSyncCertificate<TYPES>,
+            ViewSyncVote<TYPES>,
+            MEMBERSHIP,
+        > = WebCommChannel::new(
+            WebServerNetwork::create(
+                &host.to_string(),
+                DEFAULT_WEB_SERVER_VIEW_SYNC_PORT,
+                wait_between_polls,
+                pub_key,
+                known_nodes.clone(),
+                false,
+            )
+            .into(),
+        );
+
         let WebServerConfig {
             host,
             port,
@@ -615,24 +632,6 @@ where
                 )
                 .into(),
             );
-
-        let view_sync_network: WebCommChannel<
-            TYPES,
-            NODE,
-            ViewSyncCertificate<TYPES>,
-            ViewSyncVote<TYPES>,
-            MEMBERSHIP,
-        > = WebCommChannel::new(
-            WebServerNetwork::create(
-                &host.to_string(),
-                DEFAULT_WEB_SERVER_VIEW_SYNC_PORT,
-                wait_between_polls,
-                pub_key,
-                known_nodes.clone(),
-                false,
-            )
-            .into(),
-        );
 
         WebServerDARun {
             config,

--- a/examples/infra/modDA.rs
+++ b/examples/infra/modDA.rs
@@ -576,7 +576,7 @@ where
             host: da_host,
             port: da_port,
             wait_between_polls: da_wait_between_polls,
-        }: WebServerConfig = config.clone().web_server_config.unwrap();
+        }: WebServerConfig = config.clone().da_web_server_config.unwrap();
 
         let known_nodes = config.config.known_nodes.clone();
 

--- a/examples/infra/modDA.rs
+++ b/examples/infra/modDA.rs
@@ -572,11 +572,6 @@ where
             wait_between_polls,
         }: WebServerConfig = config.clone().web_server_config.unwrap();
 
-        let WebServerConfig {
-            host: da_host,
-            port: da_port,
-            wait_between_polls: da_wait_between_polls,
-        }: WebServerConfig = config.clone().da_web_server_config.unwrap();
 
         let known_nodes = config.config.known_nodes.clone();
 
@@ -602,12 +597,18 @@ where
             .into(),
         );
 
+        let WebServerConfig {
+            host,
+            port,
+            wait_between_polls,
+        }: WebServerConfig = config.clone().da_web_server_config.unwrap();
+
         let da_network: WebCommChannel<TYPES, NODE, DAProposal<TYPES>, DAVote<TYPES>, MEMBERSHIP> =
             WebCommChannel::new(
                 WebServerNetwork::create(
-                    &da_host.to_string(),
-                    da_port,
-                    da_wait_between_polls,
+                    &host.to_string(),
+                    port,
+                    wait_between_polls,
                     pub_key.clone(),
                     known_nodes.clone(),
                     true,

--- a/examples/infra/modDA.rs
+++ b/examples/infra/modDA.rs
@@ -392,7 +392,11 @@ pub trait RunDA<
                             error!("Timed out as the next leader in view {:?}", view_number);
                         }
                         EventType::ViewFinished { view_number } => {
-                            tracing::error!("view finished: {:?}", view_number);
+                            if *view_number > round {
+                                round = *view_number;
+                                tracing::error!("view finished: {:?}", view_number);
+
+                            }
                         }
                         _ => unimplemented!(),
                     }

--- a/orchestrator/src/lib.rs
+++ b/orchestrator/src/lib.rs
@@ -159,7 +159,7 @@ where
     }
 
     fn get_start(&self) -> Result<bool, ServerError> {
-        println!("{}", self.start);
+        // println!("{}", self.start);
         if !self.start {
             return Err(ServerError {
                 status: tide_disco::StatusCode::BadRequest,

--- a/src/types/handle.rs
+++ b/src/types/handle.rs
@@ -191,6 +191,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static> SystemContextHandl
                     event: EventType::Decide {
                         leaf_chain: Arc::new(vec![leaf]),
                         qc: Arc::new(qc),
+                        num_block: None,
                     },
                 };
                 self.output_event_stream.publish(event).await;

--- a/src/types/handle.rs
+++ b/src/types/handle.rs
@@ -203,6 +203,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static> SystemContextHandl
     }
 
     /// begin consensus by sending a genesis event
+    /// Use `start_consensus` on SystemContext instead
     #[deprecated]
     pub async fn start_consensus_deprecated(&self) {
         self.maybe_do_genesis_init().await;

--- a/task-impls/src/consensus.rs
+++ b/task-impls/src/consensus.rs
@@ -775,7 +775,7 @@ where
                                         consensus.saved_blocks.get(leaf.get_deltas_commitment())
                                     {
                                         if let Err(err) = leaf.fill_deltas(block.clone()) {
-                                            warn!("unable to fill leaf {} with block {}, block will not be available: {}",
+                                            error!("unable to fill leaf {} with block {}, block will not be available: {}",
                                                 leaf.commit(), block.commit(), err);
                                         }
                                     }

--- a/task-impls/src/consensus.rs
+++ b/task-impls/src/consensus.rs
@@ -855,6 +855,7 @@ where
                                 event: EventType::Decide {
                                     leaf_chain: Arc::new(leaf_views),
                                     qc: Arc::new(new_decide_qc.unwrap()),
+                                    num_block: Some(included_txn_size),
                                 },
                             });
                             let old_anchor_view = consensus.last_decided_view;

--- a/task-impls/src/consensus.rs
+++ b/task-impls/src/consensus.rs
@@ -554,7 +554,7 @@ where
                 let view_number = self.cur_view.clone();
                 async move {
                     // ED: Changing to 1 second to test timeout logic
-                    async_sleep(Duration::from_millis(5000)).await;
+                    async_sleep(Duration::from_millis(30000)).await;
                     stream
                         .publish(SequencingHotShotEvent::Timeout(ViewNumber::new(
                             *view_number,
@@ -829,7 +829,7 @@ where
                         }
                         #[allow(clippy::cast_precision_loss)]
                         if new_decide_reached {
-                            let mut included_txn_size = 0;
+                            let mut included_txn_count = 0;
                             consensus
                                 .transactions
                                 .modify(|txns| {
@@ -837,9 +837,10 @@ where
                                         .drain()
                                         .filter(|(txn_hash, txn)| {
                                             if included_txns_set.contains(txn_hash) {
-                                                included_txn_size += bincode_opts()
-                                                    .serialized_size(txn)
-                                                    .unwrap_or_default();
+                                                // included_txn_size += bincode_opts()
+                                                //     .serialized_size(txn)
+                                                //     .unwrap_or_default();
+                                                included_txn_count += 1;
                                                 false
                                             } else {
                                                 true
@@ -855,7 +856,7 @@ where
                                 event: EventType::Decide {
                                     leaf_chain: Arc::new(leaf_views),
                                     qc: Arc::new(new_decide_qc.unwrap()),
-                                    num_block: Some(included_txn_size),
+                                    num_block: Some(included_txn_count),
                                 },
                             });
                             let old_anchor_view = consensus.last_decided_view;

--- a/task-impls/src/consensus.rs
+++ b/task-impls/src/consensus.rs
@@ -1090,10 +1090,6 @@ where
 
                 // update the view in state to the one in the message
                 // ED Update_view return a bool whether it actually updated
-                if !self.update_view(new_view).await {
-                    return;
-                }
-
                 // Publish a view change event to the application
                 self.output_event_stream
                     .publish(Event {
@@ -1103,6 +1099,10 @@ where
                         },
                     })
                     .await;
+                if !self.update_view(new_view).await {
+                    return;
+                }
+
                 error!("View Change event for view {}", *new_view);
 
                 // If we are the next leader start polling for votes for this view

--- a/task-impls/src/da.rs
+++ b/task-impls/src/da.rs
@@ -265,6 +265,8 @@ where
                     error!("Throwing away DA proposal");
                     return None;
                 }
+
+                error!("Got a DA block with {} transactions!", proposal.data.deltas.contained_transactions().len());
                 let block_commitment = proposal.data.deltas.commit();
 
                 // ED Is this the right leader?

--- a/task-impls/src/network.rs
+++ b/task-impls/src/network.rs
@@ -275,17 +275,18 @@ impl<
             kind: message_kind,
             _phantom: PhantomData,
         };
-        match transmit_type {
-            TransmitType::Direct => self
-                .channel
-                .direct_message(message, recipient.unwrap())
-                .await
-                .expect("Failed to direct message"),
-            TransmitType::Broadcast => self
-                .channel
-                .broadcast_message(message, membership)
-                .await
-                .expect("Failed to broadcast message"),
+        let transmit_result = match transmit_type {
+            TransmitType::Direct => {
+                self.channel
+                    .direct_message(message, recipient.unwrap())
+                    .await
+            }
+            TransmitType::Broadcast => self.channel.broadcast_message(message, membership).await,
+        };
+
+        match transmit_result {
+            Ok(()) => {}
+            Err(e) => error!("Failed to send message from network task: {:?}", e)
         }
 
         return None;

--- a/task-impls/src/view_sync.rs
+++ b/task-impls/src/view_sync.rs
@@ -464,7 +464,7 @@ where
                 }
 
                 self.num_timeouts_tracked += 1;
-                warn!("Num timeouts tracked is {}", self.num_timeouts_tracked);
+                error!("Num timeouts tracked is {}", self.num_timeouts_tracked);
 
                 if self.num_timeouts_tracked > 2 {
                     panic!("Too many timeouts!  This shouldn't happen");

--- a/testing/src/app_tasks/safety_task.rs
+++ b/testing/src/app_tasks/safety_task.rs
@@ -216,7 +216,7 @@ impl<TYPES: NodeType, I: TestableNodeImplementation<TYPES::ConsensusType, TYPES>
                                             ViewStatus::ViewFailed(ViewFailed(error)),
                                         );
                                     }
-                                    EventType::Decide { leaf_chain, qc } => {
+                                    EventType::Decide { leaf_chain, qc, .. } => {
                                         // for leaf in leaf_chain {
                                         // TODO how to test this
                                         // }

--- a/testing/src/app_tasks/test_builder.rs
+++ b/testing/src/app_tasks/test_builder.rs
@@ -3,14 +3,17 @@ use hotshot_types::traits::election::{ConsensusExchange, Membership};
 use std::num::NonZeroUsize;
 use std::time::Duration;
 
-use hotshot::traits::TestableNodeImplementation;
-use hotshot_types::message::Message;
-use hotshot_types::traits::network::CommunicationChannel;
-use hotshot_types::traits::node_implementation::{NodeType, QuorumCommChannel, QuorumEx};
-use hotshot_types::{ExecutionType, HotShotConfig};
-
+use hotshot_types::message::SequencingMessage;
 use crate::test_builder::TimingData;
 use crate::test_launcher::ResourceGenerators;
+use hotshot::traits::TestableNodeImplementation;
+use hotshot_types::message::Message;
+use hotshot_types::traits::consensus_type::sequencing_consensus::SequencingConsensus;
+use hotshot_types::traits::network::CommunicationChannel;
+use hotshot_types::traits::node_implementation::NodeImplementation;
+use hotshot_types::traits::node_implementation::SequencingExchangesType;
+use hotshot_types::traits::node_implementation::{NodeType, QuorumCommChannel, QuorumEx};
+use hotshot_types::{ExecutionType, HotShotConfig};
 
 use super::completion_task::{CompletionTaskDescription, TimeBasedCompletionTaskDescription};
 use super::safety_task::SafetyTaskDescription;
@@ -91,6 +94,10 @@ impl TestMetadata {
             <QuorumEx<TYPES, I> as ConsensusExchange<TYPES, Message<TYPES, I>>>::Vote,
             <QuorumEx<TYPES, I> as ConsensusExchange<TYPES, Message<TYPES, I>>>::Membership,
         >,
+        TYPES: NodeType<ConsensusType = SequencingConsensus>,
+        <I as NodeImplementation<TYPES>>::Exchanges:
+            SequencingExchangesType<TYPES, Message<TYPES, I>>,
+            I: NodeImplementation<TYPES, ConsensusMessage = SequencingMessage<TYPES, I>>
     {
         let TestMetadata {
             total_nodes,

--- a/testing/src/app_tasks/txn_task.rs
+++ b/testing/src/app_tasks/txn_task.rs
@@ -1,9 +1,14 @@
 use async_compatibility_layer::{art::async_sleep, channel::UnboundedStream};
-use std::{sync::Arc, time::Duration};
-
 use either::Either::{self, Left, Right};
 use futures::{future::BoxFuture, FutureExt};
 use hotshot::traits::{NodeImplementation, TestableNodeImplementation};
+use hotshot::HotShotSequencingConsensusApi;
+use hotshot_consensus::traits::SequencingConsensusApi;
+use hotshot_types::traits::state::ConsensusTime;
+use hotshot_types::message::DataMessage;
+use hotshot_types::message::Message;
+use hotshot_types::message::SequencingMessage;
+use hotshot_types::traits::node_implementation::SequencingExchangesType;
 use hotshot_task::{
     boxed_sync,
     event_stream::{ChannelStream, SendableStream},
@@ -15,9 +20,11 @@ use hotshot_task::{
     task_impls::{HSTWithEvent, HSTWithEventAndMessage, TaskBuilder},
     GeneratedStream, Merge,
 };
+use hotshot_types::traits::consensus_type::sequencing_consensus::SequencingConsensus;
 use hotshot_types::{event::Event, traits::node_implementation::NodeType};
 use rand::thread_rng;
 use snafu::Snafu;
+use std::{sync::Arc, time::Duration};
 
 use crate::test_runner::Node;
 
@@ -75,7 +82,10 @@ impl TxnTaskDescription {
             ChannelStream<GlobalTestEvent>,
         )
             -> BoxFuture<'static, (HotShotTaskId, BoxFuture<'static, HotShotTaskCompleted>)>,
-    > {
+    > 
+    where TYPES: NodeType<ConsensusType = SequencingConsensus>, 
+    <I as NodeImplementation<TYPES>>::Exchanges: SequencingExchangesType<TYPES, Message<TYPES, I>>, I: NodeImplementation<TYPES, ConsensusMessage = SequencingMessage<TYPES, I>>
+    {
         Box::new(move |state, mut registry, test_event_stream| {
             async move {
                 // consistency check
@@ -128,8 +138,10 @@ impl TxnTaskDescription {
                                             &mut thread_rng(),
                                             0,
                                         );
-                                        node.handle
-                                            .submit_transaction(txn.clone())
+                                        let api = HotShotSequencingConsensusApi {
+                                            inner: node.handle.hotshot.inner.clone(),
+                                        };
+                                        api.send_transaction(DataMessage::SubmitTransaction(txn.clone(), TYPES::Time::new(0)))
                                             .await
                                             .expect("Could not send transaction");
                                         return (None, state);

--- a/testing/src/app_tasks/txn_task.rs
+++ b/testing/src/app_tasks/txn_task.rs
@@ -138,6 +138,8 @@ impl TxnTaskDescription {
                                             &mut thread_rng(),
                                             0,
                                         );
+
+                                        // ED Shouldn't create this each time
                                         let api = HotShotSequencingConsensusApi {
                                             inner: node.handle.hotshot.inner.clone(),
                                         };

--- a/types/src/event.rs
+++ b/types/src/event.rs
@@ -44,6 +44,8 @@ pub enum EventType<TYPES: NodeType, LEAF: LeafType<NodeType = TYPES>> {
         /// Note that the QC for each additional leaf in the chain can be obtained from the leaf
         /// before it using
         qc: Arc<QuorumCertificate<TYPES, LEAF>>,
+        /// Optional information of the number of blocks in the transaction, for logging purposes.
+        num_block: Option<u64>,
     },
     /// A replica task was canceled by a timeout interrupt
     ReplicaViewTimeout {

--- a/web_server/src/lib.rs
+++ b/web_server/src/lib.rs
@@ -27,9 +27,9 @@ type Error = ServerError;
 
 // TODO ED: Below values should be in a config file
 /// How many views to keep in memory
-const MAX_VIEWS: usize = 10;
+const MAX_VIEWS: usize = 100;
 /// How many transactions to keep in memory
-const MAX_TXNS: usize = 10;
+const MAX_TXNS: usize = 1000;
 
 /// State that tracks proposals and votes the server receives
 /// Data is stored as a `Vec<u8>` to not incur overhead from deserializing

--- a/web_server/src/lib.rs
+++ b/web_server/src/lib.rs
@@ -372,6 +372,8 @@ impl<KEY: SignatureKey> WebServerDataSource<KEY> for WebServerState<KEY> {
         self.transactions.insert(self.num_txns, txn);
         self.num_txns += 1;
 
+        error!("Received transaction!  Number of transactions received is: {}", self.num_txns);
+
         Ok(())
     }
 


### PR DESCRIPTION
Some updates from benchmarking: 
* Remove panic from failed message send in the network task
* Update testing harness and examples to use `send_transaction` instead of `submit_transaction`.  The former makes use of the event for sending transactions and allows the transactions to be submitted to the committee network
  * Unfortunately the above (at least to get it working quickly for benching) required making the testing harness sequencing consensus specific.  I think this is fine, but let's discuss in our next meeting
*  Updates some logging since we only log ERROR level in the benchmarks
* Logs the number of transactions committed upon a decide event and upon getting a DA proposal.  

We may not merge all of these changes in, but I wanted feedback to make sure this branch doesn't diverge too much from `run_view_refactor`