### PR TITLE
Update TransactionRecv event and message handling

### DIFF
--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -388,9 +388,7 @@ where
             };
             let id = handle.hotshot.inner.id;
             async move {
-                for message in messages.0 {
-                    state.handle_message(message, id).await;
-                }
+                state.handle_messages(messages.0, id).await;
                 (None, state)
             }
             .boxed()

--- a/task-impls/src/events.rs
+++ b/task-impls/src/events.rs
@@ -36,8 +36,7 @@ pub enum SequencingHotShotEvent<TYPES: NodeType, I: NodeImplementation<TYPES>> {
     ViewSyncCertificateRecv(Proposal<ViewSyncProposalType<TYPES, I>>),
     ViewSyncTrigger(ViewNumber),
     Timeout(ViewNumber),
-    TransactionRecv(TYPES::Transaction),
-    TransactionSend(TYPES::Transaction, TYPES::SignatureKey),
+    TransactionsRecv(Vec<TYPES::Transaction>),
 
     // Event to send DA block data from DA leader to next quorum leader (which should always be the same node)
     SendDABlockData(TYPES::BlockType),

--- a/task-impls/src/network.rs
+++ b/task-impls/src/network.rs
@@ -111,6 +111,7 @@ impl<
                     };
                     // TODO (Keyao benchmarking) Update these event variants (similar to the
                     // `TransactionsRecv` event) so we can send one event for a vector of messages.
+                    // <https://github.com/EspressoSystems/HotShot/issues/1428>
                     self.event_stream.publish(event).await;
                 }
                 MessageKind::Data(message) => match message {

--- a/task-impls/src/network.rs
+++ b/task-impls/src/network.rs
@@ -69,54 +69,63 @@ impl<
     > NetworkMessageTaskState<TYPES, I>
 {
     /// Handle the message.
-    pub async fn handle_message(&mut self, message: Message<TYPES, I>, id: u64) {
-        let sender = message.sender;
-        let event = match message.kind {
-            MessageKind::Consensus(consensus_message) => match consensus_message.0 {
-                Either::Left(general_message) => match general_message {
-                    GeneralConsensusMessage::Proposal(proposal) => {
-                        SequencingHotShotEvent::QuorumProposalRecv(proposal.clone(), sender)
-                    }
-                    GeneralConsensusMessage::Vote(vote) => {
-                        SequencingHotShotEvent::QuorumVoteRecv(vote.clone())
-                    }
-                    GeneralConsensusMessage::ViewSyncVote(view_sync_message) => {
-                        SequencingHotShotEvent::ViewSyncVoteRecv(view_sync_message)
-                    }
-                    GeneralConsensusMessage::ViewSyncCertificate(view_sync_message) => {
-                        SequencingHotShotEvent::ViewSyncCertificateRecv(view_sync_message)
-                    }
-                    _ => {
-                        error!("Got unexpected message type in network task!");
-                        return;
-                    }
-                },
-                Either::Right(committee_message) => match committee_message {
-                    CommitteeConsensusMessage::DAProposal(proposal) => {
-                        SequencingHotShotEvent::DAProposalRecv(proposal.clone(), sender)
-                    }
-                    CommitteeConsensusMessage::DAVote(vote) => {
-                        // error!("DA Vote message recv {:?}", vote.current_view);
-                        SequencingHotShotEvent::DAVoteRecv(vote.clone())
-                    }
-                    CommitteeConsensusMessage::DACertificate(cert) => {
-                        // panic!("Recevid DA C! ");
-                        SequencingHotShotEvent::DACRecv(cert)
-                    }
-                },
-            },
-            MessageKind::Data(message) => {
-                match message {
-                    // ED Why do we need the view number in the transaction?
-                    hotshot_types::message::DataMessage::SubmitTransaction(
-                        transaction,
-                        view_number,
-                    ) => SequencingHotShotEvent::TransactionRecv(transaction),
+    pub async fn handle_messages(&mut self, messages: Vec<Message<TYPES, I>>, id: u64) {
+        // We will send only one event for a vector of transactions.
+        let mut transactions = Vec::new();
+        for message in messages {
+            let sender = message.sender;
+            match message.kind {
+                MessageKind::Consensus(consensus_message) => {
+                    let event = match consensus_message.0 {
+                        Either::Left(general_message) => match general_message {
+                            GeneralConsensusMessage::Proposal(proposal) => {
+                                SequencingHotShotEvent::QuorumProposalRecv(proposal.clone(), sender)
+                            }
+                            GeneralConsensusMessage::Vote(vote) => {
+                                SequencingHotShotEvent::QuorumVoteRecv(vote.clone())
+                            }
+                            GeneralConsensusMessage::ViewSyncVote(view_sync_message) => {
+                                SequencingHotShotEvent::ViewSyncVoteRecv(view_sync_message)
+                            }
+                            GeneralConsensusMessage::ViewSyncCertificate(view_sync_message) => {
+                                SequencingHotShotEvent::ViewSyncCertificateRecv(view_sync_message)
+                            }
+                            _ => {
+                                error!("Got unexpected message type in network task!");
+                                return;
+                            }
+                        },
+                        Either::Right(committee_message) => match committee_message {
+                            CommitteeConsensusMessage::DAProposal(proposal) => {
+                                SequencingHotShotEvent::DAProposalRecv(proposal.clone(), sender)
+                            }
+                            CommitteeConsensusMessage::DAVote(vote) => {
+                                // error!("DA Vote message recv {:?}", vote.current_view);
+                                SequencingHotShotEvent::DAVoteRecv(vote.clone())
+                            }
+                            CommitteeConsensusMessage::DACertificate(cert) => {
+                                // panic!("Recevid DA C! ");
+                                SequencingHotShotEvent::DACRecv(cert)
+                            }
+                        },
+                    };
+                    // TODO (Keyao benchmarking) Update these event variants (similar to the
+                    // `TransactionsRecv` event) so we can send one event for a vector of messages.
+                    self.event_stream.publish(event).await;
                 }
-            }
-            MessageKind::_Unreachable(_) => unimplemented!(),
-        };
-        self.event_stream.publish(event).await;
+                MessageKind::Data(message) => match message {
+                    hotshot_types::message::DataMessage::SubmitTransaction(transaction, _) => {
+                        transactions.push(transaction)
+                    }
+                },
+                MessageKind::_Unreachable(_) => unimplemented!(),
+            };
+        }
+        if !transactions.is_empty() {
+            self.event_stream
+                .publish(SequencingHotShotEvent::TransactionsRecv(transactions))
+                .await;
+        }
     }
 }
 
@@ -247,15 +256,6 @@ impl<
                     Some(membership.get_leader(vote.round() + vote.relay())),
                 )
             }
-            SequencingHotShotEvent::TransactionSend(transaction, sender) => (
-                sender,
-                MessageKind::<SequencingConsensus, TYPES, I>::from(DataMessage::SubmitTransaction(
-                    transaction,
-                    TYPES::Time::new(*self.view),
-                )),
-                TransmitType::Broadcast,
-                None,
-            ),
             SequencingHotShotEvent::ViewChange(view) => {
                 // only if view actually changes
                 self.view = view;
@@ -286,7 +286,7 @@ impl<
 
         match transmit_result {
             Ok(()) => {}
-            Err(e) => error!("Failed to send message from network task: {:?}", e)
+            Err(e) => error!("Failed to send message from network task: {:?}", e),
         }
 
         return None;
@@ -317,8 +317,7 @@ impl<
             SequencingHotShotEvent::DAProposalSend(_, _)
             | SequencingHotShotEvent::DAVoteSend(_)
             | SequencingHotShotEvent::Shutdown
-            | SequencingHotShotEvent::ViewChange(_)
-            | SequencingHotShotEvent::TransactionSend(_, _) => true,
+            | SequencingHotShotEvent::ViewChange(_) => true,
 
             _ => false,
         }


### PR DESCRIPTION
- Modifies the network task to handle a vec of messages.
  - For txn messages: send one event for all.
  - For other messages: send one event for each.
- Updates the `TransactionRecv` event to `TransactionsRecv` that takes a vec of transactions.
- Removes the `TransactionSend` event.

Closes https://github.com/EspressoSystems/HotShot/issues/1426.