### PR TITLE
Add just command for linting imports

### DIFF
--- a/crates/hotshot-qc/src/bit_vector_old.rs
+++ b/crates/hotshot-qc/src/bit_vector_old.rs
@@ -13,9 +13,10 @@ use bitvec::prelude::*;
 use ethereum_types::U256;
 use generic_array::GenericArray;
 use hotshot_types::traits::qc::QuorumCertificate;
-use jf_primitives::errors::PrimitivesError;
-use jf_primitives::errors::PrimitivesError::ParameterError;
-use jf_primitives::signatures::AggregateableSignatureSchemes;
+use jf_primitives::{
+    errors::{PrimitivesError, PrimitivesError::ParameterError},
+    signatures::AggregateableSignatureSchemes,
+};
 use serde::{Deserialize, Serialize};
 use typenum::U32;
 
@@ -187,8 +188,10 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use jf_primitives::signatures::bls_over_bn254::{BLSOverBN254CurveSignatureScheme, KeyPair};
-    use jf_primitives::signatures::SignatureScheme;
+    use jf_primitives::signatures::{
+        bls_over_bn254::{BLSOverBN254CurveSignatureScheme, KeyPair},
+        SignatureScheme,
+    };
 
     macro_rules! test_quorum_certificate {
         ($aggsig:tt) => {

--- a/justfile
+++ b/justfile
@@ -112,6 +112,10 @@ lint_async_std_flume:
   echo Linting with async std executor and flume
   cargo clippy --workspace --all-targets --no-default-features --features=async-std-executor,demo,docs,doc-images,hotshot-testing,channel-flume --bins --tests --examples -- -D warnings
 
+lint_imports: 
+  echo Linting imports
+  cargo fmt --all -- --config unstable_features=true,imports_granularity=Crate
+
 careful: careful_tokio careful_async_std
 
 careful_tokio:


### PR DESCRIPTION
Updates the `justfile` to include `just lint_imports`, which will group imports by crate. 