### PR TITLE
Ed/view sync polling fix

### DIFF
--- a/justfile
+++ b/justfile
@@ -26,8 +26,12 @@ _test_basic:
   echo Testing with async std executor
   RUST_LOG="" cargo test  --features=full-ci --lib --bins --tests --benches --workspace --no-fail-fast test_basic -- --test-threads=1 --nocapture
 
-_test_basic_tokio:
+test_web_server:
   echo Testing with async std executor
+  RUST_LOG="" cargo test  --features=full-ci --lib --bins --tests --benches --workspace --no-fail-fast web_server_network -- --test-threads=1 --nocapture
+
+_test_basic_tokio:
+  echo Testing with tokio executor
   RUST_LOG="" cargo test  --features=tokio-ci --lib --bins --tests --benches --workspace --no-fail-fast test_basic -- --test-threads=1 --nocapture
 
 test_with_failures:

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -692,6 +692,7 @@ where
         relay_task_map: HashMap::default(),
         view_sync_timeout: Duration::new(5, 0),
         id: handle.hotshot.inner.id,
+        last_garbage_collected_view: TYPES::Time::new(0)
     };
     let registry = task_runner.registry.clone();
     let view_sync_event_handler =

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -692,7 +692,7 @@ where
         relay_task_map: HashMap::default(),
         view_sync_timeout: Duration::new(5, 0),
         id: handle.hotshot.inner.id,
-        last_garbage_collected_view: TYPES::Time::new(0)
+        last_garbage_collected_view: TYPES::Time::new(0),
     };
     let registry = task_runner.registry.clone();
     let view_sync_event_handler =

--- a/task-impls/src/view_sync.rs
+++ b/task-impls/src/view_sync.rs
@@ -60,7 +60,6 @@ pub struct ViewSyncTaskInfo {
 #[derive(Snafu, Debug)]
 pub struct ViewSyncTaskError {}
 
-// TODO ED Make a constructor function for this
 pub struct ViewSyncTaskState<
     TYPES: NodeType<ConsensusType = SequencingConsensus>,
     I: NodeImplementation<
@@ -100,7 +99,7 @@ pub struct ViewSyncTaskState<
 
     pub view_sync_timeout: Duration,
 
-    pub last_garbage_collected_view: TYPES::Time, 
+    pub last_garbage_collected_view: TYPES::Time,
 }
 
 impl<
@@ -435,13 +434,10 @@ where
                     for i in *self.last_garbage_collected_view..*self.current_view {
                         self.replica_task_map.remove_entry(&TYPES::Time::new(i));
                         self.relay_task_map.remove_entry(&TYPES::Time::new(i));
-
                     }
-                
-                    self.last_garbage_collected_view = self.current_view - 1; 
 
+                    self.last_garbage_collected_view = self.current_view - 1;
                 }
-
             }
             SequencingHotShotEvent::Timeout(view_number) => {
                 // This is an old timeout and we can ignore it

--- a/task-impls/src/view_sync.rs
+++ b/task-impls/src/view_sync.rs
@@ -60,6 +60,7 @@ pub struct ViewSyncTaskInfo {
 #[derive(Snafu, Debug)]
 pub struct ViewSyncTaskError {}
 
+// TODO ED Make a constructor function for this
 pub struct ViewSyncTaskState<
     TYPES: NodeType<ConsensusType = SequencingConsensus>,
     I: NodeImplementation<
@@ -98,6 +99,8 @@ pub struct ViewSyncTaskState<
     pub relay_task_map: HashMap<TYPES::Time, ViewSyncTaskInfo>,
 
     pub view_sync_timeout: Duration,
+
+    pub last_garbage_collected_view: TYPES::Time, 
 }
 
 impl<
@@ -359,7 +362,7 @@ where
                     .exchange
                     .is_leader(vote_internal.round + vote_internal.relay)
                 {
-                    // This will occur because everyone is pulling down votes for now, will fix soon ED
+                    // TODO ED This will occur because everyone is pulling down votes for now, will fix soon
                     debug!("View sync vote sent to wrong leader");
                     return;
                 }
@@ -428,8 +431,6 @@ where
                     self.next_view = self.current_view;
                     self.num_timeouts_tracked = 0;
 
-                    // Inject view info into network
-                    // Move this to consensus task probably
                 }
             }
             SequencingHotShotEvent::Timeout(view_number) => {

--- a/task-impls/src/view_sync.rs
+++ b/task-impls/src/view_sync.rs
@@ -248,7 +248,6 @@ where
     pub async fn handle_event(&mut self, event: SequencingHotShotEvent<TYPES, I>) {
         match &event {
             SequencingHotShotEvent::ViewSyncCertificateRecv(message) => {
-                // let message = message_ref.clone();
                 let (certificate_internal, last_seen_certificate) = match &message.data {
                     ViewSyncCertificate::PreCommit(certificate_internal) => {
                         (certificate_internal, ViewSyncPhase::PreCommit)
@@ -282,8 +281,6 @@ where
                 }
 
                 // We do not have a replica task already running, so start one
-
-                // TODO ED Need to GC old entries in task map once we know we don't need them anymore
                 let mut replica_state = ViewSyncReplicaTaskState {
                     current_view: certificate_internal.round,
                     next_view: certificate_internal.round,
@@ -360,7 +357,7 @@ where
                     .exchange
                     .is_leader(vote_internal.round + vote_internal.relay)
                 {
-                    // TODO ED This will occur because everyone is pulling down votes for now, will fix soon
+                    // TODO ED This will occur because everyone is pulling down votes for now. Will be fixed in `https://github.com/EspressoSystems/HotShot/issues/1471`
                     debug!("View sync vote sent to wrong leader");
                     return;
                 }
@@ -418,7 +415,6 @@ where
 
             &SequencingHotShotEvent::ViewChange(new_view) => {
                 let new_view = TYPES::Time::new(*new_view);
-                // TODO ED Don't call new twice
                 if self.current_view < new_view {
                     debug!(
                         "Change from view {} to view {} in view sync task",

--- a/testing/src/overall_safety_task.rs
+++ b/testing/src/overall_safety_task.rs
@@ -437,6 +437,7 @@ impl OverallSafetyPropertiesDescription {
                                         }
                                     }
                                 }
+                                // TODO Emit this event in the consensus task once canceling the timeout task is implemented
                                 EventType::ReplicaViewTimeout { view_number } => {
                                     let error = Arc::new(HotShotError::<TYPES>::ViewTimeoutError {
                                         view_number,

--- a/testing/tests/web_server.rs
+++ b/testing/tests/web_server.rs
@@ -19,7 +19,7 @@ async fn web_server_network() {
     let metadata = TestMetadata {
         timing_data: TimingData {
             round_start_delay: 25,
-            next_view_timeout: 3000,
+            next_view_timeout: 10000,
             start_delay: 120000,
 
             ..Default::default()


### PR DESCRIPTION
This PR: 
* Fixes the view sync polling bug where tasks were not correctly canceled and garbage collected if a `ViewChange` event occurred during, but not because of, view sync. 
* Minor clean up to view sync task code 

Closes: https://github.com/EspressoSystems/HotShot/issues/1524