### PR TITLE
Increase DAC logging

### DIFF
--- a/crates/task-impls/src/consensus.rs
+++ b/crates/task-impls/src/consensus.rs
@@ -45,7 +45,7 @@ use std::{
 };
 #[cfg(async_executor_impl = "tokio")]
 use tokio::task::JoinHandle;
-use tracing::{debug, error, instrument};
+use tracing::{debug, error, instrument, info};
 
 /// Error returned by the consensus task
 #[derive(Snafu, Debug)]
@@ -456,13 +456,13 @@ where
                     }
                 }
             }
-            debug!(
+            info!(
                 "Couldn't find DAC cert in certs, meaning we haven't received it yet for view {:?}",
                 *proposal.get_view_number(),
             );
             return false;
         }
-        debug!(
+        info!(
             "Could not vote because we don't have a proposal yet for view {}",
             *self.cur_view
         );


### PR DESCRIPTION
This will tell us why we don't vote in a view.  We will log once per view.  If we get the DAC before the proposal it will log that we don't yet have a proposal.  If the node gets the proposal before the DAC it will log that we don't have the DAC.  If a view times out we can use this information for debugging and know for sure if we received a proposal, DAC, or neither for that view. 