### PR TITLE
chore: inherited workspace dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2581,7 +2581,6 @@ dependencies = [
  "custom_debug",
  "dashmap",
  "derivative",
- "digest 0.10.7",
  "either",
  "embed-doc-image",
  "espresso-systems-common 0.4.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2666,7 +2666,6 @@ dependencies = [
  "hotshot-utils",
  "hotshot-web-server",
  "itertools 0.11.0",
- "jf-primitives",
  "libp2p",
  "libp2p-identity",
  "libp2p-networking",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2589,7 +2589,6 @@ dependencies = [
  "futures",
  "hotshot-consensus",
  "hotshot-orchestrator",
- "hotshot-primitives",
  "hotshot-task",
  "hotshot-task-impls",
  "hotshot-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2602,7 +2602,7 @@ dependencies = [
  "serde",
  "serde_json",
  "snafu",
- "surf-disco 0.4.1 (git+https://github.com/EspressoSystems/surf-disco.git?branch=main)",
+ "surf-disco",
  "time 0.3.27",
  "tokio",
  "toml 0.7.6",
@@ -2657,7 +2657,7 @@ dependencies = [
  "serde",
  "serde_json",
  "snafu",
- "surf-disco 0.4.1 (git+https://github.com/EspressoSystems/surf-disco.git?tag=v0.4.1)",
+ "surf-disco",
  "tide-disco",
  "tokio",
  "toml 0.5.11",
@@ -2902,7 +2902,7 @@ dependencies = [
  "serde",
  "serde_json",
  "snafu",
- "surf-disco 0.4.1 (git+https://github.com/EspressoSystems/surf-disco.git?tag=v0.4.1)",
+ "surf-disco",
  "tide",
  "tide-disco",
  "tokio",
@@ -6526,23 +6526,6 @@ dependencies = [
 name = "surf-disco"
 version = "0.4.1"
 source = "git+https://github.com/EspressoSystems/surf-disco.git?tag=v0.4.1#3f85fd53b9e5b2c0b801cf8c2252f2397aa80da0"
-dependencies = [
- "async-std",
- "async-tungstenite 0.15.0",
- "bincode",
- "derivative",
- "futures",
- "hex",
- "serde",
- "serde_json",
- "surf",
- "tide-disco",
-]
-
-[[package]]
-name = "surf-disco"
-version = "0.4.1"
-source = "git+https://github.com/EspressoSystems/surf-disco.git?branch=main#d0a89cbb29df7eaa3ce0d656ebf68cb1e0ce4091"
 dependencies = [
  "async-std",
  "async-tungstenite 0.15.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2568,7 +2568,6 @@ dependencies = [
 name = "hotshot"
 version = "0.3.3"
 dependencies = [
- "ark-serialize 0.3.0",
  "async-compatibility-layer",
  "async-lock",
  "async-std",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -232,20 +232,9 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb00293ba84f51ce3bd026bd0de55899c4e68f0a39a5728cebae3a73ffdc0a4f"
 dependencies = [
- "ark-ec 0.4.2",
- "ark-ff 0.4.2",
+ "ark-ec",
+ "ark-ff",
  "ark-std 0.4.0",
-]
-
-[[package]]
-name = "ark-bls12-381"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65be532f9dd1e98ad0150b037276cde464c6f371059e6dd02c0222395761f6aa"
-dependencies = [
- "ark-ec 0.3.0",
- "ark-ff 0.3.0",
- "ark-std 0.3.0",
 ]
 
 [[package]]
@@ -254,8 +243,8 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c775f0d12169cba7aae4caeb547bb6a50781c7449a8aa53793827c9ec4abf488"
 dependencies = [
- "ark-ec 0.4.2",
- "ark-ff 0.4.2",
+ "ark-ec",
+ "ark-ff",
  "ark-serialize 0.4.2",
  "ark-std 0.4.0",
 ]
@@ -266,8 +255,8 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a22f4561524cd949590d78d7d4c5df8f592430d221f7f3c9497bbafd8972120f"
 dependencies = [
- "ark-ec 0.4.2",
- "ark-ff 0.4.2",
+ "ark-ec",
+ "ark-ff",
  "ark-std 0.4.0",
 ]
 
@@ -278,8 +267,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e0605daf0cc5aa2034b78d008aaf159f56901d92a52ee4f6ecdfdac4f426700"
 dependencies = [
  "ark-bls12-377",
- "ark-ec 0.4.2",
- "ark-ff 0.4.2",
+ "ark-ec",
+ "ark-ff",
  "ark-std 0.4.0",
 ]
 
@@ -289,8 +278,8 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3a13b34da09176a8baba701233fdffbaa7c1b1192ce031a3da4e55ce1f1a56"
 dependencies = [
- "ark-ec 0.4.2",
- "ark-ff 0.4.2",
+ "ark-ec",
+ "ark-ff",
  "ark-relations",
  "ark-serialize 0.4.2",
  "ark-snark",
@@ -303,25 +292,11 @@ dependencies = [
 
 [[package]]
 name = "ark-ec"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dea978406c4b1ca13c2db2373b05cc55429c3575b8b21f1b9ee859aa5b03dd42"
-dependencies = [
- "ark-ff 0.3.0",
- "ark-serialize 0.3.0",
- "ark-std 0.3.0",
- "derivative",
- "num-traits",
- "zeroize",
-]
-
-[[package]]
-name = "ark-ec"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "defd9a439d56ac24968cca0571f598a61bc8c55f71d50a89cda591cb750670ba"
 dependencies = [
- "ark-ff 0.4.2",
+ "ark-ff",
  "ark-poly",
  "ark-serialize 0.4.2",
  "ark-std 0.4.0",
@@ -340,8 +315,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b10d901b9ac4b38f9c32beacedfadcdd64e46f8d7f8e88c1ae1060022cf6f6c6"
 dependencies = [
  "ark-bls12-377",
- "ark-ec 0.4.2",
- "ark-ff 0.4.2",
+ "ark-ec",
+ "ark-ff",
  "ark-std 0.4.0",
 ]
 
@@ -351,9 +326,9 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba6d678bb98a7e4f825bd4e332e93ac4f5a114ce2e3340dee4d7dc1c7ab5b323"
 dependencies = [
- "ark-bls12-381 0.4.0",
- "ark-ec 0.4.2",
- "ark-ff 0.4.2",
+ "ark-bls12-381",
+ "ark-ec",
+ "ark-ff",
  "ark-std 0.4.0",
 ]
 
@@ -364,27 +339,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71892f265d01650e34988a546b37ea1d2ba1da162a639597a03d1550f26004d8"
 dependencies = [
  "ark-bn254",
- "ark-ec 0.4.2",
- "ark-ff 0.4.2",
+ "ark-ec",
+ "ark-ff",
  "ark-std 0.4.0",
-]
-
-[[package]]
-name = "ark-ff"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b3235cc41ee7a12aaaf2c575a2ad7b46713a8a50bda2fc3b003a04845c05dd6"
-dependencies = [
- "ark-ff-asm 0.3.0",
- "ark-ff-macros 0.3.0",
- "ark-serialize 0.3.0",
- "ark-std 0.3.0",
- "derivative",
- "num-bigint",
- "num-traits",
- "paste",
- "rustc_version 0.3.3",
- "zeroize",
 ]
 
 [[package]]
@@ -393,8 +350,8 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec847af850f44ad29048935519032c33da8aa03340876d351dfab5660d2966ba"
 dependencies = [
- "ark-ff-asm 0.4.2",
- "ark-ff-macros 0.4.2",
+ "ark-ff-asm",
+ "ark-ff-macros",
  "ark-serialize 0.4.2",
  "ark-std 0.4.0",
  "derivative",
@@ -410,32 +367,10 @@ dependencies = [
 
 [[package]]
 name = "ark-ff-asm"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db02d390bf6643fb404d3d22d31aee1c4bc4459600aef9113833d17e786c6e44"
-dependencies = [
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "ark-ff-asm"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ed4aa4fe255d0bc6d79373f7e31d2ea147bcf486cba1be5ba7ea85abdb92348"
 dependencies = [
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "ark-ff-macros"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2fd794a08ccb318058009eefdf15bcaaaaf6f8161eb3345f907222bac38b20"
-dependencies = [
- "num-bigint",
- "num-traits",
  "quote",
  "syn 1.0.109",
 ]
@@ -459,8 +394,8 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "760ecac12a00211188c9101b63bd284b80da5abcc5d97d9d2b3803bca1f63a52"
 dependencies = [
- "ark-ec 0.4.2",
- "ark-ff 0.4.2",
+ "ark-ec",
+ "ark-ff",
  "ark-std 0.4.0",
 ]
 
@@ -470,7 +405,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d320bfc44ee185d899ccbadfa8bc31aab923ce1558716e1997a1e74057fe86bf"
 dependencies = [
- "ark-ff 0.4.2",
+ "ark-ff",
  "ark-serialize 0.4.2",
  "ark-std 0.4.0",
  "derivative",
@@ -484,7 +419,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00796b6efc05a3f48225e59cb6a2cda78881e7c390872d5786aaf112f31fb4f0"
 dependencies = [
- "ark-ff 0.4.2",
+ "ark-ff",
  "ark-std 0.4.0",
  "tracing",
 ]
@@ -540,7 +475,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84d3cc6833a335bb8a600241889ead68ee89a3cf8448081fb7694c0fe503da63"
 dependencies = [
- "ark-ff 0.4.2",
+ "ark-ff",
  "ark-relations",
  "ark-serialize 0.4.2",
  "ark-std 0.4.0",
@@ -2633,7 +2568,6 @@ dependencies = [
 name = "hotshot"
 version = "0.3.3"
 dependencies = [
- "ark-bls12-381 0.3.0",
  "ark-ed-on-bls12-381",
  "ark-serialize 0.3.0",
  "async-compatibility-layer",
@@ -2745,10 +2679,10 @@ source = "git+https://github.com/EspressoSystems/hotshot-primitives?branch=hotsh
 dependencies = [
  "anyhow",
  "ark-bls12-377",
- "ark-bls12-381 0.4.0",
+ "ark-bls12-381",
  "ark-bn254",
- "ark-ec 0.4.2",
- "ark-ff 0.4.2",
+ "ark-ec",
+ "ark-ff",
  "ark-pallas",
  "ark-poly",
  "ark-serialize 0.4.2",
@@ -2775,10 +2709,10 @@ name = "hotshot-qc"
 version = "0.3.3"
 dependencies = [
  "ark-bls12-377",
- "ark-bls12-381 0.4.0",
+ "ark-bls12-381",
  "ark-bn254",
- "ark-ec 0.4.2",
- "ark-ff 0.4.2",
+ "ark-ec",
+ "ark-ff",
  "ark-pallas",
  "ark-poly",
  "ark-serialize 0.4.2",
@@ -2801,7 +2735,7 @@ name = "hotshot-stake-table"
 version = "0.3.3"
 dependencies = [
  "ark-bn254",
- "ark-ff 0.4.2",
+ "ark-ff",
  "ark-serialize 0.4.2",
  "ark-std 0.4.0",
  "bincode",
@@ -2873,7 +2807,7 @@ dependencies = [
 name = "hotshot-testing"
 version = "0.1.0"
 dependencies = [
- "ark-bls12-381 0.3.0",
+ "ark-bls12-381",
  "async-compatibility-layer",
  "async-lock",
  "async-std",
@@ -2957,7 +2891,7 @@ dependencies = [
 name = "hotshot-web-server"
 version = "0.1.1"
 dependencies = [
- "ark-bls12-381 0.3.0",
+ "ark-bls12-381",
  "async-compatibility-layer",
  "async-lock",
  "async-std",
@@ -3460,15 +3394,15 @@ source = "git+https://github.com/EspressoSystems/jellyfish?branch=hotshot-compat
 dependencies = [
  "anyhow",
  "ark-bls12-377",
- "ark-bls12-381 0.4.0",
+ "ark-bls12-381",
  "ark-bn254",
  "ark-bw6-761",
  "ark-crypto-primitives",
- "ark-ec 0.4.2",
+ "ark-ec",
  "ark-ed-on-bls12-377",
  "ark-ed-on-bls12-381",
  "ark-ed-on-bn254",
- "ark-ff 0.4.2",
+ "ark-ff",
  "ark-pallas",
  "ark-poly",
  "ark-serialize 0.4.2",
@@ -3505,11 +3439,11 @@ version = "0.4.0-pre.0"
 source = "git+https://github.com/EspressoSystems/jellyfish?branch=hotshot-compat#61276c0166604e1912c1a8f4bd127c74da25482e"
 dependencies = [
  "ark-bls12-377",
- "ark-bls12-381 0.4.0",
+ "ark-bls12-381",
  "ark-bn254",
  "ark-bw6-761",
- "ark-ec 0.4.2",
- "ark-ff 0.4.2",
+ "ark-ec",
+ "ark-ff",
  "ark-poly",
  "ark-serialize 0.4.2",
  "ark-std 0.4.0",
@@ -3530,8 +3464,8 @@ name = "jf-utils"
 version = "0.4.0-pre.0"
 source = "git+https://github.com/EspressoSystems/jellyfish?branch=hotshot-compat#61276c0166604e1912c1a8f4bd127c74da25482e"
 dependencies = [
- "ark-ec 0.4.2",
- "ark-ff 0.4.2",
+ "ark-ec",
+ "ark-ff",
  "ark-serialize 0.4.2",
  "ark-std 0.4.0",
  "digest 0.10.7",
@@ -5918,15 +5852,6 @@ dependencies = [
 
 [[package]]
 name = "rustc_version"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
-dependencies = [
- "semver 0.11.0",
-]
-
-[[package]]
-name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
@@ -6112,16 +6037,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 dependencies = [
- "semver-parser 0.7.0",
-]
-
-[[package]]
-name = "semver"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
-dependencies = [
- "semver-parser 0.10.2",
+ "semver-parser",
 ]
 
 [[package]]
@@ -6135,15 +6051,6 @@ name = "semver-parser"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
-
-[[package]]
-name = "semver-parser"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
-dependencies = [
- "pest",
-]
 
 [[package]]
 name = "send_wrapper"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2634,7 +2634,6 @@ name = "hotshot"
 version = "0.3.3"
 dependencies = [
  "ark-bls12-381 0.3.0",
- "ark-ec 0.3.0",
  "ark-ed-on-bls12-381",
  "ark-serialize 0.3.0",
  "async-compatibility-layer",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2906,7 +2906,7 @@ dependencies = [
  "tide",
  "tide-disco",
  "tokio",
- "toml 0.5.11",
+ "toml 0.7.6",
  "tracing",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2568,7 +2568,6 @@ dependencies = [
 name = "hotshot"
 version = "0.3.3"
 dependencies = [
- "ark-ed-on-bls12-381",
  "ark-serialize 0.3.0",
  "async-compatibility-layer",
  "async-lock",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2605,7 +2605,6 @@ dependencies = [
  "rand_chacha 0.3.1",
  "serde",
  "serde_json",
- "sha2 0.10.7",
  "snafu",
  "surf-disco 0.4.1 (git+https://github.com/EspressoSystems/surf-disco.git?branch=main)",
  "time 0.3.27",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2596,7 +2596,6 @@ dependencies = [
  "libp2p",
  "libp2p-identity",
  "libp2p-networking",
- "libp2p-swarm-derive",
  "nll",
  "num",
  "rand 0.8.5",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2593,7 +2593,6 @@ dependencies = [
  "hotshot-types",
  "hotshot-utils",
  "hotshot-web-server",
- "itertools 0.11.0",
  "libp2p",
  "libp2p-identity",
  "libp2p-networking",
@@ -3357,15 +3356,6 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
 dependencies = [
  "either",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2637,7 +2637,6 @@ dependencies = [
  "ark-ec 0.3.0",
  "ark-ed-on-bls12-381",
  "ark-serialize 0.3.0",
- "ark-std 0.4.0",
  "async-compatibility-layer",
  "async-lock",
  "async-std",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2597,7 +2597,6 @@ dependencies = [
  "libp2p-identity",
  "libp2p-networking",
  "nll",
- "num",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "serde",
@@ -4681,20 +4680,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05180d69e3da0e530ba2a1dae5110317e49e3b7f3d41be227dc5f92e49ee7af"
-dependencies = [
- "num-bigint",
- "num-complex",
- "num-integer",
- "num-iter",
- "num-rational",
- "num-traits",
-]
-
-[[package]]
 name = "num-bigint"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4706,44 +4691,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-complex"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ba157ca0885411de85d6ca030ba7e2a83a28636056c7c699b07c8b6f7383214"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "num-integer"
 version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
 dependencies = [
  "autocfg",
- "num-traits",
-]
-
-[[package]]
-name = "num-iter"
-version = "0.1.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
-dependencies = [
- "autocfg",
- "num-bigint",
- "num-integer",
  "num-traits",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ repository = "https://github.com/EspressoSystems/HotShot"
 default = ["demo", "docs", "doc-images"]
 
 # Enable demo/testing logic
-demo = ["dep:blake3", "hotshot-types/demo", "libp2p/rsa", "dep:derivative"]
+demo = ["hotshot-types/demo", "libp2p/rsa", "dep:derivative"]
 
 # Features required for binaries
 bin-orchestrator = ["toml", "clap"]
@@ -146,7 +146,7 @@ async-std = { version = "1.12", optional = true }
 async-trait = "0.1.73"
 bimap = "0.6.3"
 bincode = "1.3.3"
-blake3 = { version = "1.4.1", optional = true, features = ["traits-preview"] }
+blake3 = { workspace = true }
 clap = { version = "4.3", features = ["derive", "env"], optional = true }
 commit = { git = "https://github.com/EspressoSystems/commit", tag = "0.2.2" }
 custom_debug = "0.5"
@@ -292,5 +292,6 @@ ark-bls12-381 = "0.4"
 ark-ec = "0.4"
 ark-serialize = "0.4"                                                                                             # features = ["derive"]
 ark-std = { version = "0.4", default-features = false }
+blake3 = "1.4"
 hotshot-primitives = { git = "https://github.com/EspressoSystems/hotshot-primitives", branch = 'hotshot-compat' } # rev = "4aee90c" for 'hotshot-compat'
 jf-primitives = { git = "https://github.com/EspressoSystems/jellyfish", branch = 'hotshot-compat' }               # rev = "470a833" for branch = 'hotshot-compat'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -161,7 +161,7 @@ hotshot-types = { path = "./types", version = "0.1.0", default-features = false 
 hotshot-utils = { path = "./utils" }
 hotshot-task = { path = "./task", version = "0.1.0", default-features = false }
 hotshot-task-impls = { path = "./task-impls", version = "0.1.0", default-features = false }
-libp2p = { version = "0.52.2", default-features = false, features = [
+libp2p = { workspace = true, features = [
         "macros",
         "autonat",
         "deflate",
@@ -302,6 +302,7 @@ espresso-systems-common = { git = "https://github.com/espressosystems/espresso-s
 futures = "0.3.28"
 hotshot-primitives = { git = "https://github.com/EspressoSystems/hotshot-primitives", branch = 'hotshot-compat' } # rev = "4aee90c" for 'hotshot-compat'
 jf-primitives = { git = "https://github.com/EspressoSystems/jellyfish", branch = 'hotshot-compat' } # rev = "470a833" for branch = 'hotshot-compat'
+libp2p = { version = "0.52.2", default-features = false }
 libp2p-identity = "0.2"
 libp2p-networking = { path = "./libp2p-networking", version = "0.1.0", default-features = false }
 libp2p-swarm-derive = { version = "=0.33.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -161,7 +161,6 @@ hotshot-types = { path = "./types", version = "0.1.0", default-features = false 
 hotshot-utils = { path = "./utils" }
 hotshot-task = { path = "./task", version = "0.1.0", default-features = false }
 hotshot-task-impls = { path = "./task-impls", version = "0.1.0", default-features = false }
-libp2p-swarm-derive = { version = "=0.33.0" }
 libp2p-networking = { path = "./libp2p-networking", version = "0.1.0", default-features = false }
 libp2p-identity = "0.2.0"
 libp2p = { version = "0.52.2", default-features = false, features = [
@@ -303,3 +302,4 @@ espresso-systems-common = { git = "https://github.com/espressosystems/espresso-s
 futures = "0.3.28"
 hotshot-primitives = { git = "https://github.com/EspressoSystems/hotshot-primitives", branch = 'hotshot-compat' } # rev = "4aee90c" for 'hotshot-compat'
 jf-primitives = { git = "https://github.com/EspressoSystems/jellyfish", branch = 'hotshot-compat' } # rev = "470a833" for branch = 'hotshot-compat'
+libp2p-swarm-derive = { version = "=0.33.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -207,7 +207,7 @@ tokio = { version = "1", optional = true, features = [
         "tracing",
 ] }
 
-tracing = "0.1.37"
+tracing = { workspace = true }
 ethereum-types = { version = "0.14.1", features = ["impl-serde"] }
 bitvec = { version = "1.0.1", default-features = false, features = [
         "alloc",
@@ -312,3 +312,4 @@ snafu = "0.7.5"
 surf-disco = { git = "https://github.com/EspressoSystems/surf-disco.git", tag = "v0.4.1" }
 time = "0.3.27"
 toml = "0.7.6"
+tracing = "0.1.37"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -210,7 +210,7 @@ tokio = { version = "1", optional = true, features = [
 
 tracing = { workspace = true }
 ethereum-types = { workspace = true }
-typenum = { version = "1.16.0" }
+typenum = { workspace = true }
 
 [dev-dependencies]
 async-std = { version = "1.12.0", features = ["attributes"] }
@@ -315,3 +315,4 @@ surf-disco = { git = "https://github.com/EspressoSystems/surf-disco.git", tag = 
 time = "0.3.27"
 toml = "0.7.6"
 tracing = "0.1.37"
+typenum = { version = "1.16.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,7 +141,7 @@ path = "examples/web-server-da/multi-web-server.rs"
 async-compatibility-layer = { workspace = true }
 async-lock = { workspace = true }
 async-std = { version = "1.12", optional = true }
-async-trait = "0.1.73"
+async-trait = { workspace = true }
 bimap = "0.6.3"
 bincode = "1.3.3"
 blake3 = { workspace = true }
@@ -294,6 +294,7 @@ async-compatibility-layer = { git = "https://github.com/EspressoSystems/async-co
         "logging-utils",
 ] }
 async-lock = "2.8"
+async-trait = "0.1.73"
 blake3 = "1.4"
 hotshot-primitives = { git = "https://github.com/EspressoSystems/hotshot-primitives", branch = 'hotshot-compat' } # rev = "4aee90c" for 'hotshot-compat'
 jf-primitives = { git = "https://github.com/EspressoSystems/jellyfish", branch = 'hotshot-compat' } # rev = "470a833" for branch = 'hotshot-compat'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -186,7 +186,6 @@ libp2p = { workspace = true, features = [
 libp2p-identity = { workspace = true }
 libp2p-networking = { workspace = true }
 nll = { workspace = true }
-num = "0.4.1"
 rand = "0.8.5"
 rand_chacha = "0.3.1"
 serde = { version = "1.0.183", features = ["derive", "rc"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,7 +146,7 @@ bimap = "0.6.3"
 bincode = { workspace = true }
 blake3 = { workspace = true }
 clap = { version = "4.3", features = ["derive", "env"], optional = true }
-commit = { git = "https://github.com/EspressoSystems/commit", tag = "0.2.2" }
+commit = { workspace = true }
 custom_debug = "0.5"
 dashmap = "5.5.0"
 derivative = { version = "2.2.0", optional = true }
@@ -297,5 +297,6 @@ async-lock = "2.8"
 async-trait = "0.1.73"
 bincode = "1.3.3"
 blake3 = "1.4"
+commit = { git = "https://github.com/EspressoSystems/commit", tag = "0.2.2" }
 hotshot-primitives = { git = "https://github.com/EspressoSystems/hotshot-primitives", branch = 'hotshot-compat' } # rev = "4aee90c" for 'hotshot-compat'
 jf-primitives = { git = "https://github.com/EspressoSystems/jellyfish", branch = 'hotshot-compat' } # rev = "470a833" for branch = 'hotshot-compat'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,7 +143,7 @@ async-lock = { workspace = true }
 async-std = { version = "1.12", optional = true }
 async-trait = { workspace = true }
 bimap = "0.6.3"
-bincode = "1.3.3"
+bincode = { workspace = true }
 blake3 = { workspace = true }
 clap = { version = "4.3", features = ["derive", "env"], optional = true }
 commit = { git = "https://github.com/EspressoSystems/commit", tag = "0.2.2" }
@@ -295,6 +295,7 @@ async-compatibility-layer = { git = "https://github.com/EspressoSystems/async-co
 ] }
 async-lock = "2.8"
 async-trait = "0.1.73"
+bincode = "1.3.3"
 blake3 = "1.4"
 hotshot-primitives = { git = "https://github.com/EspressoSystems/hotshot-primitives", branch = 'hotshot-compat' } # rev = "4aee90c" for 'hotshot-compat'
 jf-primitives = { git = "https://github.com/EspressoSystems/jellyfish", branch = 'hotshot-compat' } # rev = "470a833" for branch = 'hotshot-compat'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,7 +147,7 @@ bincode = { workspace = true }
 blake3 = { workspace = true }
 clap = { version = "4.3", features = ["derive", "env"], optional = true }
 commit = { workspace = true }
-custom_debug = "0.5"
+custom_debug = { workspace = true }
 dashmap = "5.5.0"
 derivative = { version = "2.2.0", optional = true }
 digest = "0.10.7"
@@ -298,5 +298,6 @@ async-trait = "0.1.73"
 bincode = "1.3.3"
 blake3 = "1.4"
 commit = { git = "https://github.com/EspressoSystems/commit", tag = "0.2.2" }
+custom_debug = "0.5"
 hotshot-primitives = { git = "https://github.com/EspressoSystems/hotshot-primitives", branch = 'hotshot-compat' } # rev = "4aee90c" for 'hotshot-compat'
 jf-primitives = { git = "https://github.com/EspressoSystems/jellyfish", branch = 'hotshot-compat' } # rev = "470a833" for branch = 'hotshot-compat'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -208,7 +208,7 @@ tokio = { version = "1", optional = true, features = [
 ] }
 
 tracing = { workspace = true }
-ethereum-types = { version = "0.14.1", features = ["impl-serde"] }
+ethereum-types = { workspace = true }
 bitvec = { version = "1.0.1", default-features = false, features = [
         "alloc",
         "atomic",
@@ -297,6 +297,7 @@ custom_debug = "0.5"
 digest = "0.10"
 either = { version = "1.8" }
 espresso-systems-common = { git = "https://github.com/espressosystems/espresso-systems-common", tag = "0.4.1" }
+ethereum-types = { version = "0.14.1", features = ["impl-serde"] }
 futures = "0.3.28"
 hotshot-primitives = { git = "https://github.com/EspressoSystems/hotshot-primitives", branch = 'hotshot-compat' } # rev = "4aee90c" for 'hotshot-compat'
 jf-primitives = { git = "https://github.com/EspressoSystems/jellyfish", branch = 'hotshot-compat' } # rev = "470a833" for branch = 'hotshot-compat'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,7 +191,7 @@ rand_chacha = { workspace = true }
 serde = { workspace = true, features = ["rc"] }
 snafu = { workspace = true }
 surf-disco = { workspace = true }
-time = "0.3.27"
+time = { workspace = true }
 toml = { version = "0.7.6", optional = true }
 tokio = { version = "1", optional = true, features = [
         "fs",
@@ -311,3 +311,4 @@ rand_chacha = { version = "0.3.1", default-features = false }
 serde = { version = "1.0.183", features = ["derive"] }
 snafu = "0.7.5"
 surf-disco = { git = "https://github.com/EspressoSystems/surf-disco.git", tag = "v0.4.1" }
+time = "0.3.27"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -165,7 +165,6 @@ hotshot-utils = { path = "./utils" }
 hotshot-task = { path = "./task", version = "0.1.0", default-features = false }
 hotshot-task-impls = { path = "./task-impls", version = "0.1.0", default-features = false }
 itertools = "0.11"
-hotshot-primitives = { git = "https://github.com/EspressoSystems/hotshot-primitives", branch = 'hotshot-compat' } # rev = "4aee90c" for 'hotshot-compat'
 libp2p-swarm-derive = { version = "=0.33.0" }
 libp2p-networking = { path = "./libp2p-networking", version = "0.1.0", default-features = false }
 libp2p-identity = "0.2.0"
@@ -292,6 +291,7 @@ members = [
 [workspace.dependencies]
 ark-bls12-381 = "0.4"
 ark-ec = "0.4"
-ark-serialize = "0.4"                                                                               # features = ["derive"]
+ark-serialize = "0.4"                                                                                             # features = ["derive"]
 ark-std = { version = "0.4", default-features = false }
-jf-primitives = { git = "https://github.com/EspressoSystems/jellyfish", branch = 'hotshot-compat' } # rev = "470a833" for branch = 'hotshot-compat'
+hotshot-primitives = { git = "https://github.com/EspressoSystems/hotshot-primitives", branch = 'hotshot-compat' } # rev = "4aee90c" for 'hotshot-compat'
+jf-primitives = { git = "https://github.com/EspressoSystems/jellyfish", branch = 'hotshot-compat' }               # rev = "470a833" for branch = 'hotshot-compat'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,7 +137,6 @@ required-features = ["demo", "libp2p/rsa"]
 path = "examples/web-server-da/multi-web-server.rs"
 
 [dependencies]
-ark-ec = { version = "0.3.0" }
 ark-bls12-381 = { version = "0.3.0" }
 # TODO ED We should upgrade other ark libraries accordingly with the one below
 ark-ed-on-bls12-381 = "0.4.0"
@@ -294,5 +293,6 @@ members = [
 ]
 
 [workspace.dependencies]
+ark-ec = "0.4"
 ark-std = { version = "0.4", default-features = false }
 jf-primitives = { git = "https://github.com/EspressoSystems/jellyfish", branch = 'hotshot-compat' } # rev = "470a833" for branch = 'hotshot-compat'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -187,7 +187,7 @@ libp2p-identity = { workspace = true }
 libp2p-networking = { workspace = true }
 nll = { workspace = true }
 rand = { workspace = true }
-rand_chacha = "0.3.1"
+rand_chacha = { workspace = true }
 serde = { version = "1.0.183", features = ["derive", "rc"] }
 snafu = "0.7.5"
 surf-disco = { git = "https://github.com/EspressoSystems/surf-disco.git", branch = "main" }
@@ -307,3 +307,4 @@ libp2p-networking = { path = "./libp2p-networking", version = "0.1.0", default-f
 libp2p-swarm-derive = { version = "=0.33.0" }
 nll = { git = "https://github.com/EspressoSystems/nll.git" }
 rand = "0.8.5"
+rand_chacha = { version = "0.3.1", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -186,7 +186,7 @@ libp2p = { workspace = true, features = [
 libp2p-identity = { workspace = true }
 libp2p-networking = { workspace = true }
 nll = { workspace = true }
-rand = "0.8.5"
+rand = { workspace = true }
 rand_chacha = "0.3.1"
 serde = { version = "1.0.183", features = ["derive", "rc"] }
 snafu = "0.7.5"
@@ -306,3 +306,4 @@ libp2p-identity = "0.2"
 libp2p-networking = { path = "./libp2p-networking", version = "0.1.0", default-features = false }
 libp2p-swarm-derive = { version = "=0.33.0" }
 nll = { git = "https://github.com/EspressoSystems/nll.git" }
+rand = "0.8.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -150,7 +150,7 @@ commit = { workspace = true }
 custom_debug = { workspace = true }
 dashmap = "5.5.0"
 derivative = { version = "2.2.0", optional = true }
-either = { version = "1.8.1", features = ["serde"] }
+either = { workspace = true }
 embed-doc-image = "0.1.4"
 espresso-systems-common = { git = "https://github.com/espressosystems/espresso-systems-common", tag = "0.4.1" }
 futures = "0.3.28"
@@ -299,5 +299,6 @@ blake3 = "1.4"
 commit = { git = "https://github.com/EspressoSystems/commit", tag = "0.2.2" }
 custom_debug = "0.5"
 digest = "0.10"
+either = { version = "1.8" }
 hotshot-primitives = { git = "https://github.com/EspressoSystems/hotshot-primitives", branch = 'hotshot-compat' } # rev = "4aee90c" for 'hotshot-compat'
 jf-primitives = { git = "https://github.com/EspressoSystems/jellyfish", branch = 'hotshot-compat' } # rev = "470a833" for branch = 'hotshot-compat'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,7 +152,7 @@ dashmap = "5.5.0"
 derivative = { version = "2.2.0", optional = true }
 either = { workspace = true }
 embed-doc-image = "0.1.4"
-espresso-systems-common = { git = "https://github.com/espressosystems/espresso-systems-common", tag = "0.4.1" }
+espresso-systems-common = { workspace = true }
 futures = "0.3.28"
 hotshot-web-server = { version = "0.1.1", path = "web_server", default-features = false }
 hotshot-consensus = { path = "./consensus", version = "0.1.0", default-features = false }
@@ -300,5 +300,6 @@ commit = { git = "https://github.com/EspressoSystems/commit", tag = "0.2.2" }
 custom_debug = "0.5"
 digest = "0.10"
 either = { version = "1.8" }
+espresso-systems-common = { git = "https://github.com/espressosystems/espresso-systems-common", tag = "0.4.1" }
 hotshot-primitives = { git = "https://github.com/EspressoSystems/hotshot-primitives", branch = 'hotshot-compat' } # rev = "4aee90c" for 'hotshot-compat'
 jf-primitives = { git = "https://github.com/EspressoSystems/jellyfish", branch = 'hotshot-compat' } # rev = "470a833" for branch = 'hotshot-compat'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -189,7 +189,7 @@ nll = { workspace = true }
 rand = { workspace = true }
 rand_chacha = { workspace = true }
 serde = { workspace = true, features = ["rc"] }
-snafu = "0.7.5"
+snafu = { workspace = true }
 surf-disco = { git = "https://github.com/EspressoSystems/surf-disco.git", branch = "main" }
 time = "0.3.27"
 toml = { version = "0.7.6", optional = true }
@@ -309,3 +309,4 @@ nll = { git = "https://github.com/EspressoSystems/nll.git" }
 rand = "0.8.5"
 rand_chacha = { version = "0.3.1", default-features = false }
 serde = { version = "1.0.183", features = ["derive"] }
+snafu = "0.7.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,7 +153,7 @@ derivative = { version = "2.2.0", optional = true }
 either = { workspace = true }
 embed-doc-image = "0.1.4"
 espresso-systems-common = { workspace = true }
-futures = "0.3.28"
+futures = { workspace = true }
 hotshot-web-server = { version = "0.1.1", path = "web_server", default-features = false }
 hotshot-consensus = { path = "./consensus", version = "0.1.0", default-features = false }
 hotshot-orchestrator = { version = "0.1.1", path = "orchestrator", default-features = false }
@@ -301,5 +301,6 @@ custom_debug = "0.5"
 digest = "0.10"
 either = { version = "1.8" }
 espresso-systems-common = { git = "https://github.com/espressosystems/espresso-systems-common", tag = "0.4.1" }
+futures = "0.3.28"
 hotshot-primitives = { git = "https://github.com/EspressoSystems/hotshot-primitives", branch = 'hotshot-compat' } # rev = "4aee90c" for 'hotshot-compat'
 jf-primitives = { git = "https://github.com/EspressoSystems/jellyfish", branch = 'hotshot-compat' } # rev = "470a833" for branch = 'hotshot-compat'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -185,7 +185,7 @@ libp2p = { workspace = true, features = [
 ] }
 libp2p-identity = { workspace = true }
 libp2p-networking = { workspace = true }
-nll = { git = "https://github.com/EspressoSystems/nll.git" }
+nll = { workspace = true }
 num = "0.4.1"
 rand = "0.8.5"
 rand_chacha = "0.3.1"
@@ -306,3 +306,4 @@ libp2p = { version = "0.52.2", default-features = false }
 libp2p-identity = "0.2"
 libp2p-networking = { path = "./libp2p-networking", version = "0.1.0", default-features = false }
 libp2p-swarm-derive = { version = "=0.33.0" }
+nll = { git = "https://github.com/EspressoSystems/nll.git" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -228,7 +228,6 @@ typenum = { version = "1.16.0" }
 async-std = { version = "1.12.0", features = ["attributes"] }
 clap = { version = "4.3", features = ["derive", "env"] }
 serde_json = "1.0.105"
-sha2 = { version = "0.10.7" }
 toml = "0.7.6"
 
 ### Profiles

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,6 +144,7 @@ async-std = { version = "1.12", optional = true }
 async-trait = { workspace = true }
 bimap = "0.6.3"
 bincode = { workspace = true }
+bitvec = { workspace = true }
 clap = { version = "4.3", features = ["derive", "env"], optional = true }
 commit = { workspace = true }
 custom_debug = { workspace = true }
@@ -209,11 +210,6 @@ tokio = { version = "1", optional = true, features = [
 
 tracing = { workspace = true }
 ethereum-types = { workspace = true }
-bitvec = { version = "1.0.1", default-features = false, features = [
-        "alloc",
-        "atomic",
-        "serde",
-] }
 typenum = { version = "1.16.0" }
 
 [dev-dependencies]
@@ -291,6 +287,11 @@ async-compatibility-layer = { git = "https://github.com/EspressoSystems/async-co
 async-lock = "2.8"
 async-trait = "0.1.73"
 bincode = "1.3.3"
+bitvec = { version = "1.0.1", default-features = false, features = [
+        "alloc",
+        "atomic",
+        "serde",
+] }
 blake3 = "1.4"
 commit = { git = "https://github.com/EspressoSystems/commit", tag = "0.2.2" }
 custom_debug = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -138,7 +138,6 @@ path = "examples/web-server-da/multi-web-server.rs"
 
 [dependencies]
 # TODO ED We should upgrade ark libraries to 0.4
-ark-serialize = { version = "0.3.0", features = ["derive"] }
 async-compatibility-layer = { git = "https://github.com/EspressoSystems/async-compatibility-layer.git", tag = "1.3.0", default-features = false, features = [
         "logging-utils",
 ] }
@@ -293,5 +292,6 @@ members = [
 [workspace.dependencies]
 ark-bls12-381 = "0.4"
 ark-ec = "0.4"
+ark-serialize = "0.4"                                                                               # features = ["derive"]
 ark-std = { version = "0.4", default-features = false }
 jf-primitives = { git = "https://github.com/EspressoSystems/jellyfish", branch = 'hotshot-compat' } # rev = "470a833" for branch = 'hotshot-compat'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -190,7 +190,7 @@ rand = { workspace = true }
 rand_chacha = { workspace = true }
 serde = { workspace = true, features = ["rc"] }
 snafu = { workspace = true }
-surf-disco = { git = "https://github.com/EspressoSystems/surf-disco.git", branch = "main" }
+surf-disco = { workspace = true }
 time = "0.3.27"
 toml = { version = "0.7.6", optional = true }
 tokio = { version = "1", optional = true, features = [
@@ -310,3 +310,4 @@ rand = "0.8.5"
 rand_chacha = { version = "0.3.1", default-features = false }
 serde = { version = "1.0.183", features = ["derive"] }
 snafu = "0.7.5"
+surf-disco = { git = "https://github.com/EspressoSystems/surf-disco.git", tag = "v0.4.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,8 +137,7 @@ required-features = ["demo", "libp2p/rsa"]
 path = "examples/web-server-da/multi-web-server.rs"
 
 [dependencies]
-# TODO ED We should upgrade other ark libraries accordingly with the one below
-ark-ed-on-bls12-381 = "0.4.0"
+# TODO ED We should upgrade ark libraries to 0.4
 ark-serialize = { version = "0.3.0", features = ["derive"] }
 async-compatibility-layer = { git = "https://github.com/EspressoSystems/async-compatibility-layer.git", tag = "1.3.0", default-features = false, features = [
         "logging-utils",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,7 +144,6 @@ async-std = { version = "1.12", optional = true }
 async-trait = { workspace = true }
 bimap = "0.6.3"
 bincode = { workspace = true }
-blake3 = { workspace = true }
 clap = { version = "4.3", features = ["derive", "env"], optional = true }
 commit = { workspace = true }
 custom_debug = { workspace = true }
@@ -219,6 +218,7 @@ typenum = { version = "1.16.0" }
 
 [dev-dependencies]
 async-std = { version = "1.12.0", features = ["attributes"] }
+blake3 = { workspace = true }
 clap = { version = "4.3", features = ["derive", "env"] }
 serde_json = "1.0.105"
 toml = { workspace = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -161,7 +161,6 @@ hotshot-types = { path = "./types", version = "0.1.0", default-features = false 
 hotshot-utils = { path = "./utils" }
 hotshot-task = { path = "./task", version = "0.1.0", default-features = false }
 hotshot-task-impls = { path = "./task-impls", version = "0.1.0", default-features = false }
-libp2p-networking = { path = "./libp2p-networking", version = "0.1.0", default-features = false }
 libp2p-identity = "0.2.0"
 libp2p = { version = "0.52.2", default-features = false, features = [
         "macros",
@@ -185,6 +184,7 @@ libp2p = { version = "0.52.2", default-features = false, features = [
         "websocket",
         "yamux",
 ] }
+libp2p-networking = { workspace = true }
 nll = { git = "https://github.com/EspressoSystems/nll.git" }
 num = "0.4.1"
 rand = "0.8.5"
@@ -302,4 +302,5 @@ espresso-systems-common = { git = "https://github.com/espressosystems/espresso-s
 futures = "0.3.28"
 hotshot-primitives = { git = "https://github.com/EspressoSystems/hotshot-primitives", branch = 'hotshot-compat' } # rev = "4aee90c" for 'hotshot-compat'
 jf-primitives = { git = "https://github.com/EspressoSystems/jellyfish", branch = 'hotshot-compat' } # rev = "470a833" for branch = 'hotshot-compat'
+libp2p-networking = { path = "./libp2p-networking", version = "0.1.0", default-features = false }
 libp2p-swarm-derive = { version = "=0.33.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -188,7 +188,7 @@ libp2p-networking = { workspace = true }
 nll = { workspace = true }
 rand = { workspace = true }
 rand_chacha = { workspace = true }
-serde = { version = "1.0.183", features = ["derive", "rc"] }
+serde = { workspace = true, features = ["rc"] }
 snafu = "0.7.5"
 surf-disco = { git = "https://github.com/EspressoSystems/surf-disco.git", branch = "main" }
 time = "0.3.27"
@@ -308,3 +308,4 @@ libp2p-swarm-derive = { version = "=0.33.0" }
 nll = { git = "https://github.com/EspressoSystems/nll.git" }
 rand = "0.8.5"
 rand_chacha = { version = "0.3.1", default-features = false }
+serde = { version = "1.0.183", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,7 +137,6 @@ required-features = ["demo", "libp2p/rsa"]
 path = "examples/web-server-da/multi-web-server.rs"
 
 [dependencies]
-ark-bls12-381 = { version = "0.3.0" }
 # TODO ED We should upgrade other ark libraries accordingly with the one below
 ark-ed-on-bls12-381 = "0.4.0"
 ark-serialize = { version = "0.3.0", features = ["derive"] }
@@ -293,6 +292,7 @@ members = [
 ]
 
 [workspace.dependencies]
+ark-bls12-381 = "0.4"
 ark-ec = "0.4"
 ark-std = { version = "0.4", default-features = false }
 jf-primitives = { git = "https://github.com/EspressoSystems/jellyfish", branch = 'hotshot-compat' } # rev = "470a833" for branch = 'hotshot-compat'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ default = ["demo", "docs", "doc-images"]
 demo = ["hotshot-types/demo", "libp2p/rsa", "dep:derivative"]
 
 # Features required for binaries
-bin-orchestrator = ["toml", "clap"]
+bin-orchestrator = ["clap"]
 
 # Build the extended documentation
 docs = []
@@ -192,7 +192,6 @@ serde = { workspace = true, features = ["rc"] }
 snafu = { workspace = true }
 surf-disco = { workspace = true }
 time = { workspace = true }
-toml = { version = "0.7.6", optional = true }
 tokio = { version = "1", optional = true, features = [
         "fs",
         "io-util",
@@ -222,7 +221,7 @@ typenum = { version = "1.16.0" }
 async-std = { version = "1.12.0", features = ["attributes"] }
 clap = { version = "4.3", features = ["derive", "env"] }
 serde_json = "1.0.105"
-toml = "0.7.6"
+toml = { workspace = true }
 
 ### Profiles
 ###
@@ -312,3 +311,4 @@ serde = { version = "1.0.183", features = ["derive"] }
 snafu = "0.7.5"
 surf-disco = { git = "https://github.com/EspressoSystems/surf-disco.git", tag = "v0.4.1" }
 time = "0.3.27"
+toml = "0.7.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -150,7 +150,6 @@ commit = { workspace = true }
 custom_debug = { workspace = true }
 dashmap = "5.5.0"
 derivative = { version = "2.2.0", optional = true }
-digest = "0.10.7"
 either = { version = "1.8.1", features = ["serde"] }
 embed-doc-image = "0.1.4"
 espresso-systems-common = { git = "https://github.com/espressosystems/espresso-systems-common", tag = "0.4.1" }
@@ -299,5 +298,6 @@ bincode = "1.3.3"
 blake3 = "1.4"
 commit = { git = "https://github.com/EspressoSystems/commit", tag = "0.2.2" }
 custom_debug = "0.5"
+digest = "0.10"
 hotshot-primitives = { git = "https://github.com/EspressoSystems/hotshot-primitives", branch = 'hotshot-compat' } # rev = "4aee90c" for 'hotshot-compat'
 jf-primitives = { git = "https://github.com/EspressoSystems/jellyfish", branch = 'hotshot-compat' } # rev = "470a833" for branch = 'hotshot-compat'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,7 +139,7 @@ path = "examples/web-server-da/multi-web-server.rs"
 [dependencies]
 # TODO ED We should upgrade ark libraries to 0.4
 async-compatibility-layer = { workspace = true }
-async-lock = "2.8"
+async-lock = { workspace = true }
 async-std = { version = "1.12", optional = true }
 async-trait = "0.1.73"
 bimap = "0.6.3"
@@ -293,6 +293,7 @@ ark-std = { version = "0.4", default-features = false }
 async-compatibility-layer = { git = "https://github.com/EspressoSystems/async-compatibility-layer.git", tag = "1.3.0", default-features = false, features = [
         "logging-utils",
 ] }
+async-lock = "2.8"
 blake3 = "1.4"
 hotshot-primitives = { git = "https://github.com/EspressoSystems/hotshot-primitives", branch = 'hotshot-compat' } # rev = "4aee90c" for 'hotshot-compat'
 jf-primitives = { git = "https://github.com/EspressoSystems/jellyfish", branch = 'hotshot-compat' } # rev = "470a833" for branch = 'hotshot-compat'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -161,7 +161,6 @@ hotshot-types = { path = "./types", version = "0.1.0", default-features = false 
 hotshot-utils = { path = "./utils" }
 hotshot-task = { path = "./task", version = "0.1.0", default-features = false }
 hotshot-task-impls = { path = "./task-impls", version = "0.1.0", default-features = false }
-itertools = "0.11"
 libp2p-swarm-derive = { version = "=0.33.0" }
 libp2p-networking = { path = "./libp2p-networking", version = "0.1.0", default-features = false }
 libp2p-identity = "0.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ version = "0.3.3"
 rust-version = "1.65.0"
 
 [workspace.package]
-version = "0.3.3" # same as `hotshot`, but workspace subcrate can also release its own version
+version = "0.3.3"                                         # same as `hotshot`, but workspace subcrate can also release its own version
 authors = ["Espresso Systems <hello@espressosys.com>"]
 edition = "2021"
 rust-version = "1.65.0"
@@ -143,7 +143,9 @@ ark-bls12-381 = { version = "0.3.0" }
 ark-ed-on-bls12-381 = "0.4.0"
 ark-serialize = { version = "0.3.0", features = ["derive"] }
 ark-std = { version = "0.4.0" }
-async-compatibility-layer = { git = "https://github.com/EspressoSystems/async-compatibility-layer.git", tag = "1.3.0", default-features = false, features = [ "logging-utils" ] }
+async-compatibility-layer = { git = "https://github.com/EspressoSystems/async-compatibility-layer.git", tag = "1.3.0", default-features = false, features = [
+        "logging-utils",
+] }
 async-lock = "2.8"
 async-std = { version = "1.12", optional = true }
 async-trait = "0.1.73"
@@ -156,7 +158,7 @@ custom_debug = "0.5"
 dashmap = "5.5.0"
 derivative = { version = "2.2.0", optional = true }
 digest = "0.10.7"
-either = { version = "1.8.1", features = [ "serde" ] }
+either = { version = "1.8.1", features = ["serde"] }
 embed-doc-image = "0.1.4"
 espresso-systems-common = { git = "https://github.com/espressosystems/espresso-systems-common", tag = "0.4.1" }
 futures = "0.3.28"
@@ -168,8 +170,7 @@ hotshot-utils = { path = "./utils" }
 hotshot-task = { path = "./task", version = "0.1.0", default-features = false }
 hotshot-task-impls = { path = "./task-impls", version = "0.1.0", default-features = false }
 itertools = "0.11"
-hotshot-primitives = { git = "https://github.com/EspressoSystems/hotshot-primitives",  branch = 'hotshot-compat'} # rev = "4aee90c" for 'hotshot-compat'
-jf-primitives = { git = "https://github.com/EspressoSystems/jellyfish", branch = 'hotshot-compat'} # rev = "470a833" for branch = 'hotshot-compat'
+hotshot-primitives = { git = "https://github.com/EspressoSystems/hotshot-primitives", branch = 'hotshot-compat' } # rev = "4aee90c" for 'hotshot-compat'
 libp2p-swarm-derive = { version = "=0.33.0" }
 libp2p-networking = { path = "./libp2p-networking", version = "0.1.0", default-features = false }
 libp2p-identity = "0.2.0"
@@ -222,7 +223,11 @@ tokio = { version = "1", optional = true, features = [
 
 tracing = "0.1.37"
 ethereum-types = { version = "0.14.1", features = ["impl-serde"] }
-bitvec = { version = "1.0.1", default-features = false, features = ["alloc", "atomic", "serde"] }
+bitvec = { version = "1.0.1", default-features = false, features = [
+        "alloc",
+        "atomic",
+        "serde",
+] }
 typenum = { version = "1.16.0" }
 
 [dev-dependencies]
@@ -286,5 +291,8 @@ members = [
         "task",
         "task-impls",
         "crates/hotshot-qc",
-        "crates/hotshot-stake-table"
+        "crates/hotshot-stake-table",
 ]
+
+[workspace.dependencies]
+jf-primitives = { git = "https://github.com/EspressoSystems/jellyfish", branch = 'hotshot-compat' } # rev = "470a833" for branch = 'hotshot-compat'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -161,7 +161,6 @@ hotshot-types = { path = "./types", version = "0.1.0", default-features = false 
 hotshot-utils = { path = "./utils" }
 hotshot-task = { path = "./task", version = "0.1.0", default-features = false }
 hotshot-task-impls = { path = "./task-impls", version = "0.1.0", default-features = false }
-libp2p-identity = "0.2.0"
 libp2p = { version = "0.52.2", default-features = false, features = [
         "macros",
         "autonat",
@@ -184,6 +183,7 @@ libp2p = { version = "0.52.2", default-features = false, features = [
         "websocket",
         "yamux",
 ] }
+libp2p-identity = { workspace = true }
 libp2p-networking = { workspace = true }
 nll = { git = "https://github.com/EspressoSystems/nll.git" }
 num = "0.4.1"
@@ -302,5 +302,6 @@ espresso-systems-common = { git = "https://github.com/espressosystems/espresso-s
 futures = "0.3.28"
 hotshot-primitives = { git = "https://github.com/EspressoSystems/hotshot-primitives", branch = 'hotshot-compat' } # rev = "4aee90c" for 'hotshot-compat'
 jf-primitives = { git = "https://github.com/EspressoSystems/jellyfish", branch = 'hotshot-compat' } # rev = "470a833" for branch = 'hotshot-compat'
+libp2p-identity = "0.2"
 libp2p-networking = { path = "./libp2p-networking", version = "0.1.0", default-features = false }
 libp2p-swarm-derive = { version = "=0.33.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,6 +153,7 @@ derivative = { version = "2.2.0", optional = true }
 either = { workspace = true }
 embed-doc-image = "0.1.4"
 espresso-systems-common = { workspace = true }
+ethereum-types = { workspace = true }
 futures = { workspace = true }
 hotshot-web-server = { version = "0.1.1", path = "web_server", default-features = false }
 hotshot-consensus = { path = "./consensus", version = "0.1.0", default-features = false }
@@ -209,7 +210,6 @@ tokio = { version = "1", optional = true, features = [
 ] }
 
 tracing = { workspace = true }
-ethereum-types = { workspace = true }
 typenum = { workspace = true }
 
 [dev-dependencies]
@@ -315,4 +315,4 @@ surf-disco = { git = "https://github.com/EspressoSystems/surf-disco.git", tag = 
 time = "0.3.27"
 toml = "0.7.6"
 tracing = "0.1.37"
-typenum = { version = "1.16.0" }
+typenum = "1.16.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -138,9 +138,7 @@ path = "examples/web-server-da/multi-web-server.rs"
 
 [dependencies]
 # TODO ED We should upgrade ark libraries to 0.4
-async-compatibility-layer = { git = "https://github.com/EspressoSystems/async-compatibility-layer.git", tag = "1.3.0", default-features = false, features = [
-        "logging-utils",
-] }
+async-compatibility-layer = { workspace = true }
 async-lock = "2.8"
 async-std = { version = "1.12", optional = true }
 async-trait = "0.1.73"
@@ -290,8 +288,11 @@ members = [
 [workspace.dependencies]
 ark-bls12-381 = "0.4"
 ark-ec = "0.4"
-ark-serialize = "0.4"                                                                                             # features = ["derive"]
+ark-serialize = "0.4" # features = ["derive"]
 ark-std = { version = "0.4", default-features = false }
+async-compatibility-layer = { git = "https://github.com/EspressoSystems/async-compatibility-layer.git", tag = "1.3.0", default-features = false, features = [
+        "logging-utils",
+] }
 blake3 = "1.4"
 hotshot-primitives = { git = "https://github.com/EspressoSystems/hotshot-primitives", branch = 'hotshot-compat' } # rev = "4aee90c" for 'hotshot-compat'
-jf-primitives = { git = "https://github.com/EspressoSystems/jellyfish", branch = 'hotshot-compat' }               # rev = "470a833" for branch = 'hotshot-compat'
+jf-primitives = { git = "https://github.com/EspressoSystems/jellyfish", branch = 'hotshot-compat' } # rev = "470a833" for branch = 'hotshot-compat'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,7 +142,6 @@ ark-bls12-381 = { version = "0.3.0" }
 # TODO ED We should upgrade other ark libraries accordingly with the one below
 ark-ed-on-bls12-381 = "0.4.0"
 ark-serialize = { version = "0.3.0", features = ["derive"] }
-ark-std = { version = "0.4.0" }
 async-compatibility-layer = { git = "https://github.com/EspressoSystems/async-compatibility-layer.git", tag = "1.3.0", default-features = false, features = [
         "logging-utils",
 ] }
@@ -295,4 +294,5 @@ members = [
 ]
 
 [workspace.dependencies]
+ark-std = { version = "0.4", default-features = false }
 jf-primitives = { git = "https://github.com/EspressoSystems/jellyfish", branch = 'hotshot-compat' } # rev = "470a833" for branch = 'hotshot-compat'

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -43,7 +43,7 @@ blake3 = { workspace = true, features = ["traits-preview"] }
 commit = { workspace = true }
 custom_debug = { workspace = true }
 derivative = "2.2"
-either = { version = "1.8.1" }
+either = { workspace = true }
 futures = "0.3.28"
 hotshot-types = { path = "../types", default-features = false }
 hotshot-utils = { path = "../utils" }

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -44,7 +44,7 @@ commit = { workspace = true }
 custom_debug = { workspace = true }
 derivative = "2.2"
 either = { workspace = true }
-futures = "0.3.28"
+futures = { workspace = true }
 hotshot-types = { path = "../types", default-features = false }
 hotshot-utils = { path = "../utils" }
 snafu = "0.7.5"

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -47,7 +47,7 @@ either = { workspace = true }
 futures = { workspace = true }
 hotshot-types = { path = "../types", default-features = false }
 hotshot-utils = { path = "../utils" }
-snafu = "0.7.5"
+snafu = { workspace = true }
 tokio = { version = "1", optional = true, features = [
     "fs",
     "io-util",

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -41,6 +41,7 @@ async-std = { version = "1.12", optional = true }
 async-trait = "0.1.73"
 # TODO ed: Delete this dependency after https://github.com/EspressoSystems/HotShot/issues/614 is finished
 bincode = "1.3.3"
+blake3 = { workspace = true, features = ["traits-preview"] }
 commit = { git = "https://github.com/EspressoSystems/commit", tag = "0.2.2" }
 custom_debug = "0.5"
 derivative = "2.2"
@@ -73,4 +74,3 @@ bitvec = { version = "1.0.1", default-features = false, features = [
 ] }
 hotshot-primitives = { workspace = true }
 jf-primitives = { workspace = true }
-blake3 = { version = "1.3.3", features = ["traits-preview"] }

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -33,9 +33,7 @@ channel-async-std = [
 ]
 
 [dependencies]
-async-compatibility-layer = { git = "https://github.com/EspressoSystems/async-compatibility-layer.git", tag = "1.3.0", default-features = false, features = [
-    "logging-utils",
-] }
+async-compatibility-layer = { workspace = true }
 async-lock = "2.8"
 async-std = { version = "1.12", optional = true }
 async-trait = "0.1.73"

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -19,15 +19,23 @@ tokio-executor = [
     "async-compatibility-layer/tokio-executor",
 ]
 profiling = ["async-compatibility-layer/profiling"]
-channel-flume = ["hotshot-types/channel-flume", "async-compatibility-layer/channel-flume"]
-channel-tokio = ["hotshot-types/channel-tokio", "async-compatibility-layer/channel-tokio"]
+channel-flume = [
+    "hotshot-types/channel-flume",
+    "async-compatibility-layer/channel-flume",
+]
+channel-tokio = [
+    "hotshot-types/channel-tokio",
+    "async-compatibility-layer/channel-tokio",
+]
 channel-async-std = [
     "hotshot-types/channel-async-std",
     "async-compatibility-layer/channel-async-std",
 ]
 
 [dependencies]
-async-compatibility-layer = { git = "https://github.com/EspressoSystems/async-compatibility-layer.git", tag = "1.3.0", default-features = false, features = [ "logging-utils" ] }
+async-compatibility-layer = { git = "https://github.com/EspressoSystems/async-compatibility-layer.git", tag = "1.3.0", default-features = false, features = [
+    "logging-utils",
+] }
 async-lock = "2.8"
 async-std = { version = "1.12", optional = true }
 async-trait = "0.1.73"
@@ -39,7 +47,7 @@ derivative = "2.2"
 either = { version = "1.8.1" }
 futures = "0.3.28"
 hotshot-types = { path = "../types", default-features = false }
-hotshot-utils = { path = "../utils"}
+hotshot-utils = { path = "../utils" }
 snafu = "0.7.5"
 tokio = { version = "1", optional = true, features = [
     "fs",
@@ -58,7 +66,11 @@ tokio = { version = "1", optional = true, features = [
 ] }
 tracing = "0.1.37"
 time = "0.3.27" # 0.3.23
-bitvec = { version = "1.0.1", default-features = false, features = ["alloc", "atomic", "serde"] }
-hotshot-primitives = { git = "https://github.com/EspressoSystems/hotshot-primitives",  branch = 'hotshot-compat'} # rev = "4aee90c" for 'hotshot-compat'
-jf-primitives = { git = "https://github.com/EspressoSystems/jellyfish", branch = 'hotshot-compat'} # rev = "470a833" for branch = 'hotshot-compat'
+bitvec = { version = "1.0.1", default-features = false, features = [
+    "alloc",
+    "atomic",
+    "serde",
+] }
+hotshot-primitives = { git = "https://github.com/EspressoSystems/hotshot-primitives", branch = 'hotshot-compat' } # rev = "4aee90c" for 'hotshot-compat'
+jf-primitives = { workspace = true }
 blake3 = { version = "1.3.3", features = ["traits-preview"] }

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -40,7 +40,7 @@ async-trait = { workspace = true }
 # TODO ed: Delete this dependency after https://github.com/EspressoSystems/HotShot/issues/614 is finished
 bincode = { workspace = true }
 blake3 = { workspace = true, features = ["traits-preview"] }
-commit = { git = "https://github.com/EspressoSystems/commit", tag = "0.2.2" }
+commit = { workspace = true }
 custom_debug = "0.5"
 derivative = "2.2"
 either = { version = "1.8.1" }

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -71,6 +71,6 @@ bitvec = { version = "1.0.1", default-features = false, features = [
     "atomic",
     "serde",
 ] }
-hotshot-primitives = { git = "https://github.com/EspressoSystems/hotshot-primitives", branch = 'hotshot-compat' } # rev = "4aee90c" for 'hotshot-compat'
+hotshot-primitives = { workspace = true }
 jf-primitives = { workspace = true }
 blake3 = { version = "1.3.3", features = ["traits-preview"] }

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -36,7 +36,7 @@ channel-async-std = [
 async-compatibility-layer = { workspace = true }
 async-lock = { workspace = true }
 async-std = { version = "1.12", optional = true }
-async-trait = "0.1.73"
+async-trait = { workspace = true }
 # TODO ed: Delete this dependency after https://github.com/EspressoSystems/HotShot/issues/614 is finished
 bincode = "1.3.3"
 blake3 = { workspace = true, features = ["traits-preview"] }

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -64,7 +64,7 @@ tokio = { version = "1", optional = true, features = [
     "tracing",
 ] }
 tracing = "0.1.37"
-time = "0.3.27" # 0.3.23
+time = { workspace = true }
 bitvec = { version = "1.0.1", default-features = false, features = [
     "alloc",
     "atomic",

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -63,7 +63,7 @@ tokio = { version = "1", optional = true, features = [
     "time",
     "tracing",
 ] }
-tracing = "0.1.37"
+tracing = { workspace = true }
 time = { workspace = true }
 bitvec = { version = "1.0.1", default-features = false, features = [
     "alloc",

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -38,7 +38,7 @@ async-lock = { workspace = true }
 async-std = { version = "1.12", optional = true }
 async-trait = { workspace = true }
 # TODO ed: Delete this dependency after https://github.com/EspressoSystems/HotShot/issues/614 is finished
-bincode = "1.3.3"
+bincode = { workspace = true }
 blake3 = { workspace = true, features = ["traits-preview"] }
 commit = { git = "https://github.com/EspressoSystems/commit", tag = "0.2.2" }
 custom_debug = "0.5"

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -65,10 +65,6 @@ tokio = { version = "1", optional = true, features = [
 ] }
 tracing = { workspace = true }
 time = { workspace = true }
-bitvec = { version = "1.0.1", default-features = false, features = [
-    "alloc",
-    "atomic",
-    "serde",
-] }
+bitvec = { workspace = true }
 hotshot-primitives = { workspace = true }
 jf-primitives = { workspace = true }

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -34,7 +34,7 @@ channel-async-std = [
 
 [dependencies]
 async-compatibility-layer = { workspace = true }
-async-lock = "2.8"
+async-lock = { workspace = true }
 async-std = { version = "1.12", optional = true }
 async-trait = "0.1.73"
 # TODO ed: Delete this dependency after https://github.com/EspressoSystems/HotShot/issues/614 is finished

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -41,7 +41,7 @@ async-trait = { workspace = true }
 bincode = { workspace = true }
 blake3 = { workspace = true, features = ["traits-preview"] }
 commit = { workspace = true }
-custom_debug = "0.5"
+custom_debug = { workspace = true }
 derivative = "2.2"
 either = { version = "1.8.1" }
 futures = "0.3.28"

--- a/crates/hotshot-qc/Cargo.toml
+++ b/crates/hotshot-qc/Cargo.toml
@@ -28,7 +28,7 @@ hotshot-types = { path = "../../types" }
 jf-primitives = { workspace = true }
 jf-relation = { git = "https://github.com/EspressoSystems/jellyfish", branch = "hotshot-compat" }
 jf-utils = { git = "https://github.com/espressosystems/jellyfish", branch = "hotshot-compat" }
-serde = { version = "1.0.183", features = ["derive"] }
+serde = { workspace = true }
 typenum = { version = "1.16.0" }
 
 [dev-dependencies]

--- a/crates/hotshot-qc/Cargo.toml
+++ b/crates/hotshot-qc/Cargo.toml
@@ -22,7 +22,7 @@ bitvec = { version = "1.0.1", default-features = false, features = [
     "atomic",
     "serde",
 ] }
-ethereum-types = { version = "0.14.1", features = ["impl-serde"] }
+ethereum-types = { workspace = true }
 generic-array = "0.14.7"
 hotshot-types = { path = "../../types" }
 jf-primitives = { workspace = true }

--- a/crates/hotshot-qc/Cargo.toml
+++ b/crates/hotshot-qc/Cargo.toml
@@ -15,7 +15,7 @@ ark-ff = "0.4.0"
 ark-pallas = "0.4.0"
 ark-poly = "0.4.0"
 ark-serialize = "0.4.0"
-ark-std = { version = "0.4.0", default-features = false }
+ark-std = { workspace = true }
 bincode = { version = "1.1.3" }
 bitvec = { version = "1.0.1", default-features = false, features = [
     "alloc",

--- a/crates/hotshot-qc/Cargo.toml
+++ b/crates/hotshot-qc/Cargo.toml
@@ -16,7 +16,7 @@ ark-pallas = "0.4.0"
 ark-poly = "0.4.0"
 ark-serialize = { workspace = true }
 ark-std = { workspace = true }
-bincode = { version = "1.1.3" }
+bincode = { workspace = true }
 bitvec = { version = "1.0.1", default-features = false, features = [
     "alloc",
     "atomic",

--- a/crates/hotshot-qc/Cargo.toml
+++ b/crates/hotshot-qc/Cargo.toml
@@ -8,7 +8,7 @@ rust-version = { workspace = true }
 
 [dependencies]
 ark-bls12-377 = "0.4.0"
-ark-bls12-381 = "0.4.0"
+ark-bls12-381 = { workspace = true }
 ark-bn254 = "0.4.0"
 ark-ec = { workspace = true }
 ark-ff = "0.4.0"

--- a/crates/hotshot-qc/Cargo.toml
+++ b/crates/hotshot-qc/Cargo.toml
@@ -10,7 +10,7 @@ rust-version = { workspace = true }
 ark-bls12-377 = "0.4.0"
 ark-bls12-381 = "0.4.0"
 ark-bn254 = "0.4.0"
-ark-ec = "0.4.0"
+ark-ec = { workspace = true }
 ark-ff = "0.4.0"
 ark-pallas = "0.4.0"
 ark-poly = "0.4.0"

--- a/crates/hotshot-qc/Cargo.toml
+++ b/crates/hotshot-qc/Cargo.toml
@@ -25,7 +25,7 @@ jf-primitives = { workspace = true }
 jf-relation = { git = "https://github.com/EspressoSystems/jellyfish", branch = "hotshot-compat" }
 jf-utils = { git = "https://github.com/espressosystems/jellyfish", branch = "hotshot-compat" }
 serde = { workspace = true }
-typenum = { version = "1.16.0" }
+typenum = { workspace = true }
 
 [dev-dependencies]
 hotshot-stake-table = { path = "../hotshot-stake-table" }

--- a/crates/hotshot-qc/Cargo.toml
+++ b/crates/hotshot-qc/Cargo.toml
@@ -17,11 +17,7 @@ ark-poly = "0.4.0"
 ark-serialize = { workspace = true }
 ark-std = { workspace = true }
 bincode = { workspace = true }
-bitvec = { version = "1.0.1", default-features = false, features = [
-    "alloc",
-    "atomic",
-    "serde",
-] }
+bitvec = { workspace = true }
 ethereum-types = { workspace = true }
 generic-array = "0.14.7"
 hotshot-types = { path = "../../types" }

--- a/crates/hotshot-qc/Cargo.toml
+++ b/crates/hotshot-qc/Cargo.toml
@@ -14,7 +14,7 @@ ark-ec = { workspace = true }
 ark-ff = "0.4.0"
 ark-pallas = "0.4.0"
 ark-poly = "0.4.0"
-ark-serialize = "0.4.0"
+ark-serialize = { workspace = true }
 ark-std = { workspace = true }
 bincode = { version = "1.1.3" }
 bitvec = { version = "1.0.1", default-features = false, features = [

--- a/crates/hotshot-qc/Cargo.toml
+++ b/crates/hotshot-qc/Cargo.toml
@@ -17,12 +17,16 @@ ark-poly = "0.4.0"
 ark-serialize = "0.4.0"
 ark-std = { version = "0.4.0", default-features = false }
 bincode = { version = "1.1.3" }
-bitvec = { version = "1.0.1", default-features = false, features = ["alloc", "atomic", "serde"] }
+bitvec = { version = "1.0.1", default-features = false, features = [
+    "alloc",
+    "atomic",
+    "serde",
+] }
 ethereum-types = { version = "0.14.1", features = ["impl-serde"] }
 generic-array = "0.14.7"
 hotshot-types = { path = "../../types" }
-jf-primitives = { git = "https://github.com/EspressoSystems/jellyfish", branch = "hotshot-compat" }
-jf-relation= { git = "https://github.com/EspressoSystems/jellyfish", branch = "hotshot-compat" }
+jf-primitives = { workspace = true }
+jf-relation = { git = "https://github.com/EspressoSystems/jellyfish", branch = "hotshot-compat" }
 jf-utils = { git = "https://github.com/espressosystems/jellyfish", branch = "hotshot-compat" }
 serde = { version = "1.0.183", features = ["derive"] }
 typenum = { version = "1.16.0" }

--- a/crates/hotshot-stake-table/Cargo.toml
+++ b/crates/hotshot-stake-table/Cargo.toml
@@ -12,11 +12,7 @@ ark-ff = "0.4.0"
 ark-serialize = { workspace = true }
 ark-std = { workspace = true }
 bincode = { workspace = true }
-bitvec = { version = "1.0.1", default-features = false, features = [
-    "alloc",
-    "atomic",
-    "serde",
-] }
+bitvec = { workspace = true }
 digest = { workspace = true }
 displaydoc = { version = "0.2.3", default-features = false }
 ethereum-types = { workspace = true }

--- a/crates/hotshot-stake-table/Cargo.toml
+++ b/crates/hotshot-stake-table/Cargo.toml
@@ -25,10 +25,7 @@ hotshot-types = { path = "../../types" }
 jf-primitives = { workspace = true }
 jf-relation = { git = "https://github.com/espressosystems/jellyfish", branch = "hotshot-compat" }
 jf-utils = { git = "https://github.com/espressosystems/jellyfish", branch = "hotshot-compat" }
-serde = { version = "1.0", default-features = false, features = [
-    "derive",
-    "rc",
-] }
+serde = { workspace = true, features = ["rc"] }
 tagged-base64 = { git = "https://github.com/espressosystems/tagged-base64", tag = "0.3.0" }
 typenum = { version = "1.16.0" }
 

--- a/crates/hotshot-stake-table/Cargo.toml
+++ b/crates/hotshot-stake-table/Cargo.toml
@@ -12,16 +12,23 @@ ark-ff = "0.4.0"
 ark-serialize = "0.4.0"
 ark-std = { version = "0.4.0", default-features = false }
 bincode = { version = "1.1.3" }
-bitvec = { version = "1.0.1", default-features = false, features = ["alloc", "atomic", "serde"] }
+bitvec = { version = "1.0.1", default-features = false, features = [
+    "alloc",
+    "atomic",
+    "serde",
+] }
 digest = { version = "0.10" }
 displaydoc = { version = "0.2.3", default-features = false }
 ethereum-types = { version = "0.14.1", features = ["impl-serde"] }
 generic-array = "0.14.7"
 hotshot-types = { path = "../../types" }
-jf-primitives = { git = "https://github.com/espressosystems/jellyfish", branch = "hotshot-compat" }
+jf-primitives = { workspace = true }
 jf-relation = { git = "https://github.com/espressosystems/jellyfish", branch = "hotshot-compat" }
 jf-utils = { git = "https://github.com/espressosystems/jellyfish", branch = "hotshot-compat" }
-serde = { version = "1.0", default-features = false, features = ["derive", "rc"] }
+serde = { version = "1.0", default-features = false, features = [
+    "derive",
+    "rc",
+] }
 tagged-base64 = { git = "https://github.com/espressosystems/tagged-base64", tag = "0.3.0" }
 typenum = { version = "1.16.0" }
 

--- a/crates/hotshot-stake-table/Cargo.toml
+++ b/crates/hotshot-stake-table/Cargo.toml
@@ -9,7 +9,7 @@ rust-version = { workspace = true }
 [dependencies]
 ark-bn254 = "0.4.0"
 ark-ff = "0.4.0"
-ark-serialize = "0.4.0"
+ark-serialize = { workspace = true }
 ark-std = { workspace = true }
 bincode = { version = "1.1.3" }
 bitvec = { version = "1.0.1", default-features = false, features = [

--- a/crates/hotshot-stake-table/Cargo.toml
+++ b/crates/hotshot-stake-table/Cargo.toml
@@ -33,7 +33,7 @@ tagged-base64 = { git = "https://github.com/espressosystems/tagged-base64", tag 
 typenum = { version = "1.16.0" }
 
 [dev-dependencies]
-rand_chacha = { version = "0.3.1", default-features = false }
+rand_chacha = { workspace = true }
 
 [features]
 default = ["parallel"]

--- a/crates/hotshot-stake-table/Cargo.toml
+++ b/crates/hotshot-stake-table/Cargo.toml
@@ -17,7 +17,7 @@ bitvec = { version = "1.0.1", default-features = false, features = [
     "atomic",
     "serde",
 ] }
-digest = { version = "0.10" }
+digest = { workspace = true }
 displaydoc = { version = "0.2.3", default-features = false }
 ethereum-types = { version = "0.14.1", features = ["impl-serde"] }
 generic-array = "0.14.7"

--- a/crates/hotshot-stake-table/Cargo.toml
+++ b/crates/hotshot-stake-table/Cargo.toml
@@ -19,7 +19,7 @@ bitvec = { version = "1.0.1", default-features = false, features = [
 ] }
 digest = { workspace = true }
 displaydoc = { version = "0.2.3", default-features = false }
-ethereum-types = { version = "0.14.1", features = ["impl-serde"] }
+ethereum-types = { workspace = true }
 generic-array = "0.14.7"
 hotshot-types = { path = "../../types" }
 jf-primitives = { workspace = true }

--- a/crates/hotshot-stake-table/Cargo.toml
+++ b/crates/hotshot-stake-table/Cargo.toml
@@ -11,7 +11,7 @@ ark-bn254 = "0.4.0"
 ark-ff = "0.4.0"
 ark-serialize = { workspace = true }
 ark-std = { workspace = true }
-bincode = { version = "1.1.3" }
+bincode = { workspace = true }
 bitvec = { version = "1.0.1", default-features = false, features = [
     "alloc",
     "atomic",

--- a/crates/hotshot-stake-table/Cargo.toml
+++ b/crates/hotshot-stake-table/Cargo.toml
@@ -23,7 +23,7 @@ jf-relation = { git = "https://github.com/espressosystems/jellyfish", branch = "
 jf-utils = { git = "https://github.com/espressosystems/jellyfish", branch = "hotshot-compat" }
 serde = { workspace = true, features = ["rc"] }
 tagged-base64 = { git = "https://github.com/espressosystems/tagged-base64", tag = "0.3.0" }
-typenum = { version = "1.16.0" }
+typenum = { workspace = true }
 
 [dev-dependencies]
 rand_chacha = { workspace = true }

--- a/crates/hotshot-stake-table/Cargo.toml
+++ b/crates/hotshot-stake-table/Cargo.toml
@@ -10,7 +10,7 @@ rust-version = { workspace = true }
 ark-bn254 = "0.4.0"
 ark-ff = "0.4.0"
 ark-serialize = "0.4.0"
-ark-std = { version = "0.4.0", default-features = false }
+ark-std = { workspace = true }
 bincode = { version = "1.1.3" }
 bitvec = { version = "1.0.1", default-features = false, features = [
     "alloc",

--- a/libp2p-networking/Cargo.toml
+++ b/libp2p-networking/Cargo.toml
@@ -44,7 +44,7 @@ async-compatibility-layer = { workspace = true }
 async-lock = { workspace = true }
 async-std = { version = "1.12.0", optional = true }
 async-trait = { workspace = true }
-bincode = "1.3.3"
+bincode = { workspace = true }
 blake3 = { workspace = true }
 color-eyre = "0.6.2"
 custom_debug = "0.5"

--- a/libp2p-networking/Cargo.toml
+++ b/libp2p-networking/Cargo.toml
@@ -40,9 +40,7 @@ channel-tokio = ["async-compatibility-layer/channel-tokio"]
 channel-async-std = ["async-compatibility-layer/channel-async-std"]
 
 [dependencies]
-async-compatibility-layer = { git = "https://github.com/EspressoSystems/async-compatibility-layer.git", tag = "1.3.0", default-features = false, features = [
-    "logging-utils",
-] }
+async-compatibility-layer = { workspace = true }
 async-lock = "2.8"
 async-std = { version = "1.12.0", optional = true }
 async-trait = "0.1.73"

--- a/libp2p-networking/Cargo.toml
+++ b/libp2p-networking/Cargo.toml
@@ -84,7 +84,7 @@ parking_lot = "0.12.1"
 rand = { workspace = true }
 serde = { workspace = true }
 serde_json = "1.0.105"
-snafu = "0.7.5"
+snafu = { workspace = true }
 tokio = { version = "1", optional = true, features = [
     "fs",
     "io-util",

--- a/libp2p-networking/Cargo.toml
+++ b/libp2p-networking/Cargo.toml
@@ -54,7 +54,7 @@ futures = { workspace = true }
 hotshot-utils = { path = "../utils" }
 libp2p-swarm-derive = { workspace = true }
 libp2p-identity = { workspace = true }
-libp2p = { version = "0.52.2", default-features = false, features = [
+libp2p = { workspace = true, features = [
     "macros",
     "autonat",
     "deflate",

--- a/libp2p-networking/Cargo.toml
+++ b/libp2p-networking/Cargo.toml
@@ -104,7 +104,7 @@ tide = { version = "0.16", optional = true, default-features = false, features =
     "h1-server",
 ] }
 tokio-stream = "0.1.14"
-tracing = "0.1.37"
+tracing = { workspace = true }
 void = "1.0.2"
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/libp2p-networking/Cargo.toml
+++ b/libp2p-networking/Cargo.toml
@@ -37,23 +37,23 @@ tokio-executor = [
 profiling = ["async-compatibility-layer/profiling"]
 channel-flume = ["async-compatibility-layer/channel-flume"]
 channel-tokio = ["async-compatibility-layer/channel-tokio"]
-channel-async-std = [
-    "async-compatibility-layer/channel-async-std",
-]
+channel-async-std = ["async-compatibility-layer/channel-async-std"]
 
 [dependencies]
-async-compatibility-layer = { git = "https://github.com/EspressoSystems/async-compatibility-layer.git", tag = "1.3.0", default-features = false, features = [ "logging-utils" ]  }
+async-compatibility-layer = { git = "https://github.com/EspressoSystems/async-compatibility-layer.git", tag = "1.3.0", default-features = false, features = [
+    "logging-utils",
+] }
 async-lock = "2.8"
 async-std = { version = "1.12.0", optional = true }
 async-trait = "0.1.73"
 bincode = "1.3.3"
-blake3 = "1.4.1"
+blake3 = { workspace = true }
 color-eyre = "0.6.2"
 custom_debug = "0.5"
 derive_builder = "0.12.0"
 either = { version = "1.8.1" }
 futures = "0.3.28"
-hotshot-utils = { path = "../utils"}
+hotshot-utils = { path = "../utils" }
 libp2p-swarm-derive = { version = "=0.33.0" }
 libp2p-identity = "0.2.0"
 libp2p = { version = "0.52.2", default-features = false, features = [

--- a/libp2p-networking/Cargo.toml
+++ b/libp2p-networking/Cargo.toml
@@ -82,7 +82,7 @@ libp2p = { workspace = true, features = [
 libp2p-noise = { version = "0.43.0", default-features = false }
 parking_lot = "0.12.1"
 rand = { workspace = true }
-serde = { version = "1.0.183", features = ["derive"] }
+serde = { workspace = true }
 serde_json = "1.0.105"
 snafu = "0.7.5"
 tokio = { version = "1", optional = true, features = [

--- a/libp2p-networking/Cargo.toml
+++ b/libp2p-networking/Cargo.toml
@@ -43,7 +43,7 @@ channel-async-std = ["async-compatibility-layer/channel-async-std"]
 async-compatibility-layer = { workspace = true }
 async-lock = { workspace = true }
 async-std = { version = "1.12.0", optional = true }
-async-trait = "0.1.73"
+async-trait = { workspace = true }
 bincode = "1.3.3"
 blake3 = { workspace = true }
 color-eyre = "0.6.2"

--- a/libp2p-networking/Cargo.toml
+++ b/libp2p-networking/Cargo.toml
@@ -49,7 +49,7 @@ blake3 = { workspace = true }
 color-eyre = "0.6.2"
 custom_debug = { workspace = true }
 derive_builder = "0.12.0"
-either = { version = "1.8.1" }
+either = { workspace = true }
 futures = "0.3.28"
 hotshot-utils = { path = "../utils" }
 libp2p-swarm-derive = { version = "=0.33.0" }

--- a/libp2p-networking/Cargo.toml
+++ b/libp2p-networking/Cargo.toml
@@ -41,7 +41,7 @@ channel-async-std = ["async-compatibility-layer/channel-async-std"]
 
 [dependencies]
 async-compatibility-layer = { workspace = true }
-async-lock = "2.8"
+async-lock = { workspace = true }
 async-std = { version = "1.12.0", optional = true }
 async-trait = "0.1.73"
 bincode = "1.3.3"

--- a/libp2p-networking/Cargo.toml
+++ b/libp2p-networking/Cargo.toml
@@ -52,7 +52,7 @@ derive_builder = "0.12.0"
 either = { workspace = true }
 futures = { workspace = true }
 hotshot-utils = { path = "../utils" }
-libp2p-swarm-derive = { version = "=0.33.0" }
+libp2p-swarm-derive = { workspace = true }
 libp2p-identity = "0.2.0"
 libp2p = { version = "0.52.2", default-features = false, features = [
     "macros",

--- a/libp2p-networking/Cargo.toml
+++ b/libp2p-networking/Cargo.toml
@@ -50,7 +50,7 @@ color-eyre = "0.6.2"
 custom_debug = { workspace = true }
 derive_builder = "0.12.0"
 either = { workspace = true }
-futures = "0.3.28"
+futures = { workspace = true }
 hotshot-utils = { path = "../utils" }
 libp2p-swarm-derive = { version = "=0.33.0" }
 libp2p-identity = "0.2.0"

--- a/libp2p-networking/Cargo.toml
+++ b/libp2p-networking/Cargo.toml
@@ -47,7 +47,7 @@ async-trait = { workspace = true }
 bincode = { workspace = true }
 blake3 = { workspace = true }
 color-eyre = "0.6.2"
-custom_debug = "0.5"
+custom_debug = { workspace = true }
 derive_builder = "0.12.0"
 either = { version = "1.8.1" }
 futures = "0.3.28"

--- a/libp2p-networking/Cargo.toml
+++ b/libp2p-networking/Cargo.toml
@@ -81,7 +81,7 @@ libp2p = { workspace = true, features = [
 ] }
 libp2p-noise = { version = "0.43.0", default-features = false }
 parking_lot = "0.12.1"
-rand = "0.8.5"
+rand = { workspace = true }
 serde = { version = "1.0.183", features = ["derive"] }
 serde_json = "1.0.105"
 snafu = "0.7.5"

--- a/libp2p-networking/Cargo.toml
+++ b/libp2p-networking/Cargo.toml
@@ -53,7 +53,7 @@ either = { workspace = true }
 futures = { workspace = true }
 hotshot-utils = { path = "../utils" }
 libp2p-swarm-derive = { workspace = true }
-libp2p-identity = "0.2.0"
+libp2p-identity = { workspace = true }
 libp2p = { version = "0.52.2", default-features = false, features = [
     "macros",
     "autonat",

--- a/orchestrator/Cargo.toml
+++ b/orchestrator/Cargo.toml
@@ -65,7 +65,7 @@ libp2p = { version = "0.52.0", default-features = false, features = [
 blake3 = { workspace = true, features = ["traits-preview"] }
 hotshot-types = { version = "0.1.0", path = "../types", default-features = false }
 hotshot-utils = { path = "../utils" }
-libp2p-networking = { path = "../libp2p-networking", version = "0.1.0", default-features = false }
+libp2p-networking = { workspace = true }
 nll = { git = "https://github.com/EspressoSystems/nll.git" }
 tide-disco = { git = "https://github.com/EspressoSystems/tide-disco.git", tag = "v0.4.1" }
 surf-disco = { git = "https://github.com/EspressoSystems/surf-disco.git", tag = "v0.4.1" }

--- a/orchestrator/Cargo.toml
+++ b/orchestrator/Cargo.toml
@@ -68,9 +68,7 @@ hotshot-utils = { path = "../utils" }
 libp2p-networking = { workspace = true }
 nll = { workspace = true }
 tide-disco = { git = "https://github.com/EspressoSystems/tide-disco.git", tag = "v0.4.1" }
-surf-disco = { git = "https://github.com/EspressoSystems/surf-disco.git", tag = "v0.4.1" }
-
-
+surf-disco = { workspace = true }
 tokio = { version = "1", optional = true, features = [
     "fs",
     "io-util",
@@ -91,6 +89,3 @@ serde = { workspace = true }
 serde_json = "1.0.96"
 snafu = { workspace = true }
 toml = "0.5.9"
-
-[dev-dependencies]
-surf-disco = { git = "https://github.com/EspressoSystems/surf-disco.git", tag = "v0.4.1" }

--- a/orchestrator/Cargo.toml
+++ b/orchestrator/Cargo.toml
@@ -84,7 +84,7 @@ tokio = { version = "1", optional = true, features = [
     "time",
     "tracing",
 ] }
-tracing = "0.1.37"
+tracing = { workspace = true }
 serde = { workspace = true }
 serde_json = "1.0.96"
 snafu = { workspace = true }

--- a/orchestrator/Cargo.toml
+++ b/orchestrator/Cargo.toml
@@ -35,7 +35,7 @@ channel-async-std = [
 async-compatibility-layer = { workspace = true }
 async-lock = { workspace = true }
 async-std = { version = "1.12", optional = true }
-async-trait = "0.1.68"
+async-trait = { workspace = true }
 bincode = "1.3.3"
 clap = { version = "4.0", features = ["derive", "env"], optional = false }
 futures = "0.3.28"

--- a/orchestrator/Cargo.toml
+++ b/orchestrator/Cargo.toml
@@ -88,4 +88,4 @@ tracing = "0.1.37"
 serde = { workspace = true }
 serde_json = "1.0.96"
 snafu = { workspace = true }
-toml = "0.5.9"
+toml = "0.5.9" # TODO GG upgrade to toml = { workspace = true }

--- a/orchestrator/Cargo.toml
+++ b/orchestrator/Cargo.toml
@@ -18,8 +18,14 @@ tokio-executor = [
     "async-compatibility-layer/tokio-executor",
 ]
 profiling = ["async-compatibility-layer/profiling"]
-channel-flume = ["hotshot-types/channel-flume", "async-compatibility-layer/channel-flume"]
-channel-tokio = ["hotshot-types/channel-tokio", "async-compatibility-layer/channel-tokio"]
+channel-flume = [
+    "hotshot-types/channel-flume",
+    "async-compatibility-layer/channel-flume",
+]
+channel-tokio = [
+    "hotshot-types/channel-tokio",
+    "async-compatibility-layer/channel-tokio",
+]
 channel-async-std = [
     "hotshot-types/channel-async-std",
     "async-compatibility-layer/channel-async-std",
@@ -35,30 +41,30 @@ clap = { version = "4.0", features = ["derive", "env"], optional = false }
 futures = "0.3.28"
 libp2p-core = { version = "0.40.0", default-features = false }
 libp2p = { version = "0.52.0", default-features = false, features = [
-        "macros",
-        "autonat",
-        "deflate",
-        "floodsub",
-        "identify",
-        "kad",
-        "gossipsub",
-        "noise",
-        "ping",
-        "plaintext",
-        "pnet",
-        "relay",
-        "request-response",
-        "rendezvous",
-        "secp256k1",
-        "serde",
-        "uds",
-        "wasm-ext",
-        "websocket",
-        "yamux",
+    "macros",
+    "autonat",
+    "deflate",
+    "floodsub",
+    "identify",
+    "kad",
+    "gossipsub",
+    "noise",
+    "ping",
+    "plaintext",
+    "pnet",
+    "relay",
+    "request-response",
+    "rendezvous",
+    "secp256k1",
+    "serde",
+    "uds",
+    "wasm-ext",
+    "websocket",
+    "yamux",
 ] }
-blake3 = { version = "1.3.3", optional = false, features = ["traits-preview"] }
+blake3 = { workspace = true, features = ["traits-preview"] }
 hotshot-types = { version = "0.1.0", path = "../types", default-features = false }
-hotshot-utils = { path = "../utils"}
+hotshot-utils = { path = "../utils" }
 libp2p-networking = { path = "../libp2p-networking", version = "0.1.0", default-features = false }
 nll = { git = "https://github.com/EspressoSystems/nll.git" }
 tide-disco = { git = "https://github.com/EspressoSystems/tide-disco.git", tag = "v0.4.1" }

--- a/orchestrator/Cargo.toml
+++ b/orchestrator/Cargo.toml
@@ -89,7 +89,7 @@ tokio = { version = "1", optional = true, features = [
 tracing = "0.1.37"
 serde = { workspace = true }
 serde_json = "1.0.96"
-snafu = "0.7.4"
+snafu = { workspace = true }
 toml = "0.5.9"
 
 [dev-dependencies]

--- a/orchestrator/Cargo.toml
+++ b/orchestrator/Cargo.toml
@@ -87,7 +87,7 @@ tokio = { version = "1", optional = true, features = [
     "tracing",
 ] }
 tracing = "0.1.37"
-serde = { version = "1.0.163", features = ["derive"] }
+serde = { workspace = true }
 serde_json = "1.0.96"
 snafu = "0.7.4"
 toml = "0.5.9"

--- a/orchestrator/Cargo.toml
+++ b/orchestrator/Cargo.toml
@@ -40,7 +40,7 @@ bincode = { workspace = true }
 clap = { version = "4.0", features = ["derive", "env"], optional = false }
 futures = { workspace = true }
 libp2p-core = { version = "0.40.0", default-features = false }
-libp2p = { version = "0.52.0", default-features = false, features = [
+libp2p = { workspace = true, features = [
     "macros",
     "autonat",
     "deflate",

--- a/orchestrator/Cargo.toml
+++ b/orchestrator/Cargo.toml
@@ -36,7 +36,7 @@ async-compatibility-layer = { workspace = true }
 async-lock = { workspace = true }
 async-std = { version = "1.12", optional = true }
 async-trait = { workspace = true }
-bincode = "1.3.3"
+bincode = { workspace = true }
 clap = { version = "4.0", features = ["derive", "env"], optional = false }
 futures = "0.3.28"
 libp2p-core = { version = "0.40.0", default-features = false }

--- a/orchestrator/Cargo.toml
+++ b/orchestrator/Cargo.toml
@@ -33,7 +33,7 @@ channel-async-std = [
 
 [dependencies]
 async-compatibility-layer = { workspace = true }
-async-lock = "2.7"
+async-lock = { workspace = true }
 async-std = { version = "1.12", optional = true }
 async-trait = "0.1.68"
 bincode = "1.3.3"

--- a/orchestrator/Cargo.toml
+++ b/orchestrator/Cargo.toml
@@ -38,7 +38,7 @@ async-std = { version = "1.12", optional = true }
 async-trait = { workspace = true }
 bincode = { workspace = true }
 clap = { version = "4.0", features = ["derive", "env"], optional = false }
-futures = "0.3.28"
+futures = { workspace = true }
 libp2p-core = { version = "0.40.0", default-features = false }
 libp2p = { version = "0.52.0", default-features = false, features = [
     "macros",

--- a/orchestrator/Cargo.toml
+++ b/orchestrator/Cargo.toml
@@ -66,7 +66,7 @@ blake3 = { workspace = true, features = ["traits-preview"] }
 hotshot-types = { version = "0.1.0", path = "../types", default-features = false }
 hotshot-utils = { path = "../utils" }
 libp2p-networking = { workspace = true }
-nll = { git = "https://github.com/EspressoSystems/nll.git" }
+nll = { workspace = true }
 tide-disco = { git = "https://github.com/EspressoSystems/tide-disco.git", tag = "v0.4.1" }
 surf-disco = { git = "https://github.com/EspressoSystems/surf-disco.git", tag = "v0.4.1" }
 

--- a/orchestrator/Cargo.toml
+++ b/orchestrator/Cargo.toml
@@ -32,7 +32,7 @@ channel-async-std = [
 ]
 
 [dependencies]
-async-compatibility-layer = { git = "https://github.com/EspressoSystems/async-compatibility-layer.git", tag = "1.3.0", default-features = false }
+async-compatibility-layer = { workspace = true }
 async-lock = "2.7"
 async-std = { version = "1.12", optional = true }
 async-trait = "0.1.68"

--- a/task-impls/Cargo.toml
+++ b/task-impls/Cargo.toml
@@ -45,9 +45,7 @@ channel-async-std = [
 ]
 
 [dependencies]
-async-compatibility-layer = { git = "https://github.com/EspressoSystems/async-compatibility-layer.git", default-features = false, features = [
-    "logging-utils",
-], tag = "1.3.0" }
+async-compatibility-layer = { workspace = true }
 async-std = { version = "1.12.0", optional = true, features = ["unstable"] }
 async-trait = "0.1.73"
 either = { version = "1.8.1", features = ["serde"] }

--- a/task-impls/Cargo.toml
+++ b/task-impls/Cargo.toml
@@ -52,7 +52,7 @@ either = { workspace = true }
 futures = { workspace = true }
 nll = { workspace = true }
 serde = { workspace = true }
-snafu = "0.7.4"
+snafu = { workspace = true }
 tokio = { version = "1", optional = true, features = [
     "fs",
     "io-util",

--- a/task-impls/Cargo.toml
+++ b/task-impls/Cargo.toml
@@ -77,7 +77,7 @@ hotshot-types = { path = "../types", default-features = false }
 hotshot-consensus = { path = "../consensus", default-features = false }
 hotshot-task = { path = "../task", default-features = false }
 time = "0.3.27"
-commit = { git = "https://github.com/EspressoSystems/commit", tag = "0.2.2" }
+commit = { workspace = true }
 jf-primitives = { workspace = true }
 rand_chacha = "0.3.1"
 hotshot-utils = { path = "../utils" }

--- a/task-impls/Cargo.toml
+++ b/task-impls/Cargo.toml
@@ -81,7 +81,7 @@ commit = { git = "https://github.com/EspressoSystems/commit", tag = "0.2.2" }
 jf-primitives = { workspace = true }
 rand_chacha = "0.3.1"
 hotshot-utils = { path = "../utils" }
-bincode = "1.3.3"
+bincode = { workspace = true }
 bitvec = { version = "1.0.1", default-features = false, features = [
     "alloc",
     "atomic",

--- a/task-impls/Cargo.toml
+++ b/task-impls/Cargo.toml
@@ -51,7 +51,7 @@ async-trait = { workspace = true }
 either = { workspace = true }
 futures = { workspace = true }
 nll = { workspace = true }
-serde = { version = "1.0.183", features = ["derive"] }
+serde = { workspace = true }
 snafu = "0.7.4"
 tokio = { version = "1", optional = true, features = [
     "fs",

--- a/task-impls/Cargo.toml
+++ b/task-impls/Cargo.toml
@@ -68,7 +68,7 @@ tokio = { version = "1", optional = true, features = [
     "time",
     "tracing",
 ] }
-async-lock = "2.8.0"
+async-lock = { workspace = true }
 tracing = "0.1.37"
 atomic_enum = "0.2.0"
 pin-project = "1.1.3"

--- a/task-impls/Cargo.toml
+++ b/task-impls/Cargo.toml
@@ -45,10 +45,12 @@ channel-async-std = [
 ]
 
 [dependencies]
-async-compatibility-layer = { git = "https://github.com/EspressoSystems/async-compatibility-layer.git", default-features = false, features = [ "logging-utils" ], tag = "1.3.0" }
+async-compatibility-layer = { git = "https://github.com/EspressoSystems/async-compatibility-layer.git", default-features = false, features = [
+    "logging-utils",
+], tag = "1.3.0" }
 async-std = { version = "1.12.0", optional = true, features = ["unstable"] }
 async-trait = "0.1.73"
-either = { version = "1.8.1", features = [ "serde" ] }
+either = { version = "1.8.1", features = ["serde"] }
 futures = "0.3.28"
 nll = { git = "https://github.com/EspressoSystems/nll.git" }
 serde = { version = "1.0.183", features = ["derive"] }
@@ -78,8 +80,12 @@ hotshot-consensus = { path = "../consensus", default-features = false }
 hotshot-task = { path = "../task", default-features = false }
 time = "0.3.27"
 commit = { git = "https://github.com/EspressoSystems/commit", tag = "0.2.2" }
-jf-primitives = { git = "https://github.com/EspressoSystems/jellyfish", branch = 'hotshot-compat'} # rev = "470a833" for branch = 'hotshot-compat'
+jf-primitives = { workspace = true }
 rand_chacha = "0.3.1"
 hotshot-utils = { path = "../utils" }
 bincode = "1.3.3"
-bitvec = { version = "1.0.1", default-features = false, features = ["alloc", "atomic", "serde"] }
+bitvec = { version = "1.0.1", default-features = false, features = [
+    "alloc",
+    "atomic",
+    "serde",
+] }

--- a/task-impls/Cargo.toml
+++ b/task-impls/Cargo.toml
@@ -82,8 +82,4 @@ jf-primitives = { workspace = true }
 rand_chacha = { workspace = true }
 hotshot-utils = { path = "../utils" }
 bincode = { workspace = true }
-bitvec = { version = "1.0.1", default-features = false, features = [
-    "alloc",
-    "atomic",
-    "serde",
-] }
+bitvec = { workspace = true }

--- a/task-impls/Cargo.toml
+++ b/task-impls/Cargo.toml
@@ -79,7 +79,7 @@ hotshot-task = { path = "../task", default-features = false }
 time = "0.3.27"
 commit = { workspace = true }
 jf-primitives = { workspace = true }
-rand_chacha = "0.3.1"
+rand_chacha = { workspace = true }
 hotshot-utils = { path = "../utils" }
 bincode = { workspace = true }
 bitvec = { version = "1.0.1", default-features = false, features = [

--- a/task-impls/Cargo.toml
+++ b/task-impls/Cargo.toml
@@ -69,7 +69,7 @@ tokio = { version = "1", optional = true, features = [
     "tracing",
 ] }
 async-lock = { workspace = true }
-tracing = "0.1.37"
+tracing = { workspace = true }
 atomic_enum = "0.2.0"
 pin-project = "1.1.3"
 async-stream = "0.3.5"

--- a/task-impls/Cargo.toml
+++ b/task-impls/Cargo.toml
@@ -50,7 +50,7 @@ async-std = { version = "1.12.0", optional = true, features = ["unstable"] }
 async-trait = { workspace = true }
 either = { workspace = true }
 futures = { workspace = true }
-nll = { git = "https://github.com/EspressoSystems/nll.git" }
+nll = { workspace = true }
 serde = { version = "1.0.183", features = ["derive"] }
 snafu = "0.7.4"
 tokio = { version = "1", optional = true, features = [

--- a/task-impls/Cargo.toml
+++ b/task-impls/Cargo.toml
@@ -49,7 +49,7 @@ async-compatibility-layer = { workspace = true }
 async-std = { version = "1.12.0", optional = true, features = ["unstable"] }
 async-trait = { workspace = true }
 either = { workspace = true }
-futures = "0.3.28"
+futures = { workspace = true }
 nll = { git = "https://github.com/EspressoSystems/nll.git" }
 serde = { version = "1.0.183", features = ["derive"] }
 snafu = "0.7.4"

--- a/task-impls/Cargo.toml
+++ b/task-impls/Cargo.toml
@@ -48,7 +48,7 @@ channel-async-std = [
 async-compatibility-layer = { workspace = true }
 async-std = { version = "1.12.0", optional = true, features = ["unstable"] }
 async-trait = { workspace = true }
-either = { version = "1.8.1", features = ["serde"] }
+either = { workspace = true }
 futures = "0.3.28"
 nll = { git = "https://github.com/EspressoSystems/nll.git" }
 serde = { version = "1.0.183", features = ["derive"] }

--- a/task-impls/Cargo.toml
+++ b/task-impls/Cargo.toml
@@ -47,7 +47,7 @@ channel-async-std = [
 [dependencies]
 async-compatibility-layer = { workspace = true }
 async-std = { version = "1.12.0", optional = true, features = ["unstable"] }
-async-trait = "0.1.73"
+async-trait = { workspace = true }
 either = { version = "1.8.1", features = ["serde"] }
 futures = "0.3.28"
 nll = { git = "https://github.com/EspressoSystems/nll.git" }

--- a/task-impls/Cargo.toml
+++ b/task-impls/Cargo.toml
@@ -76,7 +76,7 @@ async-stream = "0.3.5"
 hotshot-types = { path = "../types", default-features = false }
 hotshot-consensus = { path = "../consensus", default-features = false }
 hotshot-task = { path = "../task", default-features = false }
-time = "0.3.27"
+time = { workspace = true }
 commit = { workspace = true }
 jf-primitives = { workspace = true }
 rand_chacha = { workspace = true }

--- a/task/Cargo.toml
+++ b/task/Cargo.toml
@@ -45,6 +45,6 @@ tokio = { version = "1", optional = true, features = [
     "tracing",
 ] }
 async-lock = { workspace = true }
-tracing = "0.1.37"
+tracing = { workspace = true }
 atomic_enum = "0.2.0"
 pin-project = "1.1.3"

--- a/task/Cargo.toml
+++ b/task/Cargo.toml
@@ -28,7 +28,7 @@ either = { workspace = true }
 futures = { workspace = true }
 nll = { workspace = true }
 serde = { workspace = true }
-snafu = "0.7.5"
+snafu = { workspace = true }
 tokio = { version = "1", optional = true, features = [
     "fs",
     "io-util",

--- a/task/Cargo.toml
+++ b/task/Cargo.toml
@@ -23,7 +23,7 @@ channel-async-std = ["async-compatibility-layer/channel-async-std"]
 [dependencies]
 async-compatibility-layer = { workspace = true }
 async-std = { version = "1.12.0", optional = true, features = ["unstable"] }
-async-trait = "0.1.73"
+async-trait = { workspace = true }
 either = { version = "1.8.1", features = ["serde"] }
 futures = "0.3.28"
 nll = { git = "https://github.com/EspressoSystems/nll.git" }

--- a/task/Cargo.toml
+++ b/task/Cargo.toml
@@ -25,7 +25,7 @@ async-compatibility-layer = { workspace = true }
 async-std = { version = "1.12.0", optional = true, features = ["unstable"] }
 async-trait = { workspace = true }
 either = { workspace = true }
-futures = "0.3.28"
+futures = { workspace = true }
 nll = { git = "https://github.com/EspressoSystems/nll.git" }
 serde = { version = "1.0.183", features = ["derive"] }
 snafu = "0.7.5"

--- a/task/Cargo.toml
+++ b/task/Cargo.toml
@@ -26,7 +26,7 @@ async-std = { version = "1.12.0", optional = true, features = ["unstable"] }
 async-trait = { workspace = true }
 either = { workspace = true }
 futures = { workspace = true }
-nll = { git = "https://github.com/EspressoSystems/nll.git" }
+nll = { workspace = true }
 serde = { version = "1.0.183", features = ["derive"] }
 snafu = "0.7.5"
 tokio = { version = "1", optional = true, features = [

--- a/task/Cargo.toml
+++ b/task/Cargo.toml
@@ -27,7 +27,7 @@ async-trait = { workspace = true }
 either = { workspace = true }
 futures = { workspace = true }
 nll = { workspace = true }
-serde = { version = "1.0.183", features = ["derive"] }
+serde = { workspace = true }
 snafu = "0.7.5"
 tokio = { version = "1", optional = true, features = [
     "fs",

--- a/task/Cargo.toml
+++ b/task/Cargo.toml
@@ -15,25 +15,16 @@ async-std-executor = [
     "dep:async-std",
     "async-compatibility-layer/async-std-executor",
 ]
-tokio-executor = [
-    "dep:tokio",
-    "async-compatibility-layer/tokio-executor",
-]
-channel-flume = [
-    "async-compatibility-layer/channel-flume",
-]
-channel-tokio = [
-    "async-compatibility-layer/channel-tokio",
-]
-channel-async-std = [
-    "async-compatibility-layer/channel-async-std",
-]
+tokio-executor = ["dep:tokio", "async-compatibility-layer/tokio-executor"]
+channel-flume = ["async-compatibility-layer/channel-flume"]
+channel-tokio = ["async-compatibility-layer/channel-tokio"]
+channel-async-std = ["async-compatibility-layer/channel-async-std"]
 
 [dependencies]
-async-compatibility-layer = { git = "https://github.com/EspressoSystems/async-compatibility-layer.git", default-features = false, features = [ "logging-utils" ], tag = "1.3.0" }
+async-compatibility-layer = { workspace = true }
 async-std = { version = "1.12.0", optional = true, features = ["unstable"] }
 async-trait = "0.1.73"
-either = { version = "1.8.1", features = [ "serde" ] }
+either = { version = "1.8.1", features = ["serde"] }
 futures = "0.3.28"
 nll = { git = "https://github.com/EspressoSystems/nll.git" }
 serde = { version = "1.0.183", features = ["derive"] }

--- a/task/Cargo.toml
+++ b/task/Cargo.toml
@@ -24,7 +24,7 @@ channel-async-std = ["async-compatibility-layer/channel-async-std"]
 async-compatibility-layer = { workspace = true }
 async-std = { version = "1.12.0", optional = true, features = ["unstable"] }
 async-trait = { workspace = true }
-either = { version = "1.8.1", features = ["serde"] }
+either = { workspace = true }
 futures = "0.3.28"
 nll = { git = "https://github.com/EspressoSystems/nll.git" }
 serde = { version = "1.0.183", features = ["derive"] }

--- a/task/Cargo.toml
+++ b/task/Cargo.toml
@@ -44,7 +44,7 @@ tokio = { version = "1", optional = true, features = [
     "time",
     "tracing",
 ] }
-async-lock = "2.8.0"
+async-lock = { workspace = true }
 tracing = "0.1.37"
 atomic_enum = "0.2.0"
 pin-project = "1.1.3"

--- a/testing-macros/Cargo.toml
+++ b/testing-macros/Cargo.toml
@@ -63,8 +63,8 @@ hotshot = { path = "../", default-features = false }
 hotshot-consensus = { path = "../consensus", default-features = false }
 hotshot-types = { path = "../types", default-features = false }
 hotshot-testing = { path = "../testing", default-features = false }
-hotshot-primitives = { git = "https://github.com/EspressoSystems/hotshot-primitives",  branch = 'hotshot-compat'} # rev = "4aee90c" for 'hotshot-compat'
-jf-primitives = { git = "https://github.com/EspressoSystems/jellyfish", branch = 'hotshot-compat'} # rev = "470a833" for branch = 'hotshot-compat'
+hotshot-primitives = { git = "https://github.com/EspressoSystems/hotshot-primitives", branch = 'hotshot-compat' } # rev = "4aee90c" for 'hotshot-compat'
+jf-primitives = { workspace = true }
 nll = { git = "https://github.com/EspressoSystems/nll.git" }
 rand = "0.8.5"
 snafu = "0.7.5"

--- a/testing-macros/Cargo.toml
+++ b/testing-macros/Cargo.toml
@@ -57,7 +57,7 @@ async-trait = { workspace = true }
 # so non-optional for now
 blake3 = { workspace = true, features = ["traits-preview"] }
 commit = { workspace = true }
-either = { version = "1.8.1" }
+either = { workspace = true }
 futures = "0.3.28"
 hotshot = { path = "../", default-features = false }
 hotshot-consensus = { path = "../consensus", default-features = false }

--- a/testing-macros/Cargo.toml
+++ b/testing-macros/Cargo.toml
@@ -55,7 +55,7 @@ async-std = { version = "1.12.0", optional = true }
 async-trait = "0.1.71"
 # needed for vrf demo
 # so non-optional for now
-blake3 = { version = "1.4.1", features = ["traits-preview"] }
+blake3 = { workspace = true, features = ["traits-preview"] }
 commit = { git = "https://github.com/EspressoSystems/commit", tag = "0.2.2" }
 either = { version = "1.8.1" }
 futures = "0.3.28"

--- a/testing-macros/Cargo.toml
+++ b/testing-macros/Cargo.toml
@@ -56,7 +56,7 @@ async-trait = { workspace = true }
 # needed for vrf demo
 # so non-optional for now
 blake3 = { workspace = true, features = ["traits-preview"] }
-commit = { git = "https://github.com/EspressoSystems/commit", tag = "0.2.2" }
+commit = { workspace = true }
 either = { version = "1.8.1" }
 futures = "0.3.28"
 hotshot = { path = "../", default-features = false }

--- a/testing-macros/Cargo.toml
+++ b/testing-macros/Cargo.toml
@@ -58,7 +58,7 @@ async-trait = { workspace = true }
 blake3 = { workspace = true, features = ["traits-preview"] }
 commit = { workspace = true }
 either = { workspace = true }
-futures = "0.3.28"
+futures = { workspace = true }
 hotshot = { path = "../", default-features = false }
 hotshot-consensus = { path = "../consensus", default-features = false }
 hotshot-types = { path = "../types", default-features = false }

--- a/testing-macros/Cargo.toml
+++ b/testing-macros/Cargo.toml
@@ -49,7 +49,7 @@ channel-async-std = [
 ]
 
 [dependencies]
-ark-bls12-381 = { version = "0.3.0" }
+ark-bls12-381 = { workspace = true }
 async-compatibility-layer = { git = "https://github.com/EspressoSystems/async-compatibility-layer.git", tag = "1.3.0", default-features = false }
 async-std = { version = "1.12.0", optional = true }
 async-trait = "0.1.71"

--- a/testing-macros/Cargo.toml
+++ b/testing-macros/Cargo.toml
@@ -66,7 +66,7 @@ hotshot-testing = { path = "../testing", default-features = false }
 hotshot-primitives = { workspace = true }
 jf-primitives = { workspace = true }
 nll = { workspace = true }
-rand = "0.8.5"
+rand = { workspace = true }
 snafu = "0.7.5"
 tokio = { version = "1", optional = true, features = [
   "fs",

--- a/testing-macros/Cargo.toml
+++ b/testing-macros/Cargo.toml
@@ -63,7 +63,7 @@ hotshot = { path = "../", default-features = false }
 hotshot-consensus = { path = "../consensus", default-features = false }
 hotshot-types = { path = "../types", default-features = false }
 hotshot-testing = { path = "../testing", default-features = false }
-hotshot-primitives = { git = "https://github.com/EspressoSystems/hotshot-primitives", branch = 'hotshot-compat' } # rev = "4aee90c" for 'hotshot-compat'
+hotshot-primitives = { workspace = true }
 jf-primitives = { workspace = true }
 nll = { git = "https://github.com/EspressoSystems/nll.git" }
 rand = "0.8.5"

--- a/testing-macros/Cargo.toml
+++ b/testing-macros/Cargo.toml
@@ -67,7 +67,7 @@ hotshot-primitives = { workspace = true }
 jf-primitives = { workspace = true }
 nll = { workspace = true }
 rand = { workspace = true }
-snafu = "0.7.5"
+snafu = { workspace = true }
 tokio = { version = "1", optional = true, features = [
   "fs",
   "io-util",

--- a/testing-macros/Cargo.toml
+++ b/testing-macros/Cargo.toml
@@ -52,7 +52,7 @@ channel-async-std = [
 ark-bls12-381 = { workspace = true }
 async-compatibility-layer = { workspace = true }
 async-std = { version = "1.12.0", optional = true }
-async-trait = "0.1.71"
+async-trait = { workspace = true }
 # needed for vrf demo
 # so non-optional for now
 blake3 = { workspace = true, features = ["traits-preview"] }

--- a/testing-macros/Cargo.toml
+++ b/testing-macros/Cargo.toml
@@ -65,7 +65,7 @@ hotshot-types = { path = "../types", default-features = false }
 hotshot-testing = { path = "../testing", default-features = false }
 hotshot-primitives = { workspace = true }
 jf-primitives = { workspace = true }
-nll = { git = "https://github.com/EspressoSystems/nll.git" }
+nll = { workspace = true }
 rand = "0.8.5"
 snafu = "0.7.5"
 tokio = { version = "1", optional = true, features = [

--- a/testing-macros/Cargo.toml
+++ b/testing-macros/Cargo.toml
@@ -50,7 +50,7 @@ channel-async-std = [
 
 [dependencies]
 ark-bls12-381 = { workspace = true }
-async-compatibility-layer = { git = "https://github.com/EspressoSystems/async-compatibility-layer.git", tag = "1.3.0", default-features = false }
+async-compatibility-layer = { workspace = true }
 async-std = { version = "1.12.0", optional = true }
 async-trait = "0.1.71"
 # needed for vrf demo

--- a/testing-macros/Cargo.toml
+++ b/testing-macros/Cargo.toml
@@ -83,7 +83,7 @@ tokio = { version = "1", optional = true, features = [
   "time",
   "tracing",
 ] }
-tracing = "0.1.37"
+tracing = { workspace = true }
 serde = { workspace = true }
 # proc macro stuff
 quote = "1.0.32"

--- a/testing-macros/Cargo.toml
+++ b/testing-macros/Cargo.toml
@@ -92,7 +92,7 @@ proc-macro2 = "1.0.66"
 derive_builder = "0.12.0"
 
 [dev-dependencies]
-async-lock = "2.7"
+async-lock = { workspace = true }
 
 [lib]
 proc-macro = true

--- a/testing-macros/Cargo.toml
+++ b/testing-macros/Cargo.toml
@@ -84,7 +84,7 @@ tokio = { version = "1", optional = true, features = [
   "tracing",
 ] }
 tracing = "0.1.37"
-serde = { version = "1.0.171", features = ["derive"] }
+serde = { workspace = true }
 # proc macro stuff
 quote = "1.0.32"
 syn = { version = "2.0.26", features = ["full", "extra-traits"] }

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -73,7 +73,7 @@ hotshot-primitives = { workspace = true }
 jf-primitives = { workspace = true }
 rand = { workspace = true }
 rand_chacha = { workspace = true }
-snafu = "0.7.5"
+snafu = { workspace = true }
 tokio = { version = "1", optional = true, features = [
   "fs",
   "io-util",

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -102,4 +102,4 @@ bitvec = { version = "1.0.1", default-features = false, features = [
 
 [dev-dependencies]
 nll = { git = "https://github.com/EspressoSystems/nll.git" }
-async-lock = "2.8"
+async-lock = { workspace = true }

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -52,9 +52,7 @@ channel-async-std = [
 
 [dependencies]
 ark-bls12-381 = { workspace = true }
-async-compatibility-layer = { git = "https://github.com/EspressoSystems/async-compatibility-layer.git", tag = "1.3.0", default-features = false, features = [
-  "logging-utils",
-] }
+async-compatibility-layer = { workspace = true }
 async-std = { version = "1.12.0", optional = true }
 async-trait = "0.1.73"
 # needed for vrf demo

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -51,7 +51,7 @@ channel-async-std = [
 ]
 
 [dependencies]
-ark-bls12-381 = { version = "0.3.0" }
+ark-bls12-381 = { workspace = true }
 async-compatibility-layer = { git = "https://github.com/EspressoSystems/async-compatibility-layer.git", tag = "1.3.0", default-features = false, features = [
   "logging-utils",
 ] }

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -89,7 +89,7 @@ tokio = { version = "1", optional = true, features = [
   "time",
   "tracing",
 ] }
-tracing = "0.1.37"
+tracing = { workspace = true }
 nll = { workspace = true }
 serde = { workspace = true }
 ethereum-types = { version = "0.14.1", features = ["impl-serde"] }

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -92,7 +92,7 @@ tokio = { version = "1", optional = true, features = [
 tracing = { workspace = true }
 nll = { workspace = true }
 serde = { workspace = true }
-ethereum-types = { version = "0.14.1", features = ["impl-serde"] }
+ethereum-types = { workspace = true }
 bitvec = { version = "1.0.1", default-features = false, features = [
   "alloc",
   "atomic",

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -58,7 +58,7 @@ async-trait = { workspace = true }
 # needed for vrf demo
 # so non-optional for now
 blake3 = { workspace = true, features = ["traits-preview"] }
-commit = { git = "https://github.com/EspressoSystems/commit", tag = "0.2.2" }
+commit = { workspace = true }
 either = { version = "1.8.1" }
 futures = "0.3.28"
 hotshot = { path = "../", features = [

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -91,7 +91,7 @@ tokio = { version = "1", optional = true, features = [
 ] }
 tracing = "0.1.37"
 nll = { workspace = true }
-serde = { version = "1.0.164", features = ["derive"] } # 1.0.183
+serde = { workspace = true }
 ethereum-types = { version = "0.14.1", features = ["impl-serde"] }
 bitvec = { version = "1.0.1", default-features = false, features = [
   "alloc",

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -60,7 +60,7 @@ async-trait = { workspace = true }
 blake3 = { workspace = true, features = ["traits-preview"] }
 commit = { workspace = true }
 either = { workspace = true }
-futures = "0.3.28"
+futures = { workspace = true }
 hotshot = { path = "../", features = [
   "hotshot-testing",
 ], default-features = false }

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -54,7 +54,7 @@ channel-async-std = [
 ark-bls12-381 = { workspace = true }
 async-compatibility-layer = { workspace = true }
 async-std = { version = "1.12.0", optional = true }
-async-trait = "0.1.73"
+async-trait = { workspace = true }
 # needed for vrf demo
 # so non-optional for now
 blake3 = { workspace = true, features = ["traits-preview"] }

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -52,7 +52,9 @@ channel-async-std = [
 
 [dependencies]
 ark-bls12-381 = { version = "0.3.0" }
-async-compatibility-layer = { git = "https://github.com/EspressoSystems/async-compatibility-layer.git", tag = "1.3.0", default-features = false, features = [ "logging-utils"] }
+async-compatibility-layer = { git = "https://github.com/EspressoSystems/async-compatibility-layer.git", tag = "1.3.0", default-features = false, features = [
+  "logging-utils",
+] }
 async-std = { version = "1.12.0", optional = true }
 async-trait = "0.1.73"
 # needed for vrf demo
@@ -69,8 +71,8 @@ hotshot-types = { path = "../types", default-features = false }
 hotshot-utils = { path = "../utils" }
 hotshot-task = { path = "../task", version = "0.1.0", default-features = false }
 hotshot-task-impls = { path = "../task-impls", version = "0.1.0", default-features = false }
-hotshot-primitives = { git = "https://github.com/EspressoSystems/hotshot-primitives",  branch = 'hotshot-compat'} # rev = "4aee90c" for 'hotshot-compat'
-jf-primitives = { git = "https://github.com/EspressoSystems/jellyfish", branch = 'hotshot-compat'} # rev = "470a833" for branch = 'hotshot-compat'
+hotshot-primitives = { git = "https://github.com/EspressoSystems/hotshot-primitives", branch = 'hotshot-compat' } # rev = "4aee90c" for 'hotshot-compat'
+jf-primitives = { workspace = true }
 # nll = { git = "https://github.com/EspressoSystems/nll.git" }
 rand = "0.8.5"
 rand_chacha = "0.3.1"
@@ -94,7 +96,11 @@ tracing = "0.1.37"
 nll = { git = "https://github.com/EspressoSystems/nll.git" }
 serde = { version = "1.0.164", features = ["derive"] } # 1.0.183
 ethereum-types = { version = "0.14.1", features = ["impl-serde"] }
-bitvec = { version = "1.0.1", default-features = false, features = ["alloc", "atomic", "serde"] }
+bitvec = { version = "1.0.1", default-features = false, features = [
+  "alloc",
+  "atomic",
+  "serde",
+] }
 
 [dev-dependencies]
 nll = { git = "https://github.com/EspressoSystems/nll.git" }

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -93,11 +93,7 @@ tracing = { workspace = true }
 nll = { workspace = true }
 serde = { workspace = true }
 ethereum-types = { workspace = true }
-bitvec = { version = "1.0.1", default-features = false, features = [
-  "alloc",
-  "atomic",
-  "serde",
-] }
+bitvec = { workspace = true }
 
 [dev-dependencies]
 async-lock = { workspace = true }

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -71,7 +71,6 @@ hotshot-task = { path = "../task", version = "0.1.0", default-features = false }
 hotshot-task-impls = { path = "../task-impls", version = "0.1.0", default-features = false }
 hotshot-primitives = { workspace = true }
 jf-primitives = { workspace = true }
-# nll = { git = "https://github.com/EspressoSystems/nll.git" }
 rand = "0.8.5"
 rand_chacha = "0.3.1"
 snafu = "0.7.5"
@@ -91,7 +90,7 @@ tokio = { version = "1", optional = true, features = [
   "tracing",
 ] }
 tracing = "0.1.37"
-nll = { git = "https://github.com/EspressoSystems/nll.git" }
+nll = { workspace = true }
 serde = { version = "1.0.164", features = ["derive"] } # 1.0.183
 ethereum-types = { version = "0.14.1", features = ["impl-serde"] }
 bitvec = { version = "1.0.1", default-features = false, features = [
@@ -101,5 +100,4 @@ bitvec = { version = "1.0.1", default-features = false, features = [
 ] }
 
 [dev-dependencies]
-nll = { git = "https://github.com/EspressoSystems/nll.git" }
 async-lock = { workspace = true }

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -59,7 +59,7 @@ async-trait = { workspace = true }
 # so non-optional for now
 blake3 = { workspace = true, features = ["traits-preview"] }
 commit = { workspace = true }
-either = { version = "1.8.1" }
+either = { workspace = true }
 futures = "0.3.28"
 hotshot = { path = "../", features = [
   "hotshot-testing",

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -71,7 +71,7 @@ hotshot-types = { path = "../types", default-features = false }
 hotshot-utils = { path = "../utils" }
 hotshot-task = { path = "../task", version = "0.1.0", default-features = false }
 hotshot-task-impls = { path = "../task-impls", version = "0.1.0", default-features = false }
-hotshot-primitives = { git = "https://github.com/EspressoSystems/hotshot-primitives", branch = 'hotshot-compat' } # rev = "4aee90c" for 'hotshot-compat'
+hotshot-primitives = { workspace = true }
 jf-primitives = { workspace = true }
 # nll = { git = "https://github.com/EspressoSystems/nll.git" }
 rand = "0.8.5"

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -71,7 +71,7 @@ hotshot-task = { path = "../task", version = "0.1.0", default-features = false }
 hotshot-task-impls = { path = "../task-impls", version = "0.1.0", default-features = false }
 hotshot-primitives = { workspace = true }
 jf-primitives = { workspace = true }
-rand = "0.8.5"
+rand = { workspace = true }
 rand_chacha = "0.3.1"
 snafu = "0.7.5"
 tokio = { version = "1", optional = true, features = [

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -59,7 +59,7 @@ async-std = { version = "1.12.0", optional = true }
 async-trait = "0.1.73"
 # needed for vrf demo
 # so non-optional for now
-blake3 = { version = "1.4.1", features = ["traits-preview"] }
+blake3 = { workspace = true, features = ["traits-preview"] }
 commit = { git = "https://github.com/EspressoSystems/commit", tag = "0.2.2" }
 either = { version = "1.8.1" }
 futures = "0.3.28"

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -72,7 +72,7 @@ hotshot-task-impls = { path = "../task-impls", version = "0.1.0", default-featur
 hotshot-primitives = { workspace = true }
 jf-primitives = { workspace = true }
 rand = { workspace = true }
-rand_chacha = "0.3.1"
+rand_chacha = { workspace = true }
 snafu = "0.7.5"
 tokio = { version = "1", optional = true, features = [
   "fs",

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -77,9 +77,7 @@ nll = { workspace = true }
 libp2p-networking = { workspace = true }
 rand = { workspace = true }
 rand_chacha = { workspace = true }
-serde = { version = "1.0.164", features = [
-    "derive",
-] } # change to 1.0.183 if it can't work
+serde = { workspace = true }
 snafu = "0.7.4" # change to 0.7.5 if it can't work
 tagged-base64 = { git = "https://github.com/EspressoSystems/tagged-base64", tag = "0.2.4" }
 time = "0.3.27"

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -97,7 +97,7 @@ tokio = { version = "1", optional = true, features = [
     "tracing",
 ] }
 tracing = { workspace = true }
-ethereum-types = { version = "0.14.1", features = ["impl-serde"] }
+ethereum-types = { workspace = true }
 bit-vec = "0.6.3"
 typenum = { version = "1.16.0" }
 

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -46,7 +46,7 @@ arbitrary = { version = "1.3", features = ["derive"] }
 async-compatibility-layer = { workspace = true }
 async-lock = { workspace = true }
 async-std = { version = "1.12.0", optional = true, features = ["unstable"] }
-async-trait = "0.1.73"
+async-trait = { workspace = true }
 ark-serialize = { version = "0.3", features = [
     "derive",
 ] } # TODO GG upgrade to 0.4 and inherit this dep from workspace

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -64,7 +64,7 @@ derivative = "2.2.0"
 digest = { workspace = true }
 displaydoc = { version = "0.2.3", default-features = false }
 ed25519-compact = { version = "2.0.4", optional = true }
-either = { version = "1.8.1", features = ["serde"] }
+either = { workspace = true, features = ["serde"] }
 espresso-systems-common = { git = "https://github.com/espressosystems/espresso-systems-common", tag = "0.4.1" }
 futures = "0.3.28"
 generic-array = "0.14.7"

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -44,7 +44,7 @@ channel-async-std = [
 [dependencies]
 arbitrary = { version = "1.3", features = ["derive"] }
 async-compatibility-layer = { workspace = true }
-async-lock = "2.8"
+async-lock = { workspace = true }
 async-std = { version = "1.12.0", optional = true, features = ["unstable"] }
 async-trait = "0.1.73"
 ark-serialize = { version = "0.3", features = [

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -59,7 +59,7 @@ bitvec = { version = "1.0.1", default-features = false, features = [
 ] }
 blake3 = { workspace = true }
 commit = { workspace = true }
-custom_debug = "0.5"
+custom_debug = { workspace = true }
 derivative = "2.2.0"
 digest = { version = "0.10" }
 displaydoc = { version = "0.2.3", default-features = false }

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -96,7 +96,7 @@ tokio = { version = "1", optional = true, features = [
     "time",
     "tracing",
 ] }
-tracing = "0.1.37"
+tracing = { workspace = true }
 ethereum-types = { version = "0.14.1", features = ["impl-serde"] }
 bit-vec = "0.6.3"
 typenum = { version = "1.16.0" }

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -76,7 +76,7 @@ jf-primitives = { workspace = true }
 nll = { workspace = true }
 libp2p-networking = { workspace = true }
 rand = { workspace = true }
-rand_chacha = "0.3.1"
+rand_chacha = { workspace = true }
 serde = { version = "1.0.164", features = [
     "derive",
 ] } # change to 1.0.183 if it can't work

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -43,9 +43,7 @@ channel-async-std = [
 
 [dependencies]
 arbitrary = { version = "1.3", features = ["derive"] }
-async-compatibility-layer = { git = "https://github.com/EspressoSystems/async-compatibility-layer.git", tag = "1.3.0", default-features = false, features = [
-    "logging-utils",
-] }
+async-compatibility-layer = { workspace = true }
 async-lock = "2.8"
 async-std = { version = "1.12.0", optional = true, features = ["unstable"] }
 async-trait = "0.1.73"

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -73,7 +73,7 @@ hotshot-utils = { path = "../utils" }
 hotshot-task = { path = "../task", default-features = false }
 hotshot-primitives = { workspace = true }
 jf-primitives = { workspace = true }
-nll = { git = "https://github.com/EspressoSystems/nll.git" }
+nll = { workspace = true }
 libp2p-networking = { workspace = true }
 rand = "0.8.5"
 rand_chacha = "0.3.1"

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -51,7 +51,7 @@ ark-serialize = { version = "0.3", features = [
     "derive",
 ] } # TODO GG upgrade to 0.4 and inherit this dep from workspace
 ark-std = { workspace = true }
-bincode = "1.3.3"
+bincode = { workspace = true }
 bitvec = { version = "1.0.1", default-features = false, features = [
     "alloc",
     "atomic",

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -66,7 +66,7 @@ displaydoc = { version = "0.2.3", default-features = false }
 ed25519-compact = { version = "2.0.4", optional = true }
 either = { workspace = true, features = ["serde"] }
 espresso-systems-common = { workspace = true }
-futures = "0.3.28"
+futures = { workspace = true }
 generic-array = "0.14.7"
 hex_fmt = "0.3.0"
 hotshot-utils = { path = "../utils" }

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -43,14 +43,20 @@ channel-async-std = [
 
 [dependencies]
 arbitrary = { version = "1.3", features = ["derive"] }
-async-compatibility-layer = { git = "https://github.com/EspressoSystems/async-compatibility-layer.git", tag = "1.3.0", default-features = false, features = [ "logging-utils" ] }
+async-compatibility-layer = { git = "https://github.com/EspressoSystems/async-compatibility-layer.git", tag = "1.3.0", default-features = false, features = [
+    "logging-utils",
+] }
 async-lock = "2.8"
 async-std = { version = "1.12.0", optional = true, features = ["unstable"] }
 async-trait = "0.1.73"
 ark-serialize = { version = "0.3", features = ["derive"] }
 ark-std = "0.4"
 bincode = "1.3.3"
-bitvec = { version = "1.0.1", default-features = false, features = ["alloc", "atomic", "serde"] }
+bitvec = { version = "1.0.1", default-features = false, features = [
+    "alloc",
+    "atomic",
+    "serde",
+] }
 blake3 = "1.4.1"
 commit = { git = "https://github.com/EspressoSystems/commit", tag = "0.2.2" }
 custom_debug = "0.5"
@@ -58,20 +64,22 @@ derivative = "2.2.0"
 digest = { version = "0.10" }
 displaydoc = { version = "0.2.3", default-features = false }
 ed25519-compact = { version = "2.0.4", optional = true }
-either = { version = "1.8.1", features = [ "serde" ] }
+either = { version = "1.8.1", features = ["serde"] }
 espresso-systems-common = { git = "https://github.com/espressosystems/espresso-systems-common", tag = "0.4.1" }
 futures = "0.3.28"
 generic-array = "0.14.7"
 hex_fmt = "0.3.0"
 hotshot-utils = { path = "../utils" }
 hotshot-task = { path = "../task", default-features = false }
-hotshot-primitives = { git = "https://github.com/EspressoSystems/hotshot-primitives",  branch = 'hotshot-compat'} # rev = "4aee90c" for 'hotshot-compat'
-jf-primitives = { git = "https://github.com/EspressoSystems/jellyfish", branch = 'hotshot-compat'} # rev = "470a833" for branch = 'hotshot-compat'
+hotshot-primitives = { git = "https://github.com/EspressoSystems/hotshot-primitives", branch = 'hotshot-compat' } # rev = "4aee90c" for 'hotshot-compat'
+jf-primitives = { workspace = true }
 nll = { git = "https://github.com/EspressoSystems/nll.git" }
 libp2p-networking = { path = "../libp2p-networking", version = "0.1.0", default-features = false }
 rand = "0.8.5"
 rand_chacha = "0.3.1"
-serde = { version = "1.0.164", features = ["derive"] } # change to 1.0.183 if it can't work
+serde = { version = "1.0.164", features = [
+    "derive",
+] } # change to 1.0.183 if it can't work
 snafu = "0.7.4" # change to 0.7.5 if it can't work
 tagged-base64 = { git = "https://github.com/EspressoSystems/tagged-base64", tag = "0.2.4" }
 time = "0.3.27"

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -52,11 +52,7 @@ ark-serialize = { version = "0.3", features = [
 ] } # TODO GG upgrade to 0.4 and inherit this dep from workspace
 ark-std = { workspace = true }
 bincode = { workspace = true }
-bitvec = { version = "1.0.1", default-features = false, features = [
-    "alloc",
-    "atomic",
-    "serde",
-] }
+bitvec = { workspace = true }
 blake3 = { workspace = true }
 commit = { workspace = true }
 custom_debug = { workspace = true }

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -73,7 +73,7 @@ generic-array = "0.14.7"
 hex_fmt = "0.3.0"
 hotshot-utils = { path = "../utils" }
 hotshot-task = { path = "../task", default-features = false }
-hotshot-primitives = { git = "https://github.com/EspressoSystems/hotshot-primitives", branch = 'hotshot-compat' } # rev = "4aee90c" for 'hotshot-compat'
+hotshot-primitives = { workspace = true }
 jf-primitives = { workspace = true }
 nll = { git = "https://github.com/EspressoSystems/nll.git" }
 libp2p-networking = { path = "../libp2p-networking", version = "0.1.0", default-features = false }

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -95,7 +95,7 @@ tokio = { version = "1", optional = true, features = [
 tracing = { workspace = true }
 ethereum-types = { workspace = true }
 bit-vec = "0.6.3"
-typenum = { version = "1.16.0" }
+typenum = { workspace = true }
 
 [dev-dependencies]
 serde_json = "1.0.105"

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -80,7 +80,7 @@ rand_chacha = { workspace = true }
 serde = { workspace = true }
 snafu = { workspace = true }
 tagged-base64 = { git = "https://github.com/EspressoSystems/tagged-base64", tag = "0.2.4" }
-time = "0.3.27"
+time = { workspace = true }
 tokio = { version = "1", optional = true, features = [
     "fs",
     "io-util",

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -59,7 +59,7 @@ bitvec = { version = "1.0.1", default-features = false, features = [
     "atomic",
     "serde",
 ] }
-blake3 = "1.4.1"
+blake3 = { workspace = true }
 commit = { git = "https://github.com/EspressoSystems/commit", tag = "0.2.2" }
 custom_debug = "0.5"
 derivative = "2.2.0"

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -75,7 +75,7 @@ hotshot-primitives = { workspace = true }
 jf-primitives = { workspace = true }
 nll = { workspace = true }
 libp2p-networking = { workspace = true }
-rand = "0.8.5"
+rand = { workspace = true }
 rand_chacha = "0.3.1"
 serde = { version = "1.0.164", features = [
     "derive",

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -78,7 +78,7 @@ libp2p-networking = { workspace = true }
 rand = { workspace = true }
 rand_chacha = { workspace = true }
 serde = { workspace = true }
-snafu = "0.7.4" # change to 0.7.5 if it can't work
+snafu = { workspace = true }
 tagged-base64 = { git = "https://github.com/EspressoSystems/tagged-base64", tag = "0.2.4" }
 time = "0.3.27"
 tokio = { version = "1", optional = true, features = [

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -58,7 +58,7 @@ bitvec = { version = "1.0.1", default-features = false, features = [
     "serde",
 ] }
 blake3 = { workspace = true }
-commit = { git = "https://github.com/EspressoSystems/commit", tag = "0.2.2" }
+commit = { workspace = true }
 custom_debug = "0.5"
 derivative = "2.2.0"
 digest = { version = "0.10" }

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -50,7 +50,7 @@ async-lock = "2.8"
 async-std = { version = "1.12.0", optional = true, features = ["unstable"] }
 async-trait = "0.1.73"
 ark-serialize = { version = "0.3", features = ["derive"] }
-ark-std = "0.4"
+ark-std = { workspace = true }
 bincode = "1.3.3"
 bitvec = { version = "1.0.1", default-features = false, features = [
     "alloc",

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -49,7 +49,9 @@ async-compatibility-layer = { git = "https://github.com/EspressoSystems/async-co
 async-lock = "2.8"
 async-std = { version = "1.12.0", optional = true, features = ["unstable"] }
 async-trait = "0.1.73"
-ark-serialize = { version = "0.3", features = ["derive"] }
+ark-serialize = { version = "0.3", features = [
+    "derive",
+] } # TODO GG upgrade to 0.4 and inherit this dep from workspace
 ark-std = { workspace = true }
 bincode = "1.3.3"
 bitvec = { version = "1.0.1", default-features = false, features = [

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -61,7 +61,7 @@ blake3 = { workspace = true }
 commit = { workspace = true }
 custom_debug = { workspace = true }
 derivative = "2.2.0"
-digest = { version = "0.10" }
+digest = { workspace = true }
 displaydoc = { version = "0.2.3", default-features = false }
 ed25519-compact = { version = "2.0.4", optional = true }
 either = { version = "1.8.1", features = ["serde"] }

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -65,7 +65,7 @@ digest = { workspace = true }
 displaydoc = { version = "0.2.3", default-features = false }
 ed25519-compact = { version = "2.0.4", optional = true }
 either = { workspace = true, features = ["serde"] }
-espresso-systems-common = { git = "https://github.com/espressosystems/espresso-systems-common", tag = "0.4.1" }
+espresso-systems-common = { workspace = true }
 futures = "0.3.28"
 generic-array = "0.14.7"
 hex_fmt = "0.3.0"

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -74,7 +74,7 @@ hotshot-task = { path = "../task", default-features = false }
 hotshot-primitives = { workspace = true }
 jf-primitives = { workspace = true }
 nll = { git = "https://github.com/EspressoSystems/nll.git" }
-libp2p-networking = { path = "../libp2p-networking", version = "0.1.0", default-features = false }
+libp2p-networking = { workspace = true }
 rand = "0.8.5"
 rand_chacha = "0.3.1"
 serde = { version = "1.0.164", features = [

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -7,4 +7,4 @@ readme = "../README.md"
 version = "0.1.0"
 
 [dependencies]
-bincode = "1.3.3"
+bincode = { workspace = true }

--- a/web_server/Cargo.toml
+++ b/web_server/Cargo.toml
@@ -49,7 +49,7 @@ hotshot-utils = { path = "../utils" }
 hotshot-primitives = { workspace = true }
 jf-primitives = { workspace = true }
 tide-disco = { git = "https://github.com/EspressoSystems/tide-disco.git", tag = "v0.4.1" }
-nll = { git = "https://github.com/EspressoSystems/nll.git" }
+nll = { workspace = true }
 tracing = "0.1.37"
 rand = "0.8.5"
 serde = { version = "1.0.163", features = ["derive"] }

--- a/web_server/Cargo.toml
+++ b/web_server/Cargo.toml
@@ -35,7 +35,7 @@ channel-async-std = [
 ]
 
 [dependencies]
-ark-bls12-381 = { version = "0.3.0" }
+ark-bls12-381 = { workspace = true }
 async-compatibility-layer = { git = "https://github.com/EspressoSystems/async-compatibility-layer.git", tag = "1.3.0", default-features = false }
 async-lock = "2.7"
 async-std = { version = "1.12", optional = true }

--- a/web_server/Cargo.toml
+++ b/web_server/Cargo.toml
@@ -71,7 +71,7 @@ tokio = { version = "1", optional = true, features = [
     "time",
     "tracing",
 ] }
-toml = "0.5.9"
+toml = { workspace = true }
 portpicker = "0.1"
 surf-disco = { workspace = true }
 

--- a/web_server/Cargo.toml
+++ b/web_server/Cargo.toml
@@ -54,7 +54,7 @@ tracing = "0.1.37"
 rand = { workspace = true }
 serde = { workspace = true }
 serde_json = "1.0.96"
-snafu = "0.7.4"
+snafu = { workspace = true }
 tide = { version = "0.16.0", default-features = false }
 tokio = { version = "1", optional = true, features = [
     "fs",

--- a/web_server/Cargo.toml
+++ b/web_server/Cargo.toml
@@ -39,7 +39,7 @@ ark-bls12-381 = { workspace = true }
 async-compatibility-layer = { workspace = true }
 async-lock = { workspace = true }
 async-std = { version = "1.12", optional = true }
-async-trait = "0.1.68"
+async-trait = { workspace = true }
 bincode = "1.3.3"
 clap = { version = "4.0", features = ["derive", "env"], optional = false }
 futures = "0.3.28"

--- a/web_server/Cargo.toml
+++ b/web_server/Cargo.toml
@@ -21,8 +21,14 @@ tokio-executor = [
     "async-compatibility-layer/tokio-executor",
 ]
 profiling = ["async-compatibility-layer/profiling"]
-channel-flume = ["hotshot-types/channel-flume", "async-compatibility-layer/channel-flume"]
-channel-tokio = ["hotshot-types/channel-tokio", "async-compatibility-layer/channel-tokio"]
+channel-flume = [
+    "hotshot-types/channel-flume",
+    "async-compatibility-layer/channel-flume",
+]
+channel-tokio = [
+    "hotshot-types/channel-tokio",
+    "async-compatibility-layer/channel-tokio",
+]
 channel-async-std = [
     "hotshot-types/channel-async-std",
     "async-compatibility-layer/channel-async-std",
@@ -39,9 +45,9 @@ clap = { version = "4.0", features = ["derive", "env"], optional = false }
 futures = "0.3.28"
 libp2p-core = { version = "0.40.0", default-features = false }
 hotshot-types = { path = "../types", default-features = false }
-hotshot-utils = { path = "../utils"}
-hotshot-primitives = { git = "https://github.com/EspressoSystems/hotshot-primitives",  branch = 'hotshot-compat'} # rev = "4aee90c" for 'hotshot-compat'
-jf-primitives = { git = "https://github.com/EspressoSystems/jellyfish", branch = 'hotshot-compat'} # rev = "470a833" for branch = 'hotshot-compat'
+hotshot-utils = { path = "../utils" }
+hotshot-primitives = { git = "https://github.com/EspressoSystems/hotshot-primitives", branch = 'hotshot-compat' } # rev = "4aee90c" for 'hotshot-compat'
+jf-primitives = { workspace = true }
 tide-disco = { git = "https://github.com/EspressoSystems/tide-disco.git", tag = "v0.4.1" }
 nll = { git = "https://github.com/EspressoSystems/nll.git" }
 tracing = "0.1.37"

--- a/web_server/Cargo.toml
+++ b/web_server/Cargo.toml
@@ -42,7 +42,7 @@ async-std = { version = "1.12", optional = true }
 async-trait = { workspace = true }
 bincode = { workspace = true }
 clap = { version = "4.0", features = ["derive", "env"], optional = false }
-futures = "0.3.28"
+futures = { workspace = true }
 libp2p-core = { version = "0.40.0", default-features = false }
 hotshot-types = { path = "../types", default-features = false }
 hotshot-utils = { path = "../utils" }

--- a/web_server/Cargo.toml
+++ b/web_server/Cargo.toml
@@ -52,7 +52,7 @@ tide-disco = { git = "https://github.com/EspressoSystems/tide-disco.git", tag = 
 nll = { workspace = true }
 tracing = "0.1.37"
 rand = { workspace = true }
-serde = { version = "1.0.163", features = ["derive"] }
+serde = { workspace = true }
 serde_json = "1.0.96"
 snafu = "0.7.4"
 tide = { version = "0.16.0", default-features = false }

--- a/web_server/Cargo.toml
+++ b/web_server/Cargo.toml
@@ -73,7 +73,7 @@ tokio = { version = "1", optional = true, features = [
 ] }
 toml = "0.5.9"
 portpicker = "0.1"
-surf-disco = { git = "https://github.com/EspressoSystems/surf-disco.git", tag = "v0.4.1" }
+surf-disco = { workspace = true }
 
 [dev-dependencies]
 hotshot-types = { path = "../types", default-features = false }

--- a/web_server/Cargo.toml
+++ b/web_server/Cargo.toml
@@ -37,7 +37,7 @@ channel-async-std = [
 [dependencies]
 ark-bls12-381 = { workspace = true }
 async-compatibility-layer = { workspace = true }
-async-lock = "2.7"
+async-lock = { workspace = true }
 async-std = { version = "1.12", optional = true }
 async-trait = "0.1.68"
 bincode = "1.3.3"

--- a/web_server/Cargo.toml
+++ b/web_server/Cargo.toml
@@ -36,7 +36,7 @@ channel-async-std = [
 
 [dependencies]
 ark-bls12-381 = { workspace = true }
-async-compatibility-layer = { git = "https://github.com/EspressoSystems/async-compatibility-layer.git", tag = "1.3.0", default-features = false }
+async-compatibility-layer = { workspace = true }
 async-lock = "2.7"
 async-std = { version = "1.12", optional = true }
 async-trait = "0.1.68"

--- a/web_server/Cargo.toml
+++ b/web_server/Cargo.toml
@@ -46,7 +46,7 @@ futures = "0.3.28"
 libp2p-core = { version = "0.40.0", default-features = false }
 hotshot-types = { path = "../types", default-features = false }
 hotshot-utils = { path = "../utils" }
-hotshot-primitives = { git = "https://github.com/EspressoSystems/hotshot-primitives", branch = 'hotshot-compat' } # rev = "4aee90c" for 'hotshot-compat'
+hotshot-primitives = { workspace = true }
 jf-primitives = { workspace = true }
 tide-disco = { git = "https://github.com/EspressoSystems/tide-disco.git", tag = "v0.4.1" }
 nll = { git = "https://github.com/EspressoSystems/nll.git" }

--- a/web_server/Cargo.toml
+++ b/web_server/Cargo.toml
@@ -51,7 +51,7 @@ jf-primitives = { workspace = true }
 tide-disco = { git = "https://github.com/EspressoSystems/tide-disco.git", tag = "v0.4.1" }
 nll = { workspace = true }
 tracing = "0.1.37"
-rand = "0.8.5"
+rand = { workspace = true }
 serde = { version = "1.0.163", features = ["derive"] }
 serde_json = "1.0.96"
 snafu = "0.7.4"

--- a/web_server/Cargo.toml
+++ b/web_server/Cargo.toml
@@ -50,7 +50,7 @@ hotshot-primitives = { workspace = true }
 jf-primitives = { workspace = true }
 tide-disco = { git = "https://github.com/EspressoSystems/tide-disco.git", tag = "v0.4.1" }
 nll = { workspace = true }
-tracing = "0.1.37"
+tracing = { workspace = true }
 rand = { workspace = true }
 serde = { workspace = true }
 serde_json = "1.0.96"

--- a/web_server/Cargo.toml
+++ b/web_server/Cargo.toml
@@ -40,7 +40,7 @@ async-compatibility-layer = { workspace = true }
 async-lock = { workspace = true }
 async-std = { version = "1.12", optional = true }
 async-trait = { workspace = true }
-bincode = "1.3.3"
+bincode = { workspace = true }
 clap = { version = "4.0", features = ["derive", "env"], optional = false }
 futures = "0.3.28"
 libp2p-core = { version = "0.40.0", default-features = false }


### PR DESCRIPTION
close #1591 

Update everything except:
- deps used only in the root-level `Cargo.toml`
- anything with `optional = true`
- anything inside this workspace, eg. `hotshot-consensus`, etc.

This PR is therapeutic, like cleaning dirt from one's fingernails. Took more time than I originally thought.