### PR TITLE
Discard Seen Transactions

### DIFF
--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -28,6 +28,7 @@ pub use next_leader::NextValidatingLeader;
 pub use replica::Replica;
 pub use sequencing_leader::{ConsensusLeader, ConsensusNextLeader, DALeader};
 pub use sequencing_replica::SequencingReplica;
+use std::collections::HashSet;
 pub use traits::{ConsensusSharedApi, SequencingConsensusApi, ValidatingConsensusApi};
 pub use utils::{View, ViewInner};
 
@@ -70,6 +71,9 @@ pub struct Consensus<TYPES: NodeType, LEAF: LeafType<NodeType = TYPES>> {
 
     /// A list of undecided transactions
     pub transactions: Arc<SubscribableRwLock<CommitmentMap<TYPES::Transaction>>>,
+
+    /// A list of transactions we've seen decided, but didn't receive
+    pub seen_transactions: HashSet<Commitment<TYPES::Transaction>>,
 
     /// Map of leaf hash -> leaf
     /// - contains undecided leaves

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,7 +104,7 @@ use nll::nll_todo::nll_todo;
 use snafu::ResultExt;
 
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::{BTreeMap, HashMap, HashSet},
     marker::PhantomData,
     num::NonZeroUsize,
     sync::Arc,
@@ -244,6 +244,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> SystemContext<TYPES::Consens
             cur_view: start_view,
             last_decided_view: anchored_leaf.get_view_number(),
             transactions: Arc::default(),
+            seen_transactions: HashSet::new(),
             saved_leaves,
             saved_blocks,
             // TODO this is incorrect

--- a/task-impls/src/consensus.rs
+++ b/task-impls/src/consensus.rs
@@ -1,5 +1,6 @@
 use crate::events::SequencingHotShotEvent;
 use async_compatibility_layer::art::{async_sleep, async_spawn};
+use async_compatibility_layer::async_primitives::subscribable_rwlock::ReadView;
 use async_lock::RwLock;
 use async_lock::RwLockUpgradableReadGuard;
 #[cfg(feature = "async-std-executor")]
@@ -830,6 +831,14 @@ where
                         if new_decide_reached {
                             let mut included_txn_size = 0;
                             let mut included_txn_count = 0;
+                            let txns = consensus.transactions.cloned().await;
+                            // store transactions in this block we never added to our transactions.
+                            included_txns_set.iter().map(|hash| {
+                                if !txns.contains_key(hash) {
+                                    consensus.seen_transactions.insert(hash.clone());
+                                }
+                            });
+                            drop(txns);
                             consensus
                                 .transactions
                                 .modify(|txns| {
@@ -849,6 +858,7 @@ where
                                         .collect();
                                 })
                                 .await;
+
                             consensus
                                 .metrics
                                 .outstanding_transactions

--- a/task-impls/src/da.rs
+++ b/task-impls/src/da.rs
@@ -242,7 +242,7 @@ where
             SequencingHotShotEvent::TransactionsRecv(transactions) => {
                 // TODO ED Add validation checks
 
-                let consensus = self.consensus.read().await;
+                let mut consensus = self.consensus.write().await;
                 consensus
                     .get_transactions()
                     .modify(|txns| {
@@ -250,7 +250,7 @@ where
                             let size = bincode_opts().serialized_size(&transaction).unwrap_or(0);
 
                             // If we didn't already know about this transaction, update our mempool metrics.
-                            if txns.insert(transaction.commit(), transaction).is_none() {
+                            if !consensus.seen_transactions.remove(&transaction.commit()) && txns.insert(transaction.commit(), transaction).is_none() {
                                 consensus.metrics.outstanding_transactions.update(1);
                                 consensus
                                     .metrics

--- a/testing/src/overall_safety_task.rs
+++ b/testing/src/overall_safety_task.rs
@@ -31,7 +31,7 @@ use hotshot_types::{
 use nll::nll_todo::nll_todo;
 use snafu::Snafu;
 use std::marker::PhantomData;
-use tracing::{info, error};
+use tracing::{error, info};
 
 use crate::test_runner::Node;
 pub type StateAndBlock<S, B> = (Vec<S>, Vec<B>);

--- a/testing/tests/basic.rs
+++ b/testing/tests/basic.rs
@@ -24,7 +24,11 @@ async fn test_basic() {
 async fn test_with_failures() {
     use std::time::Duration;
 
-    use hotshot_testing::{spinning_task::SpinningTaskDescription, overall_safety_task::OverallSafetyPropertiesDescription, completion_task::TimeBasedCompletionTaskDescription};
+    use hotshot_testing::{
+        completion_task::TimeBasedCompletionTaskDescription,
+        overall_safety_task::OverallSafetyPropertiesDescription,
+        spinning_task::SpinningTaskDescription,
+    };
 
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();

--- a/types/src/data.rs
+++ b/types/src/data.rs
@@ -533,9 +533,7 @@ impl<TYPES: NodeType> PartialEq for SequencingLeaf<TYPES> {
             Either::Right(deltas) => deltas.clone(),
         };
         let delta_right = match &other.deltas {
-            Either::Left(deltas) => {
-                deltas.commit()
-            },
+            Either::Left(deltas) => deltas.commit(),
             Either::Right(deltas) => deltas.clone(),
         };
         self.view_number == other.view_number
@@ -556,10 +554,10 @@ impl<TYPES: NodeType> Hash for SequencingLeaf<TYPES> {
         match &self.deltas {
             Either::Left(deltas) => {
                 deltas.commit().hash(state);
-            },
+            }
             Either::Right(commitment) => {
                 commitment.hash(state);
-            },
+            }
         }
         // self.deltas.hash(state.commit());
         self.rejected.hash(state);


### PR DESCRIPTION
Current logic only considers the parent leaf's transactions when building blocks and removes transactions from our transaction store when they are decided.  New transactions are always added to the our transaction store.  The assumption was that the replica would keep it's transaction list constantly up to date with the network.  However we only poll transactions when we know we need them.  This means we see transactions committed which never our transaction store.  Late when we poll transactions we may download a bunch of transactions we previously saw and then propose them.  

The solution in this PR is to filter transactions before adding to our store if we know the transaction was in a previous block.  This should prevent us from knowingly proposing duplicate transactions.  

There may be a memory leak with this solution.  If the buffer on the webserver is removing old transactions before new leaders download them, Then old transactions will never be removed.   We're only storing the commitments so it shouldn't be a major issue.  We will want to eventually come up with a proper solution to this.  Probably the next thing to do would be make this hash set have a bounded number of entries and remove FIFO
