### PR TITLE
Republish dht keys

### DIFF
--- a/libp2p-networking/src/network/node.rs
+++ b/libp2p-networking/src/network/node.rs
@@ -240,11 +240,7 @@ impl NetworkNode {
             let record_republication_interval = config
                 .republication_interval
                 .unwrap_or(Duration::from_secs(28800));
-            let ttl = Some(
-                config
-                    .republication_interval
-                    .unwrap_or(16 * record_republication_interval),
-            );
+            let ttl = Some(config.ttl.unwrap_or(16 * record_republication_interval));
             kconfig
                 .set_parallelism(NonZeroUsize::new(1).unwrap())
                 .set_provider_publication_interval(Some(record_republication_interval))

--- a/libp2p-networking/src/network/node.rs
+++ b/libp2p-networking/src/network/node.rs
@@ -176,7 +176,8 @@ impl NetworkNode {
                 // at some point in the future.
                 match config.node_type {
                     NetworkNodeType::Bootstrap => MeshParams {
-                        mesh_n_high: 50,
+                        mesh_n_high: 1000, // make this super high in case we end up scaling to 1k
+                        // nodes
                         mesh_n_low: 10,
                         mesh_outbound_min: 5,
                         mesh_n: 15,
@@ -225,7 +226,7 @@ impl NetworkNode {
             )
             .map_err(|s| GossipsubBuildSnafu { message: s }.build())?;
 
-            // - Build a identify network behavior needed for own
+            //   Build a identify network behavior needed for own
             //   node connection information
             //   E.g. this will answer the question: how are other nodes
             //   seeing the peer from behind a NAT
@@ -235,9 +236,20 @@ impl NetworkNode {
 
             // - Build DHT needed for peer discovery
             let mut kconfig = KademliaConfig::default();
-            // FIXME do we need this?
-            // <https://github.com/EspressoSystems/HotShot/issues/344>
-            kconfig.set_parallelism(NonZeroUsize::new(1).unwrap());
+            // 8 hours by default
+            let record_republication_interval = config
+                .republication_interval
+                .unwrap_or(Duration::from_secs(28800));
+            let ttl = Some(
+                config
+                    .republication_interval
+                    .unwrap_or(16 * record_republication_interval),
+            );
+            kconfig
+                .set_parallelism(NonZeroUsize::new(1).unwrap())
+                .set_provider_publication_interval(Some(record_republication_interval))
+                .set_publication_interval(Some(record_republication_interval))
+                .set_record_ttl(ttl);
 
             if let Some(factor) = config.replication_factor {
                 kconfig.set_replication_factor(factor);

--- a/libp2p-networking/src/network/node/config.rs
+++ b/libp2p-networking/src/network/node/config.rs
@@ -31,8 +31,10 @@ pub struct NetworkNodeConfig {
     /// list of addresses to connect to at initialization
     pub to_connect_addrs: HashSet<(Option<PeerId>, Multiaddr)>,
     /// republication interval in DHT, must be much less than `ttl`
+    #[builder(default)]
     pub republication_interval: Option<Duration>,
     /// expiratiry for records in DHT
+    #[builder(default)]
     pub ttl: Option<Duration>,
 }
 

--- a/libp2p-networking/src/network/node/config.rs
+++ b/libp2p-networking/src/network/node/config.rs
@@ -1,7 +1,7 @@
 use crate::network::NetworkNodeType;
 use libp2p::{identity::Keypair, Multiaddr};
 use libp2p_identity::PeerId;
-use std::{collections::HashSet, num::NonZeroUsize};
+use std::{collections::HashSet, num::NonZeroUsize, time::Duration};
 
 /// replication factor for kademlia
 pub const DEFAULT_REPLICATION_FACTOR: Option<NonZeroUsize> = NonZeroUsize::new(20);
@@ -30,6 +30,10 @@ pub struct NetworkNodeConfig {
 
     /// list of addresses to connect to at initialization
     pub to_connect_addrs: HashSet<(Option<PeerId>, Multiaddr)>,
+    /// republication interval in DHT, must be much less than `ttl`
+    pub republication_interval: Option<Duration>,
+    /// expiratiry for records in DHT
+    pub ttl: Option<Duration>,
 }
 
 /// NOTE: `mesh_outbound_min <= mesh_n_low <= mesh_n <= mesh_n_high`

--- a/libp2p-networking/tests/common/mod.rs
+++ b/libp2p-networking/tests/common/mod.rs
@@ -126,7 +126,9 @@ pub async fn spin_up_swarms<S: Debug + Default>(
             .replication_factor(replication_factor)
             .node_type(NetworkNodeType::Bootstrap)
             .to_connect_addrs(HashSet::default())
-            .bound_addr(Some(addr));
+            .bound_addr(Some(addr))
+            .ttl(None)
+            .republication_interval(None);
         let node = NetworkNodeHandle::new(
             config
                 .build()

--- a/src/traits/networking/libp2p_network.rs
+++ b/src/traits/networking/libp2p_network.rs
@@ -190,6 +190,9 @@ where
                         .node_type(NetworkNodeType::Bootstrap)
                         .bound_addr(Some(addr))
                         .to_connect_addrs(HashSet::default())
+                        // setting to sane defaults
+                        .ttl(None)
+                        .republication_interval(None)
                         .build()
                         .unwrap()
                 } else {
@@ -207,6 +210,9 @@ where
                         .node_type(NetworkNodeType::Regular)
                         .bound_addr(Some(addr))
                         .to_connect_addrs(HashSet::default())
+                        // setting to sane defaults
+                        .ttl(None)
+                        .republication_interval(None)
                         .build()
                         .unwrap()
                 };


### PR DESCRIPTION
By default, republish DHT keys every 8 hours and set expiry for every 4 days. Enable these values as configuration options by the networking layer. Closes #1531 