### PR TITLE
Update audit.toml to remove RUSTSEC-2022-0093 ignore

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -42,12 +42,4 @@ ignore = [
     # Waiting on a new release of https://github.com/mxinden/if-watch
     # https://rustsec.org/advisories/RUSTSEC-2022-0008
     "RUSTSEC-2022-0008",
-
-    # ed25519-dalek 1.0.1
-    # Dependency of libp2p
-    # Referenced in this issue: https://github.com/libp2p/rust-libp2p/issues/4327
-    # https://rustsec.org/advisories/RUSTSEC-2022-0093
-    "RUSTSEC-2022-0093"
-
-
 ]


### PR DESCRIPTION
The issue tracking this audit finding in libp2p has been closed.  https://github.com/libp2p/rust-libp2p/issues/4327


We can merge this once we update libp2p