### PR TITLE
Clean up signature schemes, only use BN254

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1150,9 +1150,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "axum"
-version = "0.6.19"
+version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6a1de45611fdb535bfde7b7de4fd54f4fd2b17b1737c0a59b69bf9b92074b8c"
+checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
 dependencies = [
  "async-trait",
  "axum-core",
@@ -3482,6 +3482,7 @@ dependencies = [
  "libp2p-networking",
  "nll",
  "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "serde",
  "serde_json",
  "snafu",
@@ -4072,7 +4073,7 @@ dependencies = [
 [[package]]
 name = "jf-primitives"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/EspressoSystems/jellyfish?branch=hotshot-compat#58eb45ab189364a2538e5ccaa912a3afdabd2bd1"
+source = "git+https://github.com/EspressoSystems/jellyfish?branch=hotshot-compat#03b11e4f71268dd884b07a43d117331df7d611a2"
 dependencies = [
  "anyhow",
  "ark-bls12-377 0.4.0",
@@ -4118,7 +4119,7 @@ dependencies = [
 [[package]]
 name = "jf-relation"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/EspressoSystems/jellyfish?branch=hotshot-compat#58eb45ab189364a2538e5ccaa912a3afdabd2bd1"
+source = "git+https://github.com/EspressoSystems/jellyfish?branch=hotshot-compat#03b11e4f71268dd884b07a43d117331df7d611a2"
 dependencies = [
  "ark-bls12-377 0.4.0",
  "ark-bls12-381 0.4.0",
@@ -4187,7 +4188,7 @@ dependencies = [
 [[package]]
 name = "jf-utils"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/EspressoSystems/jellyfish?branch=hotshot-compat#58eb45ab189364a2538e5ccaa912a3afdabd2bd1"
+source = "git+https://github.com/EspressoSystems/jellyfish?branch=hotshot-compat#03b11e4f71268dd884b07a43d117331df7d611a2"
 dependencies = [
  "ark-ec 0.4.2",
  "ark-ff 0.4.2",
@@ -5104,9 +5105,9 @@ checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
 name = "matchit"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67827e6ea8ee8a7c4a72227ef4fc08957040acffdb5f122733b24fa12daff41b"
+checksum = "ed1202b2a6f884ae56f04cff409ab315c5ce26b5e58d7412e484f01fd52f52ef"
 
 [[package]]
 name = "maud"
@@ -7138,9 +7139,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.180"
+version = "1.0.181"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea67f183f058fe88a4e3ec6e2788e003840893b91bac4559cabedd00863b3ed"
+checksum = "6d3e73c93c3240c0bda063c239298e633114c69a888c3e37ca8bb33f343e9890"
 dependencies = [
  "serde_derive",
 ]
@@ -7156,9 +7157,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.180"
+version = "1.0.181"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24e744d7782b686ab3b73267ef05697159cc0e5abbed3f47f9933165e5219036"
+checksum = "be02f6cb0cd3a5ec20bbcfbcbd749f57daddb1a0882dc2e46a6c236c90b977ed"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -747,7 +747,7 @@ dependencies = [
  "num-traits",
  "rusticata-macros",
  "thiserror",
- "time 0.3.23",
+ "time 0.3.25",
 ]
 
 [[package]]
@@ -763,7 +763,7 @@ dependencies = [
  "num-traits",
  "rusticata-macros",
  "thiserror",
- "time 0.3.23",
+ "time 0.3.25",
 ]
 
 [[package]]
@@ -1054,7 +1054,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -1071,7 +1071,7 @@ checksum = "cc6dde6e4ed435a4c1ee4e73592f5ba9da2151af10076cc04858746af9352d09"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -1434,9 +1434,12 @@ checksum = "a2698f953def977c68f935bb0dfa959375ad4638570e969e2f1e9f433cbf1af6"
 
 [[package]]
 name = "cc"
-version = "1.0.79"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+checksum = "6c6b2562119bf28c3439f7f02db99faf0aa1a8cdfe5772a2ee155d32227239f0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "ccm"
@@ -1593,7 +1596,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -2031,9 +2034,9 @@ dependencies = [
 
 [[package]]
 name = "curl-sys"
-version = "0.4.63+curl-8.1.2"
+version = "0.4.65+curl-8.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aeb0fef7046022a1e2ad67a004978f0e3cacb9e3123dc62ce768f92197b771dc"
+checksum = "961ba061c9ef2fe34bbd12b807152d96f0badd2bebe7b90ce6c8c8b7572a0986"
 dependencies = [
  "cc",
  "libc",
@@ -2137,7 +2140,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.10.0",
- "syn 2.0.27",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -2159,7 +2162,7 @@ checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
 dependencies = [
  "darling_core 0.20.3",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -2247,6 +2250,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7684a49fb1af197853ef7b2ee694bc1f5b4179556f1e5710e1760c5db6f5e929"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "derivative"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2265,7 +2277,7 @@ checksum = "53e0efad4403bfc52dc201159c4b842a246a14b98c64b55dfd0f2d89729dfeb8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -2397,7 +2409,7 @@ checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -2562,9 +2574,9 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
+checksum = "6b30f669a7961ef1631673d2766cc92f52d64f7ef354d4fe0ddfd30ed52f0f4f"
 dependencies = [
  "errno-dragonfly",
  "libc",
@@ -2825,7 +2837,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -3239,7 +3251,7 @@ dependencies = [
  "sha2 0.10.7",
  "snafu",
  "surf-disco 0.4.1 (git+https://github.com/EspressoSystems/surf-disco.git?branch=main)",
- "time 0.3.23",
+ "time 0.3.25",
  "tokio",
  "toml 0.7.6",
  "tracing",
@@ -3289,7 +3301,7 @@ dependencies = [
  "hotshot-utils",
  "jf-primitives 0.4.0-pre.0",
  "snafu",
- "time 0.3.23",
+ "time 0.3.25",
  "tokio",
  "tracing",
 ]
@@ -3371,7 +3383,7 @@ dependencies = [
  "pin-project",
  "serde",
  "snafu",
- "time 0.3.23",
+ "time 0.3.25",
  "tokio",
  "tracing",
 ]
@@ -3401,7 +3413,7 @@ dependencies = [
  "rand_chacha 0.3.1",
  "serde",
  "snafu",
- "time 0.3.23",
+ "time 0.3.25",
  "tokio",
  "tracing",
 ]
@@ -3474,7 +3486,7 @@ dependencies = [
  "serde_json",
  "snafu",
  "tagged-base64 0.2.4",
- "time 0.3.23",
+ "time 0.3.25",
  "tokio",
  "tracing",
  "typenum",
@@ -3627,7 +3639,7 @@ dependencies = [
  "futures-util",
  "http",
  "hyper",
- "rustls 0.21.5",
+ "rustls 0.21.6",
  "tokio",
  "tokio-rustls",
 ]
@@ -3915,7 +3927,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
  "hermit-abi 0.3.2",
- "rustix 0.38.4",
+ "rustix 0.38.6",
  "windows-sys",
 ]
 
@@ -4060,7 +4072,7 @@ dependencies = [
 [[package]]
 name = "jf-primitives"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/EspressoSystems/jellyfish?branch=hotshot-compat#470a8330c744a1f2e6b543ae3f6ddf5a1622906d"
+source = "git+https://github.com/EspressoSystems/jellyfish?branch=hotshot-compat#58eb45ab189364a2538e5ccaa912a3afdabd2bd1"
 dependencies = [
  "anyhow",
  "ark-bls12-377 0.4.0",
@@ -4080,6 +4092,7 @@ dependencies = [
  "blst",
  "chacha20poly1305 0.10.1",
  "crypto_kx",
+ "curve25519-dalek 4.0.0-rc.1",
  "derivative",
  "digest 0.10.7",
  "displaydoc",
@@ -4105,7 +4118,7 @@ dependencies = [
 [[package]]
 name = "jf-relation"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/EspressoSystems/jellyfish?branch=hotshot-compat#470a8330c744a1f2e6b543ae3f6ddf5a1622906d"
+source = "git+https://github.com/EspressoSystems/jellyfish?branch=hotshot-compat#58eb45ab189364a2538e5ccaa912a3afdabd2bd1"
 dependencies = [
  "ark-bls12-377 0.4.0",
  "ark-bls12-381 0.4.0",
@@ -4174,7 +4187,7 @@ dependencies = [
 [[package]]
 name = "jf-utils"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/EspressoSystems/jellyfish?branch=hotshot-compat#470a8330c744a1f2e6b543ae3f6ddf5a1622906d"
+source = "git+https://github.com/EspressoSystems/jellyfish?branch=hotshot-compat#58eb45ab189364a2538e5ccaa912a3afdabd2bd1"
 dependencies = [
  "ark-ec 0.4.2",
  "ark-ff 0.4.2",
@@ -4992,9 +5005,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.9"
+version = "1.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56ee889ecc9568871456d42f603d6a0ce59ff328d291063a45cbdf0036baf6db"
+checksum = "d97137b25e321a73eef1418d1d5d2eda4d77e12813f8e6dead84bc52c5870a7b"
 dependencies = [
  "cc",
  "libc",
@@ -5016,9 +5029,9 @@ checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.3"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09fc20d2ca12cb9f044c93e3bd6d32d523e6e2ec3db4f7b2939cd99026ecd3f0"
+checksum = "57bcfdad1b858c2db7c38303a6d2ad4dfaf5eb53dfeb0910128b2c26d6158503"
 
 [[package]]
 name = "lock_api"
@@ -5091,9 +5104,9 @@ checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
 name = "matchit"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b87248edafb776e59e6ee64a79086f65890d3510f2c656c000bf2a7e8a0aea40"
+checksum = "67827e6ea8ee8a7c4a72227ef4fc08957040acffdb5f122733b24fa12daff41b"
 
 [[package]]
 name = "maud"
@@ -5673,7 +5686,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -6029,9 +6042,9 @@ checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "pest"
-version = "2.7.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d2d1d55045829d65aad9d389139882ad623b33b904e7c9f1b10c5b8927298e5"
+checksum = "1acb4a4365a13f749a93f1a094a7805e5cfa0955373a9de860d962eaa3a5fe5a"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -6039,9 +6052,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.7.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f94bca7e7a599d89dea5dfa309e217e7906c3c007fb9c3299c40b10d6a315d3"
+checksum = "666d00490d4ac815001da55838c500eafb0320019bbaa44444137c48b443a853"
 dependencies = [
  "pest",
  "pest_generator",
@@ -6049,22 +6062,22 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d490fe7e8556575ff6911e45567ab95e71617f43781e5c05490dc8d75c965c"
+checksum = "68ca01446f50dbda87c1786af8770d535423fa8a53aec03b8f4e3d7eb10e0929"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.28",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.7.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2674c66ebb4b4d9036012091b537aae5878970d6999f81a265034d85b136b341"
+checksum = "56af0a30af74d0445c0bf6d9d051c979b516a1a5af790d251daee76005420a48"
 dependencies = [
  "once_cell",
  "pest",
@@ -6088,7 +6101,7 @@ checksum = "ec2e072ecce94ec471b13398d5402c188e76ac03cf74dd1a975161b23a3f6d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -6434,9 +6447,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.31"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fe8a65d69dd0808184ebb5f836ab526bb259db23c657efa38711b1072ee47f0"
+checksum = "50f3b39ccfb720540debaa0164757101c08ecb8d326b15358ce76a62c7e85965"
 dependencies = [
  "proc-macro2",
 ]
@@ -6548,7 +6561,7 @@ checksum = "6413f3de1edee53342e6138e75b56d32e7bc6e332b3bd62d497b1929d4cfbcdd"
 dependencies = [
  "pem",
  "ring",
- "time 0.3.23",
+ "time 0.3.25",
  "x509-parser 0.13.2",
  "yasna",
 ]
@@ -6561,7 +6574,7 @@ checksum = "ffbe84efe2f38dea12e9bfc1f65377fdf03e53a18cb3b995faedf7934c7e785b"
 dependencies = [
  "pem",
  "ring",
- "time 0.3.23",
+ "time 0.3.25",
  "yasna",
 ]
 
@@ -6602,7 +6615,7 @@ checksum = "b2eae68fc220f7cf2532e4494aded17545fce192d59cd996e0fe7887f4ceb575"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.3.3",
+ "regex-automata 0.3.4",
  "regex-syntax 0.7.4",
 ]
 
@@ -6617,9 +6630,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39354c10dd07468c2e73926b23bb9c2caca74c5501e38a35da70406f1d923310"
+checksum = "b7b6d6190b7594385f61bd3911cd1be99dfddcfc365a4160cc2ab5bff4aed294"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -6661,7 +6674,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite 0.2.10",
- "rustls 0.21.5",
+ "rustls 0.21.6",
  "rustls-native-certs",
  "rustls-pemfile",
  "serde",
@@ -6889,14 +6902,14 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.4"
+version = "0.38.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a962918ea88d644592894bc6dc55acc6c0956488adcebbfb6e273506b7fd6e5"
+checksum = "1ee020b1716f0a80e2ace9b03441a749e402e86712f15f16fe8a8f75afac732f"
 dependencies = [
  "bitflags 2.3.3",
  "errno",
  "libc",
- "linux-raw-sys 0.4.3",
+ "linux-raw-sys 0.4.5",
  "windows-sys",
 ]
 
@@ -6927,9 +6940,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.5"
+version = "0.21.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79ea77c539259495ce8ca47f53e66ae0330a8819f67e23ac96ca02f50e7b7d36"
+checksum = "1d1feddffcfcc0b33f5c6ce9a29e341e4cd59c3f78e7ee45f4a40c038b1d6cbb"
 dependencies = [
  "log",
  "ring",
@@ -6960,9 +6973,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.1"
+version = "0.101.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15f36a6828982f422756984e47912a7a51dcbc2a197aa791158f8ca61cd8204e"
+checksum = "513722fd73ad80a71f72b61009ea1b584bcfa1483ca93949c8f290298837fa59"
 dependencies = [
  "ring",
  "untrusted",
@@ -7125,9 +7138,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.174"
+version = "1.0.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b88756493a5bd5e5395d53baa70b194b05764ab85b59e43e4b8f4e1192fa9b1"
+checksum = "0ea67f183f058fe88a4e3ec6e2788e003840893b91bac4559cabedd00863b3ed"
 dependencies = [
  "serde_derive",
 ]
@@ -7143,13 +7156,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.174"
+version = "1.0.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e5c3a298c7f978e53536f95a63bdc4c4a64550582f31a0359a9afda6aede62e"
+checksum = "24e744d7782b686ab3b73267ef05697159cc0e5abbed3f47f9933165e5219036"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -7163,9 +7176,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d03b412469450d4404fe8499a268edd7f8b79fecb074b0d812ad64ca21f4031b"
+checksum = "076066c5f1078eac5b722a31827a8832fe108bed65dfa75e233c89f8206e976c"
 dependencies = [
  "itoa 1.0.9",
  "ryu",
@@ -7217,7 +7230,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with_macros",
- "time 0.3.23",
+ "time 0.3.25",
 ]
 
 [[package]]
@@ -7229,7 +7242,7 @@ dependencies = [
  "darling 0.20.3",
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -7848,9 +7861,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.27"
+version = "2.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b60f673f44a8255b9c8c657daf66a596d435f2da81a555b06dc644d080ba45e0"
+checksum = "04361975b3f5e348b2189d8dc55bc942f278b2d482a6a0365de5bdd62d351567"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8000,7 +8013,7 @@ dependencies = [
  "cfg-if",
  "fastrand 2.0.0",
  "redox_syscall 0.3.5",
- "rustix 0.38.4",
+ "rustix 0.38.6",
  "windows-sys",
 ]
 
@@ -8030,7 +8043,7 @@ checksum = "090198534930841fab3a5d1bb637cde49e339654e606195f8d9c76eeb081dc96"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -8167,14 +8180,15 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.23"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59e399c068f43a5d116fedaf73b203fa4f9c519f17e2b34f63221d3792f81446"
+checksum = "b0fdd63d58b18d663fbdf70e049f00a22c8e42be082203be7f26589213cd75ea"
 dependencies = [
+ "deranged",
  "itoa 1.0.9",
  "serde",
  "time-core",
- "time-macros 0.2.10",
+ "time-macros 0.2.11",
 ]
 
 [[package]]
@@ -8195,9 +8209,9 @@ dependencies = [
 
 [[package]]
 name = "time-macros"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96ba15a897f3c86766b757e5ac7221554c6750054d74d5b28844fce5fb36a6c4"
+checksum = "eb71511c991639bb078fd5bf97757e03914361c48100d52878b8e52b46fb92cd"
 dependencies = [
  "time-core",
 ]
@@ -8288,7 +8302,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -8307,7 +8321,7 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "rustls 0.21.5",
+ "rustls 0.21.6",
  "tokio",
 ]
 
@@ -8506,7 +8520,7 @@ checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -8983,7 +8997,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.28",
  "wasm-bindgen-shared",
 ]
 
@@ -9017,7 +9031,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.28",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -9108,7 +9122,7 @@ dependencies = [
  "sha2 0.10.7",
  "stun",
  "thiserror",
- "time 0.3.23",
+ "time 0.3.25",
  "tokio",
  "turn",
  "url",
@@ -9439,9 +9453,9 @@ checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winnow"
-version = "0.5.0"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fac9742fd1ad1bd9643b991319f72dd031016d44b77039a26977eb667141e7"
+checksum = "f46aab759304e4d7b2075a9aecba26228bb073ee8c50db796b2c72c676b5d807"
 dependencies = [
  "memchr",
 ]
@@ -9512,7 +9526,7 @@ dependencies = [
  "ring",
  "rusticata-macros",
  "thiserror",
- "time 0.3.23",
+ "time 0.3.25",
 ]
 
 [[package]]
@@ -9530,7 +9544,7 @@ dependencies = [
  "oid-registry 0.6.1",
  "rusticata-macros",
  "thiserror",
- "time 0.3.23",
+ "time 0.3.25",
 ]
 
 [[package]]
@@ -9575,7 +9589,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
 dependencies = [
- "time 0.3.23",
+ "time 0.3.25",
 ]
 
 [[package]]
@@ -9595,5 +9609,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.28",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3928,7 +3928,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
  "hermit-abi 0.3.2",
- "rustix 0.38.6",
+ "rustix 0.38.7",
  "windows-sys",
 ]
 
@@ -4073,7 +4073,7 @@ dependencies = [
 [[package]]
 name = "jf-primitives"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/EspressoSystems/jellyfish?branch=hotshot-compat#03b11e4f71268dd884b07a43d117331df7d611a2"
+source = "git+https://github.com/EspressoSystems/jellyfish?branch=hotshot-compat#61276c0166604e1912c1a8f4bd127c74da25482e"
 dependencies = [
  "anyhow",
  "ark-bls12-377 0.4.0",
@@ -4119,7 +4119,7 @@ dependencies = [
 [[package]]
 name = "jf-relation"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/EspressoSystems/jellyfish?branch=hotshot-compat#03b11e4f71268dd884b07a43d117331df7d611a2"
+source = "git+https://github.com/EspressoSystems/jellyfish?branch=hotshot-compat#61276c0166604e1912c1a8f4bd127c74da25482e"
 dependencies = [
  "ark-bls12-377 0.4.0",
  "ark-bls12-381 0.4.0",
@@ -4188,7 +4188,7 @@ dependencies = [
 [[package]]
 name = "jf-utils"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/EspressoSystems/jellyfish?branch=hotshot-compat#03b11e4f71268dd884b07a43d117331df7d611a2"
+source = "git+https://github.com/EspressoSystems/jellyfish?branch=hotshot-compat#61276c0166604e1912c1a8f4bd127c74da25482e"
 dependencies = [
  "ark-ec 0.4.2",
  "ark-ff 0.4.2",
@@ -6610,13 +6610,13 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.9.1"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2eae68fc220f7cf2532e4494aded17545fce192d59cd996e0fe7887f4ceb575"
+checksum = "5bc4f4d719ae1d92dc7e5ef3865f93af6e28c7af68ebd7a68a367932b88c1e2c"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.3.4",
+ "regex-automata 0.3.5",
  "regex-syntax 0.7.4",
 ]
 
@@ -6631,9 +6631,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7b6d6190b7594385f61bd3911cd1be99dfddcfc365a4160cc2ab5bff4aed294"
+checksum = "26bb2039bb570943fc65037c16640a64fba171d3760138656fdfe62b3bd24239"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -6903,9 +6903,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.6"
+version = "0.38.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ee020b1716f0a80e2ace9b03441a749e402e86712f15f16fe8a8f75afac732f"
+checksum = "172891ebdceb05aa0005f533a6cbfca599ddd7d966f6f5d4d9b2e70478e70399"
 dependencies = [
  "bitflags 2.3.3",
  "errno",
@@ -8014,7 +8014,7 @@ dependencies = [
  "cfg-if",
  "fastrand 2.0.0",
  "redox_syscall 0.3.5",
- "rustix 0.38.6",
+ "rustix 0.38.7",
  "windows-sys",
 ]
 
@@ -9454,9 +9454,9 @@ checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winnow"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46aab759304e4d7b2075a9aecba26228bb073ee8c50db796b2c72c676b5d807"
+checksum = "acaaa1190073b2b101e15083c38ee8ec891b5e05cbee516521e94ec008f61e64"
 dependencies = [
  "memchr",
 ]

--- a/centralized_server/benchmark_client/src/main.rs
+++ b/centralized_server/benchmark_client/src/main.rs
@@ -7,14 +7,14 @@ use hotshot_centralized_server::{
     TcpStreamRecvUtil, TcpStreamSendUtil, TcpStreamUtilWithRecv, TcpStreamUtilWithSend,
 };
 use hotshot_types::traits::signature_key::{
-    ed25519::{Ed25519Priv, Ed25519Pub},
+    bn254::{BN254Priv, BN254Pub},
     SignatureKey,
 };
 use std::{net::ToSocketAddrs, time::Instant};
 use tracing::{error, info};
 
-type ToServer = hotshot_centralized_server::ToServer<Ed25519Pub>;
-type FromServer = hotshot_centralized_server::FromServer<Ed25519Pub, ()>;
+type ToServer = hotshot_centralized_server::ToServer<BN254Pub>;
+type FromServer = hotshot_centralized_server::FromServer<BN254Pub, ()>;
 
 #[async_main]
 async fn main() {
@@ -47,8 +47,8 @@ async fn main() {
         }
     };
     info!("Received config {config:?}");
-    let privkey = Ed25519Priv::generated_from_seed_indexed([0u8; 32], config.node_index);
-    let pubkey = Ed25519Pub::from_private(&privkey);
+    let privkey = BN254Priv::generated_from_seed_indexed([0u8; 32], config.node_index);
+    let pubkey = BN254Pub::from_private(&privkey);
     write
         .send(ToServer::Identify { key: pubkey })
         .await

--- a/examples/infra/mod.rs
+++ b/examples/infra/mod.rs
@@ -44,7 +44,7 @@ use hotshot_types::{
 use hotshot_types::{message::Message, traits::election::QuorumExchange};
 use libp2p::{
     identity::{
-        ed25519::{Keypair as EdKeypair, SecretKey},
+        bn254::{Keypair as EdKeypair, SecretKey},
         Keypair,
     },
     multiaddr::{self, Protocol},
@@ -68,7 +68,7 @@ use std::{
 };
 #[allow(deprecated)]
 use tracing::error;
-use hotshot_types::traits::signature_key::ed25519::Ed25519Priv;
+use hotshot_types::traits::signature_key::bn254::BN254Priv;
 use jf_primitives::signatures::bls_over_bn254::{KeyPair as QCKeyPair, VerKey};
 use hotshot_primitives::qc::bit_vector::StakeTableEntry;
 use rand_chacha::ChaCha20Rng;
@@ -117,7 +117,7 @@ pub fn load_config_from_file<TYPES: NodeType>(
 
     config.config.known_nodes_qc = (0..config.config.total_nodes.get())
     .map(|node_id| {
-        let real_seed = Ed25519Priv::get_seed_from_seed_indexed(
+        let real_seed = BN254Priv::get_seed_from_seed_indexed(
                 config.seed,
                 node_id.try_into().unwrap(),
             );
@@ -265,7 +265,7 @@ pub trait Run<
         let (pk, sk) =
             TYPES::SignatureKey::generated_from_seed_indexed(config.seed, config.node_index);
         // Get KeyPair for certificate Aggregation
-        let real_seed = Ed25519Priv::get_seed_from_seed_indexed(
+        let real_seed = BN254Priv::get_seed_from_seed_indexed(
             config.seed,
             config.node_index.try_into().unwrap(),
         );

--- a/examples/infra/modDA.rs
+++ b/examples/infra/modDA.rs
@@ -55,7 +55,6 @@ use hotshot_types::{
     HotShotConfig,
 };
 
-use hotshot_types::traits::signature_key::ed25519::Ed25519Priv;
 use jf_primitives::signatures::bls_over_bn254::{BLSOverBN254CurveSignatureScheme, KeyPair as QCKeyPair};
 use hotshot_primitives::qc::bit_vector::StakeTableEntry;
 use ethereum_types::U256;

--- a/examples/infra/modDA.rs
+++ b/examples/infra/modDA.rs
@@ -250,7 +250,7 @@ pub trait RunDA<
         let view_sync_network = self.get_view_sync_network();
 
         // Get KeyPair for certificate Aggregation
-        let real_seed = Ed25519Priv::get_seed_from_seed_indexed(
+        let real_seed = BN254Priv::get_seed_from_seed_indexed(
             config.seed,
             config.node_index.try_into().unwrap(),
         );

--- a/src/demos/sdemo.rs
+++ b/src/demos/sdemo.rs
@@ -7,7 +7,7 @@
 //! production use.
 use crate::traits::election::static_committee::{StaticElectionConfig, StaticVoteToken};
 use std::{
-    collections::{BTreeMap, HashSet},
+    collections::{HashSet},
     fmt::{Debug, Display},
     marker::PhantomData,
     ops::Deref,

--- a/src/demos/sdemo.rs
+++ b/src/demos/sdemo.rs
@@ -25,7 +25,7 @@ use hotshot_types::{
         consensus_type::sequencing_consensus::SequencingConsensus,
         election::Membership,
         node_implementation::NodeType,
-        signature_key::ed25519::Ed25519Pub,
+        signature_key::bn254::BN254Pub,
         state::{ConsensusTime, TestableBlock, TestableState},
         Block, State,
     },
@@ -306,7 +306,7 @@ impl NodeType for SDemoTypes {
     type ConsensusType = SequencingConsensus;
     type Time = ViewNumber;
     type BlockType = SDemoBlock;
-    type SignatureKey = Ed25519Pub;
+    type SignatureKey = BN254Pub;
     type VoteTokenType = StaticVoteToken<Self::SignatureKey>;
     type Transaction = SDemoTransaction;
     type ElectionConfigType = StaticElectionConfig;
@@ -359,7 +359,7 @@ pub fn random_quorum_certificate<TYPES: NodeType, LEAF: LeafType<NodeType = TYPE
         // block_commitment: random_commitment(rng),
         leaf_commitment: random_commitment(rng),
         view_number: TYPES::Time::new(rng.gen()),
-        signatures: AssembledSignature::Genesis(),//Sishan NOTE TODO: confirm whether this could be Genesis() or not
+        signatures: AssembledSignature::Genesis(),
         is_genesis: rng.gen(),
     }
 }

--- a/src/demos/vdemo.rs
+++ b/src/demos/vdemo.rs
@@ -22,7 +22,7 @@ use hotshot_types::{
         consensus_type::validating_consensus::ValidatingConsensus,
         election::Membership,
         node_implementation::NodeType,
-        signature_key::ed25519::Ed25519Pub,
+        signature_key::bn254::BN254Pub,
         state::{ConsensusTime, TestableBlock, TestableState},
         State,
     },
@@ -526,7 +526,7 @@ impl NodeType for VDemoTypes {
     type ConsensusType = ValidatingConsensus;
     type Time = ViewNumber;
     type BlockType = VDemoBlock;
-    type SignatureKey = Ed25519Pub;
+    type SignatureKey = BN254Pub;
     type VoteTokenType = StaticVoteToken<Self::SignatureKey>;
     type Transaction = VDemoTransaction;
     type ElectionConfigType = StaticElectionConfig;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,6 @@ use async_compatibility_layer::{
 };
 use async_lock::{Mutex, RwLock, RwLockUpgradableReadGuard, RwLockWriteGuard};
 use async_trait::async_trait;
-use bincode::Options;
 use commit::{Commitment, Committable};
 use custom_debug::Debug;
 use hotshot_task::event_stream::ChannelStream;
@@ -90,7 +89,7 @@ use hotshot_types::{
             SequencingExchangesType, SequencingQuorumEx, ValidatingExchangesType,
             ValidatingQuorumEx, ViewSyncEx,
         },
-        signature_key::{EncodedSignature, SignatureKey},
+        signature_key::SignatureKey,
         state::ConsensusTime,
         storage::StoredView,
         State,
@@ -111,7 +110,7 @@ use std::{
     time::{Duration, Instant},
 };
 use tasks::GlobalEvent;
-use tracing::{debug, error, info, instrument, trace, warn, Instrument};
+use tracing::{debug, error, info, instrument, trace, warn};
 // -- Rexports
 // External
 /// Reexport rand crate

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -56,7 +56,6 @@ use hotshot_types::{
         node_implementation::{
             CommitteeEx, ExchangesType, NodeImplementation, NodeType, SequencingExchangesType,
         },
-        signature_key::EncodedSignature,
         state::ConsensusTime,
         Block,
     },

--- a/src/traits/election/vrf.rs
+++ b/src/traits/election/vrf.rs
@@ -251,7 +251,6 @@ where
     // Sishan NOTE TODO: this one should be substitude by the one in bn254_priv.rs or ed25519_priv.rs or balabala, use SIGSCHEME;
     // Maybe the trait SignatureScheme should be deleted...At least for BLSoverBN254CurveSignatureScheme, the function inside is useless.
     fn generated_from_seed_indexed(seed: [u8; 32], index: u64) -> (Self, Self::PrivateKey) {
-        println!("Inside generated_from_seed_indexed");//Sishan NOTE TODO: delete this line
 
         let mut hasher = blake3::Hasher::new();
         hasher.update(&seed);

--- a/src/traits/election/vrf.rs
+++ b/src/traits/election/vrf.rs
@@ -248,15 +248,19 @@ where
         })
     }
 
-    // Sishan NOTE TODO: this one should be substitude by the one in bn254_priv.rs or ed25519_priv.rs or balabala, use SIGSCHEME
+    // Sishan NOTE TODO: this one should be substitude by the one in bn254_priv.rs or ed25519_priv.rs or balabala, use SIGSCHEME;
+    // Maybe the trait SignatureScheme should be deleted...At least for BLSoverBN254CurveSignatureScheme, the function inside is useless.
     fn generated_from_seed_indexed(seed: [u8; 32], index: u64) -> (Self, Self::PrivateKey) {
+        println!("Inside generated_from_seed_indexed");//Sishan NOTE TODO: delete this line
+
         let mut hasher = blake3::Hasher::new();
         hasher.update(&seed);
         hasher.update(&index.to_le_bytes());
         let new_seed = *hasher.finalize().as_bytes();
-        let mut prng = rand::rngs::StdRng::from_seed(new_seed);
 
+        let mut prng = rand::rngs::StdRng::from_seed(new_seed);
         let (sk, pk) = SIGSCHEME::key_gen(&(), &mut prng).unwrap();
+
         (
             Self {
                 pk: pk.clone(),

--- a/src/traits/election/vrf.rs
+++ b/src/traits/election/vrf.rs
@@ -250,6 +250,7 @@ where
 
     // Sishan NOTE TODO: this one should be substitude by the one in bn254_priv.rs or ed25519_priv.rs or balabala, use SIGSCHEME;
     // Maybe the trait SignatureScheme should be deleted...At least for BLSoverBN254CurveSignatureScheme, the function inside is useless.
+    // this TODO will be resolved after issue #1512 is resolved.
     fn generated_from_seed_indexed(seed: [u8; 32], index: u64) -> (Self, Self::PrivateKey) {
 
         let mut hasher = blake3::Hasher::new();

--- a/src/traits/election/vrf.rs
+++ b/src/traits/election/vrf.rs
@@ -11,7 +11,7 @@ use digest::generic_array::GenericArray;
 // use derivative::Derivative;
 // use espresso_systems_common::hotshot::tag;
 use hotshot_types::traits::signature_key::{
-    EncodedPublicKey, EncodedSignature, SignatureKey, TestableSignatureKey,
+    EncodedPublicKey, EncodedSignature, SignatureKey,
 };
 use hotshot_utils::bincode::bincode_opts;
 use jf_primitives::{
@@ -82,20 +82,6 @@ where
     pk: SIGSCHEME::VerificationKey,
     /// phantom data
     _pd: PhantomData<SIGSCHEME::SigningKey>,
-}
-
-impl<SIGSCHEME> TestableSignatureKey for JfPubKey<SIGSCHEME>
-where
-    SIGSCHEME: SignatureScheme<PublicParameter = (), MessageUnit = u8> + Sync + Send,
-    SIGSCHEME::VerificationKey: Clone + Serialize + for<'a> Deserialize<'a> + Sync + Send,
-    SIGSCHEME::SigningKey: Clone + Serialize + for<'a> Deserialize<'a> + Sync + Send,
-    SIGSCHEME::Signature: Clone + Serialize + for<'a> Deserialize<'a> + Sync + Send,
-{
-    fn generate_test_key(id: u64) -> Self::PrivateKey {
-        let seed = [0_u8; 32];
-        let vrf_key = Self::generated_from_seed_indexed(seed, id);
-        vrf_key.1
-    }
 }
 
 impl<SIGSCHEME> JfPubKey<SIGSCHEME>
@@ -262,8 +248,10 @@ where
         })
     }
 
-    fn generated_from_seed_indexed(_seed: [u8; 32], index: u64) -> (Self, Self::PrivateKey) {
+    // Sishan NOTE TODO: this one should be substitude by the one in bn254_priv.rs or ed25519_priv.rs or balabala, use SIGSCHEME
+    fn generated_from_seed_indexed(seed: [u8; 32], index: u64) -> (Self, Self::PrivateKey) {
         let mut hasher = blake3::Hasher::new();
+        hasher.update(&seed);
         hasher.update(&index.to_le_bytes());
         let new_seed = *hasher.finalize().as_bytes();
         let mut prng = rand::rngs::StdRng::from_seed(new_seed);

--- a/src/traits/networking/libp2p_network.rs
+++ b/src/traits/networking/libp2p_network.rs
@@ -27,7 +27,7 @@ use hotshot_types::{
             TransmitType,
         },
         node_implementation::NodeType,
-        signature_key::{SignatureKey, TestableSignatureKey},
+        signature_key::SignatureKey,
     },
     vote::VoteType,
 };
@@ -123,7 +123,6 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>>
     TestableNetworkingImplementation<TYPES, Message<TYPES, I>>
     for Libp2pNetwork<Message<TYPES, I>, TYPES::SignatureKey>
 where
-    TYPES::SignatureKey: TestableSignatureKey,
     MessageKind<TYPES::ConsensusType, TYPES, I>: ViewMessage<TYPES>,
 {
     /// Returns a boxed function `f(node_id, public_key) -> Libp2pNetwork`
@@ -151,7 +150,10 @@ where
         let mut da_keys = BTreeSet::new();
 
         for i in 0u64..(expected_node_count as u64) {
-            let privkey = TYPES::SignatureKey::generate_test_key(i);
+            let privkey = TYPES::SignatureKey::generated_from_seed_indexed(
+                [0u8; 32],
+                i,
+            ).1;
             let pubkey = TYPES::SignatureKey::from_private(&privkey);
             if i < da_committee_size as u64 {
                 da_keys.insert(pubkey.clone());
@@ -171,7 +173,10 @@ where
                 let addr =
                     // Multiaddr::from_str(&format!("/ip4/127.0.0.1/tcp/0")).unwrap();
                     Multiaddr::from_str(&format!("/ip4/127.0.0.1/tcp/{}{}", 5000 + node_id, network_id)).unwrap();
-                let privkey = TYPES::SignatureKey::generate_test_key(node_id);
+                let privkey = TYPES::SignatureKey::generated_from_seed_indexed(
+                    [0u8; 32],
+                    node_id,
+                ).1;
                 let pubkey = TYPES::SignatureKey::from_private(&privkey);
                 // we want the majority of peers to have this lying around.
                 let replication_factor = NonZeroUsize::new(2 * expected_node_count / 3).unwrap();
@@ -747,7 +752,6 @@ impl<
     > TestableNetworkingImplementation<TYPES, Message<TYPES, I>>
     for Libp2pCommChannel<TYPES, I, PROPOSAL, VOTE, MEMBERSHIP>
 where
-    TYPES::SignatureKey: TestableSignatureKey,
     MessageKind<TYPES::ConsensusType, TYPES, I>: ViewMessage<TYPES>,
 {
     /// Returns a boxed function `f(node_id, public_key) -> Libp2pNetwork`
@@ -880,8 +884,6 @@ impl<
         MEMBERSHIP,
         Libp2pNetwork<Message<TYPES, I>, TYPES::SignatureKey>,
     > for Libp2pCommChannel<TYPES, I, PROPOSAL, VOTE, MEMBERSHIP>
-where
-    TYPES::SignatureKey: TestableSignatureKey,
 {
     fn generate_network(
     ) -> Box<dyn Fn(Arc<Libp2pNetwork<Message<TYPES, I>, TYPES::SignatureKey>>) -> Self + 'static>

--- a/src/traits/networking/web_server_network.rs
+++ b/src/traits/networking/web_server_network.rs
@@ -1358,8 +1358,6 @@ impl<
 impl<TYPES: NodeType, I: NodeImplementation<TYPES>>
     TestableNetworkingImplementation<TYPES, Message<TYPES, I>>
     for WebServerNetwork<Message<TYPES, I>, TYPES::SignatureKey, TYPES::ElectionConfigType, TYPES>
-// where
-//     TYPES::SignatureKey: TestableSignatureKey,
 {
     fn generator(
         expected_node_count: usize,

--- a/src/traits/networking/web_server_network.rs
+++ b/src/traits/networking/web_server_network.rs
@@ -37,7 +37,7 @@ use hotshot_types::{
             WebServerNetworkError,
         },
         node_implementation::NodeType,
-        signature_key::{SignatureKey, TestableSignatureKey},
+        signature_key::SignatureKey,
     },
     vote::VoteType,
 };
@@ -1358,8 +1358,8 @@ impl<
 impl<TYPES: NodeType, I: NodeImplementation<TYPES>>
     TestableNetworkingImplementation<TYPES, Message<TYPES, I>>
     for WebServerNetwork<Message<TYPES, I>, TYPES::SignatureKey, TYPES::ElectionConfigType, TYPES>
-where
-    TYPES::SignatureKey: TestableSignatureKey,
+// where
+//     TYPES::SignatureKey: TestableSignatureKey,
 {
     fn generator(
         expected_node_count: usize,
@@ -1381,7 +1381,7 @@ where
 
         let known_nodes = (0..expected_node_count as u64)
             .map(|id| {
-                TYPES::SignatureKey::from_private(&TYPES::SignatureKey::generate_test_key(id))
+                TYPES::SignatureKey::from_private(&TYPES::SignatureKey::generated_from_seed_indexed([0u8; 32], id).1)
             })
             .collect::<Vec<_>>();
 
@@ -1419,8 +1419,6 @@ impl<
         MEMBERSHIP: Membership<TYPES>,
     > TestableNetworkingImplementation<TYPES, Message<TYPES, I>>
     for WebCommChannel<TYPES, I, PROPOSAL, VOTE, MEMBERSHIP>
-where
-    TYPES::SignatureKey: TestableSignatureKey,
 {
     fn generator(
         expected_node_count: usize,
@@ -1464,8 +1462,6 @@ impl<
         MEMBERSHIP,
         WebServerNetwork<Message<TYPES, I>, TYPES::SignatureKey, TYPES::ElectionConfigType, TYPES>,
     > for WebCommChannel<TYPES, I, PROPOSAL, VOTE, MEMBERSHIP>
-where
-    TYPES::SignatureKey: TestableSignatureKey,
 {
     fn generate_network() -> Box<
         dyn Fn(

--- a/src/traits/networking/web_sever_libp2p_fallback.rs
+++ b/src/traits/networking/web_sever_libp2p_fallback.rs
@@ -21,7 +21,6 @@ use hotshot_types::{
         election::Membership,
         network::{CommunicationChannel, ConnectedNetwork, TransmitType},
         node_implementation::NodeType,
-        signature_key::TestableSignatureKey,
     },
     vote::VoteType,
 };
@@ -81,8 +80,6 @@ pub struct CombinedNetworks<
 impl<TYPES: NodeType, I: NodeImplementation<TYPES>, MEMBERSHIP: Membership<TYPES>>
     TestableNetworkingImplementation<TYPES, Message<TYPES, I>>
     for CombinedNetworks<TYPES, I, MEMBERSHIP>
-where
-    TYPES::SignatureKey: TestableSignatureKey,
 {
     fn generator(
         expected_node_count: usize,
@@ -126,8 +123,6 @@ where
 impl<TYPES: NodeType, I: NodeImplementation<TYPES>, MEMBERSHIP: Membership<TYPES>>
     TestableNetworkingImplementation<TYPES, Message<TYPES, I>>
     for WebServerWithFallbackCommChannel<TYPES, I, MEMBERSHIP>
-where
-    TYPES::SignatureKey: TestableSignatureKey,
 {
     fn generator(
         expected_node_count: usize,
@@ -317,8 +312,6 @@ impl<
         MEMBERSHIP,
         CombinedNetworks<TYPES, I, MEMBERSHIP>,
     > for WebServerWithFallbackCommChannel<TYPES, I, MEMBERSHIP>
-where
-    TYPES::SignatureKey: TestableSignatureKey,
 {
     fn generate_network() -> Box<dyn Fn(Arc<Self::NETWORK>) -> Self + 'static> {
         Box::new(move |network| WebServerWithFallbackCommChannel::new(network))

--- a/src/traits/storage/memory_storage.rs
+++ b/src/traits/storage/memory_storage.rs
@@ -126,7 +126,7 @@ mod test {
     use hotshot_types::traits::block_contents::dummy::{DummyBlock, DummyState};
     use hotshot_types::traits::consensus_type::validating_consensus::ValidatingConsensus;
     use hotshot_types::traits::node_implementation::NodeType;
-    use hotshot_types::traits::signature_key::ed25519::Ed25519Pub;
+    use hotshot_types::traits::signature_key::bn254::BN254Pub;
     use hotshot_types::traits::state::ConsensusTime;
     use hotshot_types::traits::Block;
     use std::collections::BTreeMap;
@@ -154,8 +154,8 @@ mod test {
         type ConsensusType = ValidatingConsensus;
         type Time = ViewNumber;
         type BlockType = DummyBlock;
-        type SignatureKey = Ed25519Pub;
-        type VoteTokenType = StaticVoteToken<Ed25519Pub>;
+        type SignatureKey = BN254Pub;
+        type VoteTokenType = StaticVoteToken<BN254Pub>;
         type Transaction = <DummyBlock as Block>::Transaction;
         type ElectionConfigType = StaticElectionConfig;
         type StateType = DummyState;

--- a/src/traits/storage/memory_storage.rs
+++ b/src/traits/storage/memory_storage.rs
@@ -129,7 +129,6 @@ mod test {
     use hotshot_types::traits::signature_key::bn254::BN254Pub;
     use hotshot_types::traits::state::ConsensusTime;
     use hotshot_types::traits::Block;
-    use std::collections::BTreeMap;
     use std::fmt::Debug;
     use std::hash::Hash;
     use tracing::instrument;

--- a/src/types.rs
+++ b/src/types.rs
@@ -8,6 +8,6 @@ pub use handle::SystemContextHandle;
 pub(crate) use hotshot_types::error::HotShotError;
 pub use hotshot_types::{
     message::Message,
-    traits::signature_key::{ed25519, SignatureKey},
+    traits::signature_key::{bn254, SignatureKey},
     vote::VoteType,
 };

--- a/task-impls/src/da.rs
+++ b/task-impls/src/da.rs
@@ -23,7 +23,6 @@ use hotshot_task::task::FilterEvent;
 use hotshot_task::task::{HandleEvent, HotShotTaskCompleted, HotShotTaskTypes, TaskErr, TS};
 use hotshot_task::task_impls::HSTWithEvent;
 use hotshot_task::task_impls::TaskBuilder;
-use hotshot_types::certificate::QuorumCertificate;
 use hotshot_types::data::DAProposal;
 use hotshot_types::message::Proposal;
 use hotshot_types::message::{CommitteeConsensusMessage, Message};

--- a/task-impls/src/network.rs
+++ b/task-impls/src/network.rs
@@ -16,7 +16,6 @@ use hotshot_types::{
         election::Membership,
         network::{CommunicationChannel, TransmitType},
         node_implementation::{NodeImplementation, NodeType},
-        signature_key::EncodedSignature,
     },
     vote::VoteType,
 };

--- a/task-impls/src/view_sync.rs
+++ b/task-impls/src/view_sync.rs
@@ -19,9 +19,7 @@ use hotshot_task::{
     task::{FilterEvent, TaskErr, TS},
     task_impls::HSTWithEvent,
 };
-use hotshot_types::message::GeneralConsensusMessage::ViewSyncCertificate as ViewSyncCertificateProposal;
 use hotshot_types::traits::election::Membership;
-use hotshot_types::traits::election::SignedCertificate;
 use hotshot_types::traits::election::VoteData;
 use hotshot_types::traits::network::ConsensusIntentEvent;
 

--- a/testing-macros/src/lib.rs
+++ b/testing-macros/src/lib.rs
@@ -617,7 +617,7 @@ pub fn cross_all_types(input: TokenStream) -> TokenStream {
     } = parse_macro_input!(input as CrossAllTypesSpec);
     let tokens = quote! {
             DemoType: [ /* (SequencingConsensus, hotshot::demos::sdemo::SDemoState), */ (ValidatingConsensus, hotshot::demos::vdemo::VDemoState) ],
-            SignatureKey: [ hotshot_types::traits::signature_key::ed25519::Ed25519Pub ],
+            SignatureKey: [ hotshot_types::traits::signature_key::bn254::BN254Pub ],
             CommChannel: [ hotshot::traits::implementations::Libp2pCommChannel, hotshot::traits::implementations::CentralizedCommChannel ],
             Time: [ hotshot_types::data::ViewNumber ],
             Storage: [ hotshot::traits::implementations::MemoryStorage ],

--- a/testing-macros/tests/integration/failures.rs
+++ b/testing-macros/tests/integration/failures.rs
@@ -2,7 +2,7 @@ use hotshot_testing_macros::cross_tests;
 
 cross_tests!(
      DemoType: [ (ValidatingConsensus, hotshot::demos::vdemo::VDemoState) ],
-     SignatureKey: [ hotshot_types::traits::signature_key::ed25519::Ed25519Pub ],
+     SignatureKey: [ hotshot_types::traits::signature_key::bn254::BN254Pub ],
      CommChannel: [ hotshot::traits::implementations::MemoryCommChannel ],
      Storage: [ hotshot::traits::implementations::MemoryStorage ],
      Time: [ hotshot_types::data::ViewNumber ],
@@ -37,7 +37,7 @@ cross_tests!(
 
 cross_tests!(
      DemoType: [ (ValidatingConsensus, hotshot::demos::vdemo::VDemoState) ],
-     SignatureKey: [ hotshot_types::traits::signature_key::ed25519::Ed25519Pub ],
+     SignatureKey: [ hotshot_types::traits::signature_key::bn254::BN254Pub ],
      CommChannel: [ hotshot::traits::implementations::MemoryCommChannel ],
      Storage: [ hotshot::traits::implementations::MemoryStorage ],
      Time: [ hotshot_types::data::ViewNumber ],

--- a/testing-macros/tests/integration/smoke.rs
+++ b/testing-macros/tests/integration/smoke.rs
@@ -2,7 +2,7 @@ use hotshot_testing_macros::cross_tests;
 
 cross_tests!(
     DemoType: [(ValidatingConsensus, hotshot::demos::vdemo::VDemoState)],
-    SignatureKey: [ hotshot_types::traits::signature_key::ed25519::Ed25519Pub ],
+    SignatureKey: [ hotshot_types::traits::signature_key::bn254::BN254Pub ],
     CommChannel: [ hotshot::traits::implementations::MemoryCommChannel ],
     Storage: [ hotshot::traits::implementations::MemoryStorage ],
     Time: [ hotshot_types::data::ViewNumber ],
@@ -21,7 +21,7 @@ cross_tests!(
 
 cross_tests!(
     DemoType: [(ValidatingConsensus, hotshot::demos::vdemo::VDemoState) ],
-    SignatureKey: [ hotshot_types::traits::signature_key::ed25519::Ed25519Pub ],
+    SignatureKey: [ hotshot_types::traits::signature_key::bn254::BN254Pub ],
     CommChannel: [ hotshot::traits::implementations::MemoryCommChannel ],
     Storage: [ hotshot::traits::implementations::MemoryStorage ],
     Time: [ hotshot_types::data::ViewNumber ],

--- a/testing/src/app_tasks/mod.rs
+++ b/testing/src/app_tasks/mod.rs
@@ -5,7 +5,6 @@ use futures::{stream::Unfold, Stream};
 use hotshot_task::event_stream::SendableStream;
 use hotshot_task::{event_stream::ChannelStream, task::PassType, task_impls::HSTWithEvent};
 use rand::{prelude::Distribution, thread_rng};
-use std::marker::PhantomData;
 use std::time::Duration;
 
 ///  builder

--- a/testing/src/app_tasks/test_builder.rs
+++ b/testing/src/app_tasks/test_builder.rs
@@ -1,4 +1,5 @@
 use hotshot::types::SignatureKey;
+use hotshot::types::bn254::BN254Pub;
 use hotshot_types::traits::election::{ConsensusExchange, Membership};
 use std::num::NonZeroUsize;
 use std::time::Duration;
@@ -23,7 +24,7 @@ use super::{
     safety_task::{NodeSafetyPropertiesDescription, OverallSafetyPropertiesDescription},
     txn_task::TxnTaskDescription,
 };
-use hotshot_types::traits::signature_key::ed25519::Ed25519Priv;
+use hotshot_types::traits::signature_key::bn254::BN254Priv;
 use jf_primitives::signatures::bls_over_bn254::{KeyPair as QCKeyPair, VerKey};
 use hotshot_primitives::qc::bit_vector::StakeTableEntry;
 use rand_chacha::rand_core::SeedableRng;
@@ -121,13 +122,16 @@ impl TestMetadata {
 
         let known_nodes: Vec<<TYPES as NodeType>::SignatureKey> = (0..total_nodes)
             .map(|id| {
-                let priv_key = I::generate_test_key(id as u64);
+                let priv_key = TYPES::SignatureKey::generated_from_seed_indexed(
+                    [0u8; 32],
+                    (id as u64),
+                ).1;
                 TYPES::SignatureKey::from_private(&priv_key)
             })
             .collect();
         let known_nodes_qc: Vec<StakeTableEntry<VerKey>> = (0..total_nodes)
         .map(|id| {
-            let real_seed = Ed25519Priv::get_seed_from_seed_indexed(
+            let real_seed = BN254Priv::get_seed_from_seed_indexed(
                 [0_u8; 32],
                 (id as u64).try_into().unwrap(),
             );

--- a/testing/src/app_tasks/test_builder.rs
+++ b/testing/src/app_tasks/test_builder.rs
@@ -1,5 +1,4 @@
 use hotshot::types::SignatureKey;
-use hotshot::types::bn254::BN254Pub;
 use hotshot_types::traits::election::{ConsensusExchange, Membership};
 use std::num::NonZeroUsize;
 use std::time::Duration;
@@ -124,7 +123,7 @@ impl TestMetadata {
             .map(|id| {
                 let priv_key = TYPES::SignatureKey::generated_from_seed_indexed(
                     [0u8; 32],
-                    (id as u64),
+                    id as u64,
                 ).1;
                 TYPES::SignatureKey::from_private(&priv_key)
             })

--- a/testing/src/app_tasks/test_runner.rs
+++ b/testing/src/app_tasks/test_runner.rs
@@ -35,7 +35,7 @@ use super::{
     test_launcher::TestLauncher,
     txn_task::TxnTask,
 };
-use hotshot_types::traits::signature_key::ed25519::Ed25519Priv;
+use hotshot_types::traits::signature_key::bn254::{BN254Priv, BN254Pub};
 use jf_primitives::signatures::bls_over_bn254::{KeyPair as QCKeyPair, VerKey};
 use hotshot_primitives::qc::bit_vector::StakeTableEntry;
 use rand_chacha::ChaCha20Rng;
@@ -249,7 +249,7 @@ where
         let known_nodes = config.known_nodes.clone();
         let known_nodes_qc = config.known_nodes_qc.clone();
         // Get KeyPair for certificate Aggregation
-        let real_seed = Ed25519Priv::get_seed_from_seed_indexed(
+        let real_seed = BN254Priv::get_seed_from_seed_indexed(
             [0_u8; 32],
             node_id.try_into().unwrap(),
         );
@@ -258,7 +258,10 @@ where
             stake_key: key_pair.ver_key(),
             stake_amount: U256::from(1u8),
         };
-        let private_key = I::generate_test_key(node_id);
+        let private_key = TYPES::SignatureKey::generated_from_seed_indexed(
+            [0u8; 32],
+            node_id,
+        ).1;
         let public_key = TYPES::SignatureKey::from_private(&private_key);
         let quorum_election_config = config.election_config.clone().unwrap_or_else(|| {
             <QuorumEx<TYPES,I> as ConsensusExchange<

--- a/testing/src/app_tasks/test_runner.rs
+++ b/testing/src/app_tasks/test_runner.rs
@@ -9,9 +9,7 @@ use hotshot_task::{
     task_launcher::TaskRunner,
 };
 use hotshot_task_impls::events::SequencingHotShotEvent;
-use hotshot_types::certificate::QuorumCertificate;
 use hotshot_types::traits::election::Membership;
-use hotshot_types::traits::election::SignedCertificate;
 use hotshot_types::traits::node_implementation::ExchangesType;
 use hotshot_types::traits::signature_key::SignatureKey;
 use hotshot_types::{
@@ -36,7 +34,7 @@ use super::{
     txn_task::TxnTask,
 };
 use hotshot_types::traits::signature_key::bn254::{BN254Priv, BN254Pub};
-use jf_primitives::signatures::bls_over_bn254::{KeyPair as QCKeyPair, VerKey};
+use jf_primitives::signatures::bls_over_bn254::{KeyPair as QCKeyPair};
 use hotshot_primitives::qc::bit_vector::StakeTableEntry;
 use rand_chacha::ChaCha20Rng;
 use ethereum_types::U256;

--- a/testing/src/test_launcher.rs
+++ b/testing/src/test_launcher.rs
@@ -16,7 +16,7 @@ use hotshot_types::{
     ExecutionType, HotShotConfig,
 };
 use std::{num::NonZeroUsize, time::Duration};
-use hotshot_types::traits::signature_key::ed25519::Ed25519Priv;
+use hotshot_types::traits::signature_key::bn254::BN254Priv;
 use jf_primitives::signatures::bls_over_bn254::{KeyPair as QCKeyPair, VerKey};
 use hotshot_primitives::qc::bit_vector::StakeTableEntry;
 use rand_chacha::rand_core::SeedableRng;
@@ -110,13 +110,16 @@ where
 
         let known_nodes: Vec<<TYPES as NodeType>::SignatureKey> = (0..total_nodes)
             .map(|id| {
-                let priv_key = I::generate_test_key(id as u64);
+                let priv_key = TYPES::SignatureKey::generated_from_seed_indexed(
+                    [0u8; 32],
+                    (id as u64),
+                ).1;
                 TYPES::SignatureKey::from_private(&priv_key)
             })
             .collect();
         let known_nodes_qc: Vec<StakeTableEntry<VerKey>> = (0..total_nodes)
         .map(|id| {
-            let real_seed = Ed25519Priv::get_seed_from_seed_indexed(
+            let real_seed = BN254Priv::get_seed_from_seed_indexed(
                 [0_u8; 32],
                 (id as u64).try_into().unwrap(),
             );

--- a/testing/src/test_launcher.rs
+++ b/testing/src/test_launcher.rs
@@ -112,7 +112,7 @@ where
             .map(|id| {
                 let priv_key = TYPES::SignatureKey::generated_from_seed_indexed(
                     [0u8; 32],
-                    (id as u64),
+                    id as u64,
                 ).1;
                 TYPES::SignatureKey::from_private(&priv_key)
             })

--- a/testing/src/test_runner.rs
+++ b/testing/src/test_runner.rs
@@ -275,7 +275,7 @@ where
         let real_seed = BN254Priv::get_seed_from_seed_indexed(
             [0_u8; 32],
             (node_id as u64).try_into().unwrap(),
-        );//Sishan NOTE TODO: change this BN254Pub to SignatureKey or something else
+        );
         let key_pair = QCKeyPair::generate(&mut ChaCha20Rng::from_seed(real_seed));
         let entry = StakeTableEntry {
             stake_key: key_pair.ver_key(),

--- a/testing/src/test_runner.rs
+++ b/testing/src/test_runner.rs
@@ -29,8 +29,7 @@ use hotshot_types::{
     HotShotConfig,
 };
 use tracing::{debug, info, warn};
-
-use hotshot_types::traits::signature_key::ed25519::Ed25519Priv;
+use hotshot_types::traits::signature_key::bn254::{BN254Pub, BN254Priv};
 use jf_primitives::signatures::bls_over_bn254::{BLSOverBN254CurveSignatureScheme, KeyPair as QCKeyPair};
 use hotshot_primitives::qc::bit_vector::StakeTableEntry;
 use ethereum_types::U256;
@@ -267,13 +266,16 @@ where
 
         let known_nodes = config.known_nodes.clone();
         let known_nodes_qc = config.known_nodes_qc.clone();
-        let private_key = I::generate_test_key(node_id);
+        let private_key = TYPES::SignatureKey::generated_from_seed_indexed(
+            [0u8; 32],
+            node_id,
+        ).1;
         let public_key = TYPES::SignatureKey::from_private(&private_key);
         // Generate key pair for certificate aggregation
-        let real_seed = Ed25519Priv::get_seed_from_seed_indexed(
+        let real_seed = BN254Priv::get_seed_from_seed_indexed(
             [0_u8; 32],
             (node_id as u64).try_into().unwrap(),
-        );
+        );//Sishan NOTE TODO: change this BN254Pub to SignatureKey or something else
         let key_pair = QCKeyPair::generate(&mut ChaCha20Rng::from_seed(real_seed));
         let entry = StakeTableEntry {
             stake_key: key_pair.ver_key(),

--- a/testing/src/test_runner.rs
+++ b/testing/src/test_runner.rs
@@ -30,7 +30,7 @@ use hotshot_types::{
 };
 use tracing::{debug, info, warn};
 use hotshot_types::traits::signature_key::bn254::{BN254Pub, BN254Priv};
-use jf_primitives::signatures::bls_over_bn254::{BLSOverBN254CurveSignatureScheme, KeyPair as QCKeyPair};
+use jf_primitives::signatures::bls_over_bn254::{KeyPair as QCKeyPair};
 use hotshot_primitives::qc::bit_vector::StakeTableEntry;
 use ethereum_types::U256;
 use rand_chacha::ChaCha20Rng;
@@ -559,8 +559,7 @@ pub mod test {
         },
         vote::DAVote,
     };
-    use jf_primitives::signatures::BLSSignatureScheme;
-    use jf_primitives::signatures::bls_over_bn254::{BLSOverBN254CurveSignatureScheme, KeyPair as QCKeyPair};
+    use jf_primitives::signatures::bls_over_bn254::BLSOverBN254CurveSignatureScheme;
     use serde::{Deserialize, Serialize};
     use tracing::instrument;
     #[derive(

--- a/testing/src/test_runner.rs
+++ b/testing/src/test_runner.rs
@@ -29,7 +29,7 @@ use hotshot_types::{
     HotShotConfig,
 };
 use tracing::{debug, info, warn};
-use hotshot_types::traits::signature_key::bn254::{BN254Pub, BN254Priv};
+use hotshot_types::traits::signature_key::bn254::{BN254Priv};
 use jf_primitives::signatures::bls_over_bn254::{KeyPair as QCKeyPair};
 use hotshot_primitives::qc::bit_vector::StakeTableEntry;
 use ethereum_types::U256;

--- a/testing/tests/consensus_task.rs
+++ b/testing/tests/consensus_task.rs
@@ -82,7 +82,7 @@ use hotshot_types::{
 };
 use jf_primitives::signatures::BLSSignatureScheme;
 use jf_primitives::signatures::bls_over_bn254::{BLSOverBN254CurveSignatureScheme, KeyPair as QCKeyPair};
-use hotshot_types::traits::signature_key::ed25519::Ed25519Priv;
+use hotshot_types::traits::signature_key::bn254::BN254Priv;
 use hotshot_primitives::qc::bit_vector::StakeTableEntry;
 use rand::prelude::*;
 use ethereum_types::U256;
@@ -273,7 +273,7 @@ where
     let known_nodes = config.known_nodes.clone();
     let known_nodes_qc = config.known_nodes_qc.clone();
      // Get KeyPair for certificate Aggregation
-     let real_seed = Ed25519Priv::get_seed_from_seed_indexed(
+     let real_seed = BN254Priv::get_seed_from_seed_indexed(
         [0u8; 32],
         node_id.try_into().unwrap(),
     );
@@ -282,7 +282,7 @@ where
         stake_key: key_pair.ver_key(),
         stake_amount: U256::from(1u8),
     };
-    let private_key = I::generate_test_key(node_id);
+    let private_key = TYPES::SignatureKey::generated_from_seed_indexed([0u8; 32], node_id).1;
     let public_key = TYPES::SignatureKey::from_private(&private_key);
     let quorum_election_config = config.election_config.clone().unwrap_or_else(|| {
         <QuorumEx<TYPES,I> as ConsensusExchange<

--- a/testing/tests/consensus_task.rs
+++ b/testing/tests/consensus_task.rs
@@ -80,7 +80,6 @@ use hotshot_types::{
         state::ConsensusTime,
     },
 };
-use jf_primitives::signatures::BLSSignatureScheme;
 use jf_primitives::signatures::bls_over_bn254::{BLSOverBN254CurveSignatureScheme, KeyPair as QCKeyPair};
 use hotshot_types::traits::signature_key::bn254::BN254Priv;
 use hotshot_primitives::qc::bit_vector::StakeTableEntry;

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -66,6 +66,7 @@ jf-primitives = { git = "https://github.com/EspressoSystems/jellyfish", branch =
 nll = { git = "https://github.com/EspressoSystems/nll.git" }
 libp2p-networking = { path = "../libp2p-networking", version = "0.1.0", default-features = false }
 rand = "0.8.5"
+rand_chacha = "0.3.1"
 serde = { version = "1.0.164", features = ["derive"] }
 snafu = "0.7.4"
 tagged-base64 = { git = "https://github.com/EspressoSystems/tagged-base64", tag = "0.2.4" }

--- a/types/src/certificate.rs
+++ b/types/src/certificate.rs
@@ -130,6 +130,7 @@ pub enum AssembledSignature {
 /// Data from a vote needed to accumulate into a `SignedCertificate`
 pub struct VoteMetaData<COMMITTABLE: Committable + Serialize + Clone, T: VoteToken, TIME> {
     /// Voter's public key (Sishan NOTE: In certificate aggregation, this encoded_key is substitued by the following ver_key)
+    /// This TODO will be resolved after issue #1512 is resolved.
     pub encoded_key: EncodedPublicKey,
     /// Votes signature
     pub encoded_signature: EncodedSignature,

--- a/types/src/traits/election.rs
+++ b/types/src/traits/election.rs
@@ -36,7 +36,6 @@ use commit::{Commitment, Committable};
 use derivative::Derivative;
 use either::Either;
 use hotshot_utils::bincode::bincode_opts;
-use jf_primitives::aead::KeyPair;
 use serde::Deserialize;
 use serde::{de::DeserializeOwned, Serialize};
 use snafu::Snafu;

--- a/types/src/traits/election.rs
+++ b/types/src/traits/election.rs
@@ -1259,7 +1259,6 @@ impl<
 
     
     fn is_valid_view_sync_cert(&self, certificate: Self::Certificate, round: TYPES::Time) -> bool {
-        println!("Inside is_valid_view_sync_cert()");
         // Sishan NOTE TODO: would be better to test this, looks like this func is never called.
         let (certificate_internal, threshold, vote_data) = match certificate.clone() {
             ViewSyncCertificate::PreCommit(certificate_internal) => {
@@ -1341,7 +1340,6 @@ impl<
     }
 
     fn sign_certificate_proposal(&self, certificate: Self::Certificate) -> (EncodedSignature, VerKey) {
-        println!("Inside sign_certificate_proposal()");
         let signature = TYPES::SignatureKey::sign(self.key_pair.clone(), &certificate.commit().as_ref());
         ( signature, self.key_pair.ver_key().clone())
     }

--- a/types/src/traits/node_implementation.rs
+++ b/types/src/traits/node_implementation.rs
@@ -11,7 +11,6 @@ use super::{
         ViewSyncExchange, ViewSyncExchangeType, VoteToken,
     },
     network::{CommunicationChannel, NetworkMsg, TestableNetworkingImplementation},
-    signature_key::TestableSignatureKey,
     state::{ConsensusTime, TestableBlock, TestableState},
     storage::{StorageError, StorageState, TestableStorage},
     State,
@@ -556,8 +555,6 @@ pub trait TestableNodeImplementation<
     /// Return the full internal state. This is useful for debugging.
     async fn get_full_state(storage: &Self::Storage) -> StorageState<TYPES, Self::Leaf>;
 
-    /// The private key of the node `id` in a test.
-    fn generate_test_key(id: u64) -> <TYPES::SignatureKey as SignatureKey>::PrivateKey;
 }
 
 #[async_trait]
@@ -587,7 +584,6 @@ where
     TYPES::StateType: TestableState,
     TYPES::BlockType: TestableBlock,
     I::Storage: TestableStorage<TYPES, I::Leaf>,
-    TYPES::SignatureKey: TestableSignatureKey,
     I::Leaf: TestableLeaf<NodeType = TYPES>,
 {
     type CommitteeCommChannel = ();
@@ -663,10 +659,6 @@ where
     async fn get_full_state(storage: &Self::Storage) -> StorageState<TYPES, Self::Leaf> {
         <I::Storage as TestableStorage<TYPES, I::Leaf>>::get_full_state(storage).await
     }
-
-    fn generate_test_key(id: u64) -> <TYPES::SignatureKey as SignatureKey>::PrivateKey {
-        <TYPES::SignatureKey as TestableSignatureKey>::generate_test_key(id)
-    }
 }
 
 #[async_trait]
@@ -705,7 +697,6 @@ where
     TYPES::StateType: TestableState,
     TYPES::BlockType: TestableBlock,
     I::Storage: TestableStorage<TYPES, I::Leaf>,
-    TYPES::SignatureKey: TestableSignatureKey,
     I::Leaf: TestableLeaf<NodeType = TYPES>,
 {
     type CommitteeCommChannel = CommitteeCommChannel<TYPES, I>;
@@ -780,10 +771,6 @@ where
 
     async fn get_full_state(storage: &Self::Storage) -> StorageState<TYPES, Self::Leaf> {
         <I::Storage as TestableStorage<TYPES, I::Leaf>>::get_full_state(storage).await
-    }
-
-    fn generate_test_key(id: u64) -> <TYPES::SignatureKey as SignatureKey>::PrivateKey {
-        <TYPES::SignatureKey as TestableSignatureKey>::generate_test_key(id)
     }
 }
 

--- a/types/src/traits/signature_key.rs
+++ b/types/src/traits/signature_key.rs
@@ -7,7 +7,7 @@ use tagged_base64::tagged;
 use jf_primitives::signatures::bls_over_bn254::{KeyPair as QCKeyPair, VerKey};
 
 #[cfg(feature = "demo")]
-pub mod ed25519;
+pub mod bn254;
 
 /// Type saftey wrapper for byte encoded keys
 #[tagged(tag::ENCODED_PUB_KEY)]
@@ -76,10 +76,3 @@ pub trait SignatureKey:
     fn generated_from_seed_indexed(seed: [u8; 32], index: u64) -> (Self, Self::PrivateKey);
 }
 
-/// TODO we don't need this if we have `generated_from_seed_indexed`
-/// should use one or the other
-/// Trait for generation of keys during testing
-pub trait TestableSignatureKey: SignatureKey {
-    /// Generates a private key from the given integer seed
-    fn generate_test_key(id: u64) -> Self::PrivateKey;
-}

--- a/types/src/traits/signature_key/bn254.rs
+++ b/types/src/traits/signature_key/bn254.rs
@@ -1,5 +1,5 @@
 //! Demonstration implementation of the [`SignatureKey`] trait using BN254
-use super::{EncodedPublicKey, EncodedSignature, SignatureKey, TestableSignatureKey};
+use super::{EncodedPublicKey, EncodedSignature, SignatureKey};
 /// `BN254Priv` implementation
 mod bn254_priv;
 /// `BN254Pub` implementation
@@ -9,71 +9,3 @@ pub use self::{bn254_priv::BN254Priv, bn254_pub::BN254Pub};
 use jf_primitives::signatures::{bls_over_bn254::VerKey};
 use jf_primitives::signatures::bls_over_bn254::{BLSOverBN254CurveSignatureScheme, KeyPair as QCKeyPair};
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use rand::RngCore;
-
-    // Basic smoke test
-    #[test]
-    fn signature_should_validate() {
-        // Get some data to test sign with
-        let mut data = [0_u8; 64];
-        rand::thread_rng().fill_bytes(&mut data);
-
-        // Get a key to sign it with
-        let priv_key = BN254Priv::generate();
-        // And the matching public key
-        let pub_key = BN254Pub::from_private(&priv_key);
-
-        // KeyPair with signature scheme for certificate Aggregation
-        let key_pair = QCKeyPair::generate(&mut rand::thread_rng());
-
-        // Sign the data with it
-        let signature = BN254Pub::sign(key_pair.clone(), &data);
-        // Verify the signature
-        assert!(pub_key.validate(key_pair.ver_key(), &signature, &data));
-    }
-
-    // Make sure serialization round trip works
-    #[test]
-    fn serialize_key() {
-        // Get a private key
-        let priv_key = BN254Priv::generate();
-        // And the matching public key
-        let pub_key = BN254Pub::from_private(&priv_key);
-
-        // Convert the private key to bytes and back, then verify equality
-        let priv_key_bytes = priv_key.to_bytes();
-        let priv_key_2 = BN254Priv::from_bytes(&priv_key_bytes).expect("Failed to deser key");
-        assert!(priv_key == priv_key_2);
-
-        // Convert the public key to bytes and back, then verify equality
-        let pub_key_bytes = pub_key.to_bytes();
-        let pub_key_2 = BN254Pub::from_bytes(&pub_key_bytes).expect("Failed to deser key");
-        assert_eq!(pub_key, pub_key_2);
-
-        // Serialize the public key and back, then verify equality
-        let serialized = serde_json::to_string(&pub_key).expect("Failed to ser key");
-        let pub_key_2: BN254Pub = serde_json::from_str(&serialized).expect("Failed to deser key");
-        assert_eq!(pub_key, pub_key_2);
-
-        // .to_string() and FromStr
-        let str = pub_key.to_string();
-        let pub_key_2: BN254Pub = str.parse().expect("Failed to parse key");
-        assert_eq!(pub_key, pub_key_2);
-    }
-
-    #[test]
-    fn base64_deserialize() {
-        let valid = r#""PEER_ID~oUla6NPfKBahJVNpwlxO5UeHuwLySBnt4a3L2GR-jHla""#;
-        assert!(serde_json::from_str::<BN254Pub>(valid).is_ok());
-
-        for invalid in [
-            r#""PEERID~oUla6NPfKBahJVNpwlxO5UeHuwLySBnt4a3L2GR-jHla""#, // invalid tag
-            r#""PEER_ID~oUla6NPfKBahJVNpwlxO5UeHuwLySBnt4a3L2GR-jHlb""#, // invalid checksum
-        ] {
-            assert!(serde_json::from_str::<BN254Pub>(invalid).is_err());
-        }
-    }
-}

--- a/types/src/traits/signature_key/bn254.rs
+++ b/types/src/traits/signature_key/bn254.rs
@@ -6,6 +6,4 @@ mod bn254_priv;
 mod bn254_pub;
 
 pub use self::{bn254_priv::BN254Priv, bn254_pub::BN254Pub};
-use jf_primitives::signatures::{bls_over_bn254::VerKey};
-use jf_primitives::signatures::bls_over_bn254::{BLSOverBN254CurveSignatureScheme, KeyPair as QCKeyPair};
 

--- a/types/src/traits/signature_key/bn254.rs
+++ b/types/src/traits/signature_key/bn254.rs
@@ -1,0 +1,79 @@
+//! Demonstration implementation of the [`SignatureKey`] trait using BN254
+use super::{EncodedPublicKey, EncodedSignature, SignatureKey, TestableSignatureKey};
+/// `BN254Priv` implementation
+mod bn254_priv;
+/// `BN254Pub` implementation
+mod bn254_pub;
+
+pub use self::{bn254_priv::BN254Priv, bn254_pub::BN254Pub};
+use jf_primitives::signatures::{bls_over_bn254::VerKey};
+use jf_primitives::signatures::bls_over_bn254::{BLSOverBN254CurveSignatureScheme, KeyPair as QCKeyPair};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::RngCore;
+
+    // Basic smoke test
+    #[test]
+    fn signature_should_validate() {
+        // Get some data to test sign with
+        let mut data = [0_u8; 64];
+        rand::thread_rng().fill_bytes(&mut data);
+
+        // Get a key to sign it with
+        let priv_key = BN254Priv::generate();
+        // And the matching public key
+        let pub_key = BN254Pub::from_private(&priv_key);
+
+        // KeyPair with signature scheme for certificate Aggregation
+        let key_pair = QCKeyPair::generate(&mut rand::thread_rng());
+
+        // Sign the data with it
+        let signature = BN254Pub::sign(key_pair.clone(), &data);
+        // Verify the signature
+        assert!(pub_key.validate(key_pair.ver_key(), &signature, &data));
+    }
+
+    // Make sure serialization round trip works
+    #[test]
+    fn serialize_key() {
+        // Get a private key
+        let priv_key = BN254Priv::generate();
+        // And the matching public key
+        let pub_key = BN254Pub::from_private(&priv_key);
+
+        // Convert the private key to bytes and back, then verify equality
+        let priv_key_bytes = priv_key.to_bytes();
+        let priv_key_2 = BN254Priv::from_bytes(&priv_key_bytes).expect("Failed to deser key");
+        assert!(priv_key == priv_key_2);
+
+        // Convert the public key to bytes and back, then verify equality
+        let pub_key_bytes = pub_key.to_bytes();
+        let pub_key_2 = BN254Pub::from_bytes(&pub_key_bytes).expect("Failed to deser key");
+        assert_eq!(pub_key, pub_key_2);
+
+        // Serialize the public key and back, then verify equality
+        let serialized = serde_json::to_string(&pub_key).expect("Failed to ser key");
+        let pub_key_2: BN254Pub = serde_json::from_str(&serialized).expect("Failed to deser key");
+        assert_eq!(pub_key, pub_key_2);
+
+        // .to_string() and FromStr
+        let str = pub_key.to_string();
+        let pub_key_2: BN254Pub = str.parse().expect("Failed to parse key");
+        assert_eq!(pub_key, pub_key_2);
+    }
+
+    #[test]
+    fn base64_deserialize() {
+        let valid = r#""PEER_ID~oUla6NPfKBahJVNpwlxO5UeHuwLySBnt4a3L2GR-jHla""#;
+        assert!(serde_json::from_str::<BN254Pub>(valid).is_ok());
+
+        for invalid in [
+            r#""PEERID~oUla6NPfKBahJVNpwlxO5UeHuwLySBnt4a3L2GR-jHla""#, // invalid tag
+            r#""PEER_ID~oUla6NPfKBahJVNpwlxO5UeHuwLySBnt4a3L2GR-jHlb""#, // invalid checksum
+        ] {
+            assert!(serde_json::from_str::<BN254Pub>(invalid).is_err());
+        }
+    }
+}

--- a/types/src/traits/signature_key/bn254/bn254_priv.rs
+++ b/types/src/traits/signature_key/bn254/bn254_priv.rs
@@ -1,11 +1,7 @@
 use custom_debug::Debug;
-use espresso_systems_common::hotshot::tag::PRIVKEY_ID;
-use serde::{de::Error, Deserialize, Serialize};
-use std::{cmp::Ordering, fmt, str::FromStr};
-use tagged_base64::TaggedBase64;
-use tracing::{instrument, warn};
-use hotshot_primitives::qc::bit_vector::BitVectorQC;
-use jf_primitives::signatures::bls_over_bn254::{BLSOverBN254CurveSignatureScheme, KeyPair as QCKeyPair, VerKey, SignKey as QCSignKey};
+use serde::{Deserialize, Serialize};
+use std::{cmp::Ordering};
+use jf_primitives::signatures::bls_over_bn254::{KeyPair as QCKeyPair, SignKey as QCSignKey};
 use rand_chacha::ChaCha20Rng;
 use rand::SeedableRng;
 

--- a/types/src/traits/signature_key/bn254/bn254_priv.rs
+++ b/types/src/traits/signature_key/bn254/bn254_priv.rs
@@ -1,3 +1,4 @@
+use custom_debug::Debug;
 use ed25519_compact::{KeyPair, SecretKey, Seed};
 use espresso_systems_common::hotshot::tag::PRIVKEY_ID;
 use serde::{de::Error, Deserialize, Serialize};
@@ -6,15 +7,11 @@ use tagged_base64::TaggedBase64;
 use tracing::{instrument, warn};
 use hotshot_primitives::qc::bit_vector::BitVectorQC;
 use jf_primitives::signatures::bls_over_bn254::{BLSOverBN254CurveSignatureScheme, KeyPair as QCKeyPair, VerKey, SignKey as QCSignKey};
-use hotshot_primitives::qc::QuorumCertificate as AssembledQuorumCertificate;
-use jf_primitives::signatures::SignatureScheme;
-use blake3::traits::digest::generic_array::GenericArray;
-use typenum::U32;
-use bincode::Options;
-use hotshot_utils::bincode::bincode_opts;
+use rand_chacha::ChaCha20Rng;
+use rand::SeedableRng;
 
 /// Private key type for a ed25519 keypair
-#[derive(PartialEq, Eq, Clone)]
+#[derive(PartialEq, Eq, Clone, Serialize, Deserialize, Debug)]
 pub struct BN254Priv {
     /// The private key for  this keypair
     pub(super) priv_key: QCSignKey,
@@ -24,9 +21,9 @@ impl BN254Priv {
     /// Generate a new private key from scratch
     #[must_use]
     pub fn generate() -> Self {
-        let key_pair = KeyPair::generate(&mut rand::thread_rng());
-        let priv_key = key_pair.sk;
-        Self { priv_key }
+        let key_pair = QCKeyPair::generate(&mut rand::thread_rng());
+        let priv_key = key_pair.sign_key_ref();
+        Self { priv_key: priv_key.clone() }
     }
 
     /// Get real seed used for random key generation funtion
@@ -41,9 +38,9 @@ impl BN254Priv {
     /// Generate a new private key from a seed
     #[must_use]
     pub fn generate_from_seed(seed: [u8; 32]) -> Self {
-        let key_pair = QCKeyPair::generate(&mut ChaCha20Rng::from_seed(real_seed));
-        let priv_key = key_pair.sk;
-        Self { priv_key }
+        let key_pair = QCKeyPair::generate(&mut ChaCha20Rng::from_seed(seed));
+        let priv_key = &key_pair.sk;
+        Self { priv_key: priv_key.clone() }
     }
 
     /// Generate a new private key from a seed and a number
@@ -59,91 +56,20 @@ impl BN254Priv {
         Self::generate_from_seed(new_seed)
     }
 
-    /// Create an existing private key from bytes
-    #[instrument]
-    pub fn from_bytes(bytes: &[u8]) -> Option<Self> {
-        match SecretKey::from_slice(bytes) {
-            Ok(priv_key) => Some(Self { priv_key }),
-            Err(e) => {
-                warn!(?e, "Failed to decode private key");
-                None
-            }
-        }
-    }
-
-    /// Convert a private key to bytes
-    #[must_use]
-    pub fn to_bytes(&self) -> Vec<u8> {
-        self.priv_key.to_vec()
-    }
-
-    /// Return the [`TaggedBase64`] representation of this key.
-    #[allow(clippy::missing_panics_doc)] // `TaggedBase64::new()` only panics if `PRIVKEY_ID` is not valid base64, which it is.
-    #[must_use]
-    pub fn to_tagged_base64(&self) -> TaggedBase64 {
-        TaggedBase64::new(PRIVKEY_ID, self.priv_key.as_ref()).unwrap()
-    }
 }
 
 impl PartialOrd for BN254Priv {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        let self_bytes = self.priv_key.as_ref();
-        let other_bytes = other.priv_key.as_ref();
+        let self_bytes = &self.priv_key.to_string();
+        let other_bytes = &other.priv_key.to_string();
         self_bytes.partial_cmp(other_bytes)
     }
 }
 
 impl Ord for BN254Priv {
     fn cmp(&self, other: &Self) -> Ordering {
-        let self_bytes = self.priv_key.as_ref();
-        let other_bytes = other.priv_key.as_ref();
+        let self_bytes = &self.priv_key.to_string();
+        let other_bytes = &other.priv_key.to_string();
         self_bytes.cmp(other_bytes)
-    }
-}
-
-impl fmt::Display for BN254Priv {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let base64 = self.to_tagged_base64();
-        write!(f, "{}", tagged_base64::to_string(&base64))
-    }
-}
-
-impl Serialize for BN254Priv {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        serializer.serialize_str(&self.to_string())
-    }
-}
-
-impl<'de> Deserialize<'de> for BN254Priv {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let base64 = String::deserialize(deserializer)?;
-        Self::from_str(&base64).map_err(D::Error::custom)
-    }
-}
-
-impl FromStr for BN254Priv {
-    type Err = String;
-
-    fn from_str(s: &str) -> Result<Self, String> {
-        let base64 =
-            TaggedBase64::from_str(s).map_err(|e| format!("Could not decode BN254Pub: {e:?}"))?;
-        if base64.tag() != PRIVKEY_ID {
-            return Err(format!(
-                "Invalid BN254Priv tag: {:?}, expected {:?}",
-                base64.tag(),
-                PRIVKEY_ID
-            ));
-        }
-
-        match Self::from_bytes(&base64.value()) {
-            Some(key) => Ok(key),
-            None => Err("Failed to decode BN254 key".to_string()),
-        }
     }
 }

--- a/types/src/traits/signature_key/bn254/bn254_priv.rs
+++ b/types/src/traits/signature_key/bn254/bn254_priv.rs
@@ -1,5 +1,4 @@
 use custom_debug::Debug;
-use ed25519_compact::{KeyPair, SecretKey, Seed};
 use espresso_systems_common::hotshot::tag::PRIVKEY_ID;
 use serde::{de::Error, Deserialize, Serialize};
 use std::{cmp::Ordering, fmt, str::FromStr};
@@ -10,7 +9,7 @@ use jf_primitives::signatures::bls_over_bn254::{BLSOverBN254CurveSignatureScheme
 use rand_chacha::ChaCha20Rng;
 use rand::SeedableRng;
 
-/// Private key type for a ed25519 keypair
+/// Private key type for a bn254 keypair
 #[derive(PartialEq, Eq, Clone, Serialize, Deserialize, Debug)]
 pub struct BN254Priv {
     /// The private key for  this keypair
@@ -39,7 +38,7 @@ impl BN254Priv {
     #[must_use]
     pub fn generate_from_seed(seed: [u8; 32]) -> Self {
         let key_pair = QCKeyPair::generate(&mut ChaCha20Rng::from_seed(seed));
-        let priv_key = &key_pair.sk;
+        let priv_key = key_pair.sign_key_ref();
         Self { priv_key: priv_key.clone() }
     }
 
@@ -49,10 +48,7 @@ impl BN254Priv {
     /// useful for testing
     #[must_use]
     pub fn generated_from_seed_indexed(seed: [u8; 32], index: u64) -> Self {
-        let mut hasher = blake3::Hasher::new();
-        hasher.update(&seed);
-        hasher.update(&index.to_le_bytes());
-        let new_seed = *hasher.finalize().as_bytes();
+        let new_seed = Self::get_seed_from_seed_indexed(seed, index);
         Self::generate_from_seed(new_seed)
     }
 

--- a/types/src/traits/signature_key/bn254/bn254_priv.rs
+++ b/types/src/traits/signature_key/bn254/bn254_priv.rs
@@ -1,0 +1,149 @@
+use ed25519_compact::{KeyPair, SecretKey, Seed};
+use espresso_systems_common::hotshot::tag::PRIVKEY_ID;
+use serde::{de::Error, Deserialize, Serialize};
+use std::{cmp::Ordering, fmt, str::FromStr};
+use tagged_base64::TaggedBase64;
+use tracing::{instrument, warn};
+use hotshot_primitives::qc::bit_vector::BitVectorQC;
+use jf_primitives::signatures::bls_over_bn254::{BLSOverBN254CurveSignatureScheme, KeyPair as QCKeyPair, VerKey, SignKey as QCSignKey};
+use hotshot_primitives::qc::QuorumCertificate as AssembledQuorumCertificate;
+use jf_primitives::signatures::SignatureScheme;
+use blake3::traits::digest::generic_array::GenericArray;
+use typenum::U32;
+use bincode::Options;
+use hotshot_utils::bincode::bincode_opts;
+
+/// Private key type for a ed25519 keypair
+#[derive(PartialEq, Eq, Clone)]
+pub struct BN254Priv {
+    /// The private key for  this keypair
+    pub(super) priv_key: QCSignKey,
+}
+
+impl BN254Priv {
+    /// Generate a new private key from scratch
+    #[must_use]
+    pub fn generate() -> Self {
+        let key_pair = KeyPair::generate(&mut rand::thread_rng());
+        let priv_key = key_pair.sk;
+        Self { priv_key }
+    }
+
+    /// Get real seed used for random key generation funtion
+    pub fn get_seed_from_seed_indexed(seed: [u8; 32], index: u64) -> [u8; 32] {
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(&seed);
+        hasher.update(&index.to_le_bytes());
+        let new_seed = *hasher.finalize().as_bytes();
+        new_seed
+    }
+
+    /// Generate a new private key from a seed
+    #[must_use]
+    pub fn generate_from_seed(seed: [u8; 32]) -> Self {
+        let key_pair = QCKeyPair::generate(&mut ChaCha20Rng::from_seed(real_seed));
+        let priv_key = key_pair.sk;
+        Self { priv_key }
+    }
+
+    /// Generate a new private key from a seed and a number
+    ///
+    /// Hashes the seed and the number together using blake3. This method is
+    /// useful for testing
+    #[must_use]
+    pub fn generated_from_seed_indexed(seed: [u8; 32], index: u64) -> Self {
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(&seed);
+        hasher.update(&index.to_le_bytes());
+        let new_seed = *hasher.finalize().as_bytes();
+        Self::generate_from_seed(new_seed)
+    }
+
+    /// Create an existing private key from bytes
+    #[instrument]
+    pub fn from_bytes(bytes: &[u8]) -> Option<Self> {
+        match SecretKey::from_slice(bytes) {
+            Ok(priv_key) => Some(Self { priv_key }),
+            Err(e) => {
+                warn!(?e, "Failed to decode private key");
+                None
+            }
+        }
+    }
+
+    /// Convert a private key to bytes
+    #[must_use]
+    pub fn to_bytes(&self) -> Vec<u8> {
+        self.priv_key.to_vec()
+    }
+
+    /// Return the [`TaggedBase64`] representation of this key.
+    #[allow(clippy::missing_panics_doc)] // `TaggedBase64::new()` only panics if `PRIVKEY_ID` is not valid base64, which it is.
+    #[must_use]
+    pub fn to_tagged_base64(&self) -> TaggedBase64 {
+        TaggedBase64::new(PRIVKEY_ID, self.priv_key.as_ref()).unwrap()
+    }
+}
+
+impl PartialOrd for BN254Priv {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        let self_bytes = self.priv_key.as_ref();
+        let other_bytes = other.priv_key.as_ref();
+        self_bytes.partial_cmp(other_bytes)
+    }
+}
+
+impl Ord for BN254Priv {
+    fn cmp(&self, other: &Self) -> Ordering {
+        let self_bytes = self.priv_key.as_ref();
+        let other_bytes = other.priv_key.as_ref();
+        self_bytes.cmp(other_bytes)
+    }
+}
+
+impl fmt::Display for BN254Priv {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let base64 = self.to_tagged_base64();
+        write!(f, "{}", tagged_base64::to_string(&base64))
+    }
+}
+
+impl Serialize for BN254Priv {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for BN254Priv {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let base64 = String::deserialize(deserializer)?;
+        Self::from_str(&base64).map_err(D::Error::custom)
+    }
+}
+
+impl FromStr for BN254Priv {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, String> {
+        let base64 =
+            TaggedBase64::from_str(s).map_err(|e| format!("Could not decode BN254Pub: {e:?}"))?;
+        if base64.tag() != PRIVKEY_ID {
+            return Err(format!(
+                "Invalid BN254Priv tag: {:?}, expected {:?}",
+                base64.tag(),
+                PRIVKEY_ID
+            ));
+        }
+
+        match Self::from_bytes(&base64.value()) {
+            Some(key) => Ok(key),
+            None => Err("Failed to decode BN254 key".to_string()),
+        }
+    }
+}

--- a/types/src/traits/signature_key/bn254/bn254_pub.rs
+++ b/types/src/traits/signature_key/bn254/bn254_pub.rs
@@ -1,0 +1,183 @@
+use super::{BN254Priv, EncodedPublicKey, EncodedSignature, SignatureKey, TestableSignatureKey};
+use ed25519_compact::{PublicKey};
+use espresso_systems_common::hotshot::tag::PEER_ID;
+use serde::{de::Error, Deserialize, Serialize};
+use std::{
+    cmp::Ordering,
+    fmt::{self, Debug},
+    str::FromStr,
+};
+use tagged_base64::TaggedBase64;
+use tracing::{debug, instrument, warn};
+use hotshot_primitives::qc::bit_vector::BitVectorQC;
+use jf_primitives::signatures::bls_over_bn254::{BLSOverBN254CurveSignatureScheme, KeyPair as QCKeyPair, VerKey};
+use hotshot_primitives::qc::QuorumCertificate as AssembledQuorumCertificate;
+use jf_primitives::signatures::SignatureScheme;
+use blake3::traits::digest::generic_array::GenericArray;
+use typenum::U32;
+use bincode::Options;
+use hotshot_utils::bincode::bincode_opts;
+/// Public key type for an ed25519 [`SignatureKey`] pair
+///
+/// This type makes use of noise for non-determinisitc signatures.
+#[derive(Clone, PartialEq, Eq, Hash, Copy)]
+
+
+pub struct BN254Pub {
+    /// The public key for this keypair
+    pub_key: VerKey,
+}
+
+impl Debug for BN254Pub {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("BN254Pub")
+            .field(&tagged_base64::to_string(&self.to_tagged_base64()))
+            .finish()
+    }
+}
+
+impl PartialOrd for BN254Pub {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        let self_bytes = self.pub_key.as_ref();
+        let other_bytes = other.pub_key.as_ref();
+        self_bytes.partial_cmp(other_bytes)
+    }
+}
+
+impl Ord for BN254Pub {
+    fn cmp(&self, other: &Self) -> Ordering {
+        let self_bytes = self.pub_key.as_ref();
+        let other_bytes = other.pub_key.as_ref();
+        self_bytes.cmp(other_bytes)
+    }
+}
+
+impl BN254Pub {
+    /// Return the [`TaggedBase64`] representation of this key.
+    #[allow(clippy::missing_panics_doc)] // `TaggedBase64::new()` only panics if `PEER_ID` is not valid base64, which it is.
+    #[must_use]
+    pub fn to_tagged_base64(&self) -> TaggedBase64 {
+        TaggedBase64::new(PEER_ID, self.pub_key.as_ref()).unwrap()
+    }
+}
+
+impl SignatureKey for BN254Pub {
+    type PrivateKey = BN254Priv;
+
+    #[instrument(skip(self))]
+    fn validate(&self, ver_key: VerKey, signature: &EncodedSignature, data: &[u8]) -> bool {
+        let x: Result<<BLSOverBN254CurveSignatureScheme as SignatureScheme>::Signature, _> = 
+            bincode_opts().deserialize(&signature.0);
+            match x {
+                Ok(s) => {
+                    // This is the validation for QC partial signature before append().
+                    let generic_msg: &GenericArray<u8, U32> = GenericArray::from_slice(data);
+                    BLSOverBN254CurveSignatureScheme::verify(
+                        &(),
+                        &ver_key, 
+                        &generic_msg,
+                        &s,
+                    ).is_ok()
+                }
+                Err(_) => false,
+            }
+    }
+
+    fn sign(key_pair: QCKeyPair, data: &[u8]) -> EncodedSignature {
+        let generic_msg = GenericArray::from_slice(data);
+        let agg_signature_test = BitVectorQC::<BLSOverBN254CurveSignatureScheme>::sign(
+            &(),
+            &generic_msg,
+            key_pair.sign_key_ref(),
+            &mut rand::thread_rng(),
+        ).unwrap();
+        // Convert the signature to bytes and return
+        let bytes = bincode_opts()
+            .serialize(&agg_signature_test)
+            .expect("This serialization shouldn't be able to fail");
+        EncodedSignature(bytes)
+    }
+
+    fn from_private(private_key: &Self::PrivateKey) -> Self {
+        let pub_key = private_key.priv_key.public_key();
+        Self { pub_key }
+    }// Sishan NOTE TODO: change or remove this function
+
+    fn to_bytes(&self) -> EncodedPublicKey {
+        EncodedPublicKey(self.pub_key.to_vec())
+    }
+
+    #[instrument]
+    fn from_bytes(bytes: &EncodedPublicKey) -> Option<Self> {
+        let bytes = &bytes.0[..];
+        match PublicKey::from_slice(bytes) {
+            Ok(pub_key) => Some(Self { pub_key }),
+            Err(e) => {
+                debug!(?e, "Failed to deserialize public key");
+                None
+            }
+        }
+    }
+
+    fn generated_from_seed_indexed(seed: [u8; 32], index: u64) -> (Self, Self::PrivateKey) {
+        let real_seed = Self::PrivateKey::get_seed_from_seed_indexed(
+            seed,
+            index.try_into().unwrap(),
+        );
+        let key_pair = QCKeyPair::generate(&mut ChaCha20Rng::from_seed(real_seed));
+        (key_pair.vk, key_pair.sk)
+    }
+}
+
+impl TestableSignatureKey for BN254Pub {
+    fn generate_test_key(id: u64) -> Self::PrivateKey {
+        BN254Priv::generated_from_seed_indexed([0_u8; 32], id)
+    }
+}
+
+impl FromStr for BN254Pub {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, String> {
+        let base64 =
+            TaggedBase64::from_str(s).map_err(|e| format!("Could not decode BN254Pub: {e:?}"))?;
+        if base64.tag() != PEER_ID {
+            return Err(format!(
+                "Invalid BN254Pub tag: {:?}, expected {:?}",
+                base64.tag(),
+                PEER_ID
+            ));
+        }
+
+        match Self::from_bytes(&EncodedPublicKey(base64.value())) {
+            Some(key) => Ok(key),
+            None => Err("Failed to decode BN254 key".to_string()),
+        }
+    }
+}
+
+impl fmt::Display for BN254Pub {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let base64 = self.to_tagged_base64();
+        write!(f, "{}", tagged_base64::to_string(&base64))
+    }
+}
+
+impl Serialize for BN254Pub {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for BN254Pub {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let base64 = String::deserialize(deserializer)?;
+        Self::from_str(&base64).map_err(D::Error::custom)
+    }
+}

--- a/types/src/traits/signature_key/bn254/bn254_pub.rs
+++ b/types/src/traits/signature_key/bn254/bn254_pub.rs
@@ -1,12 +1,10 @@
 use super::{BN254Priv, EncodedPublicKey, EncodedSignature, SignatureKey};
-use espresso_systems_common::hotshot::tag::PEER_ID;
-use serde::{de::Error, Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 use std::{
     cmp::Ordering,
-    fmt::{self, Debug},
+    fmt::Debug,
     str::FromStr,
 };
-use tagged_base64::TaggedBase64;
 use tracing::{debug, instrument, warn};
 use hotshot_primitives::qc::bit_vector::BitVectorQC;
 use jf_primitives::signatures::bls_over_bn254::{BLSOverBN254CurveSignatureScheme, KeyPair as QCKeyPair, VerKey};
@@ -16,8 +14,6 @@ use blake3::traits::digest::generic_array::GenericArray;
 use typenum::U32;
 use bincode::Options;
 use hotshot_utils::bincode::bincode_opts;
-use rand_chacha::ChaCha20Rng;
-use rand::SeedableRng;
 
 /// Public key type for an bn254 [`SignatureKey`] pair
 ///

--- a/types/src/traits/signature_key/bn254/bn254_pub.rs
+++ b/types/src/traits/signature_key/bn254/bn254_pub.rs
@@ -1,5 +1,4 @@
 use super::{BN254Priv, EncodedPublicKey, EncodedSignature, SignatureKey};
-use ed25519_compact::{PublicKey};
 use espresso_systems_common::hotshot::tag::PEER_ID;
 use serde::{de::Error, Deserialize, Serialize};
 use std::{
@@ -114,11 +113,7 @@ impl SignatureKey for BN254Pub {
     }
 
     fn generated_from_seed_indexed(seed: [u8; 32], index: u64) -> (Self, Self::PrivateKey) {
-        let real_seed = Self::PrivateKey::get_seed_from_seed_indexed(
-            seed,
-            index.try_into().unwrap(),
-        );
-        let key_pair = QCKeyPair::generate(&mut ChaCha20Rng::from_seed(real_seed));
-        (BN254Pub{ pub_key: key_pair.ver_key() }, BN254Priv{priv_key: (key_pair.sign_key_ref()).clone()})
+        let priv_key = Self::PrivateKey::generated_from_seed_indexed(seed, index);
+        (Self::from_private(&priv_key), priv_key)
     }
 }

--- a/types/src/traits/signature_key/ed25519.rs
+++ b/types/src/traits/signature_key/ed25519.rs
@@ -1,5 +1,5 @@
 //! Demonstration implementation of the [`SignatureKey`] trait using ed25519
-use super::{EncodedPublicKey, EncodedSignature, SignatureKey, TestableSignatureKey};
+use super::{EncodedPublicKey, EncodedSignature, SignatureKey};
 /// `Ed25519Priv` implementation
 mod ed25519_priv;
 /// `Ed25519Pub` implementation

--- a/types/src/traits/signature_key/ed25519/ed25519_priv.rs
+++ b/types/src/traits/signature_key/ed25519/ed25519_priv.rs
@@ -44,10 +44,7 @@ impl Ed25519Priv {
     /// useful for testing
     #[must_use]
     pub fn generated_from_seed_indexed(seed: [u8; 32], index: u64) -> Self {
-        let mut hasher = blake3::Hasher::new();
-        hasher.update(&seed);
-        hasher.update(&index.to_le_bytes());
-        let new_seed = *hasher.finalize().as_bytes();
+        let new_seed = Self::PrivateKey::get_seed_from_seed_indexed(seed, index);
         Self::generate_from_seed(new_seed)
     }
 

--- a/types/src/traits/signature_key/ed25519/ed25519_pub.rs
+++ b/types/src/traits/signature_key/ed25519/ed25519_pub.rs
@@ -1,4 +1,4 @@
-use super::{Ed25519Priv, EncodedPublicKey, EncodedSignature, SignatureKey, TestableSignatureKey};
+use super::{Ed25519Priv, EncodedPublicKey, EncodedSignature, SignatureKey};
 use ed25519_compact::{PublicKey};
 use espresso_systems_common::hotshot::tag::PEER_ID;
 use serde::{de::Error, Deserialize, Serialize};
@@ -127,11 +127,6 @@ impl SignatureKey for Ed25519Pub {
     }
 }
 
-impl TestableSignatureKey for Ed25519Pub {
-    fn generate_test_key(id: u64) -> Self::PrivateKey {
-        Ed25519Priv::generated_from_seed_indexed([0_u8; 32], id)
-    }
-}
 
 impl FromStr for Ed25519Pub {
     type Err = String;

--- a/types/src/vote.rs
+++ b/types/src/vote.rs
@@ -412,7 +412,7 @@ where
             ).expect("this assembling shouldn't fail");
 
             if *yes_stake_casted >= u64::from(self.success_threshold) {
-                self.yes_vote_outcomes.remove(&commitment).unwrap().1;// Sishan NOTE TODO: Can we just use `clear` or something similar rather than deduct one vote?
+                self.yes_vote_outcomes.remove(&commitment).unwrap().1;
                 return Either::Right(AssembledSignature::Yes(real_qc_sig));
             } else if *no_stake_casted >= u64::from(self.failure_threshold) {
                 self.total_vote_outcomes.remove(&commitment).unwrap().1;

--- a/web_server/src/lib.rs
+++ b/web_server/src/lib.rs
@@ -628,11 +628,11 @@ mod test {
 
     use super::*;
     use async_compatibility_layer::art::async_spawn;
-    use hotshot_types::traits::signature_key::ed25519::Ed25519Pub;
+    use hotshot_types::traits::signature_key::bn254::BN254Pub;
     use portpicker::pick_unused_port;
     use surf_disco::error::ClientError;
 
-    type State = RwLock<WebServerState<Ed25519Pub>>;
+    type State = RwLock<WebServerState<BN254Pub>>;
     type Error = ServerError;
 
     #[cfg_attr(


### PR DESCRIPTION
This PR:

- Implement trait Serialization, Deserialization, PartialOrd, Ord, SignatureKey, and Key Generation for BN254 Key Pair.
- Delete and substitute `TestableSignatureKey` as the comment said "TODO we don't need this if we have `generated_from_seed_indexed`".
- Discard use of Ed25519, update all of them to BN254 (besides part related to libp2p). And Ed25519 can be a parameter substituting all places that use BN254 in the future.
- Clean up some warnings related to keys and signatures.