### PR TITLE
feat: global registry now cleans up after itself

### DIFF
--- a/task/src/global_registry.rs
+++ b/task/src/global_registry.rs
@@ -92,9 +92,9 @@ impl GlobalRegistry {
         // and debatable how often the other op needs to be run
         // probably much much less often
         let list = self.state_list.read().await;
-        let list_keys: BTreeSet<usize> = list.iter().map(|(k, _v)| k).cloned().collect();
+        let list_keys: BTreeSet<usize> = list.keys().cloned().collect();
         let cache_keys: BTreeSet<usize> =
-            self.state_cache.iter().map(|(k, _v)| k).cloned().collect();
+            self.state_cache.keys().cloned().collect();
         // bleh not as efficient
         let missing_key_list = list_keys.difference(&cache_keys);
         let expired_key_list = cache_keys.difference(&list_keys);

--- a/task/src/global_registry.rs
+++ b/task/src/global_registry.rs
@@ -31,7 +31,7 @@ pub type HotShotTaskId = usize;
 #[derive(Debug, Clone)]
 pub struct GlobalRegistry {
     /// up-to-date shared list of statuses
-    /// only used if `state_cpy` is out of date
+    /// only used if `state_cache` is out of date
     /// or if appending
     state_list: Arc<RwLock<BTreeMap<HotShotTaskId, (TaskState, String)>>>,
     /// possibly stale read version of state

--- a/task/src/global_registry.rs
+++ b/task/src/global_registry.rs
@@ -71,7 +71,8 @@ impl GlobalRegistry {
             .last_key_value()
             .map(|(k, _v)| k)
             .cloned()
-            .unwrap_or_default();
+            .unwrap_or_default()
+            + 1;
         let new_entry = (status.clone(), name.to_string());
         let new_entry_dup = new_entry.0.clone();
         list.insert(next_id, new_entry.clone());
@@ -93,8 +94,7 @@ impl GlobalRegistry {
         // probably much much less often
         let list = self.state_list.read().await;
         let list_keys: BTreeSet<usize> = list.keys().cloned().collect();
-        let cache_keys: BTreeSet<usize> =
-            self.state_cache.keys().cloned().collect();
+        let cache_keys: BTreeSet<usize> = self.state_cache.keys().cloned().collect();
         // bleh not as efficient
         let missing_key_list = list_keys.difference(&cache_keys);
         let expired_key_list = cache_keys.difference(&list_keys);


### PR DESCRIPTION
Closes #1379 . The global registry will now remove tasks upon shutdown of tasks. Note: this iteration of the global registry is not going to be as fast as before because we lose the assumption that taskid == vec idx. I wasn't very clever in `update_cache`, but I don't think this makes much of a difference. The happy path is still fast and hit most often. The sad path being slightly slower shouldn't matter that much.