### PR TITLE
Remove PROPOSAL and VOTE generics from CommunicationChannel; Add COMMITTABLE generic to VoteType

### DIFF
--- a/crates/hotshot/examples/infra/modDA.rs
+++ b/crates/hotshot/examples/infra/modDA.rs
@@ -19,7 +19,7 @@ use hotshot_orchestrator::{
 use hotshot_task::task::FilterEvent;
 use hotshot_types::{
     certificate::ViewSyncCertificate,
-    data::{DAProposal, QuorumProposal, SequencingLeaf, TestableLeaf},
+    data::{QuorumProposal, SequencingLeaf, TestableLeaf},
     event::{Event, EventType},
     message::{Message, SequencingMessage},
     traits::{
@@ -33,7 +33,6 @@ use hotshot_types::{
         },
         state::{ConsensusTime, TestableBlock, TestableState},
     },
-    vote::{DAVote, QuorumVote, ViewSyncVote},
     HotShotConfig,
 };
 // use libp2p::{
@@ -67,27 +66,9 @@ use tracing::{debug, error, info, warn};
 pub async fn run_orchestrator_da<
     TYPES: NodeType,
     MEMBERSHIP: Membership<TYPES> + Debug,
-    DANETWORK: CommunicationChannel<
-            TYPES,
-            Message<TYPES, NODE>,
-            DAProposal<TYPES>,
-            DAVote<TYPES>,
-            MEMBERSHIP,
-        > + Debug,
-    QUORUMNETWORK: CommunicationChannel<
-            TYPES,
-            Message<TYPES, NODE>,
-            QuorumProposal<TYPES, SequencingLeaf<TYPES>>,
-            QuorumVote<TYPES, SequencingLeaf<TYPES>>,
-            MEMBERSHIP,
-        > + Debug,
-    VIEWSYNCNETWORK: CommunicationChannel<
-            TYPES,
-            Message<TYPES, NODE>,
-            ViewSyncCertificate<TYPES>,
-            ViewSyncVote<TYPES>,
-            MEMBERSHIP,
-        > + Debug,
+    DANETWORK: CommunicationChannel<TYPES, Message<TYPES, NODE>, MEMBERSHIP> + Debug,
+    QUORUMNETWORK: CommunicationChannel<TYPES, Message<TYPES, NODE>, MEMBERSHIP> + Debug,
+    VIEWSYNCNETWORK: CommunicationChannel<TYPES, Message<TYPES, NODE>, MEMBERSHIP> + Debug,
     NODE: NodeImplementation<
         TYPES,
         Leaf = SequencingLeaf<TYPES>,
@@ -135,27 +116,9 @@ pub async fn run_orchestrator_da<
 pub trait RunDA<
     TYPES: NodeType,
     MEMBERSHIP: Membership<TYPES> + Debug,
-    DANETWORK: CommunicationChannel<
-            TYPES,
-            Message<TYPES, NODE>,
-            DAProposal<TYPES>,
-            DAVote<TYPES>,
-            MEMBERSHIP,
-        > + Debug,
-    QUORUMNETWORK: CommunicationChannel<
-            TYPES,
-            Message<TYPES, NODE>,
-            QuorumProposal<TYPES, SequencingLeaf<TYPES>>,
-            QuorumVote<TYPES, SequencingLeaf<TYPES>>,
-            MEMBERSHIP,
-        > + Debug,
-    VIEWSYNCNETWORK: CommunicationChannel<
-            TYPES,
-            Message<TYPES, NODE>,
-            ViewSyncCertificate<TYPES>,
-            ViewSyncVote<TYPES>,
-            MEMBERSHIP,
-        > + Debug,
+    DANETWORK: CommunicationChannel<TYPES, Message<TYPES, NODE>, MEMBERSHIP> + Debug,
+    QUORUMNETWORK: CommunicationChannel<TYPES, Message<TYPES, NODE>, MEMBERSHIP> + Debug,
+    VIEWSYNCNETWORK: CommunicationChannel<TYPES, Message<TYPES, NODE>, MEMBERSHIP> + Debug,
     NODE: NodeImplementation<
         TYPES,
         Leaf = SequencingLeaf<TYPES>,
@@ -416,21 +379,13 @@ pub trait RunDA<
 // WEB SERVER
 
 /// Alias for the [`WebCommChannel`] for sequencing consensus.
-type StaticDAComm<TYPES, I, MEMBERSHIP> =
-    WebCommChannel<TYPES, I, DAProposal<TYPES>, DAVote<TYPES>, MEMBERSHIP>;
+type StaticDAComm<TYPES, I, MEMBERSHIP> = WebCommChannel<TYPES, I, MEMBERSHIP>;
 
 /// Alias for the ['WebCommChannel'] for validating consensus
-type StaticQuorumComm<TYPES, I, MEMBERSHIP> = WebCommChannel<
-    TYPES,
-    I,
-    QuorumProposal<TYPES, SequencingLeaf<TYPES>>,
-    QuorumVote<TYPES, SequencingLeaf<TYPES>>,
-    MEMBERSHIP,
->;
+type StaticQuorumComm<TYPES, I, MEMBERSHIP> = WebCommChannel<TYPES, I, MEMBERSHIP>;
 
 /// Alias for the ['WebCommChannel'] for view sync consensus
-type StaticViewSyncComm<TYPES, I, MEMBERSHIP> =
-    WebCommChannel<TYPES, I, ViewSyncCertificate<TYPES>, ViewSyncVote<TYPES>, MEMBERSHIP>;
+type StaticViewSyncComm<TYPES, I, MEMBERSHIP> = WebCommChannel<TYPES, I, MEMBERSHIP>;
 
 /// Represents a web server-based run
 pub struct WebServerDARun<
@@ -463,32 +418,20 @@ impl<
                     SequencingLeaf<TYPES>,
                     QuorumProposal<TYPES, SequencingLeaf<TYPES>>,
                     MEMBERSHIP,
-                    WebCommChannel<
-                        TYPES,
-                        NODE,
-                        QuorumProposal<TYPES, SequencingLeaf<TYPES>>,
-                        QuorumVote<TYPES, SequencingLeaf<TYPES>>,
-                        MEMBERSHIP,
-                    >,
+                    WebCommChannel<TYPES, NODE, MEMBERSHIP>,
                     Message<TYPES, NODE>,
                 >,
                 CommitteeExchange<
                     TYPES,
                     MEMBERSHIP,
-                    WebCommChannel<TYPES, NODE, DAProposal<TYPES>, DAVote<TYPES>, MEMBERSHIP>,
+                    WebCommChannel<TYPES, NODE, MEMBERSHIP>,
                     Message<TYPES, NODE>,
                 >,
                 ViewSyncExchange<
                     TYPES,
                     ViewSyncCertificate<TYPES>,
                     MEMBERSHIP,
-                    WebCommChannel<
-                        TYPES,
-                        NODE,
-                        ViewSyncCertificate<TYPES>,
-                        ViewSyncVote<TYPES>,
-                        MEMBERSHIP,
-                    >,
+                    WebCommChannel<TYPES, NODE, MEMBERSHIP>,
                     Message<TYPES, NODE>,
                 >,
             >,
@@ -540,21 +483,11 @@ where
         );
 
         // Create the network
-        let quorum_network: WebCommChannel<
-            TYPES,
-            NODE,
-            QuorumProposal<TYPES, SequencingLeaf<TYPES>>,
-            QuorumVote<TYPES, SequencingLeaf<TYPES>>,
-            MEMBERSHIP,
-        > = WebCommChannel::new(underlying_quorum_network.clone().into());
+        let quorum_network: WebCommChannel<TYPES, NODE, MEMBERSHIP> =
+            WebCommChannel::new(underlying_quorum_network.clone().into());
 
-        let view_sync_network: WebCommChannel<
-            TYPES,
-            NODE,
-            ViewSyncCertificate<TYPES>,
-            ViewSyncVote<TYPES>,
-            MEMBERSHIP,
-        > = WebCommChannel::new(underlying_quorum_network.into());
+        let view_sync_network: WebCommChannel<TYPES, NODE, MEMBERSHIP> =
+            WebCommChannel::new(underlying_quorum_network.into());
 
         let WebServerConfig {
             host,
@@ -563,17 +496,10 @@ where
         }: WebServerConfig = config.clone().da_web_server_config.unwrap();
 
         // Each node runs the DA network so that leaders have access to transactions and DA votes
-        let da_network: WebCommChannel<TYPES, NODE, DAProposal<TYPES>, DAVote<TYPES>, MEMBERSHIP> =
-            WebCommChannel::new(
-                WebServerNetwork::create(
-                    &host.to_string(),
-                    port,
-                    wait_between_polls,
-                    pub_key,
-                    true,
-                )
+        let da_network: WebCommChannel<TYPES, NODE, MEMBERSHIP> = WebCommChannel::new(
+            WebServerNetwork::create(&host.to_string(), port, wait_between_polls, pub_key, true)
                 .into(),
-            );
+        );
 
         WebServerDARun {
             config,
@@ -583,28 +509,15 @@ where
         }
     }
 
-    fn get_da_network(
-        &self,
-    ) -> WebCommChannel<TYPES, NODE, DAProposal<TYPES>, DAVote<TYPES>, MEMBERSHIP> {
+    fn get_da_network(&self) -> WebCommChannel<TYPES, NODE, MEMBERSHIP> {
         self.da_network.clone()
     }
 
-    fn get_quorum_network(
-        &self,
-    ) -> WebCommChannel<
-        TYPES,
-        NODE,
-        QuorumProposal<TYPES, SequencingLeaf<TYPES>>,
-        QuorumVote<TYPES, SequencingLeaf<TYPES>>,
-        MEMBERSHIP,
-    > {
+    fn get_quorum_network(&self) -> WebCommChannel<TYPES, NODE, MEMBERSHIP> {
         self.quorum_network.clone()
     }
 
-    fn get_view_sync_network(
-        &self,
-    ) -> WebCommChannel<TYPES, NODE, ViewSyncCertificate<TYPES>, ViewSyncVote<TYPES>, MEMBERSHIP>
-    {
+    fn get_view_sync_network(&self) -> WebCommChannel<TYPES, NODE, MEMBERSHIP> {
         self.view_sync_network.clone()
     }
 
@@ -623,27 +536,9 @@ where
 pub async fn main_entry_point<
     TYPES: NodeType,
     MEMBERSHIP: Membership<TYPES> + Debug,
-    DANETWORK: CommunicationChannel<
-            TYPES,
-            Message<TYPES, NODE>,
-            DAProposal<TYPES>,
-            DAVote<TYPES>,
-            MEMBERSHIP,
-        > + Debug,
-    QUORUMNETWORK: CommunicationChannel<
-            TYPES,
-            Message<TYPES, NODE>,
-            QuorumProposal<TYPES, SequencingLeaf<TYPES>>,
-            QuorumVote<TYPES, SequencingLeaf<TYPES>>,
-            MEMBERSHIP,
-        > + Debug,
-    VIEWSYNCNETWORK: CommunicationChannel<
-            TYPES,
-            Message<TYPES, NODE>,
-            ViewSyncCertificate<TYPES>,
-            ViewSyncVote<TYPES>,
-            MEMBERSHIP,
-        > + Debug,
+    DANETWORK: CommunicationChannel<TYPES, Message<TYPES, NODE>, MEMBERSHIP> + Debug,
+    QUORUMNETWORK: CommunicationChannel<TYPES, Message<TYPES, NODE>, MEMBERSHIP> + Debug,
+    VIEWSYNCNETWORK: CommunicationChannel<TYPES, Message<TYPES, NODE>, MEMBERSHIP> + Debug,
     NODE: NodeImplementation<
         TYPES,
         Leaf = SequencingLeaf<TYPES>,

--- a/crates/hotshot/examples/web-server-da/types.rs
+++ b/crates/hotshot/examples/web-server-da/types.rs
@@ -25,12 +25,9 @@ pub struct NodeImpl {}
 pub type ThisLeaf = SequencingLeaf<SDemoTypes>;
 pub type ThisMembership =
     GeneralStaticCommittee<SDemoTypes, ThisLeaf, <SDemoTypes as NodeType>::SignatureKey>;
-pub type DANetwork =
-    WebCommChannel<SDemoTypes, NodeImpl, ThisDAProposal, ThisDAVote, ThisMembership>;
-pub type QuorumNetwork =
-    WebCommChannel<SDemoTypes, NodeImpl, ThisQuorumProposal, ThisQuorumVote, ThisMembership>;
-pub type ViewSyncNetwork =
-    WebCommChannel<SDemoTypes, NodeImpl, ThisViewSyncProposal, ThisViewSyncVote, ThisMembership>;
+pub type DANetwork = WebCommChannel<SDemoTypes, NodeImpl, ThisMembership>;
+pub type QuorumNetwork = WebCommChannel<SDemoTypes, NodeImpl, ThisMembership>;
+pub type ViewSyncNetwork = WebCommChannel<SDemoTypes, NodeImpl, ThisMembership>;
 
 pub type ThisDAProposal = DAProposal<SDemoTypes>;
 pub type ThisDAVote = DAVote<SDemoTypes>;

--- a/crates/hotshot/src/lib.rs
+++ b/crates/hotshot/src/lib.rs
@@ -59,7 +59,7 @@ use hotshot_task_impls::{events::SequencingHotShotEvent, network::NetworkTaskKin
 use hotshot_types::{
     certificate::{DACertificate, ViewSyncCertificate},
     consensus::{BlockStore, Consensus, ConsensusMetrics, View, ViewInner, ViewQueue},
-    data::{DAProposal, DeltasType, LeafType, ProposalType, QuorumProposal, SequencingLeaf},
+    data::{DAProposal, DeltasType, LeafType, QuorumProposal, SequencingLeaf},
     error::StorageSnafu,
     message::{
         ConsensusMessageType, DataMessage, InternalTrigger, Message, MessageKind,
@@ -79,7 +79,7 @@ use hotshot_types::{
         storage::StoredView,
         State,
     },
-    vote::{ViewSyncData, VoteType},
+    vote::ViewSyncData,
     HotShotConfig,
 };
 use snafu::ResultExt;
@@ -936,10 +936,7 @@ impl<
         I: NodeImplementation<TYPES, ConsensusMessage = SequencingMessage<TYPES, I>>,
     > SequencingConsensusApi<TYPES, I::Leaf, I> for HotShotSequencingConsensusApi<TYPES, I>
 {
-    async fn send_direct_message<
-        PROPOSAL: ProposalType<NodeType = TYPES>,
-        VOTE: VoteType<TYPES>,
-    >(
+    async fn send_direct_message(
         &self,
         recipient: TYPES::SignatureKey,
         message: SequencingMessage<TYPES, I>,
@@ -964,10 +961,7 @@ impl<
         Ok(())
     }
 
-    async fn send_direct_da_message<
-        PROPOSAL: ProposalType<NodeType = TYPES>,
-        VOTE: VoteType<TYPES>,
-    >(
+    async fn send_direct_da_message(
         &self,
         recipient: TYPES::SignatureKey,
         message: SequencingMessage<TYPES, I>,
@@ -994,10 +988,7 @@ impl<
 
     // TODO (DA) Refactor ConsensusApi and HotShot to use SystemContextInner directly.
     // <https://github.com/EspressoSystems/HotShot/issues/1194>
-    async fn send_broadcast_message<
-        PROPOSAL: ProposalType<NodeType = TYPES>,
-        VOTE: VoteType<TYPES>,
-    >(
+    async fn send_broadcast_message(
         &self,
         message: SequencingMessage<TYPES, I>,
     ) -> std::result::Result<(), NetworkError> {

--- a/crates/hotshot/src/tasks/mod.rs
+++ b/crates/hotshot/src/tasks/mod.rs
@@ -148,7 +148,7 @@ pub async fn add_network_message_task<
 // This bound is required so that we can call the `recv_msgs` function of `CommunicationChannel`.
 where
     EXCHANGE::Networking:
-        CommunicationChannel<TYPES, Message<TYPES, I>, PROPOSAL, VOTE, MEMBERSHIP>,
+        CommunicationChannel<TYPES, Message<TYPES, I>,  MEMBERSHIP>,
 {
     let channel = exchange.network().clone();
     let broadcast_stream = GeneratedStream::<Messages<TYPES, I>>::new(Arc::new(move || {
@@ -259,13 +259,12 @@ pub async fn add_network_event_task<
 // This bound is required so that we can call the `recv_msgs` function of `CommunicationChannel`.
 where
     EXCHANGE::Networking:
-        CommunicationChannel<TYPES, Message<TYPES, I>, PROPOSAL, VOTE, MEMBERSHIP>,
+        CommunicationChannel<TYPES, Message<TYPES, I>,  MEMBERSHIP>,
 {
     let filter = NetworkEventTaskState::<
         TYPES,
         I,
-        PROPOSAL,
-        VOTE,
+
         MEMBERSHIP,
         <EXCHANGE as ConsensusExchange<_, _>>::Networking,
     >::filter(task_kind);

--- a/crates/hotshot/src/traits/networking/libp2p_network.rs
+++ b/crates/hotshot/src/traits/networking/libp2p_network.rs
@@ -715,21 +715,14 @@ impl<M: NetworkMsg, K: SignatureKey + 'static> ConnectedNetwork<M, K> for Libp2p
 pub struct Libp2pCommChannel<
     TYPES: NodeType,
     I: NodeImplementation<TYPES>,
-    PROPOSAL: ProposalType<NodeType = TYPES>,
-    VOTE: VoteType<TYPES>,
     MEMBERSHIP: Membership<TYPES>,
 >(
     Arc<Libp2pNetwork<Message<TYPES, I>, TYPES::SignatureKey>>,
-    PhantomData<(TYPES, I, PROPOSAL, VOTE, MEMBERSHIP)>,
+    PhantomData<(TYPES, I, MEMBERSHIP)>,
 );
 
-impl<
-        TYPES: NodeType,
-        I: NodeImplementation<TYPES>,
-        PROPOSAL: ProposalType<NodeType = TYPES>,
-        VOTE: VoteType<TYPES>,
-        MEMBERSHIP: Membership<TYPES>,
-    > Libp2pCommChannel<TYPES, I, PROPOSAL, VOTE, MEMBERSHIP>
+impl<TYPES: NodeType, I: NodeImplementation<TYPES>, MEMBERSHIP: Membership<TYPES>>
+    Libp2pCommChannel<TYPES, I, MEMBERSHIP>
 {
     /// create a new libp2p communication channel
     #[must_use]
@@ -741,11 +734,10 @@ impl<
 impl<
         TYPES: NodeType,
         I: NodeImplementation<TYPES>,
-        PROPOSAL: ProposalType<NodeType = TYPES>,
-        VOTE: VoteType<TYPES>,
+      
         MEMBERSHIP: Membership<TYPES>,
     > TestableNetworkingImplementation<TYPES, Message<TYPES, I>>
-    for Libp2pCommChannel<TYPES, I, PROPOSAL, VOTE, MEMBERSHIP>
+    for Libp2pCommChannel<TYPES, I,  MEMBERSHIP>
 where
     MessageKind<TYPES, I>: ViewMessage<TYPES>,
 {
@@ -787,14 +779,9 @@ where
 // top
 // we don't really want to make this the default implementation because that forces it to require ConnectedNetwork to be implemented. The struct we implement over might use multiple ConnectedNetworks
 #[async_trait]
-impl<
-        TYPES: NodeType,
-        I: NodeImplementation<TYPES>,
-        PROPOSAL: ProposalType<NodeType = TYPES>,
-        VOTE: VoteType<TYPES>,
-        MEMBERSHIP: Membership<TYPES>,
-    > CommunicationChannel<TYPES, Message<TYPES, I>, PROPOSAL, VOTE, MEMBERSHIP>
-    for Libp2pCommChannel<TYPES, I, PROPOSAL, VOTE, MEMBERSHIP>
+impl<TYPES: NodeType, I: NodeImplementation<TYPES>, MEMBERSHIP: Membership<TYPES>>
+    CommunicationChannel<TYPES, Message<TYPES, I>, MEMBERSHIP>
+    for Libp2pCommChannel<TYPES, I, MEMBERSHIP>
 where
     MessageKind<TYPES, I>: ViewMessage<TYPES>,
 {
@@ -860,21 +847,13 @@ where
     }
 }
 
-impl<
-        TYPES: NodeType,
-        I: NodeImplementation<TYPES>,
-        PROPOSAL: ProposalType<NodeType = TYPES>,
-        VOTE: VoteType<TYPES>,
-        MEMBERSHIP: Membership<TYPES>,
-    >
+impl<TYPES: NodeType, I: NodeImplementation<TYPES>, MEMBERSHIP: Membership<TYPES>>
     TestableChannelImplementation<
         TYPES,
         Message<TYPES, I>,
-        PROPOSAL,
-        VOTE,
         MEMBERSHIP,
         Libp2pNetwork<Message<TYPES, I>, TYPES::SignatureKey>,
-    > for Libp2pCommChannel<TYPES, I, PROPOSAL, VOTE, MEMBERSHIP>
+    > for Libp2pCommChannel<TYPES, I, MEMBERSHIP>
 {
     fn generate_network(
     ) -> Box<dyn Fn(Arc<Libp2pNetwork<Message<TYPES, I>, TYPES::SignatureKey>>) -> Self + 'static>

--- a/crates/hotshot/src/traits/networking/libp2p_network.rs
+++ b/crates/hotshot/src/traits/networking/libp2p_network.rs
@@ -14,7 +14,6 @@ use bimap::BiHashMap;
 use bincode::Options;
 use hotshot_task::{boxed_sync, BoxSyncFuture};
 use hotshot_types::{
-    data::ProposalType,
     message::{Message, MessageKind},
     traits::{
         election::Membership,
@@ -27,7 +26,6 @@ use hotshot_types::{
         node_implementation::NodeType,
         signature_key::SignatureKey,
     },
-    vote::VoteType,
 };
 use hotshot_utils::bincode::bincode_opts;
 use libp2p_identity::PeerId;
@@ -731,13 +729,9 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, MEMBERSHIP: Membership<TYPES
     }
 }
 
-impl<
-        TYPES: NodeType,
-        I: NodeImplementation<TYPES>,
-      
-        MEMBERSHIP: Membership<TYPES>,
-    > TestableNetworkingImplementation<TYPES, Message<TYPES, I>>
-    for Libp2pCommChannel<TYPES, I,  MEMBERSHIP>
+impl<TYPES: NodeType, I: NodeImplementation<TYPES>, MEMBERSHIP: Membership<TYPES>>
+    TestableNetworkingImplementation<TYPES, Message<TYPES, I>>
+    for Libp2pCommChannel<TYPES, I, MEMBERSHIP>
 where
     MessageKind<TYPES, I>: ViewMessage<TYPES>,
 {

--- a/crates/hotshot/src/traits/networking/memory_network.rs
+++ b/crates/hotshot/src/traits/networking/memory_network.rs
@@ -465,21 +465,18 @@ impl<M: NetworkMsg, K: SignatureKey + 'static> ConnectedNetwork<M, K> for Memory
 pub struct MemoryCommChannel<
     TYPES: NodeType,
     I: NodeImplementation<TYPES>,
-    PROPOSAL: ProposalType<NodeType = TYPES>,
-    VOTE: VoteType<TYPES>,
     MEMBERSHIP: Membership<TYPES>,
 >(
     Arc<MemoryNetwork<Message<TYPES, I>, TYPES::SignatureKey>>,
-    PhantomData<(I, PROPOSAL, VOTE, MEMBERSHIP)>,
+    PhantomData<(I, MEMBERSHIP)>,
 );
 
 impl<
         TYPES: NodeType,
         I: NodeImplementation<TYPES>,
-        PROPOSAL: ProposalType<NodeType = TYPES>,
-        VOTE: VoteType<TYPES>,
+     
         MEMBERSHIP: Membership<TYPES>,
-    > MemoryCommChannel<TYPES, I, PROPOSAL, VOTE, MEMBERSHIP>
+    > MemoryCommChannel<TYPES, I,  MEMBERSHIP>
 {
     /// create new communication channel
     #[must_use]
@@ -488,14 +485,9 @@ impl<
     }
 }
 
-impl<
-        TYPES: NodeType,
-        I: NodeImplementation<TYPES>,
-        PROPOSAL: ProposalType<NodeType = TYPES>,
-        VOTE: VoteType<TYPES>,
-        MEMBERSHIP: Membership<TYPES>,
-    > TestableNetworkingImplementation<TYPES, Message<TYPES, I>>
-    for MemoryCommChannel<TYPES, I, PROPOSAL, VOTE, MEMBERSHIP>
+impl<TYPES: NodeType, I: NodeImplementation<TYPES>, MEMBERSHIP: Membership<TYPES>>
+    TestableNetworkingImplementation<TYPES, Message<TYPES, I>>
+    for MemoryCommChannel<TYPES, I, MEMBERSHIP>
 where
     MessageKind<TYPES, I>: ViewMessage<TYPES>,
 {
@@ -525,14 +517,9 @@ where
 }
 
 #[async_trait]
-impl<
-        TYPES: NodeType,
-        I: NodeImplementation<TYPES>,
-        PROPOSAL: ProposalType<NodeType = TYPES>,
-        VOTE: VoteType<TYPES>,
-        MEMBERSHIP: Membership<TYPES>,
-    > CommunicationChannel<TYPES, Message<TYPES, I>, PROPOSAL, VOTE, MEMBERSHIP>
-    for MemoryCommChannel<TYPES, I, PROPOSAL, VOTE, MEMBERSHIP>
+impl<TYPES: NodeType, I: NodeImplementation<TYPES>, MEMBERSHIP: Membership<TYPES>>
+    CommunicationChannel<TYPES, Message<TYPES, I>, MEMBERSHIP>
+    for MemoryCommChannel<TYPES, I, MEMBERSHIP>
 where
     MessageKind<TYPES, I>: ViewMessage<TYPES>,
 {
@@ -598,21 +585,13 @@ where
     }
 }
 
-impl<
-        TYPES: NodeType,
-        I: NodeImplementation<TYPES>,
-        PROPOSAL: ProposalType<NodeType = TYPES>,
-        VOTE: VoteType<TYPES>,
-        MEMBERSHIP: Membership<TYPES>,
-    >
+impl<TYPES: NodeType, I: NodeImplementation<TYPES>, MEMBERSHIP: Membership<TYPES>>
     TestableChannelImplementation<
         TYPES,
         Message<TYPES, I>,
-        PROPOSAL,
-        VOTE,
         MEMBERSHIP,
         MemoryNetwork<Message<TYPES, I>, TYPES::SignatureKey>,
-    > for MemoryCommChannel<TYPES, I, PROPOSAL, VOTE, MEMBERSHIP>
+    > for MemoryCommChannel<TYPES, I, MEMBERSHIP>
 {
     fn generate_network(
     ) -> Box<dyn Fn(Arc<MemoryNetwork<Message<TYPES, I>, TYPES::SignatureKey>>) -> Self + 'static>

--- a/crates/hotshot/src/traits/networking/memory_network.rs
+++ b/crates/hotshot/src/traits/networking/memory_network.rs
@@ -16,7 +16,6 @@ use dashmap::DashMap;
 use futures::StreamExt;
 use hotshot_task::{boxed_sync, BoxSyncFuture};
 use hotshot_types::{
-    data::ProposalType,
     message::{Message, MessageKind},
     traits::{
         election::Membership,
@@ -29,7 +28,6 @@ use hotshot_types::{
         node_implementation::NodeType,
         signature_key::SignatureKey,
     },
-    vote::VoteType,
 };
 use hotshot_utils::bincode::bincode_opts;
 use rand::Rng;
@@ -471,12 +469,8 @@ pub struct MemoryCommChannel<
     PhantomData<(I, MEMBERSHIP)>,
 );
 
-impl<
-        TYPES: NodeType,
-        I: NodeImplementation<TYPES>,
-     
-        MEMBERSHIP: Membership<TYPES>,
-    > MemoryCommChannel<TYPES, I,  MEMBERSHIP>
+impl<TYPES: NodeType, I: NodeImplementation<TYPES>, MEMBERSHIP: Membership<TYPES>>
+    MemoryCommChannel<TYPES, I, MEMBERSHIP>
 {
     /// create new communication channel
     #[must_use]

--- a/crates/hotshot/src/traits/networking/web_server_libp2p_fallback.rs
+++ b/crates/hotshot/src/traits/networking/web_server_libp2p_fallback.rs
@@ -12,7 +12,6 @@ use futures::join;
 
 use hotshot_task::{boxed_sync, BoxSyncFuture};
 use hotshot_types::{
-    data::ProposalType,
     message::Message,
     traits::{
         election::Membership,
@@ -23,7 +22,6 @@ use hotshot_types::{
         },
         node_implementation::NodeType,
     },
-    vote::VoteType,
 };
 use std::{marker::PhantomData, sync::Arc};
 use tracing::error;
@@ -155,13 +153,8 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, MEMBERSHIP: Membership<TYPES
 }
 
 #[async_trait]
-impl<
-        TYPES: NodeType,
-        I: NodeImplementation<TYPES>,
-        PROPOSAL: ProposalType<NodeType = TYPES>,
-        VOTE: VoteType<TYPES>,
-        MEMBERSHIP: Membership<TYPES>,
-    > CommunicationChannel<TYPES, Message<TYPES, I>,MEMBERSHIP>
+impl<TYPES: NodeType, I: NodeImplementation<TYPES>, MEMBERSHIP: Membership<TYPES>>
+    CommunicationChannel<TYPES, Message<TYPES, I>, MEMBERSHIP>
     for WebServerWithFallbackCommChannel<TYPES, I, MEMBERSHIP>
 {
     type NETWORK = CombinedNetworks<TYPES, I, MEMBERSHIP>;
@@ -296,16 +289,10 @@ impl<
     }
 }
 
-impl<
-        TYPES: NodeType,
-        I: NodeImplementation<TYPES>,
-       
-        MEMBERSHIP: Membership<TYPES>,
-    >
+impl<TYPES: NodeType, I: NodeImplementation<TYPES>, MEMBERSHIP: Membership<TYPES>>
     TestableChannelImplementation<
         TYPES,
         Message<TYPES, I>,
-    
         MEMBERSHIP,
         CombinedNetworks<TYPES, I, MEMBERSHIP>,
     > for WebServerWithFallbackCommChannel<TYPES, I, MEMBERSHIP>

--- a/crates/hotshot/src/traits/networking/web_server_libp2p_fallback.rs
+++ b/crates/hotshot/src/traits/networking/web_server_libp2p_fallback.rs
@@ -161,7 +161,7 @@ impl<
         PROPOSAL: ProposalType<NodeType = TYPES>,
         VOTE: VoteType<TYPES>,
         MEMBERSHIP: Membership<TYPES>,
-    > CommunicationChannel<TYPES, Message<TYPES, I>, PROPOSAL, VOTE, MEMBERSHIP>
+    > CommunicationChannel<TYPES, Message<TYPES, I>,MEMBERSHIP>
     for WebServerWithFallbackCommChannel<TYPES, I, MEMBERSHIP>
 {
     type NETWORK = CombinedNetworks<TYPES, I, MEMBERSHIP>;
@@ -299,15 +299,13 @@ impl<
 impl<
         TYPES: NodeType,
         I: NodeImplementation<TYPES>,
-        PROPOSAL: ProposalType<NodeType = TYPES>,
-        VOTE: VoteType<TYPES>,
+       
         MEMBERSHIP: Membership<TYPES>,
     >
     TestableChannelImplementation<
         TYPES,
         Message<TYPES, I>,
-        PROPOSAL,
-        VOTE,
+    
         MEMBERSHIP,
         CombinedNetworks<TYPES, I, MEMBERSHIP>,
     > for WebServerWithFallbackCommChannel<TYPES, I, MEMBERSHIP>

--- a/crates/hotshot/src/traits/networking/web_server_network.rs
+++ b/crates/hotshot/src/traits/networking/web_server_network.rs
@@ -13,7 +13,6 @@ use async_lock::RwLock;
 use async_trait::async_trait;
 use hotshot_task::{boxed_sync, BoxSyncFuture};
 use hotshot_types::{
-    data::ProposalType,
     message::{Message, MessagePurpose},
     traits::{
         election::Membership,
@@ -25,7 +24,6 @@ use hotshot_types::{
         node_implementation::{NodeImplementation, NodeType},
         signature_key::SignatureKey,
     },
-    vote::VoteType,
 };
 use hotshot_web_server::{self, config};
 use rand::random;
@@ -54,12 +52,8 @@ pub struct WebCommChannel<
     PhantomData<(MEMBERSHIP, I)>,
 );
 
-impl<
-        TYPES: NodeType,
-        I: NodeImplementation<TYPES>,
-
-        MEMBERSHIP: Membership<TYPES>,
-    > WebCommChannel<TYPES, I,  MEMBERSHIP>
+impl<TYPES: NodeType, I: NodeImplementation<TYPES>, MEMBERSHIP: Membership<TYPES>>
+    WebCommChannel<TYPES, I, MEMBERSHIP>
 {
     /// Create new communication channel
     #[must_use]
@@ -515,13 +509,9 @@ impl<
 }
 
 #[async_trait]
-impl<
-        TYPES: NodeType,
-        I: NodeImplementation<TYPES>,
-
-        MEMBERSHIP: Membership<TYPES>,
-    > CommunicationChannel<TYPES, Message<TYPES, I>,  MEMBERSHIP>
-    for WebCommChannel<TYPES, I,  MEMBERSHIP>
+impl<TYPES: NodeType, I: NodeImplementation<TYPES>, MEMBERSHIP: Membership<TYPES>>
+    CommunicationChannel<TYPES, Message<TYPES, I>, MEMBERSHIP>
+    for WebCommChannel<TYPES, I, MEMBERSHIP>
 {
     type NETWORK = WebServerNetwork<Message<TYPES, I>, TYPES::SignatureKey, TYPES>;
     /// Blocks until node is successfully initialized
@@ -1048,13 +1038,9 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>>
     }
 }
 
-impl<
-        TYPES: NodeType,
-        I: NodeImplementation<TYPES>,
-
-        MEMBERSHIP: Membership<TYPES>,
-    > TestableNetworkingImplementation<TYPES, Message<TYPES, I>>
-    for WebCommChannel<TYPES, I,  MEMBERSHIP>
+impl<TYPES: NodeType, I: NodeImplementation<TYPES>, MEMBERSHIP: Membership<TYPES>>
+    TestableNetworkingImplementation<TYPES, Message<TYPES, I>>
+    for WebCommChannel<TYPES, I, MEMBERSHIP>
 {
     fn generator(
         expected_node_count: usize,

--- a/crates/hotshot/src/traits/networking/web_server_network.rs
+++ b/crates/hotshot/src/traits/networking/web_server_network.rs
@@ -48,21 +48,18 @@ use tracing::{debug, error, info};
 pub struct WebCommChannel<
     TYPES: NodeType,
     I: NodeImplementation<TYPES>,
-    PROPOSAL: ProposalType<NodeType = TYPES>,
-    VOTE: VoteType<TYPES>,
     MEMBERSHIP: Membership<TYPES>,
 >(
     Arc<WebServerNetwork<Message<TYPES, I>, TYPES::SignatureKey, TYPES>>,
-    PhantomData<(MEMBERSHIP, I, PROPOSAL, VOTE)>,
+    PhantomData<(MEMBERSHIP, I)>,
 );
 
 impl<
         TYPES: NodeType,
         I: NodeImplementation<TYPES>,
-        PROPOSAL: ProposalType<NodeType = TYPES>,
-        VOTE: VoteType<TYPES>,
+
         MEMBERSHIP: Membership<TYPES>,
-    > WebCommChannel<TYPES, I, PROPOSAL, VOTE, MEMBERSHIP>
+    > WebCommChannel<TYPES, I,  MEMBERSHIP>
 {
     /// Create new communication channel
     #[must_use]
@@ -521,11 +518,10 @@ impl<
 impl<
         TYPES: NodeType,
         I: NodeImplementation<TYPES>,
-        PROPOSAL: ProposalType<NodeType = TYPES>,
-        VOTE: VoteType<TYPES>,
+
         MEMBERSHIP: Membership<TYPES>,
-    > CommunicationChannel<TYPES, Message<TYPES, I>, PROPOSAL, VOTE, MEMBERSHIP>
-    for WebCommChannel<TYPES, I, PROPOSAL, VOTE, MEMBERSHIP>
+    > CommunicationChannel<TYPES, Message<TYPES, I>,  MEMBERSHIP>
+    for WebCommChannel<TYPES, I,  MEMBERSHIP>
 {
     type NETWORK = WebServerNetwork<Message<TYPES, I>, TYPES::SignatureKey, TYPES>;
     /// Blocks until node is successfully initialized
@@ -1055,11 +1051,10 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>>
 impl<
         TYPES: NodeType,
         I: NodeImplementation<TYPES>,
-        PROPOSAL: ProposalType<NodeType = TYPES>,
-        VOTE: VoteType<TYPES>,
+
         MEMBERSHIP: Membership<TYPES>,
     > TestableNetworkingImplementation<TYPES, Message<TYPES, I>>
-    for WebCommChannel<TYPES, I, PROPOSAL, VOTE, MEMBERSHIP>
+    for WebCommChannel<TYPES, I,  MEMBERSHIP>
 {
     fn generator(
         expected_node_count: usize,
@@ -1087,21 +1082,13 @@ impl<
     }
 }
 
-impl<
-        TYPES: NodeType,
-        I: NodeImplementation<TYPES>,
-        PROPOSAL: ProposalType<NodeType = TYPES>,
-        VOTE: VoteType<TYPES>,
-        MEMBERSHIP: Membership<TYPES>,
-    >
+impl<TYPES: NodeType, I: NodeImplementation<TYPES>, MEMBERSHIP: Membership<TYPES>>
     TestableChannelImplementation<
         TYPES,
         Message<TYPES, I>,
-        PROPOSAL,
-        VOTE,
         MEMBERSHIP,
         WebServerNetwork<Message<TYPES, I>, TYPES::SignatureKey, TYPES>,
-    > for WebCommChannel<TYPES, I, PROPOSAL, VOTE, MEMBERSHIP>
+    > for WebCommChannel<TYPES, I, MEMBERSHIP>
 {
     fn generate_network() -> Box<
         dyn Fn(Arc<WebServerNetwork<Message<TYPES, I>, TYPES::SignatureKey, TYPES>>) -> Self

--- a/crates/task-impls/src/consensus.rs
+++ b/crates/task-impls/src/consensus.rs
@@ -368,7 +368,7 @@ where
                         if let GeneralConsensusMessage::Vote(vote) = message {
                             debug!(
                                 "Sending vote to next quorum leader {:?}",
-                                vote.current_view()
+                                vote.get_view()
                             );
                             self.event_stream
                                 .publish(SequencingHotShotEvent::QuorumVoteSend(vote))
@@ -446,7 +446,7 @@ where
                         if let GeneralConsensusMessage::Vote(vote) = message {
                             debug!(
                                 "Sending vote to next quorum leader {:?}",
-                                vote.current_view()
+                                vote.get_view()
                             );
                             self.event_stream
                                 .publish(SequencingHotShotEvent::QuorumVoteSend(vote))
@@ -890,13 +890,13 @@ where
                 }
             }
             SequencingHotShotEvent::QuorumVoteRecv(vote) => {
-                debug!("Received quroum vote: {:?}", vote.current_view());
+                debug!("Received quroum vote: {:?}", vote.get_view());
 
-                if !self.quorum_exchange.is_leader(vote.current_view() + 1) {
+                if !self.quorum_exchange.is_leader(vote.get_view() + 1) {
                     error!(
                         "We are not the leader for view {} are we the leader for view + 1? {}",
-                        *vote.current_view() + 1,
-                        self.quorum_exchange.is_leader(vote.current_view() + 2)
+                        *vote.get_view() + 1,
+                        self.quorum_exchange.is_leader(vote.get_view() + 2)
                     );
                     return;
                 }

--- a/crates/task-impls/src/consensus.rs
+++ b/crates/task-impls/src/consensus.rs
@@ -366,10 +366,7 @@ where
                             );
 
                         if let GeneralConsensusMessage::Vote(vote) = message {
-                            debug!(
-                                "Sending vote to next quorum leader {:?}",
-                                vote.get_view()
-                            );
+                            debug!("Sending vote to next quorum leader {:?}", vote.get_view());
                             self.event_stream
                                 .publish(SequencingHotShotEvent::QuorumVoteSend(vote))
                                 .await;
@@ -444,10 +441,7 @@ where
 
                         // TODO ED Only publish event in vote if able
                         if let GeneralConsensusMessage::Vote(vote) = message {
-                            debug!(
-                                "Sending vote to next quorum leader {:?}",
-                                vote.get_view()
-                            );
+                            debug!("Sending vote to next quorum leader {:?}", vote.get_view());
                             self.event_stream
                                 .publish(SequencingHotShotEvent::QuorumVoteSend(vote))
                                 .await;

--- a/crates/task-impls/src/da.rs
+++ b/crates/task-impls/src/da.rs
@@ -108,6 +108,8 @@ pub struct DAVoteCollectionTaskState<
     pub accumulator:
         Either<VoteAccumulator<TYPES::VoteTokenType, TYPES::BlockType>, DACertificate<TYPES>>,
 
+    /// The accumulator
+    #[allow(clippy::type_complexity)]
     pub accumulator2: Either<
         <DACertificate<TYPES> as SignedCertificate<
             TYPES,
@@ -393,13 +395,13 @@ where
                     None,
                 );
                 let accumulator2 = AccumulatorPlaceholder {
-                    phantom: PhantomData::default(),
+                    phantom: PhantomData,
                 };
                 if view > collection_view {
                     let state = DAVoteCollectionTaskState {
                         committee_exchange: self.committee_exchange.clone(),
                         accumulator,
-                        accumulator2: either::Left(accumulator2), 
+                        accumulator2: either::Left(accumulator2),
                         cur_view: view,
                         event_stream: self.event_stream.clone(),
                         id: self.id,

--- a/crates/task-impls/src/network.rs
+++ b/crates/task-impls/src/network.rs
@@ -137,10 +137,8 @@ pub struct NetworkEventTaskState<
         Leaf = SequencingLeaf<TYPES>,
         ConsensusMessage = SequencingMessage<TYPES, I>,
     >,
-    PROPOSAL: ProposalType<NodeType = TYPES>,
-    VOTE: VoteType<TYPES>,
     MEMBERSHIP: Membership<TYPES>,
-    COMMCHANNEL: CommunicationChannel<TYPES, Message<TYPES, I>, PROPOSAL, VOTE, MEMBERSHIP>,
+    COMMCHANNEL: CommunicationChannel<TYPES, Message<TYPES, I>, MEMBERSHIP>,
 > {
     /// comm channel
     pub channel: COMMCHANNEL,
@@ -149,7 +147,7 @@ pub struct NetworkEventTaskState<
     /// view number
     pub view: TYPES::Time,
     /// phantom data
-    pub phantom: PhantomData<(PROPOSAL, VOTE, MEMBERSHIP)>,
+    pub phantom: PhantomData<(MEMBERSHIP)>,
     // TODO ED Need to add exchange so we can get the recipient key and our own key?
 }
 
@@ -160,11 +158,9 @@ impl<
             Leaf = SequencingLeaf<TYPES>,
             ConsensusMessage = SequencingMessage<TYPES, I>,
         >,
-        PROPOSAL: ProposalType<NodeType = TYPES>,
-        VOTE: VoteType<TYPES>,
         MEMBERSHIP: Membership<TYPES>,
-        COMMCHANNEL: CommunicationChannel<TYPES, Message<TYPES, I>, PROPOSAL, VOTE, MEMBERSHIP>,
-    > TS for NetworkEventTaskState<TYPES, I, PROPOSAL, VOTE, MEMBERSHIP, COMMCHANNEL>
+        COMMCHANNEL: CommunicationChannel<TYPES, Message<TYPES, I>, MEMBERSHIP>,
+    > TS for NetworkEventTaskState<TYPES, I, MEMBERSHIP, COMMCHANNEL>
 {
 }
 
@@ -175,11 +171,9 @@ impl<
             Leaf = SequencingLeaf<TYPES>,
             ConsensusMessage = SequencingMessage<TYPES, I>,
         >,
-        PROPOSAL: ProposalType<NodeType = TYPES>,
-        VOTE: VoteType<TYPES>,
         MEMBERSHIP: Membership<TYPES>,
-        COMMCHANNEL: CommunicationChannel<TYPES, Message<TYPES, I>, PROPOSAL, VOTE, MEMBERSHIP>,
-    > NetworkEventTaskState<TYPES, I, PROPOSAL, VOTE, MEMBERSHIP, COMMCHANNEL>
+        COMMCHANNEL: CommunicationChannel<TYPES, Message<TYPES, I>, MEMBERSHIP>,
+    > NetworkEventTaskState<TYPES, I, MEMBERSHIP, COMMCHANNEL>
 {
     /// Handle the given event.
     ///
@@ -348,9 +342,9 @@ pub type NetworkMessageTaskTypes<TYPES, I> = HSTWithMessage<
 >;
 
 /// network event task types
-pub type NetworkEventTaskTypes<TYPES, I, PROPOSAL, VOTE, MEMBERSHIP, COMMCHANNEL> = HSTWithEvent<
+pub type NetworkEventTaskTypes<TYPES, I, MEMBERSHIP, COMMCHANNEL> = HSTWithEvent<
     NetworkTaskError,
     SequencingHotShotEvent<TYPES, I>,
     ChannelStream<SequencingHotShotEvent<TYPES, I>>,
-    NetworkEventTaskState<TYPES, I, PROPOSAL, VOTE, MEMBERSHIP, COMMCHANNEL>,
+    NetworkEventTaskState<TYPES, I, MEMBERSHIP, COMMCHANNEL>,
 >;

--- a/crates/task-impls/src/network.rs
+++ b/crates/task-impls/src/network.rs
@@ -7,7 +7,7 @@ use hotshot_task::{
     GeneratedStream, Merge,
 };
 use hotshot_types::{
-    data::{ProposalType, SequencingLeaf},
+    data::SequencingLeaf,
     message::{
         CommitteeConsensusMessage, GeneralConsensusMessage, Message, MessageKind, Messages,
         SequencingMessage,
@@ -147,7 +147,7 @@ pub struct NetworkEventTaskState<
     /// view number
     pub view: TYPES::Time,
     /// phantom data
-    pub phantom: PhantomData<(MEMBERSHIP)>,
+    pub phantom: PhantomData<MEMBERSHIP>,
     // TODO ED Need to add exchange so we can get the recipient key and our own key?
 }
 

--- a/crates/task-impls/src/network.rs
+++ b/crates/task-impls/src/network.rs
@@ -208,7 +208,7 @@ impl<
                     GeneralConsensusMessage::Vote(vote.clone()),
                 ))),
                 TransmitType::Direct,
-                Some(membership.get_leader(vote.current_view() + 1)),
+                Some(membership.get_leader(vote.get_view() + 1)),
             ),
 
             SequencingHotShotEvent::DAProposalSend(proposal, sender) => (

--- a/crates/testing/src/node_types.rs
+++ b/crates/testing/src/node_types.rs
@@ -15,14 +15,13 @@ use hotshot::{
 };
 use hotshot_types::{
     certificate::ViewSyncCertificate,
-    data::{DAProposal, QuorumProposal, SequencingLeaf, ViewNumber},
+    data::{QuorumProposal, SequencingLeaf, ViewNumber},
     message::{Message, SequencingMessage},
     traits::{
         election::{CommitteeExchange, QuorumExchange, ViewSyncExchange},
         network::{TestableChannelImplementation, TestableNetworkingImplementation},
         node_implementation::{ChannelMaps, NodeType, SequencingExchanges, TestableExchange},
     },
-    vote::{DAVote, QuorumVote, ViewSyncVote},
 };
 use serde::{Deserialize, Serialize};
 
@@ -65,80 +64,33 @@ pub struct StaticFallbackImpl;
 pub type StaticMembership =
     StaticCommittee<SequencingTestTypes, SequencingLeaf<SequencingTestTypes>>;
 
-pub type StaticMemoryDAComm = MemoryCommChannel<
-    SequencingTestTypes,
-    SequencingMemoryImpl,
-    DAProposal<SequencingTestTypes>,
-    DAVote<SequencingTestTypes>,
-    StaticMembership,
->;
+pub type StaticMemoryDAComm =
+    MemoryCommChannel<SequencingTestTypes, SequencingMemoryImpl, StaticMembership>;
 
-type StaticLibp2pDAComm = Libp2pCommChannel<
-    SequencingTestTypes,
-    SequencingLibp2pImpl,
-    DAProposal<SequencingTestTypes>,
-    DAVote<SequencingTestTypes>,
-    StaticMembership,
->;
+type StaticLibp2pDAComm =
+    Libp2pCommChannel<SequencingTestTypes, SequencingLibp2pImpl, StaticMembership>;
 
-type StaticWebDAComm = WebCommChannel<
-    SequencingTestTypes,
-    SequencingWebImpl,
-    DAProposal<SequencingTestTypes>,
-    DAVote<SequencingTestTypes>,
-    StaticMembership,
->;
+type StaticWebDAComm = WebCommChannel<SequencingTestTypes, SequencingWebImpl, StaticMembership>;
 
 type StaticFallbackComm =
     WebServerWithFallbackCommChannel<SequencingTestTypes, StaticFallbackImpl, StaticMembership>;
 
-pub type StaticMemoryQuorumComm = MemoryCommChannel<
-    SequencingTestTypes,
-    SequencingMemoryImpl,
-    QuorumProposal<SequencingTestTypes, SequencingLeaf<SequencingTestTypes>>,
-    QuorumVote<SequencingTestTypes, SequencingLeaf<SequencingTestTypes>>,
-    StaticMembership,
->;
+pub type StaticMemoryQuorumComm =
+    MemoryCommChannel<SequencingTestTypes, SequencingMemoryImpl, StaticMembership>;
 
-type StaticLibp2pQuorumComm = Libp2pCommChannel<
-    SequencingTestTypes,
-    SequencingLibp2pImpl,
-    QuorumProposal<SequencingTestTypes, SequencingLeaf<SequencingTestTypes>>,
-    QuorumVote<SequencingTestTypes, SequencingLeaf<SequencingTestTypes>>,
-    StaticMembership,
->;
+type StaticLibp2pQuorumComm =
+    Libp2pCommChannel<SequencingTestTypes, SequencingLibp2pImpl, StaticMembership>;
 
-type StaticWebQuorumComm = WebCommChannel<
-    SequencingTestTypes,
-    SequencingWebImpl,
-    QuorumProposal<SequencingTestTypes, SequencingLeaf<SequencingTestTypes>>,
-    QuorumVote<SequencingTestTypes, SequencingLeaf<SequencingTestTypes>>,
-    StaticMembership,
->;
+type StaticWebQuorumComm = WebCommChannel<SequencingTestTypes, SequencingWebImpl, StaticMembership>;
 
-pub type StaticMemoryViewSyncComm = MemoryCommChannel<
-    SequencingTestTypes,
-    SequencingMemoryImpl,
-    ViewSyncCertificate<SequencingTestTypes>,
-    ViewSyncVote<SequencingTestTypes>,
-    StaticMembership,
->;
+pub type StaticMemoryViewSyncComm =
+    MemoryCommChannel<SequencingTestTypes, SequencingMemoryImpl, StaticMembership>;
 
-type StaticLibp2pViewSyncComm = Libp2pCommChannel<
-    SequencingTestTypes,
-    SequencingLibp2pImpl,
-    ViewSyncCertificate<SequencingTestTypes>,
-    ViewSyncVote<SequencingTestTypes>,
-    StaticMembership,
->;
+type StaticLibp2pViewSyncComm =
+    Libp2pCommChannel<SequencingTestTypes, SequencingLibp2pImpl, StaticMembership>;
 
-type StaticWebViewSyncComm = WebCommChannel<
-    SequencingTestTypes,
-    SequencingWebImpl,
-    ViewSyncCertificate<SequencingTestTypes>,
-    ViewSyncVote<SequencingTestTypes>,
-    StaticMembership,
->;
+type StaticWebViewSyncComm =
+    WebCommChannel<SequencingTestTypes, SequencingWebImpl, StaticMembership>;
 
 pub type SequencingLibp2pExchange = SequencingExchanges<
     SequencingTestTypes,
@@ -231,9 +183,24 @@ impl
 
         Box::new(move |id| {
             let network = Arc::new(network_generator(id));
-            let quorum_chan = <<Self::QuorumExchange as hotshot_types::traits::election::ConsensusExchange<SequencingTestTypes, Message<SequencingTestTypes, SequencingLibp2pImpl>>>::Networking as TestableChannelImplementation<_, _, _, _, _, _>>::generate_network()(network.clone());
-            let committee_chan = <<Self::CommitteeExchange as hotshot_types::traits::election::ConsensusExchange<SequencingTestTypes, Message<SequencingTestTypes, SequencingLibp2pImpl>>>::Networking as TestableChannelImplementation<_, _, _, _, _, _>>::generate_network()(network.clone());
-            let view_sync_chan = <<Self::ViewSyncExchange as hotshot_types::traits::election::ConsensusExchange<SequencingTestTypes, Message<SequencingTestTypes, SequencingLibp2pImpl>>>::Networking as TestableChannelImplementation<_, _, _, _, _, _>>::generate_network()(network);
+            let quorum_chan =
+                <<Self::QuorumExchange as hotshot_types::traits::election::ConsensusExchange<
+                    SequencingTestTypes,
+                    Message<SequencingTestTypes, SequencingLibp2pImpl>,
+                >>::Networking as TestableChannelImplementation<_, _, _, _>>::generate_network(
+                )(network.clone());
+            let committee_chan =
+                <<Self::CommitteeExchange as hotshot_types::traits::election::ConsensusExchange<
+                    SequencingTestTypes,
+                    Message<SequencingTestTypes, SequencingLibp2pImpl>,
+                >>::Networking as TestableChannelImplementation<_, _, _, _>>::generate_network(
+                )(network.clone());
+            let view_sync_chan =
+                <<Self::ViewSyncExchange as hotshot_types::traits::election::ConsensusExchange<
+                    SequencingTestTypes,
+                    Message<SequencingTestTypes, SequencingLibp2pImpl>,
+                >>::Networking as TestableChannelImplementation<_, _, _, _>>::generate_network(
+                )(network);
 
             (quorum_chan, committee_chan, view_sync_chan)
         })
@@ -325,9 +292,24 @@ impl
         Box::new(move |id| {
             let network = Arc::new(network_generator(id));
             let network_da = Arc::new(network_da_generator(id));
-            let quorum_chan = <<Self::QuorumExchange as hotshot_types::traits::election::ConsensusExchange<SequencingTestTypes, Message<SequencingTestTypes, SequencingMemoryImpl>>>::Networking as TestableChannelImplementation<_, _, _, _, _, _>>::generate_network()(network.clone());
-            let committee_chan = <<Self::CommitteeExchange as hotshot_types::traits::election::ConsensusExchange<SequencingTestTypes, Message<SequencingTestTypes, SequencingMemoryImpl>>>::Networking as TestableChannelImplementation<_, _, _, _, _, _>>::generate_network()(network_da);
-            let view_sync_chan = <<Self::ViewSyncExchange as hotshot_types::traits::election::ConsensusExchange<SequencingTestTypes, Message<SequencingTestTypes, SequencingMemoryImpl>>>::Networking as TestableChannelImplementation<_, _, _, _, _, _>>::generate_network()(network);
+            let quorum_chan =
+                <<Self::QuorumExchange as hotshot_types::traits::election::ConsensusExchange<
+                    SequencingTestTypes,
+                    Message<SequencingTestTypes, SequencingMemoryImpl>,
+                >>::Networking as TestableChannelImplementation<_, _, _, _>>::generate_network(
+                )(network.clone());
+            let committee_chan =
+                <<Self::CommitteeExchange as hotshot_types::traits::election::ConsensusExchange<
+                    SequencingTestTypes,
+                    Message<SequencingTestTypes, SequencingMemoryImpl>,
+                >>::Networking as TestableChannelImplementation<_, _, _, _>>::generate_network(
+                )(network_da);
+            let view_sync_chan =
+                <<Self::ViewSyncExchange as hotshot_types::traits::election::ConsensusExchange<
+                    SequencingTestTypes,
+                    Message<SequencingTestTypes, SequencingMemoryImpl>,
+                >>::Networking as TestableChannelImplementation<_, _, _, _>>::generate_network(
+                )(network);
 
             (quorum_chan, committee_chan, view_sync_chan)
         })
@@ -445,9 +427,24 @@ impl
         Box::new(move |id| {
             let network = Arc::new(network_generator(id));
             let network_da = Arc::new(network_da_generator(id));
-            let quorum_chan = <<Self::QuorumExchange as hotshot_types::traits::election::ConsensusExchange<SequencingTestTypes, Message<SequencingTestTypes, SequencingWebImpl>>>::Networking as TestableChannelImplementation<_, _, _, _, _, _>>::generate_network()(network.clone());
-            let committee_chan = <<Self::CommitteeExchange as hotshot_types::traits::election::ConsensusExchange<SequencingTestTypes, Message<SequencingTestTypes, SequencingWebImpl>>>::Networking as TestableChannelImplementation<_, _, _, _, _, _>>::generate_network()(network_da);
-            let view_sync_chan = <<Self::ViewSyncExchange as hotshot_types::traits::election::ConsensusExchange<SequencingTestTypes, Message<SequencingTestTypes, SequencingWebImpl>>>::Networking as TestableChannelImplementation<_, _, _, _, _, _>>::generate_network()(network);
+            let quorum_chan =
+                <<Self::QuorumExchange as hotshot_types::traits::election::ConsensusExchange<
+                    SequencingTestTypes,
+                    Message<SequencingTestTypes, SequencingWebImpl>,
+                >>::Networking as TestableChannelImplementation<_, _, _, _>>::generate_network(
+                )(network.clone());
+            let committee_chan =
+                <<Self::CommitteeExchange as hotshot_types::traits::election::ConsensusExchange<
+                    SequencingTestTypes,
+                    Message<SequencingTestTypes, SequencingWebImpl>,
+                >>::Networking as TestableChannelImplementation<_, _, _, _>>::generate_network(
+                )(network_da);
+            let view_sync_chan =
+                <<Self::ViewSyncExchange as hotshot_types::traits::election::ConsensusExchange<
+                    SequencingTestTypes,
+                    Message<SequencingTestTypes, SequencingWebImpl>,
+                >>::Networking as TestableChannelImplementation<_, _, _, _>>::generate_network(
+                )(network);
 
             (quorum_chan, committee_chan, view_sync_chan)
         })
@@ -584,44 +581,20 @@ impl
                 <<Self::QuorumExchange as hotshot_types::traits::election::ConsensusExchange<
                     SequencingTestTypes,
                     Message<SequencingTestTypes, StaticFallbackImpl>,
-                >>::Networking as TestableChannelImplementation<
-                    _,
-                    _,
-                    QuorumProposal<
-                        SequencingTestTypes,
-                        <StaticFallbackImpl as NodeImplementation<SequencingTestTypes>>::Leaf,
-                    >,
-                    QuorumVote<
-                        SequencingTestTypes,
-                        <StaticFallbackImpl as NodeImplementation<SequencingTestTypes>>::Leaf,
-                    >,
-                    _,
-                    _,
-                >>::generate_network()(network.clone());
+                >>::Networking as TestableChannelImplementation<_, _, _, _>>::generate_network(
+                )(network.clone());
             let committee_chan =
                 <<Self::CommitteeExchange as hotshot_types::traits::election::ConsensusExchange<
                     SequencingTestTypes,
                     Message<SequencingTestTypes, StaticFallbackImpl>,
-                >>::Networking as TestableChannelImplementation<
-                    _,
-                    _,
-                    DAProposal<SequencingTestTypes>,
-                    DAVote<SequencingTestTypes>,
-                    _,
-                    _,
-                >>::generate_network()(network_da);
+                >>::Networking as TestableChannelImplementation<_, _, _, _>>::generate_network(
+                )(network_da);
             let view_sync_chan =
                 <<Self::ViewSyncExchange as hotshot_types::traits::election::ConsensusExchange<
                     SequencingTestTypes,
                     Message<SequencingTestTypes, StaticFallbackImpl>,
-                >>::Networking as TestableChannelImplementation<
-                    _,
-                    _,
-                    ViewSyncCertificate<SequencingTestTypes>,
-                    ViewSyncVote<SequencingTestTypes>,
-                    _,
-                    _,
-                >>::generate_network()(network);
+                >>::Networking as TestableChannelImplementation<_, _, _, _>>::generate_network(
+                )(network);
             (quorum_chan, committee_chan, view_sync_chan)
         })
     }

--- a/crates/testing/src/test_launcher.rs
+++ b/crates/testing/src/test_launcher.rs
@@ -83,8 +83,6 @@ where
     QuorumCommChannel<TYPES, I>: CommunicationChannel<
         TYPES,
         Message<TYPES, I>,
-        <QuorumEx<TYPES, I> as ConsensusExchange<TYPES, Message<TYPES, I>>>::Proposal,
-        <QuorumEx<TYPES, I> as ConsensusExchange<TYPES, Message<TYPES, I>>>::Vote,
         <QuorumEx<TYPES, I> as ConsensusExchange<TYPES, Message<TYPES, I>>>::Membership,
     >,
 {

--- a/crates/testing/src/test_runner.rs
+++ b/crates/testing/src/test_runner.rs
@@ -41,8 +41,6 @@ where
     QuorumCommChannel<TYPES, I>: CommunicationChannel<
         TYPES,
         Message<TYPES, I>,
-        <QuorumEx<TYPES, I> as ConsensusExchange<TYPES, Message<TYPES, I>>>::Proposal,
-        <QuorumEx<TYPES, I> as ConsensusExchange<TYPES, Message<TYPES, I>>>::Vote,
         <QuorumEx<TYPES, I> as ConsensusExchange<TYPES, Message<TYPES, I>>>::Membership,
     >,
 {
@@ -59,8 +57,6 @@ where
     QuorumCommChannel<TYPES, I>: CommunicationChannel<
         TYPES,
         Message<TYPES, I>,
-        <QuorumEx<TYPES, I> as ConsensusExchange<TYPES, Message<TYPES, I>>>::Proposal,
-        <QuorumEx<TYPES, I> as ConsensusExchange<TYPES, Message<TYPES, I>>>::Vote,
         <QuorumEx<TYPES, I> as ConsensusExchange<TYPES, Message<TYPES, I>>>::Membership,
     >,
 {

--- a/crates/types/src/certificate.rs
+++ b/crates/types/src/certificate.rs
@@ -160,7 +160,7 @@ impl<TYPES: NodeType, LEAF: LeafType<NodeType = TYPES>>
     for QuorumCertificate<TYPES, LEAF>
 {
     type Vote = QuorumVote<TYPES, LEAF>;
-    type VoteAccumulator = AccumulatorPlaceholder<TYPES, Self::Vote>;
+    type VoteAccumulator = AccumulatorPlaceholder<TYPES, LEAF, Self::Vote>;
 
     fn from_signatures_and_commitment(
         view_number: TYPES::Time,
@@ -233,7 +233,7 @@ impl<TYPES: NodeType> SignedCertificate<TYPES, TYPES::Time, TYPES::VoteTokenType
     for DACertificate<TYPES>
 {
     type Vote = DAVote<TYPES>;
-    type VoteAccumulator = AccumulatorPlaceholder<TYPES, Self::Vote>;
+    type VoteAccumulator = AccumulatorPlaceholder<TYPES, TYPES::BlockType, Self::Vote>;
 
     fn from_signatures_and_commitment(
         view_number: TYPES::Time,
@@ -324,7 +324,7 @@ impl<TYPES: NodeType>
     for ViewSyncCertificate<TYPES>
 {
     type Vote = ViewSyncVote<TYPES>;
-    type VoteAccumulator = AccumulatorPlaceholder<TYPES, Self::Vote>;
+    type VoteAccumulator = AccumulatorPlaceholder<TYPES, ViewSyncData<TYPES>, Self::Vote>;
     /// Build a QC from the threshold signature and commitment
     fn from_signatures_and_commitment(
         view_number: TYPES::Time,

--- a/crates/types/src/certificate.rs
+++ b/crates/types/src/certificate.rs
@@ -1,6 +1,5 @@
 //! Provides two types of cerrtificates and their accumulators.
 
-use crate::vote::Accumulator;
 use crate::vote::AccumulatorPlaceholder;
 use crate::vote::QuorumVote;
 use crate::{
@@ -11,11 +10,11 @@ use crate::{
         signature_key::{EncodedPublicKey, EncodedSignature, SignatureKey},
         state::ConsensusTime,
     },
-    vote::{DAVote, ViewSyncData, ViewSyncVote, VoteAccumulator},
+    vote::{DAVote, ViewSyncData, ViewSyncVote},
 };
 use bincode::Options;
 use commit::{Commitment, Committable};
-use either::Either;
+
 use espresso_systems_common::hotshot::tag;
 use hotshot_utils::bincode::bincode_opts;
 use serde::{Deserialize, Serialize};

--- a/crates/types/src/certificate.rs
+++ b/crates/types/src/certificate.rs
@@ -8,7 +8,7 @@ use crate::{
         signature_key::{EncodedPublicKey, EncodedSignature, SignatureKey},
         state::ConsensusTime,
     },
-    vote::{ViewSyncData, VoteAccumulator},
+    vote::{ViewSyncData, VoteAccumulator, DAVote, ViewSyncVote},
 };
 use bincode::Options;
 use commit::{Commitment, Committable};
@@ -230,6 +230,9 @@ impl<TYPES: NodeType, LEAF: LeafType<NodeType = TYPES>> Committable
 impl<TYPES: NodeType> SignedCertificate<TYPES, TYPES::Time, TYPES::VoteTokenType, TYPES::BlockType>
     for DACertificate<TYPES>
 {
+    type Vote = DAVote<TYPES>;
+    type VoteAccumulator = AccumulatorPlaceholder<TYPES, Self::Vote>;
+
     fn from_signatures_and_commitment(
         view_number: TYPES::Time,
         signatures: AssembledSignature<TYPES>,
@@ -318,6 +321,8 @@ impl<TYPES: NodeType>
     SignedCertificate<TYPES, TYPES::Time, TYPES::VoteTokenType, ViewSyncData<TYPES>>
     for ViewSyncCertificate<TYPES>
 {
+    type Vote = ViewSyncVote<TYPES>;
+    type VoteAccumulator = AccumulatorPlaceholder<TYPES, Self::Vote>;
     /// Build a QC from the threshold signature and commitment
     fn from_signatures_and_commitment(
         view_number: TYPES::Time,

--- a/crates/types/src/certificate.rs
+++ b/crates/types/src/certificate.rs
@@ -1,5 +1,8 @@
 //! Provides two types of cerrtificates and their accumulators.
 
+use crate::vote::Accumulator;
+use crate::vote::AccumulatorPlaceholder;
+use crate::vote::QuorumVote;
 use crate::{
     data::{fake_commitment, serialize_signature, LeafType},
     traits::{
@@ -8,10 +11,11 @@ use crate::{
         signature_key::{EncodedPublicKey, EncodedSignature, SignatureKey},
         state::ConsensusTime,
     },
-    vote::{ViewSyncData, VoteAccumulator, DAVote, ViewSyncVote},
+    vote::{DAVote, ViewSyncData, ViewSyncVote, VoteAccumulator},
 };
 use bincode::Options;
 use commit::{Commitment, Committable};
+use either::Either;
 use espresso_systems_common::hotshot::tag;
 use hotshot_utils::bincode::bincode_opts;
 use serde::{Deserialize, Serialize};
@@ -20,8 +24,6 @@ use std::{
     ops::Deref,
 };
 use tracing::debug;
-use crate::vote::QuorumVote;
-use crate::vote::AccumulatorPlaceholder;
 
 /// A `DACertificate` is a threshold signature that some data is available.
 /// It is signed by the members of the DA committee, not the entire network. It is used
@@ -115,7 +117,7 @@ pub struct ViewSyncCertificateInternal<TYPES: NodeType> {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash)]
 #[serde(bound(deserialize = ""))]
 /// Enum representing whether a signatures is for a 'Yes' or 'No' or 'DA' or 'Genesis' certificate
-// TODO ED Should this be a trait? 
+// TODO ED Should this be a trait?
 pub enum AssembledSignature<TYPES: NodeType> {
     // (enum, signature)
     /// These signatures are for a 'Yes' certificate

--- a/crates/types/src/certificate.rs
+++ b/crates/types/src/certificate.rs
@@ -8,7 +8,7 @@ use crate::{
         signature_key::{EncodedPublicKey, EncodedSignature, SignatureKey},
         state::ConsensusTime,
     },
-    vote::ViewSyncData,
+    vote::{ViewSyncData, VoteAccumulator},
 };
 use bincode::Options;
 use commit::{Commitment, Committable};
@@ -20,6 +20,8 @@ use std::{
     ops::Deref,
 };
 use tracing::debug;
+use crate::vote::QuorumVote;
+use crate::vote::AccumulatorPlaceholder;
 
 /// A `DACertificate` is a threshold signature that some data is available.
 /// It is signed by the members of the DA committee, not the entire network. It is used
@@ -113,6 +115,7 @@ pub struct ViewSyncCertificateInternal<TYPES: NodeType> {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash)]
 #[serde(bound(deserialize = ""))]
 /// Enum representing whether a signatures is for a 'Yes' or 'No' or 'DA' or 'Genesis' certificate
+// TODO ED Should this be a trait? 
 pub enum AssembledSignature<TYPES: NodeType> {
     // (enum, signature)
     /// These signatures are for a 'Yes' certificate
@@ -154,6 +157,9 @@ impl<TYPES: NodeType, LEAF: LeafType<NodeType = TYPES>>
     SignedCertificate<TYPES, TYPES::Time, TYPES::VoteTokenType, LEAF>
     for QuorumCertificate<TYPES, LEAF>
 {
+    type Vote = QuorumVote<TYPES, LEAF>;
+    type VoteAccumulator = AccumulatorPlaceholder<TYPES, Self::Vote>;
+
     fn from_signatures_and_commitment(
         view_number: TYPES::Time,
         signatures: AssembledSignature<TYPES>,

--- a/crates/types/src/message.rs
+++ b/crates/types/src/message.rs
@@ -359,7 +359,7 @@ impl<
                         // this should match replica upon receipt
                         p.data.get_view_number()
                     }
-                    GeneralConsensusMessage::Vote(vote_message) => vote_message.current_view(),
+                    GeneralConsensusMessage::Vote(vote_message) => vote_message.get_view(),
                     GeneralConsensusMessage::InternalTrigger(trigger) => match trigger {
                         InternalTrigger::Timeout(time) => *time,
                     },
@@ -376,7 +376,7 @@ impl<
                         // this should match replica upon receipt
                         p.data.get_view_number()
                     }
-                    CommitteeConsensusMessage::DAVote(vote_message) => vote_message.current_view(),
+                    CommitteeConsensusMessage::DAVote(vote_message) => vote_message.get_view(),
                     CommitteeConsensusMessage::DACertificate(cert) => cert.view_number,
                 }
             }

--- a/crates/types/src/traits/consensus_api.rs
+++ b/crates/types/src/traits/consensus_api.rs
@@ -128,9 +128,10 @@ pub trait SequencingConsensusApi<
     LEAF: LeafType<NodeType = TYPES>,
     I: NodeImplementation<TYPES, ConsensusMessage = SequencingMessage<TYPES, I>>,
 >: ConsensusSharedApi<TYPES, LEAF, I>
+// TODO ED VoteType should not always be over LEAF, but for the API it doesn't matter and we are removing it soon anyway
 {
     /// Send a direct message to the given recipient
-    async fn send_direct_message<PROPOSAL: ProposalType<NodeType = TYPES>, VOTE: VoteType<TYPES>>(
+    async fn send_direct_message<PROPOSAL: ProposalType<NodeType = TYPES>, VOTE: VoteType<TYPES, LEAF>>(
         &self,
         recipient: TYPES::SignatureKey,
         message: SequencingMessage<TYPES, I>,
@@ -139,7 +140,7 @@ pub trait SequencingConsensusApi<
     /// send a direct message using the DA communication channel
     async fn send_direct_da_message<
         PROPOSAL: ProposalType<NodeType = TYPES>,
-        VOTE: VoteType<TYPES>,
+        VOTE: VoteType<TYPES, LEAF>,
     >(
         &self,
         recipient: TYPES::SignatureKey,
@@ -149,7 +150,7 @@ pub trait SequencingConsensusApi<
     /// Send a broadcast message to the entire network.
     async fn send_broadcast_message<
         PROPOSAL: ProposalType<NodeType = TYPES>,
-        VOTE: VoteType<TYPES>,
+        VOTE: VoteType<TYPES LEAF>,
     >(
         &self,
         message: SequencingMessage<TYPES, I>,

--- a/crates/types/src/traits/consensus_api.rs
+++ b/crates/types/src/traits/consensus_api.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     certificate::QuorumCertificate,
-    data::{LeafType, ProposalType},
+    data::LeafType,
     error::HotShotError,
     event::{Event, EventType},
     message::{DataMessage, SequencingMessage},
@@ -12,7 +12,6 @@ use crate::{
         signature_key::SignatureKey,
         storage::StorageError,
     },
-    vote::VoteType,
 };
 use async_trait::async_trait;
 
@@ -128,30 +127,23 @@ pub trait SequencingConsensusApi<
     LEAF: LeafType<NodeType = TYPES>,
     I: NodeImplementation<TYPES, ConsensusMessage = SequencingMessage<TYPES, I>>,
 >: ConsensusSharedApi<TYPES, LEAF, I>
-// TODO ED VoteType should not always be over LEAF, but for the API it doesn't matter and we are removing it soon anyway
 {
     /// Send a direct message to the given recipient
-    async fn send_direct_message<PROPOSAL: ProposalType<NodeType = TYPES>, VOTE: VoteType<TYPES, LEAF>>(
+    async fn send_direct_message(
         &self,
         recipient: TYPES::SignatureKey,
         message: SequencingMessage<TYPES, I>,
     ) -> std::result::Result<(), NetworkError>;
 
     /// send a direct message using the DA communication channel
-    async fn send_direct_da_message<
-        PROPOSAL: ProposalType<NodeType = TYPES>,
-        VOTE: VoteType<TYPES, LEAF>,
-    >(
+    async fn send_direct_da_message(
         &self,
         recipient: TYPES::SignatureKey,
         message: SequencingMessage<TYPES, I>,
     ) -> std::result::Result<(), NetworkError>;
 
     /// Send a broadcast message to the entire network.
-    async fn send_broadcast_message<
-        PROPOSAL: ProposalType<NodeType = TYPES>,
-        VOTE: VoteType<TYPES, LEAF>,
-    >(
+    async fn send_broadcast_message(
         &self,
         message: SequencingMessage<TYPES, I>,
     ) -> std::result::Result<(), NetworkError>;

--- a/crates/types/src/traits/consensus_api.rs
+++ b/crates/types/src/traits/consensus_api.rs
@@ -150,7 +150,7 @@ pub trait SequencingConsensusApi<
     /// Send a broadcast message to the entire network.
     async fn send_broadcast_message<
         PROPOSAL: ProposalType<NodeType = TYPES>,
-        VOTE: VoteType<TYPES LEAF>,
+        VOTE: VoteType<TYPES, LEAF>,
     >(
         &self,
         message: SequencingMessage<TYPES, I>,

--- a/crates/types/src/traits/election.rs
+++ b/crates/types/src/traits/election.rs
@@ -182,9 +182,9 @@ where
     COMMITTABLE: Committable + Serialize + Clone,
     TOKEN: VoteToken,
 {
-    type Vote: VoteType<TYPES>;
+    type Vote: VoteType<TYPES, COMMITTABLE>;
 
-    type VoteAccumulator: Accumulator2<TYPES, Self::Vote>; 
+    type VoteAccumulator: Accumulator2<TYPES, COMMITTABLE, Self::Vote>; 
 
     fn accumulate_vote(accumulator: Self::VoteAccumulator, vote: Self::Vote, commit: COMMITTABLE) -> Either<Self::VoteAccumulator, Self> {
         // if !self.is_valid_vote(

--- a/crates/types/src/traits/election.rs
+++ b/crates/types/src/traits/election.rs
@@ -42,6 +42,7 @@ use serde::{Deserialize, Serialize};
 use snafu::Snafu;
 use std::{collections::BTreeSet, fmt::Debug, hash::Hash, marker::PhantomData, num::NonZeroU64};
 use tracing::error;
+use crate::vote::Accumulator2;
 
 /// Error for election problems
 #[derive(Snafu, Debug)]
@@ -181,6 +182,10 @@ where
     COMMITTABLE: Committable + Serialize + Clone,
     TOKEN: VoteToken,
 {
+    type Vote: VoteType<TYPES>;
+
+    type VoteAccumulator: Accumulator2<TYPES, Self::Vote>; 
+
     /// Build a QC from the threshold signature and commitment
     fn from_signatures_and_commitment(
         view_number: TIME,

--- a/crates/types/src/traits/election.rs
+++ b/crates/types/src/traits/election.rs
@@ -182,27 +182,19 @@ where
     COMMITTABLE: Committable + Serialize + Clone,
     TOKEN: VoteToken,
 {
+    /// `VoteType` that is used in this certificate
     type Vote: VoteType<TYPES, COMMITTABLE>;
 
+    /// `Accumulator` type to accumulate votes.
     type VoteAccumulator: Accumulator2<TYPES, COMMITTABLE, Self::Vote>;
 
+    /// Accumulates votes given an accumulator, vote, and commit.  
+    /// Returns either the accumulator or a certificate
     fn accumulate_vote(
-        accumulator: Self::VoteAccumulator,
-        vote: Self::Vote,
-        commit: COMMITTABLE,
+        _accumulator: Self::VoteAccumulator,
+        _vote: Self::Vote,
+        _commit: COMMITTABLE,
     ) -> Either<Self::VoteAccumulator, Self> {
-        // if !self.is_valid_vote(
-        //     &vote.encoded_key,
-        //     &vote.encoded_signature,
-        //     vote.data.clone(),
-        //     // Ignoring deserialization errors below since we are getting rid of it soon
-        //     Checked::Unchecked(vote.vote_token.clone()),
-        // ) {
-        //     error!("Invalid vote!");
-        //     return Either::Left(accumulator);
-        // }
-        // Call append
-
         todo!()
     }
 

--- a/crates/types/src/traits/election.rs
+++ b/crates/types/src/traits/election.rs
@@ -186,7 +186,24 @@ where
 
     type VoteAccumulator: Accumulator2<TYPES, Self::Vote>; 
 
+    fn accumulate_vote(accumulator: Self::VoteAccumulator, vote: Self::Vote, commit: COMMITTABLE) -> Either<Self::VoteAccumulator, Self> {
+        // if !self.is_valid_vote(
+        //     &vote.encoded_key,
+        //     &vote.encoded_signature,
+        //     vote.data.clone(),
+        //     // Ignoring deserialization errors below since we are getting rid of it soon
+        //     Checked::Unchecked(vote.vote_token.clone()),
+        // ) {
+        //     error!("Invalid vote!");
+        //     return Either::Left(accumulator);
+        // }
+        // Call append
+
+        todo!()
+    }
+
     /// Build a QC from the threshold signature and commitment
+    // TODO ED Rename this function
     fn from_signatures_and_commitment(
         view_number: TIME,
         signatures: AssembledSignature<TYPES>,

--- a/crates/types/src/traits/election.rs
+++ b/crates/types/src/traits/election.rs
@@ -302,7 +302,7 @@ pub trait ConsensusExchange<TYPES: NodeType, M: NetworkMsg>: Send + Sync {
     /// A proposal for participants to vote on.
     type Proposal: ProposalType<NodeType = TYPES>;
     /// A vote on a [`Proposal`](Self::Proposal).
-    type Vote: VoteType<TYPES>;
+    type Vote: VoteType<TYPES, Self::Commitment>;
     /// A [`SignedCertificate`] attesting to a decision taken by the committee.
     type Certificate: SignedCertificate<TYPES, TYPES::Time, TYPES::VoteTokenType, Self::Commitment>
         + Hash

--- a/crates/types/src/traits/network.rs
+++ b/crates/types/src/traits/network.rs
@@ -195,6 +195,7 @@ pub trait ViewMessage<TYPES: NodeType> {
 
 /// API for interacting directly with a consensus committee
 /// intended to be implemented for both DA and for validating consensus committees
+// TODO ED Why is this generic over VOTE? 
 #[async_trait]
 pub trait CommunicationChannel<
     TYPES: NodeType,
@@ -332,6 +333,7 @@ pub trait TestableNetworkingImplementation<TYPES: NodeType, M: NetworkMsg> {
     fn in_flight_message_count(&self) -> Option<usize>;
 }
 /// Describes additional functionality needed by the test communication channel
+// TODO ED Why is this generic over VOTE? 
 pub trait TestableChannelImplementation<
     TYPES: NodeType,
     M: NetworkMsg,

--- a/crates/types/src/traits/network.rs
+++ b/crates/types/src/traits/network.rs
@@ -11,7 +11,7 @@ use tokio::time::error::Elapsed as TimeoutError;
 #[cfg(not(any(async_executor_impl = "async-std", async_executor_impl = "tokio")))]
 compile_error! {"Either config option \"async-std\" or \"tokio\" must be enabled for this crate."}
 use super::{election::Membership, node_implementation::NodeType, signature_key::SignatureKey};
-use crate::{data::ProposalType, message::MessagePurpose, vote::VoteType};
+use crate::message::MessagePurpose;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use snafu::Snafu;
@@ -195,13 +195,10 @@ pub trait ViewMessage<TYPES: NodeType> {
 
 /// API for interacting directly with a consensus committee
 /// intended to be implemented for both DA and for validating consensus committees
-// TODO ED Why is this generic over VOTE? 
+// TODO ED Why is this generic over VOTE?
 #[async_trait]
-pub trait CommunicationChannel<
-    TYPES: NodeType,
-    M: NetworkMsg,
-    MEMBERSHIP: Membership<TYPES>,
->: Clone + Debug + Send + Sync + 'static
+pub trait CommunicationChannel<TYPES: NodeType, M: NetworkMsg, MEMBERSHIP: Membership<TYPES>>:
+    Clone + Debug + Send + Sync + 'static
 {
     /// Underlying Network implementation's type
     type NETWORK;
@@ -331,7 +328,7 @@ pub trait TestableNetworkingImplementation<TYPES: NodeType, M: NetworkMsg> {
     fn in_flight_message_count(&self) -> Option<usize>;
 }
 /// Describes additional functionality needed by the test communication channel
-// TODO ED Why is this generic over VOTE? 
+// TODO ED Why is this generic over VOTE?
 pub trait TestableChannelImplementation<
     TYPES: NodeType,
     M: NetworkMsg,

--- a/crates/types/src/traits/network.rs
+++ b/crates/types/src/traits/network.rs
@@ -200,8 +200,6 @@ pub trait ViewMessage<TYPES: NodeType> {
 pub trait CommunicationChannel<
     TYPES: NodeType,
     M: NetworkMsg,
-    PROPOSAL: ProposalType<NodeType = TYPES>,
-    VOTE: VoteType<TYPES>,
     MEMBERSHIP: Membership<TYPES>,
 >: Clone + Debug + Send + Sync + 'static
 {
@@ -337,11 +335,9 @@ pub trait TestableNetworkingImplementation<TYPES: NodeType, M: NetworkMsg> {
 pub trait TestableChannelImplementation<
     TYPES: NodeType,
     M: NetworkMsg,
-    PROPOSAL: ProposalType<NodeType = TYPES>,
-    VOTE: VoteType<TYPES>,
     MEMBERSHIP: Membership<TYPES>,
     NETWORK,
->: CommunicationChannel<TYPES, M, PROPOSAL, VOTE, MEMBERSHIP>
+>: CommunicationChannel<TYPES, M, MEMBERSHIP>
 {
     /// generates the `CommunicationChannel` given it's associated network type
     fn generate_network() -> Box<dyn Fn(Arc<NETWORK>) -> Self + 'static>;

--- a/crates/types/src/traits/node_implementation.rs
+++ b/crates/types/src/traits/node_implementation.rs
@@ -401,21 +401,18 @@ where
     QuorumCommChannel<TYPES, I>: TestableChannelImplementation<
         TYPES,
         Message<TYPES, I>,
- 
         QuorumMembership<TYPES, I>,
         QuorumNetwork<TYPES, I>,
     >,
     CommitteeCommChannel<TYPES, I>: TestableChannelImplementation<
         TYPES,
         Message<TYPES, I>,
-      
         CommitteeMembership<TYPES, I>,
         QuorumNetwork<TYPES, I>,
     >,
     ViewSyncCommChannel<TYPES, I>: TestableChannelImplementation<
         TYPES,
         Message<TYPES, I>,
-
         ViewSyncMembership<TYPES, I>,
         QuorumNetwork<TYPES, I>,
     >,
@@ -515,7 +512,6 @@ pub type ViewSyncMembership<TYPES, I> = QuorumMembership<TYPES, I>;
 pub type QuorumNetwork<TYPES, I> = <QuorumCommChannel<TYPES, I> as CommunicationChannel<
     TYPES,
     Message<TYPES, I>,
-
     QuorumMembership<TYPES, I>,
 >>::NETWORK;
 
@@ -523,7 +519,6 @@ pub type QuorumNetwork<TYPES, I> = <QuorumCommChannel<TYPES, I> as Communication
 pub type CommitteeNetwork<TYPES, I> = <CommitteeCommChannel<TYPES, I> as CommunicationChannel<
     TYPES,
     Message<TYPES, I>,
-
     CommitteeMembership<TYPES, I>,
 >>::NETWORK;
 

--- a/crates/types/src/traits/node_implementation.rs
+++ b/crates/types/src/traits/node_implementation.rs
@@ -401,24 +401,21 @@ where
     QuorumCommChannel<TYPES, I>: TestableChannelImplementation<
         TYPES,
         Message<TYPES, I>,
-        QuorumProposalType<TYPES, I>,
-        QuorumVoteType<TYPES, I>,
+ 
         QuorumMembership<TYPES, I>,
         QuorumNetwork<TYPES, I>,
     >,
     CommitteeCommChannel<TYPES, I>: TestableChannelImplementation<
         TYPES,
         Message<TYPES, I>,
-        CommitteeProposalType<TYPES, I>,
-        CommitteeVote<TYPES, I>,
+      
         CommitteeMembership<TYPES, I>,
         QuorumNetwork<TYPES, I>,
     >,
     ViewSyncCommChannel<TYPES, I>: TestableChannelImplementation<
         TYPES,
         Message<TYPES, I>,
-        ViewSyncProposalType<TYPES, I>,
-        ViewSyncVoteType<TYPES, I>,
+
         ViewSyncMembership<TYPES, I>,
         QuorumNetwork<TYPES, I>,
     >,
@@ -518,8 +515,7 @@ pub type ViewSyncMembership<TYPES, I> = QuorumMembership<TYPES, I>;
 pub type QuorumNetwork<TYPES, I> = <QuorumCommChannel<TYPES, I> as CommunicationChannel<
     TYPES,
     Message<TYPES, I>,
-    QuorumProposalType<TYPES, I>,
-    QuorumVoteType<TYPES, I>,
+
     QuorumMembership<TYPES, I>,
 >>::NETWORK;
 
@@ -527,8 +523,7 @@ pub type QuorumNetwork<TYPES, I> = <QuorumCommChannel<TYPES, I> as Communication
 pub type CommitteeNetwork<TYPES, I> = <CommitteeCommChannel<TYPES, I> as CommunicationChannel<
     TYPES,
     Message<TYPES, I>,
-    CommitteeProposalType<TYPES, I>,
-    CommitteeVote<TYPES, I>,
+
     CommitteeMembership<TYPES, I>,
 >>::NETWORK;
 
@@ -536,8 +531,6 @@ pub type CommitteeNetwork<TYPES, I> = <CommitteeCommChannel<TYPES, I> as Communi
 pub type ViewSyncNetwork<TYPES, I> = <ViewSyncCommChannel<TYPES, I> as CommunicationChannel<
     TYPES,
     Message<TYPES, I>,
-    ViewSyncProposalType<TYPES, I>,
-    ViewSyncVoteType<TYPES, I>,
     ViewSyncMembership<TYPES, I>,
 >>::NETWORK;
 

--- a/crates/types/src/vote.rs
+++ b/crates/types/src/vote.rs
@@ -294,7 +294,7 @@ pub trait Accumulator2<TYPES: NodeType, COMMITTABLE: Committable + Serialize + C
 }
 
 pub struct AccumulatorPlaceholder<TYPES: NodeType, COMMITTABLE: Committable + Serialize + Clone, VOTE: VoteType<TYPES, COMMITTABLE>> {
-    pub phantom: PhantomData<(TYPES, VOTE)>
+    pub phantom: PhantomData<(TYPES, VOTE, COMMITTABLE)>
 }
 
 impl <TYPES: NodeType, COMMITTABLE: Committable + Serialize + Clone, VOTE: VoteType<TYPES, COMMITTABLE>> Accumulator2<TYPES, COMMITTABLE, VOTE> for AccumulatorPlaceholder<TYPES, COMMITTABLE, VOTE> {

--- a/crates/types/src/vote.rs
+++ b/crates/types/src/vote.rs
@@ -263,7 +263,7 @@ pub trait Accumulator2<TYPES: NodeType, VOTE: VoteType<TYPES>>: Sized
 }
 
 pub struct AccumulatorPlaceholder<TYPES: NodeType, VOTE: VoteType<TYPES>> {
-    phantom: PhantomData<(TYPES, VOTE)>
+    pub phantom: PhantomData<(TYPES, VOTE)>
 }
 
 impl <TYPES: NodeType, VOTE: VoteType<TYPES>> Accumulator2<TYPES, VOTE> for AccumulatorPlaceholder<TYPES, VOTE> {


### PR DESCRIPTION
This PR: 
* Removes PROPOSAL and VOTE generics from the CommunicationChannel trait
* Adds COMMITTABLE generic to VoteType, since each vote needs to be over a specific committable type
* Adds placeholder `Accumulator2` code for the new accumulator that will be certificate-based instead of exchange based. 

NOTE: There are still TODO ED notes in the code.  We can merge this in now to get the above changes in, or we can wait until I finish the accumulator logic.  I don't mind either way. 