### PR TITLE
quick fix: in_flight test nondeterminism

### DIFF
--- a/crates/testing/tests/memory_network.rs
+++ b/crates/testing/tests/memory_network.rs
@@ -358,9 +358,12 @@ async fn memory_network_test_in_flight_message_count() {
         network1.recv_msgs(TransmitType::Broadcast).await.unwrap();
     }
 
+    while network2.in_flight_message_count().unwrap() > messages.len() {
+        network2.recv_msgs(TransmitType::Direct).await.unwrap();
+    }
+
     while network2.in_flight_message_count().unwrap() > 0 {
         network2.recv_msgs(TransmitType::Broadcast).await.unwrap();
-        network2.recv_msgs(TransmitType::Direct).await.unwrap();
     }
 
     assert_eq!(network1.in_flight_message_count(), Some(0));


### PR DESCRIPTION
Test was occasionally hanging when using the Tokio runtime 

> aims to close #1857