### PR TITLE
Ed/update timeout vote and cert

### DIFF
--- a/consensus/src/sequencing_leader.rs
+++ b/consensus/src/sequencing_leader.rs
@@ -518,7 +518,7 @@ where
                                 }
                             }
                             QuorumVote::Timeout(vote) => {
-                                qcs.insert(vote.justify_qc);
+                                qcs.insert(vote.high_qc);
                             }
                             QuorumVote::No(_) => {
                                 warn!("The next leader has received an unexpected vote!");

--- a/consensus/src/sequencing_leader.rs
+++ b/consensus/src/sequencing_leader.rs
@@ -388,6 +388,7 @@ where
             view_number: leaf.view_number,
             height: leaf.height,
             justify_qc: self.high_qc.clone(),
+            timeout_certificate: None, 
             dac: Some(self.cert),
             proposer_id: leaf.proposer_id,
         };

--- a/consensus/src/sequencing_leader.rs
+++ b/consensus/src/sequencing_leader.rs
@@ -388,7 +388,7 @@ where
             view_number: leaf.view_number,
             height: leaf.height,
             justify_qc: self.high_qc.clone(),
-            timeout_certificate: None, 
+            timeout_certificate: None,
             dac: Some(self.cert),
             proposer_id: leaf.proposer_id,
         };

--- a/consensus/src/traits.rs
+++ b/consensus/src/traits.rs
@@ -160,6 +160,8 @@ pub trait SequencingConsensusApi<
     ) -> std::result::Result<(), NetworkError>;
 
     /// Send a message with a transaction.
+    /// This function is deprecated in favor of `submit_transaction` in `handle.rs`
+    #[deprecated]
     async fn send_transaction(
         &self,
         message: DataMessage<TYPES>,

--- a/examples/infra/modDA.rs
+++ b/examples/infra/modDA.rs
@@ -388,12 +388,7 @@ pub trait RunDA<
 
                                         debug!("Submitting txn on round {}", round);
 
-                                        let result = api
-                                            .send_transaction(DataMessage::SubmitTransaction(
-                                                txn.clone(),
-                                                TYPES::Time::new(0),
-                                            ))
-                                            .await;
+                                        let result = context.submit_transaction(txn).await;
 
                                         if result.is_err() {
                                             error! (

--- a/examples/infra/modDA.rs
+++ b/examples/infra/modDA.rs
@@ -3,7 +3,6 @@ use crate::infra::{load_config_from_file, OrchestratorArgs};
 use async_compatibility_layer::logging::{setup_backtrace, setup_logging};
 use async_trait::async_trait;
 use futures::StreamExt;
-use hotshot::HotShotSequencingConsensusApi;
 use hotshot::{
     traits::{
         implementations::{MemoryStorage, WebCommChannel, WebServerNetwork},
@@ -12,7 +11,6 @@ use hotshot::{
     types::{SignatureKey, SystemContextHandle},
     HotShotType, SystemContext, ViewRunner,
 };
-use hotshot_consensus::traits::SequencingConsensusApi;
 use hotshot_orchestrator::{
     self,
     client::{OrchestratorClient, ValidatorArgs},
@@ -20,7 +18,6 @@ use hotshot_orchestrator::{
 };
 use hotshot_task::task::FilterEvent;
 use hotshot_types::event::{Event, EventType};
-use hotshot_types::message::DataMessage;
 use hotshot_types::traits::state::ConsensusTime;
 use hotshot_types::{
     certificate::ViewSyncCertificate,
@@ -325,10 +322,6 @@ pub trait RunDA<
         let mut num_successful_commits = 0;
 
         let total_nodes_u64 = total_nodes.get() as u64;
-
-        let api = HotShotSequencingConsensusApi {
-            inner: context.hotshot.inner.clone(),
-        };
 
         context.hotshot.start_consensus().await;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1594,24 +1594,27 @@ impl<
         message: DataMessage<TYPES>,
     ) -> std::result::Result<(), NetworkError> {
         debug!(?message, "send_broadcast_message");
-        self.inner
-            .exchanges
-            .committee_exchange()
-            .network()
-            .broadcast_message(
-                Message {
-                    sender: self.inner.public_key.clone(),
-                    kind: MessageKind::from(message),
-                    _phantom: PhantomData,
-                },
-                &self
-                    .inner
-                    .exchanges
-                    .committee_exchange()
-                    .membership()
-                    .clone(),
-            )
-            .await?;
+        let api = self.clone();
+        async_spawn(async move {
+            let _result = api
+                .inner
+                .exchanges
+                .committee_exchange()
+                .network()
+                .broadcast_message(
+                    Message {
+                        sender: api.inner.public_key.clone(),
+                        kind: MessageKind::from(message),
+                        _phantom: PhantomData,
+                    },
+                    &api.inner
+                        .exchanges
+                        .committee_exchange()
+                        .membership()
+                        .clone(),
+                )
+                .await;
+        });
         Ok(())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -324,29 +324,45 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> SystemContext<TYPES, I> {
         };
     }
 
-    /// Publishes a transaction to the network
+    /// Publishes a transaction asynchronously to the network
     ///
     /// # Errors
     ///
-    /// Will generate an error if an underlying network error occurs
+    /// Always returns Ok; does not return an error if the transaction couldn't be published to the network
     #[instrument(skip(self), err)]
     pub async fn publish_transaction_async(
         &self,
         transaction: TYPES::Transaction,
     ) -> Result<(), HotShotError<TYPES>> {
-        // Add the transaction to our own queue first
         trace!("Adding transaction to our own queue");
         // Wrap up a message
         // TODO place a view number here that makes sense
         // we haven't worked out how this will work yet
-        // let message = DataMessage::SubmitTransaction(transaction, TYPES::Time::new(0));
-
-        // self.inner.exchanges.committee_exchange().network.broadcast(message).await;
-
-        // let api = self.clone();
-        // async_spawn(async move {
-        //     // let _result = self.inner.exchanges.committee_exchange().network.broadcast(message).await.is_err();
-        // });
+        let message = DataMessage::SubmitTransaction(transaction, TYPES::Time::new(0));
+        let api = self.clone();
+        // TODO We should have a function that can return a network error if there is one
+        // but first we'd need to ensure our network implementations can support that
+        // (and not hang instead)
+        async_spawn(async move {
+            let _result = api
+                .inner
+                .exchanges
+                .committee_exchange()
+                .network()
+                .broadcast_message(
+                    Message {
+                        sender: api.inner.public_key.clone(),
+                        kind: MessageKind::from(message),
+                        _phantom: PhantomData,
+                    },
+                    &api.inner
+                        .exchanges
+                        .committee_exchange()
+                        .membership()
+                        .clone(),
+                )
+                .await;
+        });
         Ok(())
     }
 

--- a/src/types/handle.rs
+++ b/src/types/handle.rs
@@ -167,10 +167,6 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static> SystemContextHandl
     ///
     /// Will return a [`HotShotError`] if some error occurs in the underlying
     /// [`SystemContext`] instance.
-    ///
-    /// For now this function is deprecated.  Use `send_transaction` instead
-    /// This function will be updated with <https://github.com/EspressoSystems/HotShot/issues/1526>
-    #[deprecated]
     pub async fn submit_transaction(
         &self,
         tx: TYPES::Transaction,

--- a/task-impls/src/consensus.rs
+++ b/task-impls/src/consensus.rs
@@ -529,11 +529,9 @@ where
                 // let next_view_timeout = hotshot.inner.config.next_view_timeout;
                 // let next_view_timeout = next_view_timeout;
                 // let hotshot: HotShot<TYPES::ConsensusType, TYPES, I> = hotshot.clone();
-                // TODO(bf): get the real timeout from the config.
                 let stream = self.event_stream.clone();
                 let view_number = self.cur_view;
                 async move {
-                    // ED: Changing to 1 second to test timeout logic
                     async_sleep(Duration::from_millis(timeout)).await;
                     stream
                         .publish(SequencingHotShotEvent::Timeout(ViewNumber::new(

--- a/task-impls/src/consensus.rs
+++ b/task-impls/src/consensus.rs
@@ -1093,7 +1093,7 @@ where
                     })
                     .await;
                 if !self.update_view(new_view).await {
-                    error!("view not updated");
+                    debug!("view not updated");
                     return;
                 }
 

--- a/task-impls/src/consensus.rs
+++ b/task-impls/src/consensus.rs
@@ -887,7 +887,6 @@ where
                         if !self.vote_if_able().await {
                             // TOOD ED This means we publish the proposal without updating our own view, which doesn't seem right
                             return;
-
                         }
 
                         // ED Only do this GC if we are able to vote
@@ -1065,13 +1064,13 @@ where
                 }
 
                 self.output_event_stream
-                .publish(Event {
-                    view_number: old_view_number,
-                    event: EventType::ViewFinished {
+                    .publish(Event {
                         view_number: old_view_number,
-                    },
-                })
-                .await;
+                        event: EventType::ViewFinished {
+                            view_number: old_view_number,
+                        },
+                    })
+                    .await;
 
                 debug!("View Change event for view {}", *new_view);
 
@@ -1086,10 +1085,10 @@ where
                 let qc = consensus.high_qc.clone();
                 drop(consensus);
                 // TODO ED We should only publish on view change, not just when we form a QC
-                // Normally I'd argue leader logic should be completely separate, but maybe not in this case? 
+                // Normally I'd argue leader logic should be completely separate, but maybe not in this case?
                 // TODO ED What in the last proposal does this leader need to propose?
-                // Seems like a good optimization to wait for replica side to hear proposal, so we don't get a bunch 
-                // of repeated views in testing. 
+                // Seems like a good optimization to wait for replica side to hear proposal, so we don't get a bunch
+                // of repeated views in testing.
                 if !self.publish_proposal_if_able(qc).await {
                     error!(
                         "Failed to publish proposal on view change.  View = {:?}",
@@ -1119,7 +1118,7 @@ where
 
     /// Sends a proposal if possible from the high qc we have
     pub async fn publish_proposal_if_able(&self, qc: QuorumCertificate<TYPES, I::Leaf>) -> bool {
-        // TODO ED This should not be qc view number + 1, how did this ever pass before?  I guess there were never timeouts? 
+        // TODO ED This should not be qc view number + 1, how did this ever pass before?  I guess there were never timeouts?
         if !self.quorum_exchange.is_leader(qc.view_number + 1) {
             error!("Somehow we formed a QC but are not the leader for the next view");
             return false;
@@ -1205,7 +1204,7 @@ where
             height: leaf.height,
             justify_qc: consensus.high_qc.clone(),
             // TODO ED Update this to be the actual TC if there is one
-            timeout_certificate: None, 
+            timeout_certificate: None,
             proposer_id: leaf.proposer_id,
             dac: None,
         };

--- a/task-impls/src/consensus.rs
+++ b/task-impls/src/consensus.rs
@@ -589,6 +589,8 @@ where
                         let consensus = self.consensus.upgradable_read().await;
                         let message;
 
+                        // TODO ED Insert TC logic here
+
                         // Construct the leaf.
                         let justify_qc = proposal.data.justify_qc;
                         let parent = if justify_qc.is_genesis() {

--- a/task-impls/src/view_sync.rs
+++ b/task-impls/src/view_sync.rs
@@ -918,7 +918,6 @@ where
     >,
 {
     #[instrument(skip_all, fields(id = self.id), name = "View Sync Relay Task", level = "error")]
-
     pub async fn handle_event(
         mut self,
         event: SequencingHotShotEvent<TYPES, I>,

--- a/task-impls/src/view_sync.rs
+++ b/task-impls/src/view_sync.rs
@@ -456,8 +456,6 @@ where
                 if view_number < ViewNumber::new(*self.current_view) {
                     return;
                 }
-                
-
 
                 self.num_timeouts_tracked += 1;
                 error!("Num timeouts tracked is {}", self.num_timeouts_tracked);

--- a/task-impls/src/view_sync.rs
+++ b/task-impls/src/view_sync.rs
@@ -456,6 +456,8 @@ where
                 if view_number < ViewNumber::new(*self.current_view) {
                     return;
                 }
+                
+
 
                 self.num_timeouts_tracked += 1;
                 error!("Num timeouts tracked is {}", self.num_timeouts_tracked);

--- a/testing/src/test_builder.rs
+++ b/testing/src/test_builder.rs
@@ -44,7 +44,7 @@ pub struct TestMetadata {
     pub start_nodes: usize,
     /// number of bootstrap nodes (libp2p usage only)
     pub num_bootstrap_nodes: usize,
-    /// Size of the DA committee for the test.  0 == no DA.
+    /// Size of the DA committee for the test
     pub da_committee_size: usize,
     // overall safety property description
     pub overall_safety_properties: OverallSafetyPropertiesDescription,

--- a/testing/src/test_runner.rs
+++ b/testing/src/test_runner.rs
@@ -145,7 +145,6 @@ where
         task_runner = task_runner.add_task(id, "Test Overall Safety Task".to_string(), task);
 
         // Start hotshot
-        // Goes through all nodes, but really only needs to call this on the leader node of the first view
         for node in nodes {
             node.handle.hotshot.start_consensus().await;
         }

--- a/testing/src/txn_task.rs
+++ b/testing/src/txn_task.rs
@@ -2,8 +2,6 @@ use crate::test_runner::Node;
 use async_compatibility_layer::art::async_sleep;
 use futures::FutureExt;
 use hotshot::traits::TestableNodeImplementation;
-use hotshot::HotShotSequencingConsensusApi;
-use hotshot_consensus::traits::SequencingConsensusApi;
 use hotshot_task::{
     boxed_sync,
     event_stream::ChannelStream,
@@ -11,11 +9,9 @@ use hotshot_task::{
     task_impls::{HSTWithEventAndMessage, TaskBuilder},
     GeneratedStream,
 };
-use hotshot_types::message::DataMessage;
 use hotshot_types::message::SequencingMessage;
 use hotshot_types::traits::node_implementation::NodeImplementation;
 use hotshot_types::traits::node_implementation::NodeType;
-use hotshot_types::traits::state::ConsensusTime;
 use rand::thread_rng;
 use snafu::Snafu;
 use std::{sync::Arc, time::Duration};

--- a/testing/src/txn_task.rs
+++ b/testing/src/txn_task.rs
@@ -108,7 +108,6 @@ impl TxnTaskDescription {
                                     }
                                     Some(node) => {
                                         // use rand::seq::IteratorRandom;
-                                        // handle.submit_transaction()
                                         // we're assuming all nodes have the same leaf.
                                         // If they don't match, this is probably fine since
                                         // it should be caught by an assertion (and the txn will be rejected anyway)
@@ -118,16 +117,10 @@ impl TxnTaskDescription {
                                             &mut thread_rng(),
                                             0,
                                         );
-                                        // ED Shouldn't create this each time
-                                        let api = HotShotSequencingConsensusApi {
-                                            inner: node.handle.hotshot.inner.clone(),
-                                        };
-                                        api.send_transaction(DataMessage::SubmitTransaction(
-                                            txn.clone(),
-                                            TYPES::Time::new(0),
-                                        ))
-                                        .await
-                                        .expect("Could not send transaction");
+                                        node.handle
+                                            .submit_transaction(txn.clone())
+                                            .await
+                                            .expect("Could not send transaction");
                                         (None, state)
                                     }
                                 }

--- a/testing/tests/consensus_task.rs
+++ b/testing/tests/consensus_task.rs
@@ -89,6 +89,7 @@ async fn build_proposal_and_signature(
         view_number: ViewNumber::new(1),
         height: 1,
         justify_qc: QuorumCertificate::genesis(),
+        timeout_certificate: None, 
         proposer_id: leaf.proposer_id,
         dac: None,
     };

--- a/testing/tests/consensus_task.rs
+++ b/testing/tests/consensus_task.rs
@@ -89,7 +89,7 @@ async fn build_proposal_and_signature(
         view_number: ViewNumber::new(1),
         height: 1,
         justify_qc: QuorumCertificate::genesis(),
-        timeout_certificate: None, 
+        timeout_certificate: None,
         proposer_id: leaf.proposer_id,
         dac: None,
     };

--- a/testing/tests/timeout.rs
+++ b/testing/tests/timeout.rs
@@ -31,6 +31,9 @@ async fn test_timeout() {
     metadata.spinning_properties = SpinningTaskDescription {
         node_changes: vec![(Duration::new(1, 0), dead_nodes)],
     };
+
+    // TODO ED Add safety task, etc to confirm TCs are being formed
+
     metadata.completion_task_description =
         CompletionTaskDescription::TimeBasedCompletionTaskBuilder(
             TimeBasedCompletionTaskDescription {

--- a/testing/tests/timeout.rs
+++ b/testing/tests/timeout.rs
@@ -4,6 +4,7 @@
     tokio::test(flavor = "multi_thread", worker_threads = 2)
 )]
 #[cfg_attr(feature = "async-std-executor", async_std::test)]
+#[ignore]
 async fn test_timeout() {
     use std::time::Duration;
 

--- a/testing/tests/timeout.rs
+++ b/testing/tests/timeout.rs
@@ -1,0 +1,43 @@
+#[cfg(test)]
+#[cfg_attr(
+    feature = "tokio-executor",
+    tokio::test(flavor = "multi_thread", worker_threads = 2)
+)]
+#[cfg_attr(feature = "async-std-executor", async_std::test)]
+async fn test_timeout() {
+    use std::time::Duration;
+
+    use hotshot_testing::{
+        node_types::{SequencingMemoryImpl, SequencingTestTypes},
+        spinning_task::{ChangeNode, SpinningTaskDescription, UpDown},
+        test_builder::{TestMetadata, TimingData},
+        completion_task::{TimeBasedCompletionTaskDescription, CompletionTaskDescription},
+    };
+
+    async_compatibility_layer::logging::setup_logging();
+    async_compatibility_layer::logging::setup_backtrace();
+    let mut timing_data = TimingData::default(); 
+    timing_data.next_view_timeout = 1000;
+    let mut metadata = TestMetadata::default();
+    let dead_nodes = vec![ChangeNode {
+        idx: 2,
+        updown: UpDown::Down,
+    }];
+
+    metadata.timing_data = timing_data; 
+
+    metadata.spinning_properties = SpinningTaskDescription {
+        node_changes: vec![(Duration::new(1, 0), dead_nodes)],
+    };
+    metadata.completion_task_description = CompletionTaskDescription::TimeBasedCompletionTaskBuilder(
+        TimeBasedCompletionTaskDescription {
+            duration: Duration::from_millis(30000),
+        },
+    );
+    metadata
+        .gen_launcher::<SequencingTestTypes, SequencingMemoryImpl>()
+        .launch()
+        .run_test()
+        .await;
+}
+

--- a/testing/tests/timeout.rs
+++ b/testing/tests/timeout.rs
@@ -31,7 +31,7 @@ async fn test_timeout() {
     };
     metadata.completion_task_description = CompletionTaskDescription::TimeBasedCompletionTaskBuilder(
         TimeBasedCompletionTaskDescription {
-            duration: Duration::from_millis(30000),
+            duration: Duration::from_millis(10000),
         },
     );
     metadata

--- a/testing/tests/timeout.rs
+++ b/testing/tests/timeout.rs
@@ -8,36 +8,38 @@ async fn test_timeout() {
     use std::time::Duration;
 
     use hotshot_testing::{
+        completion_task::{CompletionTaskDescription, TimeBasedCompletionTaskDescription},
         node_types::{SequencingMemoryImpl, SequencingTestTypes},
         spinning_task::{ChangeNode, SpinningTaskDescription, UpDown},
         test_builder::{TestMetadata, TimingData},
-        completion_task::{TimeBasedCompletionTaskDescription, CompletionTaskDescription},
     };
 
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
-    let mut timing_data = TimingData::default(); 
-    timing_data.next_view_timeout = 1000;
+    let timing_data = TimingData {
+        next_view_timeout: 1000,
+        ..Default::default()
+    };
     let mut metadata = TestMetadata::default();
     let dead_nodes = vec![ChangeNode {
-        idx: 2,
+        idx: 0,
         updown: UpDown::Down,
     }];
 
-    metadata.timing_data = timing_data; 
+    metadata.timing_data = timing_data;
 
     metadata.spinning_properties = SpinningTaskDescription {
         node_changes: vec![(Duration::new(1, 0), dead_nodes)],
     };
-    metadata.completion_task_description = CompletionTaskDescription::TimeBasedCompletionTaskBuilder(
-        TimeBasedCompletionTaskDescription {
-            duration: Duration::from_millis(10000),
-        },
-    );
+    metadata.completion_task_description =
+        CompletionTaskDescription::TimeBasedCompletionTaskBuilder(
+            TimeBasedCompletionTaskDescription {
+                duration: Duration::from_millis(10000),
+            },
+        );
     metadata
         .gen_launcher::<SequencingTestTypes, SequencingMemoryImpl>()
         .launch()
         .run_test()
         .await;
 }
-

--- a/types/src/certificate.rs
+++ b/types/src/certificate.rs
@@ -103,6 +103,7 @@ pub struct ViewSyncCertificateInternal<TYPES: NodeType> {
 #[serde(bound(deserialize = ""))]
 /// Enum representing whether a signatures is for a 'Yes' or 'No' or 'DA' or 'Genesis' certificate
 pub enum AssembledSignature<TYPES: NodeType> {
+    // (enum, signature)
     /// These signatures are for a 'Yes' certificate
     Yes(<TYPES::SignatureKey as SignatureKey>::QCType),
     /// These signatures are for a 'No' certificate

--- a/types/src/certificate.rs
+++ b/types/src/certificate.rs
@@ -67,7 +67,7 @@ impl<TYPES: NodeType, LEAF: LeafType<NodeType = TYPES>> Display for QuorumCertif
 }
 
 /// Timeout Certificate
-#[derive(custom_debug::Debug, serde::Serialize, serde::Deserialize, Clone, PartialEq, Hash)]
+#[derive(custom_debug::Debug, serde::Serialize, serde::Deserialize, Clone, PartialEq, Eq, Hash)]
 #[serde(bound(deserialize = ""))]
 pub struct TimeoutCertificate<TYPES: NodeType> {
     /// View that timed out
@@ -109,7 +109,7 @@ pub struct ViewSyncCertificateInternal<TYPES: NodeType> {
     pub signatures: AssembledSignature<TYPES>,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Hash)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash)]
 #[serde(bound(deserialize = ""))]
 /// Enum representing whether a signatures is for a 'Yes' or 'No' or 'DA' or 'Genesis' certificate
 pub enum AssembledSignature<TYPES: NodeType> {

--- a/types/src/certificate.rs
+++ b/types/src/certificate.rs
@@ -66,6 +66,16 @@ impl<TYPES: NodeType, LEAF: LeafType<NodeType = TYPES>> Display for QuorumCertif
     }
 }
 
+/// Timeout Certificate
+#[derive(custom_debug::Debug, serde::Serialize, serde::Deserialize, Clone, PartialEq, Hash)]
+#[serde(bound(deserialize = ""))]
+pub struct TimeoutCertificate<TYPES: NodeType> {
+    /// View that timed out
+    pub view_number: TYPES::Time,
+    /// assembled signature for certificate aggregation
+    pub signatures: AssembledSignature<TYPES>,
+}
+
 /// Certificate for view sync.
 #[derive(custom_debug::Debug, serde::Serialize, serde::Deserialize, Clone, PartialEq, Hash)]
 #[serde(bound(deserialize = ""))]

--- a/types/src/data.rs
+++ b/types/src/data.rs
@@ -4,7 +4,7 @@
 //! `HotShot`'s version of a block, and proposals, messages upon which to reach the consensus.
 
 use crate::{
-    certificate::{AssembledSignature, DACertificate, QuorumCertificate, ViewSyncCertificate},
+    certificate::{AssembledSignature, DACertificate, QuorumCertificate, ViewSyncCertificate, TimeoutCertificate},
     constants::genesis_proposer_id,
     traits::{
         election::SignedCertificate,
@@ -166,10 +166,14 @@ pub struct QuorumProposal<TYPES: NodeType, LEAF: LeafType<NodeType = TYPES>> {
     /// Per spec, justification
     pub justify_qc: QuorumCertificate<TYPES, LEAF>,
 
+    /// Possible timeout certificate.  Only present if the justify_qc is not for the preceding view
+    pub timeout_certificate: Option<TimeoutCertificate<TYPES>>,
+
     /// the propser id
     pub proposer_id: EncodedPublicKey,
 
     /// Data availibity certificate
+    // TODO We should be able to remove this
     pub dac: Option<DACertificate<TYPES>>,
 }
 

--- a/types/src/data.rs
+++ b/types/src/data.rs
@@ -4,7 +4,10 @@
 //! `HotShot`'s version of a block, and proposals, messages upon which to reach the consensus.
 
 use crate::{
-    certificate::{AssembledSignature, DACertificate, QuorumCertificate, ViewSyncCertificate, TimeoutCertificate},
+    certificate::{
+        AssembledSignature, DACertificate, QuorumCertificate, TimeoutCertificate,
+        ViewSyncCertificate,
+    },
     constants::genesis_proposer_id,
     traits::{
         election::SignedCertificate,

--- a/types/src/traits/election.rs
+++ b/types/src/traits/election.rs
@@ -887,7 +887,7 @@ impl<
     /// Create a message with a timeout vote on validating or commitment proposal.
     fn create_timeout_message<I: NodeImplementation<TYPES, Leaf = LEAF>>(
         &self,
-        justify_qc: QuorumCertificate<TYPES, LEAF>,
+        high_qc: QuorumCertificate<TYPES, LEAF>,
         current_view: TYPES::Time,
         vote_token: TYPES::VoteTokenType,
     ) -> GeneralConsensusMessage<TYPES, I>
@@ -896,7 +896,7 @@ impl<
     {
         let signature = self.sign_timeout_vote(current_view);
         GeneralConsensusMessage::<TYPES, I>::Vote(QuorumVote::Timeout(TimeoutVote {
-            justify_qc,
+            high_qc,
             signature,
             current_view,
             vote_token,

--- a/types/src/traits/election.rs
+++ b/types/src/traits/election.rs
@@ -1224,7 +1224,7 @@ impl<
                 let real_commit = VoteData::ViewSyncPreCommit(vote_data.commit()).commit();
                 let real_qc_pp = <TYPES::SignatureKey as SignatureKey>::get_public_parameter(
                     self.membership().get_committee_qc_stake_table(),
-                    U256::from(self.membership().success_threshold().get()),
+                    U256::from(self.membership().failure_threshold().get()),
                 );
                 <TYPES::SignatureKey as SignatureKey>::check(
                     &real_qc_pp,

--- a/types/src/vote.rs
+++ b/types/src/vote.rs
@@ -460,7 +460,7 @@ where
         if *viewsync_precommit_stake_casted >= u64::from(self.failure_threshold) {
             let real_qc_pp = <TYPES::SignatureKey as SignatureKey>::get_public_parameter(
                 entries,
-                U256::from(self.success_threshold.get()),
+                U256::from(self.failure_threshold.get()),
             );
 
             let real_qc_sig = <TYPES::SignatureKey as SignatureKey>::assemble(

--- a/types/src/vote.rs
+++ b/types/src/vote.rs
@@ -38,8 +38,6 @@ pub trait VoteType<TYPES: NodeType>:
 #[serde(bound(deserialize = ""))]
 pub struct DAVote<TYPES: NodeType> {
     /// The signature share associated with this vote
-    /// TODO ct/vrf make ConsensusMessage generic over I instead of serializing to a [`Vec<u8>`]
-    // signature.2 = entry including public key for certificate aggregation
     pub signature: (EncodedPublicKey, EncodedSignature),
     /// The block commitment being voted on.
     pub block_commitment: Commitment<TYPES::BlockType>,
@@ -60,8 +58,6 @@ pub struct YesOrNoVote<TYPES: NodeType, LEAF: LeafType<NodeType = TYPES>> {
     /// we should check a cache, and if that fails request the qc
     pub justify_qc_commitment: Commitment<QuorumCertificate<TYPES, LEAF>>,
     /// The signature share associated with this vote
-    /// TODO ct/vrf make ConsensusMessage generic over I instead of serializing to a [`Vec<u8>`]
-    // signature.2 = entry with public key for certificate aggregation
     pub signature: (EncodedPublicKey, EncodedSignature),
     /// The leaf commitment being voted on.
     pub leaf_commitment: Commitment<LEAF>,
@@ -77,13 +73,9 @@ pub struct YesOrNoVote<TYPES: NodeType, LEAF: LeafType<NodeType = TYPES>> {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash)]
 #[serde(bound(deserialize = ""))]
 pub struct TimeoutVote<TYPES: NodeType, LEAF: LeafType<NodeType = TYPES>> {
-    /// The justification qc for this view
-    // TODO ED This should be the high_qc instead, and the signature should be over it,
-    // not just over the view number
-    pub justify_qc: QuorumCertificate<TYPES, LEAF>,
+    // The highest valid QC this node knows about
+    pub high_qc: QuorumCertificate<TYPES, LEAF>,
     /// The signature share associated with this vote
-    /// TODO ct/vrf make ConsensusMessage generic over I instead of serializing to a [`Vec<u8>`]
-    // signature.2 = entry with public key for certificate aggregation
     pub signature: (EncodedPublicKey, EncodedSignature),
     /// The view this vote was cast for
     pub current_view: TYPES::Time,

--- a/types/src/vote.rs
+++ b/types/src/vote.rs
@@ -73,7 +73,7 @@ pub struct YesOrNoVote<TYPES: NodeType, LEAF: LeafType<NodeType = TYPES>> {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash)]
 #[serde(bound(deserialize = ""))]
 pub struct TimeoutVote<TYPES: NodeType, LEAF: LeafType<NodeType = TYPES>> {
-    // The highest valid QC this node knows about
+    /// The highest valid QC this node knows about
     pub high_qc: QuorumCertificate<TYPES, LEAF>,
     /// The signature share associated with this vote
     pub signature: (EncodedPublicKey, EncodedSignature),


### PR DESCRIPTION
I want to get this merged before I start reworking the view change logic based on this discussion: https://espresso.zulipchat.com/#narrow/stream/311646-Consensus/topic/.E2.9C.94.20Timeout.20Logic

This PR: 

- [x] Updates view sync pre-commit certificates to properly work with signature aggregation by changing their threshold to `failure_threshold`, which is correct since pre-commit certificates only need f + 1 votes instead of the usual 2f + 1
- [x] Fixes https://github.com/EspressoSystems/HotShot/issues/1567 by making transaction submission create an async task to send the transaction.  This is how it was previously implemented before the event-based architecture refactor.  Also fixes https://github.com/EspressoSystems/HotShot/issues/1526 by un-deprecating `submit_transaction` and deprecating `send_transaction`
  * In the future we should support a client waiting for the result of the transaction submission
- [x] Creates basic test for timeouts
  * This test is currently ignored since it fails.  That is expected because timeout is not fully implemented
- [x] Add basic `TimeoutCertificate`