### PR TITLE
Remove nonzero check for view sync indices

### DIFF
--- a/crates/task-impls/src/consensus.rs
+++ b/crates/task-impls/src/consensus.rs
@@ -45,7 +45,7 @@ use std::{
 };
 #[cfg(async_executor_impl = "tokio")]
 use tokio::task::JoinHandle;
-use tracing::{debug, error, instrument, info};
+use tracing::{debug, error, info, instrument};
 
 /// Error returned by the consensus task
 #[derive(Snafu, Debug)]

--- a/crates/web_server/src/lib.rs
+++ b/crates/web_server/src/lib.rs
@@ -280,11 +280,11 @@ impl<KEY: SignatureKey> WebServerDataSource<KEY> for WebServerState<KEY> {
                 self.oldest_vote += 1;
             }
         }
-        let highest_index = self.vote_index.entry(view_number).or_insert(0);
+        let next_index = self.vote_index.entry(view_number).or_insert(0);
         self.votes
             .entry(view_number)
-            .and_modify(|current_votes| current_votes.push((*highest_index, vote.clone())))
-            .or_insert_with(|| vec![(*highest_index, vote)]);
+            .and_modify(|current_votes| current_votes.push((*next_index, vote.clone())))
+            .or_insert_with(|| vec![(*next_index, vote)]);
         self.vote_index
             .entry(view_number)
             .and_modify(|index| *index += 1);
@@ -302,19 +302,14 @@ impl<KEY: SignatureKey> WebServerDataSource<KEY> for WebServerState<KEY> {
                 self.oldest_view_sync_vote += 1;
             }
         }
-        let highest_index = self.view_sync_vote_index.entry(view_number).or_insert(0);
+        let next_index = self.view_sync_vote_index.entry(view_number).or_insert(0);
         self.view_sync_votes
             .entry(view_number)
-            .and_modify(|current_votes| current_votes.push((*highest_index, vote.clone())))
-            .or_insert_with(|| vec![(*highest_index, vote)]);
+            .and_modify(|current_votes| current_votes.push((*next_index, vote.clone())))
+            .or_insert_with(|| vec![(*next_index, vote)]);
         self.view_sync_vote_index
             .entry(view_number)
-            .and_modify(|index| {
-                // Update the index if it's not just added.
-                if *index > 0 {
-                    *index += 1
-                }
-            });
+            .and_modify(|index| *index += 1);
         Ok(())
     }
     /// Stores a received proposal in the `WebServerState`
@@ -351,22 +346,17 @@ impl<KEY: SignatureKey> WebServerDataSource<KEY> for WebServerState<KEY> {
                 self.oldest_view_sync_proposal += 1;
             }
         }
-        let highest_index = self
+        let next_index = self
             .view_sync_proposal_index
             .entry(view_number)
             .or_insert(0);
         self.view_sync_proposals
             .entry(view_number)
-            .and_modify(|current_props| current_props.push((*highest_index, proposal.clone())))
-            .or_insert_with(|| vec![(*highest_index, proposal)]);
+            .and_modify(|current_props| current_props.push((*next_index, proposal.clone())))
+            .or_insert_with(|| vec![(*next_index, proposal)]);
         self.view_sync_proposal_index
             .entry(view_number)
-            .and_modify(|index| {
-                // Update the index if it's not just added.
-                if *index > 0 {
-                    *index += 1
-                }
-            });
+            .and_modify(|index| *index += 1);
         Ok(())
     }
 


### PR DESCRIPTION
- Removes the `index > 0` check when posting view sync vote and proposal.
- Renames `highest_index` to `next_index`.
- Fmt fix.

Relevant Zulip discussion: https://espresso.zulipchat.com/#narrow/stream/311646-Consensus/topic/Pair.20programming.20-.20timeout/near/394500009.