### PR TITLE
Update DA task and test builder to fix commitment inconsistency and memory leak

### DIFF
--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -249,7 +249,7 @@ impl<TYPES: NodeType, LEAF: LeafType<NodeType = TYPES>> Consensus<TYPES, LEAF> {
     }
 
     /// garbage collects based on state change
-    /// right now, this removes from both the `saved_leaves`
+    /// right now, this removes from both the `saved_blocks`
     /// and `state_map` fields of `Consensus`
     #[allow(clippy::unused_async)] // async for API compatibility reasons
     pub async fn collect_garbage(

--- a/consensus/src/traits.rs
+++ b/consensus/src/traits.rs
@@ -111,7 +111,7 @@ pub trait ConsensusSharedApi<
             event: EventType::Decide {
                 leaf_chain: Arc::new(leaf_views),
                 qc: Arc::new(decide_qc),
-                num_block: None,
+                block_size: None,
             },
         })
         .await;

--- a/examples/infra/mod.rs
+++ b/examples/infra/mod.rs
@@ -388,7 +388,7 @@ pub trait Run<
                             error!("Error in consensus: {:?}", error);
                             // TODO what to do here
                         }
-                        EventType::Decide { leaf_chain, qc, num_block } => {
+                        EventType::Decide { leaf_chain, qc, _ } => {
                             // this might be a obob
                             if let Some(leaf) = leaf_chain.get(0) {
                                 let new_anchor = leaf.view_number;

--- a/examples/infra/modDA.rs
+++ b/examples/infra/modDA.rs
@@ -377,7 +377,7 @@ pub trait RunDA<
                             error!("Error in consensus: {:?}", error);
                             // TODO what to do here
                         }
-                        EventType::Decide { leaf_chain, qc, num_block } => {
+                        EventType::Decide { leaf_chain, qc, block_size } => {
                             // this might be a obob
                             if let Some(leaf) = leaf_chain.get(0) {
                                 error!("Decide event for leaf: {}", *leaf.view_number);
@@ -389,8 +389,8 @@ pub trait RunDA<
     
                             }
 
-                            if num_block.is_some() {
-                                total_transactions += num_block.unwrap();
+                            if block_size.is_some() {
+                                total_transactions += block_size.unwrap();
                                 
                             }
 

--- a/src/types/handle.rs
+++ b/src/types/handle.rs
@@ -191,7 +191,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static> SystemContextHandl
                     event: EventType::Decide {
                         leaf_chain: Arc::new(vec![leaf]),
                         qc: Arc::new(qc),
-                        num_block: None,
+                        block_size: None,
                     },
                 };
                 self.output_event_stream.publish(event).await;

--- a/task-impls/src/consensus.rs
+++ b/task-impls/src/consensus.rs
@@ -851,7 +851,7 @@ where
                                 event: EventType::Decide {
                                     leaf_chain: Arc::new(leaf_views),
                                     qc: Arc::new(new_decide_qc.unwrap()),
-                                    num_block: Some(included_txns_set.len().try_into().unwrap()),
+                                    block_size: Some(included_txns_set.len().try_into().unwrap()),
                                 },
                             });
                             let old_anchor_view = consensus.last_decided_view;

--- a/testing/src/app_tasks/test_builder.rs
+++ b/testing/src/app_tasks/test_builder.rs
@@ -68,7 +68,9 @@ impl Default for TestMetadata {
             },
             overall_safety_properties: OverallSafetyPropertiesDescription {},
             // arbitrary, haven't done the math on this
-            txn_description: TxnTaskDescription::RoundRobinTimeBased(Duration::from_millis(10)),
+            // Set the duration large to make the transaction submission slow, avoiding memory
+            // leaks.
+            txn_description: TxnTaskDescription::RoundRobinTimeBased(Duration::from_millis(1000)),
             completion_task_description: CompletionTaskDescription::TimeBasedCompletionTaskBuilder(
                 TimeBasedCompletionTaskDescription {
                     // TODO ED Put a configurable time here - 10 seconds for now

--- a/types/src/event.rs
+++ b/types/src/event.rs
@@ -44,8 +44,8 @@ pub enum EventType<TYPES: NodeType, LEAF: LeafType<NodeType = TYPES>> {
         /// Note that the QC for each additional leaf in the chain can be obtained from the leaf
         /// before it using
         qc: Arc<QuorumCertificate<TYPES, LEAF>>,
-        /// Optional information of the number of blocks in the transaction, for logging purposes.
-        num_block: Option<u64>,
+        /// Optional information of the number of transactions in the block, for logging purposes.
+        block_size: Option<u64>,
     },
     /// A replica task was canceled by a timeout interrupt
     ReplicaViewTimeout {


### PR DESCRIPTION
- Allows DA proposal that's one view old.
- Decreases txn submission frequency.
- Adds logging for txn size.
- Renames `num_block` to `block_size`.

Closes https://github.com/EspressoSystems/HotShot/issues/1424.