### PR TITLE
feat(block_contents): Change Block::add_transaction_raw function signature to accept &mut self.

### DIFF
--- a/crates/hotshot/src/demos/sdemo.rs
+++ b/crates/hotshot/src/demos/sdemo.rs
@@ -206,15 +206,14 @@ impl Block for SDemoBlock {
     }
 
     fn add_transaction_raw(
-        &self,
+        &mut self,
         tx: &Self::Transaction,
-    ) -> std::result::Result<Self, Self::Error> {
+    ) -> std::result::Result<(), Self::Error> {
         match self {
             SDemoBlock::Genesis(_) => Err(SDemoError::GenesisCantHaveTransactions),
             SDemoBlock::Normal(n) => {
-                let mut new = n.clone();
-                new.transactions.push(tx.clone());
-                Ok(SDemoBlock::Normal(new))
+                n.transactions.push(tx.clone());
+                Ok(())
             }
         }
     }

--- a/crates/task-impls/src/da.rs
+++ b/crates/task-impls/src/da.rs
@@ -511,8 +511,7 @@ where
                     .await;
 
                 for txn in txns {
-                    if let Ok(new_block) = block.add_transaction_raw(&txn) {
-                        block = new_block;
+                    if block.add_transaction_raw(&txn).is_ok() {
                         continue;
                     }
                 }

--- a/crates/types/src/traits/block_contents.rs
+++ b/crates/types/src/traits/block_contents.rs
@@ -50,8 +50,10 @@ pub trait Block:
     /// # Errors
     ///
     /// Should return an error if this transaction leads to an invalid block
-    fn add_transaction_raw(&self, tx: &Self::Transaction)
-        -> std::result::Result<Self, Self::Error>;
+    fn add_transaction_raw(
+        &mut self,
+        tx: &Self::Transaction,
+    ) -> std::result::Result<(), Self::Error>;
 
     /// returns hashes of all the transactions in this block
     /// TODO make this ordered with a vec
@@ -142,12 +144,11 @@ pub mod dummy {
         }
 
         fn add_transaction_raw(
-            &self,
+            &mut self,
             _tx: &Self::Transaction,
-        ) -> std::result::Result<Self, Self::Error> {
-            Ok(Self {
-                nonce: self.nonce + 1,
-            })
+        ) -> std::result::Result<(), Self::Error> {
+            self.nonce += 1;
+            Ok(())
         }
 
         fn contained_transactions(&self) -> HashSet<Commitment<Self::Transaction>> {


### PR DESCRIPTION
Aims to close #1588. Appreciate any nits and if this is stale let me know.