### PR TITLE
import granularity for cargo fmt

### DIFF
--- a/consensus/src/da_member.rs
+++ b/consensus/src/da_member.rs
@@ -24,8 +24,7 @@ use hotshot_types::{
         signature_key::SignatureKey,
     },
 };
-use std::marker::PhantomData;
-use std::sync::Arc;
+use std::{marker::PhantomData, sync::Arc};
 use tracing::{error, info, instrument, warn};
 
 /// This view's DA committee member.

--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -28,13 +28,12 @@ pub use utils::{View, ViewInner};
 
 use commit::{Commitment, Committable};
 use derivative::Derivative;
-use hotshot_types::certificate::QuorumCertificate;
-use hotshot_types::traits::metrics::Counter;
 use hotshot_types::{
+    certificate::QuorumCertificate,
     data::LeafType,
     error::HotShotError,
     traits::{
-        metrics::{Gauge, Histogram, Metrics},
+        metrics::{Counter, Gauge, Histogram, Metrics},
         node_implementation::NodeType,
     },
 };

--- a/consensus/src/sequencing_leader.rs
+++ b/consensus/src/sequencing_leader.rs
@@ -2,45 +2,44 @@
 //! leader steps in the consensus algorithm with DA committee, i.e. in the sequencing consensus.
 
 use crate::{CommitmentMap, Consensus, SequencingConsensusApi};
-use async_compatibility_layer::channel::UnboundedReceiver;
 use async_compatibility_layer::{
     art::async_timeout,
     async_primitives::subscribable_rwlock::{ReadView, SubscribableRwLock},
+    channel::UnboundedReceiver,
 };
 use async_lock::{Mutex, RwLock};
 use bitvec::prelude::*;
-use commit::Commitment;
-use commit::Committable;
-use either::Either;
-use either::{Left, Right};
-use hotshot_types::message::Message;
-use hotshot_types::traits::election::CommitteeExchangeType;
-use hotshot_types::traits::election::ConsensusExchange;
-use hotshot_types::traits::election::QuorumExchangeType;
-use hotshot_types::traits::node_implementation::{
-    NodeImplementation, QuorumProposalType, QuorumVoteType,
-};
-use hotshot_types::traits::state::State;
+use commit::{Commitment, Committable};
+use either::{Either, Left, Right};
 use hotshot_types::{
     certificate::{AssembledSignature, DACertificate, QuorumCertificate},
     data::{DAProposal, QuorumProposal, SequencingLeaf},
     message::{
         CommitteeConsensusMessage, ConsensusMessageType, GeneralConsensusMessage, InternalTrigger,
-        ProcessedCommitteeConsensusMessage, ProcessedGeneralConsensusMessage,
+        Message, ProcessedCommitteeConsensusMessage, ProcessedGeneralConsensusMessage,
         ProcessedSequencingMessage, Proposal, SequencingMessage,
     },
     traits::{
-        election::SignedCertificate,
-        node_implementation::{CommitteeEx, NodeType, SequencingQuorumEx},
+        election::{
+            CommitteeExchangeType, ConsensusExchange, QuorumExchangeType, SignedCertificate,
+        },
+        node_implementation::{
+            CommitteeEx, NodeImplementation, NodeType, QuorumProposalType, QuorumVoteType,
+            SequencingQuorumEx,
+        },
         signature_key::SignatureKey,
+        state::State,
         Block,
     },
     vote::{QuorumVote, VoteAccumulator},
 };
-use std::collections::HashMap;
-use std::marker::PhantomData;
-use std::num::NonZeroU64;
-use std::{collections::HashSet, sync::Arc, time::Instant};
+use std::{
+    collections::{HashMap, HashSet},
+    marker::PhantomData,
+    num::NonZeroU64,
+    sync::Arc,
+    time::Instant,
+};
 use tracing::{error, info, instrument, warn};
 /// This view's DA committee leader
 #[derive(Debug, Clone)]
@@ -260,9 +259,9 @@ where
     )> {
         // Prepare the DA Proposal
         let Some(parent_leaf) = self.parent_leaf().await else {
-             warn!("Couldn't find high QC parent in state map.");
-             return None;
-         };
+            warn!("Couldn't find high QC parent in state map.");
+            return None;
+        };
 
         let mut block = <TYPES as NodeType>::StateType::next_block(None);
         let txns = self.wait_for_transactions().await?;

--- a/consensus/src/sequencing_replica.rs
+++ b/consensus/src/sequencing_replica.rs
@@ -10,31 +10,31 @@ use async_lock::{Mutex, RwLock, RwLockUpgradableReadGuard, RwLockWriteGuard};
 use bincode::Options;
 use commit::Committable;
 use either::{Left, Right};
-use hotshot_types::data::QuorumProposal;
-use hotshot_types::message::Message;
-use hotshot_types::traits::election::ConsensusExchange;
-use hotshot_types::traits::election::QuorumExchangeType;
-use hotshot_types::traits::node_implementation::{
-    CommitteeEx, NodeImplementation, QuorumProposalType, QuorumVoteType, SequencingQuorumEx,
-};
-use hotshot_types::traits::state::ConsensusTime;
 use hotshot_types::{
     certificate::{DACertificate, QuorumCertificate},
-    data::{LeafType, SequencingLeaf},
+    data::{LeafType, QuorumProposal, SequencingLeaf},
     message::{
-        ConsensusMessageType, InternalTrigger, ProcessedCommitteeConsensusMessage,
+        ConsensusMessageType, InternalTrigger, Message, ProcessedCommitteeConsensusMessage,
         ProcessedGeneralConsensusMessage, ProcessedSequencingMessage, SequencingMessage,
     },
     traits::{
-        election::SignedCertificate, node_implementation::NodeType, signature_key::SignatureKey,
+        election::{ConsensusExchange, QuorumExchangeType, SignedCertificate},
+        node_implementation::{
+            CommitteeEx, NodeImplementation, NodeType, QuorumProposalType, QuorumVoteType,
+            SequencingQuorumEx,
+        },
+        signature_key::SignatureKey,
+        state::ConsensusTime,
         Block,
     },
 };
 use hotshot_utils::bincode::bincode_opts;
-use std::collections::HashSet;
-use std::marker::PhantomData;
-use std::ops::Bound::{Excluded, Included};
-use std::sync::Arc;
+use std::{
+    collections::HashSet,
+    marker::PhantomData,
+    ops::Bound::{Excluded, Included},
+    sync::Arc,
+};
 use tracing::{error, info, instrument, warn};
 /// This view's replica for sequencing consensus.
 #[derive(Debug, Clone)]

--- a/consensus/src/traits.rs
+++ b/consensus/src/traits.rs
@@ -1,16 +1,18 @@
 //! Contains the [`SequencingConsensusApi`] and [`ValidatingConsensusApi`] traits.
 
 use async_trait::async_trait;
-use hotshot_types::certificate::QuorumCertificate;
-use hotshot_types::message::DataMessage;
-use hotshot_types::message::SequencingMessage;
-use hotshot_types::traits::node_implementation::{NodeImplementation, NodeType};
-use hotshot_types::traits::storage::StorageError;
 use hotshot_types::{
+    certificate::QuorumCertificate,
     data::{LeafType, ProposalType},
     error::HotShotError,
     event::{Event, EventType},
-    traits::{network::NetworkError, signature_key::SignatureKey},
+    message::{DataMessage, SequencingMessage},
+    traits::{
+        network::NetworkError,
+        node_implementation::{NodeImplementation, NodeType},
+        signature_key::SignatureKey,
+        storage::StorageError,
+    },
     vote::VoteType,
 };
 

--- a/crates/hotshot-qc/src/bit_vector.rs
+++ b/crates/hotshot-qc/src/bit_vector.rs
@@ -16,9 +16,10 @@ use hotshot_types::traits::{
     qc::QuorumCertificate,
     stake_table::{SnapshotVersion, StakeTableScheme},
 };
-use jf_primitives::errors::PrimitivesError;
-use jf_primitives::errors::PrimitivesError::ParameterError;
-use jf_primitives::signatures::AggregateableSignatureSchemes;
+use jf_primitives::{
+    errors::{PrimitivesError, PrimitivesError::ParameterError},
+    signatures::AggregateableSignatureSchemes,
+};
 use serde::{Deserialize, Serialize};
 use typenum::U32;
 
@@ -202,8 +203,10 @@ mod tests {
     use super::*;
     use hotshot_stake_table::mt_based::StakeTable;
     use hotshot_types::traits::stake_table::StakeTableScheme;
-    use jf_primitives::signatures::bls_over_bn254::{BLSOverBN254CurveSignatureScheme, KeyPair};
-    use jf_primitives::signatures::SignatureScheme;
+    use jf_primitives::signatures::{
+        bls_over_bn254::{BLSOverBN254CurveSignatureScheme, KeyPair},
+        SignatureScheme,
+    };
 
     macro_rules! test_quorum_certificate {
         ($aggsig:tt) => {

--- a/crates/hotshot-stake-table/src/mt_based/internal.rs
+++ b/crates/hotshot-stake-table/src/mt_based/internal.rs
@@ -612,8 +612,7 @@ pub fn from_merkle_path(path: &[usize]) -> usize {
 
 #[cfg(test)]
 mod tests {
-    use super::super::config;
-    use super::{to_merkle_path, PersistentMerkleNode};
+    use super::{super::config, to_merkle_path, PersistentMerkleNode};
     use ark_std::{
         rand::{Rng, RngCore},
         sync::Arc,

--- a/examples/infra/mod.rs
+++ b/examples/infra/mod.rs
@@ -3,8 +3,7 @@ use hotshot_orchestrator::{
     self,
     config::{NetworkConfig, NetworkConfigFile},
 };
-use hotshot_types::traits::node_implementation::NodeType;
-use hotshot_types::traits::signature_key::SignatureKey;
+use hotshot_types::traits::{node_implementation::NodeType, signature_key::SignatureKey};
 use libp2p::{
     identity::{
         ed25519::{Keypair as EdKeypair, SecretKey},
@@ -13,8 +12,7 @@ use libp2p::{
     multiaddr::{self},
     Multiaddr,
 };
-use std::{fmt::Debug, fs};
-use std::{net::IpAddr, str::FromStr};
+use std::{fmt::Debug, fs, net::IpAddr, str::FromStr};
 
 // ORCHESTRATOR
 

--- a/examples/infra/modDA.rs
+++ b/examples/infra/modDA.rs
@@ -17,29 +17,21 @@ use hotshot_orchestrator::{
     config::{NetworkConfig, WebServerConfig},
 };
 use hotshot_task::task::FilterEvent;
-use hotshot_types::event::{Event, EventType};
-use hotshot_types::traits::state::ConsensusTime;
 use hotshot_types::{
     certificate::ViewSyncCertificate,
-    message::Message,
-    traits::election::{CommitteeExchange, QuorumExchange},
-};
-use hotshot_types::{
-    data::ViewNumber,
+    data::{DAProposal, QuorumProposal, SequencingLeaf, TestableLeaf, ViewNumber},
+    event::{Event, EventType},
+    message::{Message, SequencingMessage},
     traits::{
-        election::{ConsensusExchange, ViewSyncExchange},
-        node_implementation::{CommitteeEx, QuorumEx},
-    },
-};
-use hotshot_types::{
-    data::{DAProposal, QuorumProposal, SequencingLeaf, TestableLeaf},
-    message::SequencingMessage,
-    traits::{
-        election::Membership,
+        election::{
+            CommitteeExchange, ConsensusExchange, Membership, QuorumExchange, ViewSyncExchange,
+        },
         metrics::NoMetrics,
         network::CommunicationChannel,
-        node_implementation::{ExchangesType, NodeType, SequencingExchanges},
-        state::{TestableBlock, TestableState},
+        node_implementation::{
+            CommitteeEx, ExchangesType, NodeType, QuorumEx, SequencingExchanges,
+        },
+        state::{ConsensusTime, TestableBlock, TestableState},
     },
     vote::{DAVote, QuorumVote, ViewSyncVote},
     HotShotConfig,
@@ -54,8 +46,6 @@ use hotshot_types::{
 // };
 // use libp2p_identity::PeerId;
 // use libp2p_networking::network::{MeshParams, NetworkNodeConfigBuilder, NetworkNodeType};
-use std::fmt::Debug;
-use std::net::Ipv4Addr;
 use std::{
     //collections::{BTreeSet, VecDeque},
     collections::VecDeque,
@@ -68,12 +58,10 @@ use std::{
     //time::{Duration, Instant},
     time::Instant,
 };
+use std::{fmt::Debug, net::Ipv4Addr};
 //use surf_disco::error::ClientError;
 //use surf_disco::Client;
-use tracing::debug;
-use tracing::error;
-use tracing::info;
-use tracing::warn;
+use tracing::{debug, error, info, warn};
 
 /// Runs the orchestrator
 pub async fn run_orchestrator_da<

--- a/examples/web-server-da/multi-validator.rs
+++ b/examples/web-server-da/multi-validator.rs
@@ -1,5 +1,7 @@
-use async_compatibility_layer::art::async_spawn;
-use async_compatibility_layer::logging::{setup_backtrace, setup_logging};
+use async_compatibility_layer::{
+    art::async_spawn,
+    logging::{setup_backtrace, setup_logging},
+};
 use clap::Parser;
 use hotshot::demos::sdemo::SDemoTypes;
 use hotshot_orchestrator::client::ValidatorArgs;

--- a/examples/web-server-da/multi-web-server.rs
+++ b/examples/web-server-da/multi-web-server.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 
-use async_compatibility_layer::art::async_spawn;
-use async_compatibility_layer::channel::oneshot;
+use async_compatibility_layer::{art::async_spawn, channel::oneshot};
 use clap::Parser;
 use hotshot::demos::sdemo::SDemoTypes;
 use tracing::error;

--- a/examples/web-server-da/orchestrator.rs
+++ b/examples/web-server-da/orchestrator.rs
@@ -6,9 +6,11 @@ use hotshot::demos::sdemo::SDemoTypes;
 use tracing::instrument;
 use types::ThisMembership;
 
-use crate::infra::OrchestratorArgs;
-use crate::infra_da::run_orchestrator_da;
-use crate::types::{DANetwork, NodeImpl, QuorumNetwork, ViewSyncNetwork};
+use crate::{
+    infra::OrchestratorArgs,
+    infra_da::run_orchestrator_da,
+    types::{DANetwork, NodeImpl, QuorumNetwork, ViewSyncNetwork},
+};
 
 #[path = "../infra/mod.rs"]
 pub mod infra;

--- a/examples/web-server-da/types.rs
+++ b/examples/web-server-da/types.rs
@@ -1,21 +1,18 @@
 use crate::infra_da::WebServerDARun;
-use hotshot::traits::implementations::MemoryStorage;
 use hotshot::{
     demos::sdemo::SDemoTypes,
-    traits::{election::static_committee::GeneralStaticCommittee, implementations::WebCommChannel},
-};
-use hotshot_types::message::Message;
-use hotshot_types::traits::{
-    election::{CommitteeExchange, QuorumExchange},
-    node_implementation::{NodeImplementation, SequencingExchanges},
+    traits::{
+        election::static_committee::GeneralStaticCommittee,
+        implementations::{MemoryStorage, WebCommChannel},
+    },
 };
 use hotshot_types::{
     certificate::ViewSyncCertificate,
     data::{DAProposal, QuorumProposal, SequencingLeaf, ViewNumber},
-    message::SequencingMessage,
+    message::{Message, SequencingMessage},
     traits::{
-        election::ViewSyncExchange,
-        node_implementation::{ChannelMaps, NodeType},
+        election::{CommitteeExchange, QuorumExchange, ViewSyncExchange},
+        node_implementation::{ChannelMaps, NodeImplementation, NodeType, SequencingExchanges},
     },
     vote::{DAVote, QuorumVote, ViewSyncVote},
 };

--- a/libp2p-networking/examples/common/lossy_network.rs
+++ b/libp2p-networking/examples/common/lossy_network.rs
@@ -12,12 +12,12 @@ use rtnetlink::{
     NETNS_PATH,
 };
 use snafu::{ResultExt, Snafu};
-use std::process::Command;
 use std::{
     fs::File,
     net::{AddrParseError, Ipv4Addr},
     os::unix::{io::IntoRawFd, prelude::AsRawFd},
     path::Path,
+    process::Command,
 };
 use tracing::{error, info};
 

--- a/libp2p-networking/examples/common/mod.rs
+++ b/libp2p-networking/examples/common/mod.rs
@@ -12,8 +12,10 @@ use tokio_stream::StreamExt;
 #[cfg(not(any(feature = "async-std-executor", feature = "tokio-executor")))]
 std::compile_error! {"Either feature \"async-std-executor\" or feature \"tokio-executor\" must be enabled for this crate."}
 
-use async_compatibility_layer::art::{async_sleep, async_spawn};
-use async_compatibility_layer::channel::oneshot;
+use async_compatibility_layer::{
+    art::{async_sleep, async_spawn},
+    channel::oneshot,
+};
 use clap::{Args, Parser};
 use libp2p::{multiaddr, request_response::ResponseChannel, Multiaddr};
 use libp2p_identity::PeerId;
@@ -27,9 +29,9 @@ use rand::{
 };
 use serde::{Deserialize, Serialize};
 use snafu::{ResultExt, Snafu};
-use std::fmt::Debug;
 use std::{
     collections::{HashMap, HashSet},
+    fmt::Debug,
     str::FromStr,
     sync::Arc,
     time::{Duration, SystemTime},

--- a/libp2p-networking/tests/common/mod.rs
+++ b/libp2p-networking/tests/common/mod.rs
@@ -1,8 +1,9 @@
-use async_compatibility_layer::art::async_sleep;
-use async_compatibility_layer::channel::RecvError;
-use async_compatibility_layer::logging::{setup_backtrace, setup_logging};
-use futures::FutureExt;
-use futures::{future::join_all, Future};
+use async_compatibility_layer::{
+    art::async_sleep,
+    channel::RecvError,
+    logging::{setup_backtrace, setup_logging},
+};
+use futures::{future::join_all, Future, FutureExt};
 use libp2p::{identity::Keypair, Multiaddr};
 use libp2p_identity::PeerId;
 use libp2p_networking::network::{

--- a/orchestrator/src/config.rs
+++ b/orchestrator/src/config.rs
@@ -1,6 +1,9 @@
 use hotshot_types::{ExecutionType, HotShotConfig};
-use std::net::{Ipv4Addr, SocketAddr};
-use std::{net::IpAddr, num::NonZeroUsize, time::Duration};
+use std::{
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+    num::NonZeroUsize,
+    time::Duration,
+};
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
 pub struct Libp2pConfig {
     pub bootstrap_nodes: Vec<(SocketAddr, Vec<u8>)>,

--- a/orchestrator/src/lib.rs
+++ b/orchestrator/src/lib.rs
@@ -2,20 +2,20 @@ pub mod client;
 pub mod config;
 
 use async_lock::RwLock;
-use hotshot_types::traits::election::ElectionConfig;
-use hotshot_types::traits::signature_key::SignatureKey;
-use std::io;
-use std::io::ErrorKind;
-use std::net::IpAddr;
-use std::net::SocketAddr;
-use tide_disco::Api;
-use tide_disco::App;
+use hotshot_types::traits::{election::ElectionConfig, signature_key::SignatureKey};
+use std::{
+    io,
+    io::ErrorKind,
+    net::{IpAddr, SocketAddr},
+};
+use tide_disco::{Api, App};
 
 use surf_disco::error::ClientError;
-use tide_disco::api::ApiError;
-use tide_disco::error::ServerError;
-use tide_disco::method::ReadState;
-use tide_disco::method::WriteState;
+use tide_disco::{
+    api::ApiError,
+    error::ServerError,
+    method::{ReadState, WriteState},
+};
 
 use futures::FutureExt;
 

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -1,10 +1,8 @@
 //! Provides a number of tasks that run continuously on a [`HotShot`]
 
-use crate::async_spawn;
-use crate::types::SystemContextHandle;
 use crate::{
-    DACertificate, HotShotSequencingConsensusApi, QuorumCertificate, SequencingQuorumEx,
-    SystemContext,
+    async_spawn, types::SystemContextHandle, DACertificate, HotShotSequencingConsensusApi,
+    QuorumCertificate, SequencingQuorumEx, SystemContext,
 };
 use async_compatibility_layer::art::{async_sleep, async_spawn_local};
 use futures::FutureExt;
@@ -16,35 +14,32 @@ use hotshot_task::{
     task_launcher::TaskRunner,
     GeneratedStream, Merge,
 };
-use hotshot_task_impls::network::NetworkTaskKind;
-use hotshot_task_impls::view_sync::ViewSyncTaskState;
-use hotshot_task_impls::view_sync::ViewSyncTaskStateTypes;
 use hotshot_task_impls::{
     consensus::{consensus_event_filter, ConsensusTaskTypes, SequencingConsensusTaskState},
     da::{DATaskState, DATaskTypes},
     events::SequencingHotShotEvent,
     network::{
         NetworkEventTaskState, NetworkEventTaskTypes, NetworkMessageTaskState,
-        NetworkMessageTaskTypes,
+        NetworkMessageTaskTypes, NetworkTaskKind,
     },
+    view_sync::{ViewSyncTaskState, ViewSyncTaskStateTypes},
 };
-use hotshot_types::certificate::ViewSyncCertificate;
-use hotshot_types::data::QuorumProposal;
-use hotshot_types::event::Event;
-use hotshot_types::message::{Message, Messages, SequencingMessage};
-use hotshot_types::traits::election::{ConsensusExchange, Membership};
-use hotshot_types::traits::node_implementation::ViewSyncEx;
-use hotshot_types::vote::ViewSyncData;
 use hotshot_types::{
+    certificate::ViewSyncCertificate,
     constants::LOOK_AHEAD,
-    data::{ProposalType, SequencingLeaf, ViewNumber},
+    data::{ProposalType, QuorumProposal, SequencingLeaf, ViewNumber},
+    event::Event,
+    message::{Message, Messages, SequencingMessage},
     traits::{
+        election::{ConsensusExchange, Membership},
         network::{CommunicationChannel, TransmitType},
-        node_implementation::{CommitteeEx, ExchangesType, NodeImplementation, NodeType},
+        node_implementation::{
+            CommitteeEx, ExchangesType, NodeImplementation, NodeType, ViewSyncEx,
+        },
         state::ConsensusTime,
         Block,
     },
-    vote::VoteType,
+    vote::{ViewSyncData, VoteType},
 };
 use std::{
     collections::HashMap,

--- a/src/traits/election/static_committee.rs
+++ b/src/traits/election/static_committee.rs
@@ -11,8 +11,7 @@ use hotshot_types::{
 };
 #[allow(deprecated)]
 use serde::{Deserialize, Serialize};
-use std::marker::PhantomData;
-use std::num::NonZeroU64;
+use std::{marker::PhantomData, num::NonZeroU64};
 use tracing::debug;
 
 /// Dummy implementation of [`Membership`]

--- a/src/traits/networking/libp2p_network.rs
+++ b/src/traits/networking/libp2p_network.rs
@@ -13,8 +13,6 @@ use async_trait::async_trait;
 use bimap::BiHashMap;
 use bincode::Options;
 use hotshot_task::{boxed_sync, BoxSyncFuture};
-use hotshot_types::traits::network::ConsensusIntentEvent;
-use hotshot_types::traits::network::ViewMessage;
 use hotshot_types::{
     data::ProposalType,
     message::{Message, MessageKind},
@@ -22,9 +20,9 @@ use hotshot_types::{
         election::Membership,
         metrics::{Metrics, NoMetrics},
         network::{
-            CommunicationChannel, ConnectedNetwork, FailedToSerializeSnafu, NetworkError,
-            NetworkMsg, TestableChannelImplementation, TestableNetworkingImplementation,
-            TransmitType,
+            CommunicationChannel, ConnectedNetwork, ConsensusIntentEvent, FailedToSerializeSnafu,
+            NetworkError, NetworkMsg, TestableChannelImplementation,
+            TestableNetworkingImplementation, TransmitType, ViewMessage,
         },
         node_implementation::NodeType,
         signature_key::SignatureKey,

--- a/src/traits/networking/memory_network.rs
+++ b/src/traits/networking/memory_network.rs
@@ -15,8 +15,6 @@ use bincode::Options;
 use dashmap::DashMap;
 use futures::StreamExt;
 use hotshot_task::{boxed_sync, BoxSyncFuture};
-use hotshot_types::traits::network::ConsensusIntentEvent;
-use hotshot_types::traits::network::ViewMessage;
 use hotshot_types::{
     data::ProposalType,
     message::{Message, MessageKind},
@@ -24,8 +22,9 @@ use hotshot_types::{
         election::Membership,
         metrics::{Metrics, NoMetrics},
         network::{
-            CommunicationChannel, ConnectedNetwork, NetworkMsg, TestableChannelImplementation,
-            TestableNetworkingImplementation, TransmitType,
+            CommunicationChannel, ConnectedNetwork, ConsensusIntentEvent, NetworkMsg,
+            TestableChannelImplementation, TestableNetworkingImplementation, TransmitType,
+            ViewMessage,
         },
         node_implementation::NodeType,
         signature_key::SignatureKey,

--- a/src/traits/networking/web_server_network.rs
+++ b/src/traits/networking/web_server_network.rs
@@ -8,9 +8,7 @@
 #[cfg(not(any(feature = "async-std-executor", feature = "tokio-executor")))]
 std::compile_error! {"Either feature \"async-std-executor\" or feature \"tokio-executor\" must be enabled for this crate."}
 
-use async_compatibility_layer::channel::unbounded;
-use async_compatibility_layer::channel::UnboundedReceiver;
-use async_compatibility_layer::channel::UnboundedSender;
+use async_compatibility_layer::channel::{unbounded, UnboundedReceiver, UnboundedSender};
 
 use async_compatibility_layer::{
     art::{async_sleep, async_spawn},
@@ -19,19 +17,17 @@ use async_compatibility_layer::{
 use async_lock::RwLock;
 use async_trait::async_trait;
 use hotshot_task::{boxed_sync, BoxSyncFuture};
-use hotshot_types::message::{Message, MessagePurpose};
-use hotshot_types::traits::network::ConsensusIntentEvent;
-use hotshot_types::traits::node_implementation::NodeImplementation;
 use hotshot_types::{
     data::ProposalType,
+    message::{Message, MessagePurpose},
     traits::{
         election::{ElectionConfig, Membership},
         network::{
-            CommunicationChannel, ConnectedNetwork, NetworkError, NetworkMsg,
+            CommunicationChannel, ConnectedNetwork, ConsensusIntentEvent, NetworkError, NetworkMsg,
             TestableChannelImplementation, TestableNetworkingImplementation, TransmitType,
             WebServerNetworkError,
         },
-        node_implementation::NodeType,
+        node_implementation::{NodeImplementation, NodeType},
         signature_key::SignatureKey,
     },
     vote::VoteType,
@@ -41,10 +37,8 @@ use rand::random;
 use serde::{Deserialize, Serialize};
 
 use hotshot_types::traits::network::ViewMessage;
-use std::collections::hash_map::Entry;
-use std::collections::HashMap;
 use std::{
-    collections::BTreeSet,
+    collections::{hash_map::Entry, BTreeSet, HashMap},
     marker::PhantomData,
     sync::{
         atomic::{AtomicBool, Ordering},

--- a/src/traits/networking/web_sever_libp2p_fallback.rs
+++ b/src/traits/networking/web_sever_libp2p_fallback.rs
@@ -1,25 +1,26 @@
 //! Networking Implementation that has a primary and a fallback newtork.  If the primary
 //! Errors we will use the backup to send or receive
 use super::NetworkError;
-use crate::traits::implementations::Libp2pNetwork;
-use crate::traits::implementations::WebServerNetwork;
-use crate::NodeImplementation;
+use crate::{
+    traits::implementations::{Libp2pNetwork, WebServerNetwork},
+    NodeImplementation,
+};
 
 use async_trait::async_trait;
 
 use futures::join;
 
 use hotshot_task::{boxed_sync, BoxSyncFuture};
-use hotshot_types::traits::network::ConsensusIntentEvent;
-use hotshot_types::traits::network::TestableChannelImplementation;
-use hotshot_types::traits::network::TestableNetworkingImplementation;
-use hotshot_types::traits::network::ViewMessage;
 use hotshot_types::{
     data::ProposalType,
     message::Message,
     traits::{
         election::Membership,
-        network::{CommunicationChannel, ConnectedNetwork, TransmitType},
+        network::{
+            CommunicationChannel, ConnectedNetwork, ConsensusIntentEvent,
+            TestableChannelImplementation, TestableNetworkingImplementation, TransmitType,
+            ViewMessage,
+        },
         node_implementation::NodeType,
     },
     vote::VoteType,

--- a/src/traits/storage/memory_storage.rs
+++ b/src/traits/storage/memory_storage.rs
@@ -114,21 +114,22 @@ impl<TYPES: NodeType, LEAF: LeafType<NodeType = TYPES>> Storage<TYPES, LEAF>
 
 #[cfg(test)]
 mod test {
-    use crate::traits::election::static_committee::StaticElectionConfig;
-    use crate::traits::election::static_committee::StaticVoteToken;
+    use crate::traits::election::static_committee::{StaticElectionConfig, StaticVoteToken};
 
     use super::*;
-    use hotshot_types::certificate::{AssembledSignature, QuorumCertificate};
-    use hotshot_types::constants::genesis_proposer_id;
-    use hotshot_types::data::fake_commitment;
-    use hotshot_types::data::{ValidatingLeaf, ViewNumber};
-    use hotshot_types::traits::block_contents::dummy::{DummyBlock, DummyState};
-    use hotshot_types::traits::node_implementation::NodeType;
-    use hotshot_types::traits::signature_key::bn254::BN254Pub;
-    use hotshot_types::traits::state::ConsensusTime;
-    use hotshot_types::traits::Block;
-    use std::fmt::Debug;
-    use std::hash::Hash;
+    use hotshot_types::{
+        certificate::{AssembledSignature, QuorumCertificate},
+        constants::genesis_proposer_id,
+        data::{fake_commitment, ValidatingLeaf, ViewNumber},
+        traits::{
+            block_contents::dummy::{DummyBlock, DummyState},
+            node_implementation::NodeType,
+            signature_key::bn254::BN254Pub,
+            state::ConsensusTime,
+            Block,
+        },
+    };
+    use std::{fmt::Debug, hash::Hash};
     use tracing::instrument;
 
     #[derive(

--- a/src/types/handle.rs
+++ b/src/types/handle.rs
@@ -1,28 +1,26 @@
 //! Provides an event-streaming handle for a [`HotShot`] running in the background
 
-use crate::Message;
-use crate::QuorumCertificate;
-use crate::{traits::NodeImplementation, types::Event, SystemContext};
+use crate::{traits::NodeImplementation, types::Event, Message, QuorumCertificate, SystemContext};
 use async_compatibility_layer::channel::UnboundedStream;
 use async_lock::RwLock;
 use commit::Committable;
 use futures::Stream;
 use hotshot_consensus::Consensus;
-use hotshot_task::event_stream::ChannelStream;
-use hotshot_task::event_stream::EventStream;
-use hotshot_task::event_stream::StreamId;
-use hotshot_task::global_registry::GlobalRegistry;
-use hotshot_task::{boxed_sync, task::FilterEvent, BoxSyncFuture};
+use hotshot_task::{
+    boxed_sync,
+    event_stream::{ChannelStream, EventStream, StreamId},
+    global_registry::GlobalRegistry,
+    task::FilterEvent,
+    BoxSyncFuture,
+};
 use hotshot_task_impls::events::SequencingHotShotEvent;
-use hotshot_types::traits::election::QuorumExchangeType;
 use hotshot_types::{
     data::LeafType,
     error::HotShotError,
     event::EventType,
     message::{GeneralConsensusMessage, MessageKind},
     traits::{
-        election::ConsensusExchange,
-        election::SignedCertificate,
+        election::{ConsensusExchange, QuorumExchangeType, SignedCertificate},
         node_implementation::{ExchangesType, NodeType, QuorumEx},
         state::ConsensusTime,
         storage::Storage,

--- a/task-impls/src/consensus.rs
+++ b/task-impls/src/consensus.rs
@@ -1,62 +1,49 @@
 use crate::events::SequencingHotShotEvent;
-use async_compatibility_layer::art::{async_sleep, async_spawn};
-use async_compatibility_layer::async_primitives::subscribable_rwlock::ReadView;
-use async_lock::RwLock;
-use async_lock::RwLockUpgradableReadGuard;
+use async_compatibility_layer::{
+    art::{async_sleep, async_spawn},
+    async_primitives::subscribable_rwlock::ReadView,
+};
+use async_lock::{RwLock, RwLockUpgradableReadGuard};
 #[cfg(feature = "async-std-executor")]
 use async_std::task::JoinHandle;
 use bincode::Options;
 use bitvec::prelude::*;
 use commit::Committable;
 use core::time::Duration;
-use either::Either;
-use either::Left;
-use either::Right;
+use either::{Either, Left, Right};
 use futures::FutureExt;
-use hotshot_consensus::utils::Terminator;
-use hotshot_consensus::utils::ViewInner;
-use hotshot_consensus::Consensus;
-use hotshot_consensus::SequencingConsensusApi;
-use hotshot_consensus::View;
-use hotshot_task::event_stream::ChannelStream;
-use hotshot_task::event_stream::EventStream;
-use hotshot_task::global_registry::GlobalRegistry;
-use hotshot_task::task::FilterEvent;
-use hotshot_task::task::HotShotTaskTypes;
-use hotshot_task::task::{HandleEvent, HotShotTaskCompleted, TS};
-use hotshot_task::task_impls::HSTWithEvent;
-use hotshot_task::task_impls::TaskBuilder;
-use hotshot_types::data::LeafType;
-use hotshot_types::data::ProposalType;
-use hotshot_types::data::ViewNumber;
-use hotshot_types::event::{Event, EventType};
-use hotshot_types::message::Message;
-use hotshot_types::message::Proposal;
-use hotshot_types::traits::election::ConsensusExchange;
-use hotshot_types::traits::election::QuorumExchangeType;
-use hotshot_types::traits::network::CommunicationChannel;
-use hotshot_types::traits::network::ConsensusIntentEvent;
-use hotshot_types::traits::node_implementation::NodeImplementation;
-use hotshot_types::traits::state::ConsensusTime;
-use hotshot_types::traits::Block;
-use hotshot_types::vote::VoteType;
+use hotshot_consensus::{
+    utils::{Terminator, ViewInner},
+    Consensus, SequencingConsensusApi, View,
+};
+use hotshot_task::{
+    event_stream::{ChannelStream, EventStream},
+    global_registry::GlobalRegistry,
+    task::{FilterEvent, HandleEvent, HotShotTaskCompleted, HotShotTaskTypes, TS},
+    task_impls::{HSTWithEvent, TaskBuilder},
+};
 use hotshot_types::{
     certificate::{DACertificate, QuorumCertificate},
-    data::{QuorumProposal, SequencingLeaf},
-    message::{GeneralConsensusMessage, SequencingMessage},
+    data::{LeafType, ProposalType, QuorumProposal, SequencingLeaf, ViewNumber},
+    event::{Event, EventType},
+    message::{GeneralConsensusMessage, Message, Proposal, SequencingMessage},
     traits::{
-        election::SignedCertificate,
-        node_implementation::{CommitteeEx, NodeType, SequencingQuorumEx},
+        election::{ConsensusExchange, QuorumExchangeType, SignedCertificate},
+        network::{CommunicationChannel, ConsensusIntentEvent},
+        node_implementation::{CommitteeEx, NodeImplementation, NodeType, SequencingQuorumEx},
         signature_key::SignatureKey,
+        state::ConsensusTime,
+        Block,
     },
-    vote::{QuorumVote, VoteAccumulator},
+    vote::{QuorumVote, VoteAccumulator, VoteType},
 };
 use hotshot_utils::bincode::bincode_opts;
 use snafu::Snafu;
-use std::collections::HashMap;
-use std::collections::HashSet;
-use std::marker::PhantomData;
-use std::sync::Arc;
+use std::{
+    collections::{HashMap, HashSet},
+    marker::PhantomData,
+    sync::Arc,
+};
 #[cfg(feature = "tokio-executor")]
 use tokio::task::JoinHandle;
 use tracing::{debug, error, instrument};
@@ -352,7 +339,10 @@ where
 
                         // Justify qc's leaf commitment is not the same as the parent's leaf commitment, but it should be (in this case)
                         let Some(parent) = parent else {
-                            error!("Proposal's parent missing from storage with commitment: {:?}", justify_qc.leaf_commitment());
+                            error!(
+                                "Proposal's parent missing from storage with commitment: {:?}",
+                                justify_qc.leaf_commitment()
+                            );
                             return false;
                         };
                         let parent_commitment = parent.commit();
@@ -418,7 +408,10 @@ where
 
                         // Justify qc's leaf commitment is not the same as the parent's leaf commitment, but it should be (in this case)
                         let Some(parent) = parent else {
-                            error!("Proposal's parent missing from storage with commitment: {:?}", justify_qc.leaf_commitment());
+                            error!(
+                                "Proposal's parent missing from storage with commitment: {:?}",
+                                justify_qc.leaf_commitment()
+                            );
                             return false;
                         };
                         let parent_commitment = parent.commit();
@@ -592,7 +585,10 @@ where
 
                         // Justify qc's leaf commitment is not the same as the parent's leaf commitment, but it should be (in this case)
                         let Some(parent) = parent else {
-                            error!("Proposal's parent missing from storage with commitment: {:?}", justify_qc.leaf_commitment());
+                            error!(
+                                "Proposal's parent missing from storage with commitment: {:?}",
+                                justify_qc.leaf_commitment()
+                            );
                             return;
                         };
                         let parent_commitment = parent.commit();

--- a/task-impls/src/da.rs
+++ b/task-impls/src/da.rs
@@ -1,52 +1,42 @@
 use crate::events::SequencingHotShotEvent;
-use async_compatibility_layer::art::async_spawn;
-use async_compatibility_layer::art::async_timeout;
-use async_compatibility_layer::async_primitives::subscribable_rwlock::ReadView;
+use async_compatibility_layer::{
+    art::{async_spawn, async_timeout},
+    async_primitives::subscribable_rwlock::ReadView,
+};
 use async_lock::RwLock;
 use bincode::config::Options;
 use bitvec::prelude::*;
 use commit::Committable;
-use either::Either;
-use either::{Left, Right};
+use either::{Either, Left, Right};
 use futures::FutureExt;
-use hotshot_consensus::utils::ViewInner;
-use hotshot_consensus::Consensus;
-use hotshot_consensus::SequencingConsensusApi;
-use hotshot_consensus::View;
-use hotshot_task::event_stream::ChannelStream;
-use hotshot_task::event_stream::EventStream;
-use hotshot_task::global_registry::GlobalRegistry;
-use hotshot_task::task::FilterEvent;
-use hotshot_task::task::{HandleEvent, HotShotTaskCompleted, HotShotTaskTypes, TS};
-use hotshot_task::task_impls::HSTWithEvent;
-use hotshot_task::task_impls::TaskBuilder;
-use hotshot_types::data::DAProposal;
-use hotshot_types::message::Proposal;
-use hotshot_types::message::{CommitteeConsensusMessage, Message};
-use hotshot_types::traits::election::Membership;
-use hotshot_types::traits::election::{CommitteeExchangeType, ConsensusExchange};
-use hotshot_types::traits::network::CommunicationChannel;
-use hotshot_types::traits::network::ConsensusIntentEvent;
-use hotshot_types::traits::node_implementation::NodeImplementation;
-use hotshot_types::traits::Block;
-use hotshot_types::traits::State;
+use hotshot_consensus::{utils::ViewInner, Consensus, SequencingConsensusApi, View};
+use hotshot_task::{
+    event_stream::{ChannelStream, EventStream},
+    global_registry::GlobalRegistry,
+    task::{FilterEvent, HandleEvent, HotShotTaskCompleted, HotShotTaskTypes, TS},
+    task_impls::{HSTWithEvent, TaskBuilder},
+};
 use hotshot_types::{
     certificate::DACertificate,
-    data::{ProposalType, SequencingLeaf, ViewNumber},
-    message::SequencingMessage,
+    data::{DAProposal, ProposalType, SequencingLeaf, ViewNumber},
+    message::{CommitteeConsensusMessage, Message, Proposal, SequencingMessage},
     traits::{
-        node_implementation::{CommitteeEx, NodeType},
+        election::{CommitteeExchangeType, ConsensusExchange, Membership},
+        network::{CommunicationChannel, ConsensusIntentEvent},
+        node_implementation::{CommitteeEx, NodeImplementation, NodeType},
         signature_key::SignatureKey,
         state::ConsensusTime,
+        Block, State,
     },
     vote::VoteAccumulator,
 };
 use hotshot_utils::bincode::bincode_opts;
 use snafu::Snafu;
-use std::collections::HashMap;
-use std::collections::HashSet;
-use std::sync::Arc;
-use std::time::Instant;
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+    time::Instant,
+};
 use tracing::{debug, error, instrument, warn};
 
 #[derive(Snafu, Debug)]
@@ -483,7 +473,10 @@ where
                 let parent_view_number = &consensus.high_qc.view_number;
 
                 let Some(parent_view) = consensus.state_map.get(parent_view_number) else {
-                    error!("Couldn't find high QC parent in state map. Parent view {:?}", parent_view_number);
+                    error!(
+                        "Couldn't find high QC parent in state map. Parent view {:?}",
+                        parent_view_number
+                    );
                     return None;
                 };
                 let Some(leaf) = parent_view.get_leaf_commitment() else {

--- a/task-impls/src/events.rs
+++ b/task-impls/src/events.rs
@@ -1,12 +1,12 @@
-use hotshot_types::certificate::{DACertificate, QuorumCertificate};
-use hotshot_types::data::{DAProposal, ViewNumber};
-use hotshot_types::message::Proposal;
-use hotshot_types::traits::node_implementation::NodeImplementation;
-use hotshot_types::traits::node_implementation::NodeType;
-use hotshot_types::traits::node_implementation::QuorumProposalType;
-use hotshot_types::traits::node_implementation::ViewSyncProposalType;
-use hotshot_types::vote::ViewSyncVote;
-use hotshot_types::vote::{DAVote, QuorumVote};
+use hotshot_types::{
+    certificate::{DACertificate, QuorumCertificate},
+    data::{DAProposal, ViewNumber},
+    message::Proposal,
+    traits::node_implementation::{
+        NodeImplementation, NodeType, QuorumProposalType, ViewSyncProposalType,
+    },
+    vote::{DAVote, QuorumVote, ViewSyncVote},
+};
 
 use crate::view_sync::ViewSyncPhase;
 

--- a/task-impls/src/harness.rs
+++ b/task-impls/src/harness.rs
@@ -2,18 +2,15 @@ use crate::events::SequencingHotShotEvent;
 use async_compatibility_layer::art::async_spawn;
 
 use futures::FutureExt;
-use hotshot_task::event_stream::EventStream;
 use hotshot_task::{
-    event_stream::{self, ChannelStream},
+    event_stream::{self, ChannelStream, EventStream},
     task::{FilterEvent, HandleEvent, HotShotTaskCompleted, HotShotTaskTypes, TS},
     task_impls::{HSTWithEvent, TaskBuilder},
     task_launcher::TaskRunner,
 };
 use hotshot_types::traits::node_implementation::{NodeImplementation, NodeType};
 use snafu::Snafu;
-use std::collections::HashMap;
-use std::future::Future;
-use std::sync::Arc;
+use std::{collections::HashMap, future::Future, sync::Arc};
 
 /// The state for the test harness task. Keeps track of which events and how many we expect to get
 pub struct TestHarnessState<TYPES: NodeType, I: NodeImplementation<TYPES>> {

--- a/task-impls/src/network.rs
+++ b/task-impls/src/network.rs
@@ -6,11 +6,12 @@ use hotshot_task::{
     task_impls::{HSTWithEvent, HSTWithMessage},
     GeneratedStream, Merge,
 };
-use hotshot_types::message::Message;
-use hotshot_types::message::{CommitteeConsensusMessage, SequencingMessage};
 use hotshot_types::{
     data::{ProposalType, SequencingLeaf, ViewNumber},
-    message::{GeneralConsensusMessage, MessageKind, Messages},
+    message::{
+        CommitteeConsensusMessage, GeneralConsensusMessage, Message, MessageKind, Messages,
+        SequencingMessage,
+    },
     traits::{
         election::Membership,
         network::{CommunicationChannel, TransmitType},

--- a/task-impls/src/view_sync.rs
+++ b/task-impls/src/view_sync.rs
@@ -1,47 +1,34 @@
 #![allow(clippy::module_name_repetitions)]
 use crate::events::SequencingHotShotEvent;
-use async_compatibility_layer::art::async_sleep;
-use async_compatibility_layer::art::async_spawn;
+use async_compatibility_layer::art::{async_sleep, async_spawn};
 use commit::Committable;
 use either::Either::{self, Left, Right};
 use futures::FutureExt;
 use hotshot_consensus::SequencingConsensusApi;
-use hotshot_task::task::HandleEvent;
-use hotshot_task::task::HotShotTaskCompleted;
-use hotshot_task::task::HotShotTaskTypes;
-use hotshot_task::task_impls::TaskBuilder;
 use hotshot_task::{
     event_stream::{ChannelStream, EventStream},
-    task::{FilterEvent, TS},
-    task_impls::HSTWithEvent,
+    task::{FilterEvent, HandleEvent, HotShotTaskCompleted, HotShotTaskTypes, TS},
+    task_impls::{HSTWithEvent, TaskBuilder},
 };
-use hotshot_types::traits::election::Membership;
-use hotshot_types::traits::network::ConsensusIntentEvent;
+use hotshot_types::traits::{election::Membership, network::ConsensusIntentEvent};
 
 use bitvec::prelude::*;
 use hotshot_task::global_registry::GlobalRegistry;
-use hotshot_types::certificate::ViewSyncCertificate;
-use hotshot_types::data::SequencingLeaf;
-use hotshot_types::data::ViewNumber;
-use hotshot_types::message::GeneralConsensusMessage;
-use hotshot_types::message::Message;
-use hotshot_types::message::Proposal;
-use hotshot_types::message::SequencingMessage;
-use hotshot_types::traits::election::ConsensusExchange;
-use hotshot_types::traits::election::ViewSyncExchangeType;
-use hotshot_types::traits::network::CommunicationChannel;
-use hotshot_types::traits::node_implementation::NodeImplementation;
-use hotshot_types::traits::node_implementation::NodeType;
-use hotshot_types::traits::node_implementation::ViewSyncEx;
-use hotshot_types::traits::signature_key::SignatureKey;
-use hotshot_types::traits::state::ConsensusTime;
-use hotshot_types::vote::ViewSyncData;
-use hotshot_types::vote::ViewSyncVote;
-use hotshot_types::vote::VoteAccumulator;
+use hotshot_types::{
+    certificate::ViewSyncCertificate,
+    data::{SequencingLeaf, ViewNumber},
+    message::{GeneralConsensusMessage, Message, Proposal, SequencingMessage},
+    traits::{
+        election::{ConsensusExchange, ViewSyncExchangeType},
+        network::CommunicationChannel,
+        node_implementation::{NodeImplementation, NodeType, ViewSyncEx},
+        signature_key::SignatureKey,
+        state::ConsensusTime,
+    },
+    vote::{ViewSyncData, ViewSyncVote, VoteAccumulator},
+};
 use snafu::Snafu;
-use std::collections::HashMap;
-use std::sync::Arc;
-use std::time::Duration;
+use std::{collections::HashMap, sync::Arc, time::Duration};
 use tracing::{debug, error, instrument};
 #[derive(PartialEq, PartialOrd, Clone, Debug, Eq, Hash)]
 /// Phases of view sync

--- a/task/src/event_stream.rs
+++ b/task/src/event_stream.rs
@@ -1,9 +1,9 @@
 use async_compatibility_layer::channel::{unbounded, UnboundedSender, UnboundedStream};
 use async_lock::RwLock;
-use std::sync::Arc;
 use std::{
     collections::HashMap,
     pin::Pin,
+    sync::Arc,
     task::{Context, Poll},
 };
 

--- a/task/src/global_registry.rs
+++ b/task/src/global_registry.rs
@@ -1,9 +1,11 @@
 use async_lock::RwLock;
 use either::Either;
 use futures::{future::BoxFuture, FutureExt};
-use std::collections::{BTreeMap, BTreeSet};
-use std::ops::Deref;
-use std::sync::Arc;
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    ops::Deref,
+    sync::Arc,
+};
 
 use crate::task_state::{TaskState, TaskStatus};
 

--- a/task/src/lib.rs
+++ b/task/src/lib.rs
@@ -302,7 +302,7 @@ impl<O> Stream for GeneratedStream<O> {
             }
             None => {
                 let wrapped_fut = (*projection.generator)();
-                let Some( mut fut )=  wrapped_fut else {
+                let Some(mut fut) = wrapped_fut else {
                     return Poll::Ready(None);
                 };
                 match fut.as_mut().poll(cx) {
@@ -370,8 +370,7 @@ pub mod test {
     #[cfg_attr(feature = "async-std-executor", async_std::test)]
     async fn test_stream_fancy() {
         use async_compatibility_layer::art::async_sleep;
-        use std::sync::atomic::Ordering;
-        use std::time::Duration;
+        use std::{sync::atomic::Ordering, time::Duration};
 
         let value = Arc::<std::sync::atomic::AtomicU8>::default();
         let mut stream = GeneratedStream::<u32> {

--- a/task/src/task.rs
+++ b/task/src/task.rs
@@ -1,20 +1,22 @@
-use std::fmt::{Debug, Formatter};
-use std::ops::Deref;
-use std::pin::Pin;
-use std::task::{Context, Poll};
+use std::{
+    fmt::{Debug, Formatter},
+    ops::Deref,
+    pin::Pin,
+    task::{Context, Poll},
+};
 
 use async_compatibility_layer::art::async_yield_now;
 use either::Either::{self, Left, Right};
-use futures::{future::BoxFuture, stream::Fuse, Stream};
-use futures::{Future, FutureExt, StreamExt};
+use futures::{future::BoxFuture, stream::Fuse, Future, FutureExt, Stream, StreamExt};
 use pin_project::pin_project;
 use std::sync::Arc;
 
-use crate::event_stream::{SendableStream, StreamId};
-use crate::global_registry::{GlobalRegistry, HotShotTaskId};
-use crate::task_impls::TaskBuilder;
-use crate::task_state::TaskStatus;
-use crate::{event_stream::EventStream, global_registry::ShutdownFn, task_state::TaskState};
+use crate::{
+    event_stream::{EventStream, SendableStream, StreamId},
+    global_registry::{GlobalRegistry, HotShotTaskId, ShutdownFn},
+    task_impls::TaskBuilder,
+    task_state::{TaskState, TaskStatus},
+};
 
 /// restrictions on types we wish to pass around.
 /// Includes messages and events

--- a/task/src/task_impls.rs
+++ b/task/src/task_impls.rs
@@ -236,14 +236,10 @@ pub mod test {
     use async_compatibility_layer::channel::{unbounded, UnboundedStream};
     use snafu::Snafu;
 
-    use crate::event_stream;
-    use crate::event_stream::ChannelStream;
-    use crate::task::TS;
+    use crate::{event_stream, event_stream::ChannelStream, task::TS};
 
     use super::{HSTWithEvent, HSTWithEventAndMessage, HSTWithMessage};
-    use crate::event_stream::EventStream;
-    use crate::task::HotShotTaskTypes;
-    use crate::task_impls::TaskBuilder;
+    use crate::{event_stream::EventStream, task::HotShotTaskTypes, task_impls::TaskBuilder};
     use async_compatibility_layer::art::async_spawn;
     use futures::FutureExt;
     use std::sync::Arc;

--- a/testing/src/node_types.rs
+++ b/testing/src/node_types.rs
@@ -1,6 +1,5 @@
 use hotshot::traits::implementations::CombinedNetworks;
-use std::marker::PhantomData;
-use std::sync::Arc;
+use std::{marker::PhantomData, sync::Arc};
 
 use hotshot::{
     demos::sdemo::{SDemoBlock, SDemoState, SDemoTransaction},
@@ -14,24 +13,16 @@ use hotshot::{
     },
     types::bn254::BN254Pub,
 };
-use hotshot_types::traits::election::ViewSyncExchange;
-use hotshot_types::vote::QuorumVote;
-use hotshot_types::vote::ViewSyncVote;
-use hotshot_types::{certificate::ViewSyncCertificate, data::QuorumProposal};
 use hotshot_types::{
-    data::{DAProposal, SequencingLeaf, ViewNumber},
-    traits::{
-        election::{CommitteeExchange, QuorumExchange},
-        node_implementation::{ChannelMaps, NodeType, SequencingExchanges},
-    },
-    vote::DAVote,
-};
-use hotshot_types::{
+    certificate::ViewSyncCertificate,
+    data::{DAProposal, QuorumProposal, SequencingLeaf, ViewNumber},
     message::{Message, SequencingMessage},
     traits::{
+        election::{CommitteeExchange, QuorumExchange, ViewSyncExchange},
         network::{TestableChannelImplementation, TestableNetworkingImplementation},
-        node_implementation::TestableExchange,
+        node_implementation::{ChannelMaps, NodeType, SequencingExchanges, TestableExchange},
     },
+    vote::{DAVote, QuorumVote, ViewSyncVote},
 };
 use serde::{Deserialize, Serialize};
 

--- a/testing/src/overall_safety_task.rs
+++ b/testing/src/overall_safety_task.rs
@@ -13,10 +13,9 @@ use hotshot::{
     traits::{NodeImplementation, TestableNodeImplementation},
     HotShotError,
 };
-use hotshot_task::task::TS;
 use hotshot_task::{
     event_stream::ChannelStream,
-    task::{FilterEvent, HandleEvent, HandleMessage, HotShotTaskCompleted, HotShotTaskTypes},
+    task::{FilterEvent, HandleEvent, HandleMessage, HotShotTaskCompleted, HotShotTaskTypes, TS},
     task_impls::{HSTWithEventAndMessage, TaskBuilder},
     MergeN,
 };

--- a/testing/src/task_helpers.rs
+++ b/testing/src/task_helpers.rs
@@ -1,33 +1,29 @@
-use crate::node_types::SequencingMemoryImpl;
-use crate::node_types::SequencingTestTypes;
-use crate::test_builder::TestMetadata;
+use crate::{
+    node_types::{SequencingMemoryImpl, SequencingTestTypes},
+    test_builder::TestMetadata,
+};
 use commit::Committable;
 use either::Right;
-use hotshot::certificate::QuorumCertificate;
-use hotshot::traits::Block;
-use hotshot::traits::{NodeImplementation, TestableNodeImplementation};
-use hotshot::types::bn254::BN254Pub;
-use hotshot::types::SignatureKey;
-use hotshot::types::SystemContextHandle;
-use hotshot::HotShotSequencingConsensusApi;
-use hotshot::{HotShotInitializer, SystemContext};
+use hotshot::{
+    certificate::QuorumCertificate,
+    traits::{Block, NodeImplementation, TestableNodeImplementation},
+    types::{bn254::BN254Pub, SignatureKey, SystemContextHandle},
+    HotShotInitializer, HotShotSequencingConsensusApi, SystemContext,
+};
 use hotshot_consensus::ConsensusSharedApi;
 use hotshot_task::event_stream::ChannelStream;
 use hotshot_task_impls::events::SequencingHotShotEvent;
-use hotshot_types::data::QuorumProposal;
-use hotshot_types::data::SequencingLeaf;
-use hotshot_types::data::ViewNumber;
-use hotshot_types::message::Message;
-use hotshot_types::message::Proposal;
-use hotshot_types::traits::election::Membership;
-use hotshot_types::traits::election::SignedCertificate;
-use hotshot_types::traits::metrics::NoMetrics;
-use hotshot_types::traits::node_implementation::CommitteeEx;
-use hotshot_types::traits::node_implementation::ExchangesType;
-use hotshot_types::traits::node_implementation::QuorumEx;
-use hotshot_types::traits::signature_key::EncodedSignature;
-use hotshot_types::traits::state::ConsensusTime;
-use hotshot_types::traits::{election::ConsensusExchange, node_implementation::NodeType};
+use hotshot_types::{
+    data::{QuorumProposal, SequencingLeaf, ViewNumber},
+    message::{Message, Proposal},
+    traits::{
+        election::{ConsensusExchange, Membership, SignedCertificate},
+        metrics::NoMetrics,
+        node_implementation::{CommitteeEx, ExchangesType, NodeType, QuorumEx},
+        signature_key::EncodedSignature,
+        state::ConsensusTime,
+    },
+};
 
 pub async fn build_system_handle(
     node_id: u64,
@@ -110,16 +106,14 @@ async fn build_quorum_proposal_and_signature(
 
     let parent_view_number = &consensus.high_qc.view_number();
     let Some(parent_view) = consensus.state_map.get(parent_view_number) else {
-                    panic!("Couldn't find high QC parent in state map.");
-                };
+        panic!("Couldn't find high QC parent in state map.");
+    };
     let Some(leaf) = parent_view.get_leaf_commitment() else {
-                    panic!(
-                        "Parent of high QC points to a view without a proposal"
-                    );
-                };
+        panic!("Parent of high QC points to a view without a proposal");
+    };
     let Some(leaf) = consensus.saved_leaves.get(&leaf) else {
-                    panic!("Failed to find high QC parent.");
-                };
+        panic!("Failed to find high QC parent.");
+    };
     let parent_leaf = leaf.clone();
 
     // every event input is seen on the event stream in the output.

--- a/testing/src/test_builder.rs
+++ b/testing/src/test_builder.rs
@@ -1,18 +1,20 @@
 use hotshot::types::SignatureKey;
 use hotshot_types::traits::election::{ConsensusExchange, Membership};
-use std::num::NonZeroUsize;
-use std::sync::Arc;
-use std::time::Duration;
+use std::{num::NonZeroUsize, sync::Arc, time::Duration};
 
 use hotshot::traits::{NodeImplementation, TestableNodeImplementation};
 use hotshot_types::message::{Message, SequencingMessage};
 
-use hotshot_types::traits::node_implementation::{NodeType, QuorumEx, TestableExchange};
-use hotshot_types::{ExecutionType, HotShotConfig};
+use hotshot_types::{
+    traits::node_implementation::{NodeType, QuorumEx, TestableExchange},
+    ExecutionType, HotShotConfig,
+};
 
 use super::completion_task::{CompletionTaskDescription, TimeBasedCompletionTaskDescription};
-use crate::spinning_task::SpinningTaskDescription;
-use crate::test_launcher::{ResourceGenerators, TestLauncher};
+use crate::{
+    spinning_task::SpinningTaskDescription,
+    test_launcher::{ResourceGenerators, TestLauncher},
+};
 
 use super::{
     overall_safety_task::OverallSafetyPropertiesDescription, txn_task::TxnTaskDescription,

--- a/testing/src/test_runner.rs
+++ b/testing/src/test_runner.rs
@@ -1,8 +1,9 @@
-use super::overall_safety_task::OverallSafetyTask;
-use super::overall_safety_task::RoundCtx;
-use super::{completion_task::CompletionTask, txn_task::TxnTask};
-use crate::test_launcher::Networks;
-use crate::test_launcher::TestLauncher;
+use super::{
+    completion_task::CompletionTask,
+    overall_safety_task::{OverallSafetyTask, RoundCtx},
+    txn_task::TxnTask,
+};
+use crate::test_launcher::{Networks, TestLauncher};
 use hotshot::types::SystemContextHandle;
 
 use hotshot::{
@@ -11,16 +12,14 @@ use hotshot::{
 use hotshot_task::{
     event_stream::ChannelStream, global_registry::GlobalRegistry, task_launcher::TaskRunner,
 };
-use hotshot_types::traits::election::Membership;
-use hotshot_types::traits::node_implementation::ExchangesType;
-use hotshot_types::traits::signature_key::SignatureKey;
 use hotshot_types::{
     message::Message,
     traits::{
-        election::ConsensusExchange,
+        election::{ConsensusExchange, Membership},
         metrics::NoMetrics,
         network::CommunicationChannel,
-        node_implementation::{NodeType, QuorumCommChannel, QuorumEx},
+        node_implementation::{ExchangesType, NodeType, QuorumCommChannel, QuorumEx},
+        signature_key::SignatureKey,
     },
     HotShotConfig,
 };

--- a/testing/src/txn_task.rs
+++ b/testing/src/txn_task.rs
@@ -9,15 +9,15 @@ use hotshot_task::{
     task_impls::{HSTWithEventAndMessage, TaskBuilder},
     GeneratedStream,
 };
-use hotshot_types::message::SequencingMessage;
-use hotshot_types::traits::node_implementation::NodeImplementation;
-use hotshot_types::traits::node_implementation::NodeType;
+use hotshot_types::{
+    message::SequencingMessage,
+    traits::node_implementation::{NodeImplementation, NodeType},
+};
 use rand::thread_rng;
 use snafu::Snafu;
 use std::{sync::Arc, time::Duration};
 
-use super::test_launcher::TaskGenerator;
-use super::GlobalTestEvent;
+use super::{test_launcher::TaskGenerator, GlobalTestEvent};
 
 // the obvious idea here is to pass in a "stream" that completes every `n` seconds
 // the stream construction can definitely be fancier but that's the baseline idea

--- a/testing/tests/consensus_task.rs
+++ b/testing/tests/consensus_task.rs
@@ -1,22 +1,25 @@
 use commit::Committable;
 use either::Right;
-use hotshot::tasks::add_consensus_task;
-use hotshot::types::SignatureKey;
-use hotshot::types::SystemContextHandle;
-use hotshot::HotShotSequencingConsensusApi;
+use hotshot::{
+    tasks::add_consensus_task,
+    types::{SignatureKey, SystemContextHandle},
+    HotShotSequencingConsensusApi,
+};
 use hotshot_task::event_stream::ChannelStream;
 use hotshot_task_impls::events::SequencingHotShotEvent;
-use hotshot_testing::node_types::SequencingMemoryImpl;
-use hotshot_testing::node_types::SequencingTestTypes;
-use hotshot_testing::task_helpers::{build_quorum_proposal, key_pair_for_id};
-use hotshot_types::data::QuorumProposal;
-use hotshot_types::data::SequencingLeaf;
-use hotshot_types::data::ViewNumber;
-use hotshot_types::message::GeneralConsensusMessage;
-use hotshot_types::traits::election::QuorumExchangeType;
-use hotshot_types::traits::election::SignedCertificate;
-use hotshot_types::traits::node_implementation::ExchangesType;
-use hotshot_types::traits::{election::ConsensusExchange, state::ConsensusTime};
+use hotshot_testing::{
+    node_types::{SequencingMemoryImpl, SequencingTestTypes},
+    task_helpers::{build_quorum_proposal, key_pair_for_id},
+};
+use hotshot_types::{
+    data::{QuorumProposal, SequencingLeaf, ViewNumber},
+    message::GeneralConsensusMessage,
+    traits::{
+        election::{ConsensusExchange, QuorumExchangeType, SignedCertificate},
+        node_implementation::ExchangesType,
+        state::ConsensusTime,
+    },
+};
 
 use std::collections::HashMap;
 
@@ -41,9 +44,7 @@ async fn build_vote(
             panic!("Couldn't find genesis view in state map.");
         };
         let Some(leaf) = genesis_view.get_leaf_commitment() else {
-            panic!(
-                "Genesis view points to a view without a leaf"
-            );
+            panic!("Genesis view points to a view without a leaf");
         };
         let Some(leaf) = consensus.saved_leaves.get(&leaf) else {
             panic!("Failed to find genesis leaf.");

--- a/testing/tests/da_task.rs
+++ b/testing/tests/da_task.rs
@@ -2,12 +2,13 @@ use commit::Committable;
 use hotshot::HotShotSequencingConsensusApi;
 use hotshot_consensus::traits::ConsensusSharedApi;
 use hotshot_task_impls::events::SequencingHotShotEvent;
-use hotshot_testing::node_types::SequencingMemoryImpl;
-use hotshot_testing::node_types::SequencingTestTypes;
-use hotshot_types::data::DAProposal;
-use hotshot_types::data::ViewNumber;
-use hotshot_types::traits::node_implementation::ExchangesType;
-use hotshot_types::traits::{election::ConsensusExchange, state::ConsensusTime};
+use hotshot_testing::node_types::{SequencingMemoryImpl, SequencingTestTypes};
+use hotshot_types::{
+    data::{DAProposal, ViewNumber},
+    traits::{
+        election::ConsensusExchange, node_implementation::ExchangesType, state::ConsensusTime,
+    },
+};
 use std::collections::HashMap;
 
 #[cfg(test)]

--- a/testing/tests/network_task.rs
+++ b/testing/tests/network_task.rs
@@ -2,13 +2,14 @@ use commit::Committable;
 use hotshot::HotShotSequencingConsensusApi;
 use hotshot_consensus::traits::ConsensusSharedApi;
 use hotshot_task_impls::events::SequencingHotShotEvent;
-use hotshot_testing::node_types::SequencingMemoryImpl;
-use hotshot_testing::node_types::SequencingTestTypes;
-use hotshot_testing::task_helpers::build_quorum_proposal;
-use hotshot_types::data::DAProposal;
-use hotshot_types::data::ViewNumber;
-use hotshot_types::traits::node_implementation::ExchangesType;
-use hotshot_types::traits::state::ConsensusTime;
+use hotshot_testing::{
+    node_types::{SequencingMemoryImpl, SequencingTestTypes},
+    task_helpers::build_quorum_proposal,
+};
+use hotshot_types::{
+    data::{DAProposal, ViewNumber},
+    traits::{node_implementation::ExchangesType, state::ConsensusTime},
+};
 use std::collections::HashMap;
 
 #[cfg(test)]

--- a/types/src/certificate.rs
+++ b/types/src/certificate.rs
@@ -1,23 +1,24 @@
 //! Provides two types of cerrtificates and their accumulators.
 
-use crate::data::serialize_signature;
-use crate::vote::ViewSyncData;
 use crate::{
-    data::{fake_commitment, LeafType},
+    data::{fake_commitment, serialize_signature, LeafType},
     traits::{
         election::{SignedCertificate, VoteData, VoteToken},
         node_implementation::NodeType,
         signature_key::{EncodedPublicKey, EncodedSignature, SignatureKey},
         state::ConsensusTime,
     },
+    vote::ViewSyncData,
 };
 use bincode::Options;
 use commit::{Commitment, Committable};
 use espresso_systems_common::hotshot::tag;
 use hotshot_utils::bincode::bincode_opts;
 use serde::{Deserialize, Serialize};
-use std::fmt::{self, Display, Formatter};
-use std::{fmt::Debug, ops::Deref};
+use std::{
+    fmt::{self, Debug, Display, Formatter},
+    ops::Deref,
+};
 use tracing::debug;
 
 /// A `DACertificate` is a threshold signature that some data is available.

--- a/types/src/event.rs
+++ b/types/src/event.rs
@@ -1,7 +1,9 @@
 //! Events that a `HotShot` instance can emit
 
-use crate::certificate::QuorumCertificate;
-use crate::{data::LeafType, error::HotShotError, traits::node_implementation::NodeType};
+use crate::{
+    certificate::QuorumCertificate, data::LeafType, error::HotShotError,
+    traits::node_implementation::NodeType,
+};
 use std::sync::Arc;
 /// A status event emitted by a `HotShot` instance
 ///

--- a/types/src/message.rs
+++ b/types/src/message.rs
@@ -3,25 +3,22 @@
 //! This module contains types used to represent the various types of messages that
 //! `HotShot` nodes can send among themselves.
 
-use crate::certificate::DACertificate;
-use crate::data::DAProposal;
-use crate::traits::network::ViewMessage;
-use crate::traits::node_implementation::ViewSyncProposalType;
-use crate::vote::{DAVote, QuorumVote};
 use crate::{
-    data::ProposalType,
+    certificate::DACertificate,
+    data::{DAProposal, ProposalType},
     traits::{
-        network::NetworkMsg,
-        node_implementation::{ExchangesType, NodeImplementation, NodeType, QuorumProposalType},
+        network::{NetworkMsg, ViewMessage},
+        node_implementation::{
+            ExchangesType, NodeImplementation, NodeType, QuorumProposalType, ViewSyncProposalType,
+        },
         signature_key::EncodedSignature,
     },
-    vote::{ViewSyncVote, VoteType},
+    vote::{DAVote, QuorumVote, ViewSyncVote, VoteType},
 };
 use derivative::Derivative;
 use either::Either::{self, Left, Right};
 use serde::{Deserialize, Serialize};
-use std::fmt::Debug;
-use std::marker::PhantomData;
+use std::{fmt::Debug, marker::PhantomData};
 
 /// Incoming message
 #[derive(Serialize, Deserialize, Clone, Debug, Derivative)]

--- a/types/src/traits/election.rs
+++ b/types/src/traits/election.rs
@@ -3,39 +3,44 @@
 // Needed to avoid the non-biding `let` warning.
 #![allow(clippy::let_underscore_untyped)]
 
-use super::node_implementation::{NodeImplementation, NodeType};
-use super::signature_key::{EncodedPublicKey, EncodedSignature};
-use crate::certificate::VoteMetaData;
-use crate::certificate::{AssembledSignature, ViewSyncCertificate};
-use crate::certificate::{DACertificate, QuorumCertificate};
-use crate::data::DAProposal;
-use crate::data::ProposalType;
+use super::{
+    node_implementation::{NodeImplementation, NodeType},
+    signature_key::{EncodedPublicKey, EncodedSignature},
+};
+use crate::{
+    certificate::{
+        AssembledSignature, DACertificate, QuorumCertificate, ViewSyncCertificate, VoteMetaData,
+    },
+    data::{DAProposal, ProposalType},
+};
 
-use crate::message::{CommitteeConsensusMessage, GeneralConsensusMessage, Message};
-use crate::vote::ViewSyncVoteInternal;
+use crate::{
+    message::{CommitteeConsensusMessage, GeneralConsensusMessage, Message},
+    vote::ViewSyncVoteInternal,
+};
 
-use crate::traits::network::CommunicationChannel;
-use crate::traits::network::NetworkMsg;
-use crate::traits::{node_implementation::ExchangesType, state::ConsensusTime};
-use crate::vote::ViewSyncData;
-use crate::vote::ViewSyncVote;
-use crate::vote::VoteAccumulator;
-use crate::vote::{Accumulator, DAVote, QuorumVote, TimeoutVote, VoteType, YesOrNoVote};
-use crate::{data::LeafType, traits::signature_key::SignatureKey};
+use crate::{
+    data::LeafType,
+    traits::{
+        network::{CommunicationChannel, NetworkMsg},
+        node_implementation::ExchangesType,
+        signature_key::SignatureKey,
+        state::ConsensusTime,
+    },
+    vote::{
+        Accumulator, DAVote, QuorumVote, TimeoutVote, ViewSyncData, ViewSyncVote, VoteAccumulator,
+        VoteType, YesOrNoVote,
+    },
+};
 use bincode::Options;
 use commit::{Commitment, Committable};
 use derivative::Derivative;
 use either::Either;
 use ethereum_types::U256;
 use hotshot_utils::bincode::bincode_opts;
-use serde::Deserialize;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use snafu::Snafu;
-use std::collections::BTreeSet;
-use std::fmt::Debug;
-use std::hash::Hash;
-use std::marker::PhantomData;
-use std::num::NonZeroU64;
+use std::{collections::BTreeSet, fmt::Debug, hash::Hash, marker::PhantomData, num::NonZeroU64};
 use tracing::error;
 
 /// Error for election problems

--- a/types/src/traits/metrics.rs
+++ b/types/src/traits/metrics.rs
@@ -104,8 +104,10 @@ pub trait Label: Send + Sync {
 #[cfg(test)]
 mod test {
     use super::*;
-    use std::collections::HashMap;
-    use std::sync::{Arc, Mutex};
+    use std::{
+        collections::HashMap,
+        sync::{Arc, Mutex},
+    };
 
     struct TestMetrics {
         prefix: String,

--- a/types/src/traits/node_implementation.rs
+++ b/types/src/traits/node_implementation.rs
@@ -14,14 +14,12 @@ use super::{
     storage::{StorageError, StorageState, TestableStorage},
     State,
 };
-use crate::traits::election::Membership;
-use crate::{data::TestableLeaf, message::Message};
 use crate::{
-    data::{LeafType, SequencingLeaf},
-    message::{ConsensusMessageType, SequencingMessage},
+    data::{LeafType, SequencingLeaf, TestableLeaf},
+    message::{ConsensusMessageType, Message, SequencingMessage},
     traits::{
-        network::TestableChannelImplementation, signature_key::SignatureKey, storage::Storage,
-        Block,
+        election::Membership, network::TestableChannelImplementation, signature_key::SignatureKey,
+        storage::Storage, Block,
     },
 };
 use async_compatibility_layer::channel::{unbounded, UnboundedReceiver, UnboundedSender};
@@ -29,10 +27,10 @@ use async_lock::{Mutex, RwLock};
 use async_trait::async_trait;
 use commit::Committable;
 use serde::{Deserialize, Serialize};
-use std::hash::Hash;
 use std::{
     collections::BTreeMap,
     fmt::Debug,
+    hash::Hash,
     marker::PhantomData,
     sync::{atomic::AtomicBool, Arc},
 };

--- a/types/src/traits/qc.rs
+++ b/types/src/traits/qc.rs
@@ -7,8 +7,7 @@ use ark_std::{
 };
 use bitvec::prelude::*;
 use generic_array::{ArrayLength, GenericArray};
-use jf_primitives::errors::PrimitivesError;
-use jf_primitives::signatures::AggregateableSignatureSchemes;
+use jf_primitives::{errors::PrimitivesError, signatures::AggregateableSignatureSchemes};
 use serde::{Deserialize, Serialize};
 
 /// Trait for validating a QC built from different signatures on the same message

--- a/types/src/traits/signature_key.rs
+++ b/types/src/traits/signature_key.rs
@@ -8,8 +8,9 @@ use std::{fmt::Debug, hash::Hash};
 use tagged_base64::tagged;
 #[cfg(feature = "demo")]
 pub mod bn254;
-use jf_primitives::signatures::bls_over_bn254::BLSOverBN254CurveSignatureScheme;
-use jf_primitives::signatures::SignatureScheme;
+use jf_primitives::signatures::{
+    bls_over_bn254::BLSOverBN254CurveSignatureScheme, SignatureScheme,
+};
 
 /// Type saftey wrapper for byte encoded keys
 #[tagged(tag::ENCODED_PUB_KEY)]

--- a/types/src/traits/signature_key/bn254/bn254_pub.rs
+++ b/types/src/traits/signature_key/bn254/bn254_pub.rs
@@ -3,13 +3,15 @@ use bincode::Options;
 use bitvec::prelude::*;
 use blake3::traits::digest::generic_array::GenericArray;
 use ethereum_types::U256;
-use hotshot_primitives::qc::bit_vector::{
-    BitVectorQC, QCParams as JFQCParams, StakeTableEntry as JFStakeTableEntry,
+use hotshot_primitives::qc::{
+    bit_vector::{BitVectorQC, QCParams as JFQCParams, StakeTableEntry as JFStakeTableEntry},
+    QuorumCertificate,
 };
-use hotshot_primitives::qc::QuorumCertificate;
 use hotshot_utils::bincode::bincode_opts;
-use jf_primitives::signatures::bls_over_bn254::{BLSOverBN254CurveSignatureScheme, VerKey};
-use jf_primitives::signatures::SignatureScheme;
+use jf_primitives::signatures::{
+    bls_over_bn254::{BLSOverBN254CurveSignatureScheme, VerKey},
+    SignatureScheme,
+};
 use serde::{Deserialize, Serialize};
 use std::{cmp::Ordering, fmt::Debug};
 use tracing::{debug, instrument, warn};

--- a/types/src/traits/storage.rs
+++ b/types/src/traits/storage.rs
@@ -1,8 +1,8 @@
 //! Abstraction over on-disk storage of node state
 
 use super::{node_implementation::NodeType, signature_key::EncodedPublicKey};
-use crate::certificate::QuorumCertificate;
 use crate::{
+    certificate::QuorumCertificate,
     data::LeafType,
     traits::{election::SignedCertificate, Block},
 };

--- a/types/src/vote.rs
+++ b/types/src/vote.rs
@@ -18,12 +18,15 @@ use commit::{Commitment, Committable};
 use either::Either;
 use ethereum_types::U256;
 use hotshot_utils::bincode::bincode_opts;
-use jf_primitives::signatures::bls_over_bn254::BLSOverBN254CurveSignatureScheme;
-use jf_primitives::signatures::SignatureScheme;
+use jf_primitives::signatures::{
+    bls_over_bn254::BLSOverBN254CurveSignatureScheme, SignatureScheme,
+};
 use serde::{Deserialize, Serialize};
-use std::collections::{BTreeMap, HashMap};
-use std::fmt::Debug;
-use std::num::NonZeroU64;
+use std::{
+    collections::{BTreeMap, HashMap},
+    fmt::Debug,
+    num::NonZeroU64,
+};
 
 /// The vote sent by consensus messages.
 pub trait VoteType<TYPES: NodeType>:

--- a/web_server/src/lib.rs
+++ b/web_server/src/lib.rs
@@ -5,23 +5,16 @@ use async_lock::RwLock;
 use clap::Args;
 use futures::FutureExt;
 
-use hotshot_types::traits::signature_key::EncodedPublicKey;
-use hotshot_types::traits::signature_key::SignatureKey;
-use rand::rngs::StdRng;
-use rand::SeedableRng;
-use rand::{distributions::Alphanumeric, thread_rng, Rng};
-use std::collections::HashMap;
-use std::io;
-use std::path::PathBuf;
-use tide_disco::api::ApiError;
-use tide_disco::error::ServerError;
-use tide_disco::method::ReadState;
-use tide_disco::method::WriteState;
-use tide_disco::Api;
-use tide_disco::App;
-use tide_disco::StatusCode;
-use tracing::debug;
-use tracing::info;
+use hotshot_types::traits::signature_key::{EncodedPublicKey, SignatureKey};
+use rand::{distributions::Alphanumeric, rngs::StdRng, thread_rng, Rng, SeedableRng};
+use std::{collections::HashMap, io, path::PathBuf};
+use tide_disco::{
+    api::ApiError,
+    error::ServerError,
+    method::{ReadState, WriteState},
+    Api, App, StatusCode,
+};
+use tracing::{debug, info};
 
 type State<KEY> = RwLock<WebServerState<KEY>>;
 type Error = ServerError;


### PR DESCRIPTION
This PR runs `cargo fmt -- --config unstable_features=true,imports_granularity=Crate`, which groups imports from a single crate together.  I find this makes the imports section of a file cleaner.  