### PR TITLE
Sishan/finishing parameterizing curve

### DIFF
--- a/crates/hotshot-signature-key/src/bn254.rs
+++ b/crates/hotshot-signature-key/src/bn254.rs
@@ -1,8 +1,8 @@
 //! Demonstration implementation of the [`SignatureKey`] trait using BN254
 use hotshot_types::traits::signature_key::{EncodedPublicKey, EncodedSignature, SignatureKey};
-/// `BN254Priv` implementation
+/// `BLSPrivKey` implementation
 mod bn254_priv;
 /// `BN254Pub` implementation
 mod bn254_pub;
 
-pub use self::{bn254_priv::BN254Priv, bn254_pub::BN254Pub};
+pub use self::{bn254_priv::BLSPrivKey, bn254_pub::BN254Pub};

--- a/crates/hotshot-signature-key/src/bn254.rs
+++ b/crates/hotshot-signature-key/src/bn254.rs
@@ -2,7 +2,7 @@
 use hotshot_types::traits::signature_key::{EncodedPublicKey, EncodedSignature, SignatureKey};
 /// `BLSPrivKey` implementation
 mod bn254_priv;
-/// `BN254Pub` implementation
+/// `BLSPubKey` implementation
 mod bn254_pub;
 
-pub use self::{bn254_priv::BLSPrivKey, bn254_pub::BN254Pub};
+pub use self::{bn254_priv::BLSPrivKey, bn254_pub::BLSPubKey};

--- a/crates/hotshot-signature-key/src/bn254/bn254_priv.rs
+++ b/crates/hotshot-signature-key/src/bn254/bn254_priv.rs
@@ -7,12 +7,12 @@ use std::cmp::Ordering;
 
 /// Private key type for a bn254 keypair
 #[derive(PartialEq, Eq, Clone, Serialize, Deserialize, Debug)]
-pub struct BN254Priv {
+pub struct BLSPrivKey {
     /// The private key for  this keypair
     pub(super) priv_key: QCSignKey,
 }
 
-impl BN254Priv {
+impl BLSPrivKey {
     /// Generate a new private key from scratch
     #[must_use]
     pub fn generate() -> Self {
@@ -54,7 +54,7 @@ impl BN254Priv {
     }
 }
 
-impl PartialOrd for BN254Priv {
+impl PartialOrd for BLSPrivKey {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         let self_bytes = &self.priv_key.to_string();
         let other_bytes = &other.priv_key.to_string();
@@ -62,7 +62,7 @@ impl PartialOrd for BN254Priv {
     }
 }
 
-impl Ord for BN254Priv {
+impl Ord for BLSPrivKey {
     fn cmp(&self, other: &Self) -> Ordering {
         let self_bytes = &self.priv_key.to_string();
         let other_bytes = &other.priv_key.to_string();

--- a/crates/hotshot-signature-key/src/bn254/bn254_pub.rs
+++ b/crates/hotshot-signature-key/src/bn254/bn254_pub.rs
@@ -50,7 +50,6 @@ impl SignatureKey for BN254Pub {
         <BLSOverBN254CurveSignatureScheme as SignatureScheme>::VerificationKey,
         <BLSOverBN254CurveSignatureScheme as SignatureScheme>::PublicParameter,
     >;
-    type SignatureKeySignatureScheme = BLSOverBN254CurveSignatureScheme;
     type PureAssembledSignatureType = <BLSOverBN254CurveSignatureScheme as SignatureScheme>::Signature;
     type QCType = (
         Self::PureAssembledSignatureType,
@@ -169,7 +168,7 @@ impl SignatureKey for BN254Pub {
     fn assemble(
         real_qc_pp: &Self::QCParams,
         signers: &BitSlice,
-        sigs: &[<BLSOverBN254CurveSignatureScheme as SignatureScheme>::Signature],
+        sigs: &[Self::PureAssembledSignatureType],
     ) -> Self::QCType {
         BitVectorQC::<BLSOverBN254CurveSignatureScheme>::assemble(real_qc_pp, signers, sigs)
             .expect("this assembling shouldn't fail")

--- a/crates/hotshot-signature-key/src/bn254/bn254_pub.rs
+++ b/crates/hotshot-signature-key/src/bn254/bn254_pub.rs
@@ -1,4 +1,4 @@
-use super::{BN254Priv, EncodedPublicKey, EncodedSignature, SignatureKey};
+use super::{BLSPrivKey, EncodedPublicKey, EncodedSignature, SignatureKey};
 use bincode::Options;
 use bitvec::prelude::*;
 use blake3::traits::digest::generic_array::GenericArray;
@@ -44,7 +44,7 @@ impl Ord for BN254Pub {
 }
 
 impl SignatureKey for BN254Pub {
-    type PrivateKey = BN254Priv;
+    type PrivateKey = BLSPrivKey;
     type StakeTableEntry = JFStakeTableEntry<VerKey>;
     type QCParams = JFQCParams<
         <BLSOverBN254CurveSignatureScheme as SignatureScheme>::VerificationKey,

--- a/crates/hotshot-signature-key/src/bn254/bn254_pub.rs
+++ b/crates/hotshot-signature-key/src/bn254/bn254_pub.rs
@@ -50,11 +50,12 @@ impl SignatureKey for BN254Pub {
         <BLSOverBN254CurveSignatureScheme as SignatureScheme>::VerificationKey,
         <BLSOverBN254CurveSignatureScheme as SignatureScheme>::PublicParameter,
     >;
+    type SignatureKeySignatureScheme = BLSOverBN254CurveSignatureScheme;
+    type PureAssembledSignatureType = <BLSOverBN254CurveSignatureScheme as SignatureScheme>::Signature;
     type QCType = (
-        <BLSOverBN254CurveSignatureScheme as SignatureScheme>::Signature,
+        Self::PureAssembledSignatureType,
         BitVec,
     );
-    // <BitVectorQC<BLSOverBN254CurveSignatureScheme> as AssembledQuorumCertificate<BLSOverBN254CurveSignatureScheme>>::QC;
 
     #[instrument(skip(self))]
     fn validate(&self, signature: &EncodedSignature, data: &[u8]) -> bool {
@@ -159,7 +160,7 @@ impl SignatureKey for BN254Pub {
     fn get_sig_proof(
         signature: &Self::QCType,
     ) -> (
-        <BLSOverBN254CurveSignatureScheme as SignatureScheme>::Signature,
+        Self::PureAssembledSignatureType,
         BitVec,
     ) {
         signature.clone()

--- a/crates/hotshot-signature-key/src/bn254/bn254_pub.rs
+++ b/crates/hotshot-signature-key/src/bn254/bn254_pub.rs
@@ -22,12 +22,12 @@ use typenum::U32;
 /// This type makes use of noise for non-determinisitc signatures.
 #[derive(Clone, PartialEq, Eq, Hash, Copy, Serialize, Deserialize, Debug)]
 
-pub struct BN254Pub {
+pub struct BLSPubKey {
     /// The public key for this keypair
     pub_key: VerKey,
 }
 
-impl PartialOrd for BN254Pub {
+impl PartialOrd for BLSPubKey {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         let self_bytes = &self.pub_key.to_string();
         let other_bytes = &other.pub_key.to_string();
@@ -35,7 +35,7 @@ impl PartialOrd for BN254Pub {
     }
 }
 
-impl Ord for BN254Pub {
+impl Ord for BLSPubKey {
     fn cmp(&self, other: &Self) -> Ordering {
         let self_bytes = &self.pub_key.to_string();
         let other_bytes = &other.pub_key.to_string();
@@ -43,7 +43,7 @@ impl Ord for BN254Pub {
     }
 }
 
-impl SignatureKey for BN254Pub {
+impl SignatureKey for BLSPubKey {
     type PrivateKey = BLSPrivKey;
     type StakeTableEntry = JFStakeTableEntry<VerKey>;
     type QCParams = JFQCParams<
@@ -114,7 +114,7 @@ impl SignatureKey for BN254Pub {
     fn from_bytes(bytes: &EncodedPublicKey) -> Option<Self> {
         let x: Result<VerKey, _> = bincode_opts().deserialize(&bytes.0);
         match x {
-            Ok(pub_key) => Some(BN254Pub { pub_key }),
+            Ok(pub_key) => Some(BLSPubKey { pub_key }),
             Err(e) => {
                 debug!(?e, "Failed to deserialize public key");
                 None

--- a/crates/hotshot/src/demos/sdemo.rs
+++ b/crates/hotshot/src/demos/sdemo.rs
@@ -16,7 +16,7 @@ use std::{
 use commit::{Commitment, Committable};
 use derivative::Derivative;
 use either::Either;
-use hotshot_signature_key::bn254::BN254Pub;
+use hotshot_signature_key::bn254::BLSPubKey;
 use hotshot_types::{
     certificate::{AssembledSignature, QuorumCertificate},
     data::{
@@ -310,7 +310,7 @@ pub struct SDemoTypes;
 impl NodeType for SDemoTypes {
     type Time = ViewNumber;
     type BlockType = SDemoBlock;
-    type SignatureKey = BN254Pub;
+    type SignatureKey = BLSPubKey;
     type VoteTokenType = StaticVoteToken<Self::SignatureKey>;
     type Transaction = SDemoTransaction;
     type ElectionConfigType = StaticElectionConfig;

--- a/crates/hotshot/src/traits/election/static_committee.rs
+++ b/crates/hotshot/src/traits/election/static_committee.rs
@@ -1,7 +1,7 @@
 // use ark_bls12_381::Parameters as Param381;
 use commit::{Commitment, Committable, RawCommitmentBuilder};
 use espresso_systems_common::hotshot::tag;
-use hotshot_signature_key::bn254::BN254Pub;
+use hotshot_signature_key::bn254::BLSPubKey;
 use hotshot_types::{
     data::LeafType,
     traits::{
@@ -30,7 +30,7 @@ pub struct GeneralStaticCommittee<T, LEAF: LeafType<NodeType = T>, PUBKEY: Signa
 }
 
 /// static committee using a vrf kp
-pub type StaticCommittee<T, LEAF> = GeneralStaticCommittee<T, LEAF, BN254Pub>;
+pub type StaticCommittee<T, LEAF> = GeneralStaticCommittee<T, LEAF, BLSPubKey>;
 
 impl<T, LEAF: LeafType<NodeType = T>, PUBKEY: SignatureKey>
     GeneralStaticCommittee<T, LEAF, PUBKEY>

--- a/crates/hotshot/src/traits/storage/memory_storage.rs
+++ b/crates/hotshot/src/traits/storage/memory_storage.rs
@@ -117,7 +117,7 @@ mod test {
     use crate::traits::election::static_committee::{StaticElectionConfig, StaticVoteToken};
 
     use super::*;
-    use hotshot_signature_key::bn254::BN254Pub;
+    use hotshot_signature_key::bn254::BLSPubKey;
     use hotshot_types::{
         certificate::{AssembledSignature, QuorumCertificate},
         data::{fake_commitment, genesis_proposer_id, ValidatingLeaf, ViewNumber},
@@ -149,7 +149,7 @@ mod test {
     impl NodeType for DummyTypes {
         type Time = ViewNumber;
         type BlockType = DummyBlock;
-        type SignatureKey = BN254Pub;
+        type SignatureKey = BLSPubKey;
         type VoteTokenType = StaticVoteToken<Self::SignatureKey>;
         type Transaction = <DummyBlock as BlockPayload>::Transaction;
         type ElectionConfigType = StaticElectionConfig;

--- a/crates/task-impls/src/consensus.rs
+++ b/crates/task-impls/src/consensus.rs
@@ -150,7 +150,7 @@ pub struct VoteCollectionTaskState<
     #[allow(clippy::type_complexity)]
     /// Accumulator for votes
     pub accumulator:
-        Either<VoteAccumulator<TYPES::VoteTokenType, I::Leaf>, QuorumCertificate<TYPES, I::Leaf>>,
+        Either<VoteAccumulator<TYPES::VoteTokenType, I::Leaf, TYPES>, QuorumCertificate<TYPES, I::Leaf>>,
     /// View which this vote collection task is collecting votes in
     pub cur_view: TYPES::Time,
     /// The event stream shared by all tasks

--- a/crates/task-impls/src/da.rs
+++ b/crates/task-impls/src/da.rs
@@ -103,7 +103,7 @@ pub struct DAVoteCollectionTaskState<
     pub committee_exchange: Arc<CommitteeEx<TYPES, I>>,
     /// the vote accumulator
     pub accumulator:
-        Either<VoteAccumulator<TYPES::VoteTokenType, TYPES::BlockType>, DACertificate<TYPES>>,
+        Either<VoteAccumulator<TYPES::VoteTokenType, TYPES::BlockType, TYPES>, DACertificate<TYPES>>,
     // TODO ED Make this just "view" since it is only for this task
     /// the current view
     pub cur_view: TYPES::Time,

--- a/crates/task-impls/src/view_sync.rs
+++ b/crates/task-impls/src/view_sync.rs
@@ -217,7 +217,7 @@ pub struct ViewSyncRelayTaskState<
     pub exchange: Arc<ViewSyncEx<TYPES, I>>,
     /// Vote accumulator
     pub accumulator: Either<
-        VoteAccumulator<TYPES::VoteTokenType, ViewSyncData<TYPES>>,
+        VoteAccumulator<TYPES::VoteTokenType, ViewSyncData<TYPES>, TYPES>,
         ViewSyncCertificate<TYPES>,
     >,
     /// Our node id; for logging

--- a/crates/testing/src/node_types.rs
+++ b/crates/testing/src/node_types.rs
@@ -11,7 +11,7 @@ use hotshot::{
         },
         NodeImplementation,
     },
-    types::bn254::BN254Pub,
+    types::bn254::BLSPubKey,
 };
 use hotshot_types::{
     certificate::ViewSyncCertificate,
@@ -43,7 +43,7 @@ pub struct SequencingTestTypes;
 impl NodeType for SequencingTestTypes {
     type Time = ViewNumber;
     type BlockType = SDemoBlock;
-    type SignatureKey = BN254Pub;
+    type SignatureKey = BLSPubKey;
     type VoteTokenType = StaticVoteToken<Self::SignatureKey>;
     type Transaction = SDemoTransaction;
     type ElectionConfigType = StaticElectionConfig;

--- a/crates/testing/src/task_helpers.rs
+++ b/crates/testing/src/task_helpers.rs
@@ -7,7 +7,7 @@ use either::Right;
 use hotshot::{
     certificate::QuorumCertificate,
     traits::{BlockPayload, NodeImplementation, TestableNodeImplementation},
-    types::{bn254::BN254Pub, SignatureKey, SystemContextHandle},
+    types::{bn254::BLSPubKey, SignatureKey, SystemContextHandle},
     HotShotInitializer, HotShotSequencingConsensusApi, SystemContext,
 };
 use hotshot_task::event_stream::ChannelStream;
@@ -48,7 +48,7 @@ pub async fn build_system_handle(
     .unwrap();
 
     let known_nodes_with_stake = config.known_nodes_with_stake.clone();
-    let private_key = <BN254Pub as SignatureKey>::generated_from_seed_indexed([0u8; 32], node_id).1;
+    let private_key = <BLSPubKey as SignatureKey>::generated_from_seed_indexed([0u8; 32], node_id).1;
     let public_key = <SequencingTestTypes as NodeType>::SignatureKey::from_private(&private_key);
     let quorum_election_config = config.election_config.clone().unwrap_or_else(|| {
         <QuorumEx<SequencingTestTypes, SequencingMemoryImpl> as ConsensusExchange<
@@ -88,7 +88,7 @@ pub async fn build_system_handle(
 
 async fn build_quorum_proposal_and_signature(
     handle: &SystemContextHandle<SequencingTestTypes, SequencingMemoryImpl>,
-    private_key: &<BN254Pub as SignatureKey>::PrivateKey,
+    private_key: &<BLSPubKey as SignatureKey>::PrivateKey,
     view: u64,
 ) -> (
     QuorumProposal<SequencingTestTypes, SequencingLeaf<SequencingTestTypes>>,
@@ -129,7 +129,7 @@ async fn build_quorum_proposal_and_signature(
         timestamp: 0,
         proposer_id: api.public_key().to_bytes(),
     };
-    let signature = <BN254Pub as SignatureKey>::sign(private_key, leaf.commit().as_ref());
+    let signature = <BLSPubKey as SignatureKey>::sign(private_key, leaf.commit().as_ref());
     let proposal = QuorumProposal::<SequencingTestTypes, SequencingLeaf<SequencingTestTypes>> {
         block_commitment,
         view_number: ViewNumber::new(view),
@@ -145,7 +145,7 @@ async fn build_quorum_proposal_and_signature(
 
 pub async fn build_quorum_proposal(
     handle: &SystemContextHandle<SequencingTestTypes, SequencingMemoryImpl>,
-    private_key: &<BN254Pub as SignatureKey>::PrivateKey,
+    private_key: &<BLSPubKey as SignatureKey>::PrivateKey,
     view: u64,
 ) -> Proposal<QuorumProposal<SequencingTestTypes, SequencingLeaf<SequencingTestTypes>>> {
     let (proposal, signature) =
@@ -156,8 +156,8 @@ pub async fn build_quorum_proposal(
     }
 }
 
-pub fn key_pair_for_id(node_id: u64) -> (<BN254Pub as SignatureKey>::PrivateKey, BN254Pub) {
-    let private_key = <BN254Pub as SignatureKey>::generated_from_seed_indexed([0u8; 32], node_id).1;
+pub fn key_pair_for_id(node_id: u64) -> (<BLSPubKey as SignatureKey>::PrivateKey, BLSPubKey) {
+    let private_key = <BLSPubKey as SignatureKey>::generated_from_seed_indexed([0u8; 32], node_id).1;
     let public_key = <SequencingTestTypes as NodeType>::SignatureKey::from_private(&private_key);
     (private_key, public_key)
 }

--- a/crates/types/src/traits/election.rs
+++ b/crates/types/src/traits/election.rs
@@ -418,8 +418,8 @@ pub trait ConsensusExchange<TYPES: NodeType, M: NetworkMsg>: Send + Sync {
     fn accumulate_internal(
         &self,
         vota_meta: VoteMetaData<Self::Commitment, TYPES::VoteTokenType, TYPES::Time>,
-        accumulator: VoteAccumulator<TYPES::VoteTokenType, Self::Commitment>,
-    ) -> Either<VoteAccumulator<TYPES::VoteTokenType, Self::Commitment>, Self::Certificate> {
+        accumulator: VoteAccumulator<TYPES::VoteTokenType, Self::Commitment, TYPES>,
+    ) -> Either<VoteAccumulator<TYPES::VoteTokenType, Self::Commitment, TYPES>, Self::Certificate> {
         if !self.is_valid_vote(
             &vota_meta.encoded_key,
             &vota_meta.encoded_signature,
@@ -480,9 +480,9 @@ pub trait ConsensusExchange<TYPES: NodeType, M: NetworkMsg>: Send + Sync {
         vote_data: VoteData<Self::Commitment>,
         vote_token: TYPES::VoteTokenType,
         view_number: TYPES::Time,
-        accumlator: VoteAccumulator<TYPES::VoteTokenType, Self::Commitment>,
+        accumlator: VoteAccumulator<TYPES::VoteTokenType, Self::Commitment, TYPES>,
         relay: Option<u64>,
-    ) -> Either<VoteAccumulator<TYPES::VoteTokenType, Self::Commitment>, Self::Certificate>;
+    ) -> Either<VoteAccumulator<TYPES::VoteTokenType, Self::Commitment, TYPES>, Self::Certificate>;
 
     /// The committee which votes on proposals.
     fn membership(&self) -> &Self::Membership;
@@ -696,9 +696,9 @@ impl<
         vote_data: VoteData<Self::Commitment>,
         vote_token: TYPES::VoteTokenType,
         view_number: TYPES::Time,
-        accumlator: VoteAccumulator<TYPES::VoteTokenType, Self::Commitment>,
+        accumlator: VoteAccumulator<TYPES::VoteTokenType, Self::Commitment, TYPES>,
         _relay: Option<u64>,
-    ) -> Either<VoteAccumulator<TYPES::VoteTokenType, Self::Commitment>, Self::Certificate> {
+    ) -> Either<VoteAccumulator<TYPES::VoteTokenType, Self::Commitment, TYPES>, Self::Certificate> {
         let meta = VoteMetaData {
             encoded_key: encoded_key.clone(),
             encoded_signature: encoded_signature.clone(),
@@ -1008,9 +1008,9 @@ impl<
         vote_data: VoteData<Self::Commitment>,
         vote_token: TYPES::VoteTokenType,
         view_number: TYPES::Time,
-        accumlator: VoteAccumulator<TYPES::VoteTokenType, LEAF>,
+        accumlator: VoteAccumulator<TYPES::VoteTokenType, LEAF, TYPES>,
         _relay: Option<u64>,
-    ) -> Either<VoteAccumulator<TYPES::VoteTokenType, LEAF>, Self::Certificate> {
+    ) -> Either<VoteAccumulator<TYPES::VoteTokenType, LEAF, TYPES>, Self::Certificate> {
         let meta = VoteMetaData {
             encoded_key: encoded_key.clone(),
             encoded_signature: encoded_signature.clone(),
@@ -1363,9 +1363,9 @@ impl<
         vote_data: VoteData<Self::Commitment>,
         vote_token: TYPES::VoteTokenType,
         view_number: TYPES::Time,
-        accumlator: VoteAccumulator<TYPES::VoteTokenType, ViewSyncData<TYPES>>,
+        accumlator: VoteAccumulator<TYPES::VoteTokenType, ViewSyncData<TYPES>, TYPES>,
         relay: Option<u64>,
-    ) -> Either<VoteAccumulator<TYPES::VoteTokenType, ViewSyncData<TYPES>>, Self::Certificate> {
+    ) -> Either<VoteAccumulator<TYPES::VoteTokenType, ViewSyncData<TYPES>, TYPES>, Self::Certificate> {
         let meta = VoteMetaData {
             encoded_key: encoded_key.clone(),
             encoded_signature: encoded_signature.clone(),

--- a/crates/types/src/traits/signature_key.rs
+++ b/crates/types/src/traits/signature_key.rs
@@ -70,6 +70,19 @@ pub trait SignatureKey:
         + for<'a> Deserialize<'a>;
     /// The type of the quorum certificate parameters used for assembled signature
     type QCParams: Send + Sync + Sized + Clone + Debug + Hash;
+    /// An aggregateable signature scheme used from jellyfish
+    type SignatureKeySignatureScheme: Send + Sync + Sized + Debug;
+    /// The type of the assembled signature, without `BitVec`
+    type PureAssembledSignatureType: Send
+        + Sync
+        + Sized
+        + Clone
+        + Debug
+        + Hash
+        + PartialEq
+        + Eq
+        + Serialize
+        + for<'a> Deserialize<'a>;
     /// The type of the assembled qc: assembled signature + `BitVec`
     type QCType: Send
         + Sync
@@ -117,7 +130,7 @@ pub trait SignatureKey:
     fn get_sig_proof(
         signature: &Self::QCType,
     ) -> (
-        <BLSOverBN254CurveSignatureScheme as SignatureScheme>::Signature,
+        Self::PureAssembledSignatureType,
         BitVec,
     );
 

--- a/crates/types/src/traits/signature_key.rs
+++ b/crates/types/src/traits/signature_key.rs
@@ -3,9 +3,6 @@ use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, Read, Serializatio
 use bitvec::prelude::*;
 use espresso_systems_common::hotshot::tag;
 use ethereum_types::U256;
-use jf_primitives::signatures::{
-    bls_over_bn254::BLSOverBN254CurveSignatureScheme, SignatureScheme,
-};
 use serde::{Deserialize, Serialize};
 use std::{fmt::Debug, hash::Hash};
 use tagged_base64::tagged;
@@ -70,8 +67,6 @@ pub trait SignatureKey:
         + for<'a> Deserialize<'a>;
     /// The type of the quorum certificate parameters used for assembled signature
     type QCParams: Send + Sync + Sized + Clone + Debug + Hash;
-    /// An aggregateable signature scheme used from jellyfish
-    type SignatureKeySignatureScheme: Send + Sync + Sized + Debug;
     /// The type of the assembled signature, without `BitVec`
     type PureAssembledSignatureType: Send
         + Sync
@@ -138,6 +133,6 @@ pub trait SignatureKey:
     fn assemble(
         real_qc_pp: &Self::QCParams,
         signers: &BitSlice,
-        sigs: &[<BLSOverBN254CurveSignatureScheme as SignatureScheme>::Signature],
+        sigs: &[Self::PureAssembledSignatureType],
     ) -> Self::QCType;
 }

--- a/crates/types/src/traits/signature_key.rs
+++ b/crates/types/src/traits/signature_key.rs
@@ -21,7 +21,7 @@ use tagged_base64::tagged;
     Ord,
 )]
 pub struct EncodedPublicKey(
-    #[debug(with = "custom_debug::hexbuf")] pub Vec<u8>, // pub <BLSOverBN254CurveSignatureScheme as SignatureScheme>::VerificationKey
+    #[debug(with = "custom_debug::hexbuf")] pub Vec<u8>, 
 );
 
 /// Type saftey wrapper for byte encoded signature
@@ -29,7 +29,7 @@ pub struct EncodedPublicKey(
     Clone, custom_debug::Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord,
 )]
 pub struct EncodedSignature(
-    #[debug(with = "custom_debug::hexbuf")] pub Vec<u8>, // pub <BLSOverBN254CurveSignatureScheme as SignatureScheme>::Signature
+    #[debug(with = "custom_debug::hexbuf")] pub Vec<u8>,
 );
 
 impl AsRef<[u8]> for EncodedSignature {

--- a/testing-macros/src/lib.rs
+++ b/testing-macros/src/lib.rs
@@ -617,7 +617,7 @@ pub fn cross_all_types(input: TokenStream) -> TokenStream {
     } = parse_macro_input!(input as CrossAllTypesSpec);
     let tokens = quote! {
             DemoType: [ /* (SequencingConsensus, hotshot::demos::sdemo::SDemoState), */ (ValidatingConsensus, hotshot::demos::vdemo::VDemoState) ],
-            SignatureKey: [ hotshot_types::traits::signature_key::bn254::BN254Pub ],
+            SignatureKey: [ hotshot_types::traits::signature_key::bn254::BLSPubKey ],
             CommChannel: [ hotshot::traits::implementations::Libp2pCommChannel, hotshot::traits::implementations::CentralizedCommChannel ],
             Time: [ hotshot_types::data::ViewNumber ],
             Storage: [ hotshot::traits::implementations::MemoryStorage ],

--- a/testing-macros/tests/integration/failures.rs
+++ b/testing-macros/tests/integration/failures.rs
@@ -2,7 +2,7 @@ use hotshot_testing_macros::cross_tests;
 
 cross_tests!(
      DemoType: [ (ValidatingConsensus, hotshot::demos::vdemo::VDemoState) ],
-     SignatureKey: [ hotshot_types::traits::signature_key::bn254::BN254Pub ],
+     SignatureKey: [ hotshot_types::traits::signature_key::bn254::BLSPubKey ],
      CommChannel: [ hotshot::traits::implementations::MemoryCommChannel ],
      Storage: [ hotshot::traits::implementations::MemoryStorage ],
      Time: [ hotshot_types::data::ViewNumber ],
@@ -37,7 +37,7 @@ cross_tests!(
 
 cross_tests!(
      DemoType: [ (ValidatingConsensus, hotshot::demos::vdemo::VDemoState) ],
-     SignatureKey: [ hotshot_types::traits::signature_key::bn254::BN254Pub ],
+     SignatureKey: [ hotshot_types::traits::signature_key::bn254::BLSPubKey ],
      CommChannel: [ hotshot::traits::implementations::MemoryCommChannel ],
      Storage: [ hotshot::traits::implementations::MemoryStorage ],
      Time: [ hotshot_types::data::ViewNumber ],

--- a/testing-macros/tests/integration/smoke.rs
+++ b/testing-macros/tests/integration/smoke.rs
@@ -2,7 +2,7 @@ use hotshot_testing_macros::cross_tests;
 
 cross_tests!(
     DemoType: [(ValidatingConsensus, hotshot::demos::vdemo::VDemoState)],
-    SignatureKey: [ hotshot_types::traits::signature_key::bn254::BN254Pub ],
+    SignatureKey: [ hotshot_types::traits::signature_key::bn254::BLSPubKey ],
     CommChannel: [ hotshot::traits::implementations::MemoryCommChannel ],
     Storage: [ hotshot::traits::implementations::MemoryStorage ],
     Time: [ hotshot_types::data::ViewNumber ],
@@ -21,7 +21,7 @@ cross_tests!(
 
 cross_tests!(
     DemoType: [(ValidatingConsensus, hotshot::demos::vdemo::VDemoState) ],
-    SignatureKey: [ hotshot_types::traits::signature_key::bn254::BN254Pub ],
+    SignatureKey: [ hotshot_types::traits::signature_key::bn254::BLSPubKey ],
     CommChannel: [ hotshot::traits::implementations::MemoryCommChannel ],
     Storage: [ hotshot::traits::implementations::MemoryStorage ],
     Time: [ hotshot_types::data::ViewNumber ],


### PR DESCRIPTION
This PR:

- Make sure parameters related to the curve only appear in the definition part.
- Rename BN254Pub and BN254Priv to BLSPubKey and BLSPrivKey.