### PR TITLE
fix: Transaction task use quorum exchange instead of committee exchange

### DIFF
--- a/crates/hotshot/src/lib.rs
+++ b/crates/hotshot/src/lib.rs
@@ -713,7 +713,7 @@ where
         let task_runner = add_network_event_task(
             task_runner,
             internal_event_stream.clone(),
-            quorum_exchange,
+            quorum_exchange.clone(),
             NetworkTaskKind::Quorum,
         )
         .await;
@@ -748,7 +748,7 @@ where
         let task_runner = add_transaction_task(
             task_runner,
             internal_event_stream.clone(),
-            committee_exchange.clone(),
+            quorum_exchange,
             handle.clone(),
         )
         .await;

--- a/crates/hotshot/src/tasks/mod.rs
+++ b/crates/hotshot/src/tasks/mod.rs
@@ -36,7 +36,7 @@ use hotshot_types::{
         election::{ConsensusExchange, Membership},
         network::{CommunicationChannel, TransmitType},
         node_implementation::{
-            CommitteeEx, ExchangesType, NodeImplementation, NodeType, ViewSyncEx,
+            CommitteeEx, ExchangesType, NodeImplementation, NodeType, QuorumEx, ViewSyncEx,
         },
         state::ConsensusTime,
     },
@@ -425,15 +425,14 @@ pub async fn add_transaction_task<
 >(
     task_runner: TaskRunner,
     event_stream: ChannelStream<SequencingHotShotEvent<TYPES, I>>,
-    committee_exchange: CommitteeEx<TYPES, I>,
+    quorum_exchange: QuorumEx<TYPES, I>,
     handle: SystemContextHandle<TYPES, I>,
 ) -> TaskRunner
 where
-    CommitteeEx<TYPES, I>: ConsensusExchange<
+    QuorumEx<TYPES, I>: ConsensusExchange<
         TYPES,
         Message<TYPES, I>,
-        Certificate = DACertificate<TYPES>,
-        Commitment = Commitment<TYPES::BlockType>,
+        Certificate = QuorumCertificate<TYPES, Commitment<I::Leaf>>,
     >,
 {
     // build the transactions task
@@ -448,7 +447,7 @@ where
         transactions: Arc::default(),
         seen_transactions: HashSet::new(),
         cur_view: TYPES::Time::new(0),
-        committee_exchange: committee_exchange.into(),
+        quorum_exchange: quorum_exchange.into(),
         event_stream: event_stream.clone(),
         id: handle.hotshot.inner.id,
     };

--- a/crates/task-impls/src/transactions.rs
+++ b/crates/task-impls/src/transactions.rs
@@ -240,11 +240,8 @@ where
                 // <https://github.com/EspressoSystems/HotShot/issues/1822>
                 let txns = self.wait_for_transactions(parent_leaf).await?;
 
-                // TODO GG discuss: Normally we'd simply publish the BlockReady event here
-                // but we need to prepare the VID committment.
-                // VID commitment is expensive but comes free with VID disperse
-                // so do all VID disperse computation here, too.
-                // https://github.com/EspressoSystems/HotShot/issues/1817
+                // TODO move all VID stuff to a new VID task
+                // details here: https://github.com/EspressoSystems/HotShot/issues/1817#issuecomment-1747143528
                 let num_storage_nodes = self.quorum_exchange.membership().total_nodes();
                 debug!("Prepare VID shares for {} storage nodes", num_storage_nodes);
 

--- a/crates/task-impls/src/transactions.rs
+++ b/crates/task-impls/src/transactions.rs
@@ -201,8 +201,6 @@ where
                 self.cur_view = view;
 
                 // If we are not the next leader (DA leader for this view) immediately exit
-                //
-                // TODO GG is it okay to use quorum_exchange.is_leader instead of committee_exchange.is_leader? If we keep committee_exchange in this task then this is the only place where it would be used.
                 if !self.quorum_exchange.is_leader(self.cur_view + 1) {
                     // panic!("We are not the DA leader for view {}", *self.cur_view + 1);
                     return None;

--- a/crates/task-impls/src/transactions.rs
+++ b/crates/task-impls/src/transactions.rs
@@ -244,6 +244,7 @@ where
                 // but we need to prepare the VID committment.
                 // VID commitment is expensive but comes free with VID disperse
                 // so do all VID disperse computation here, too.
+                // https://github.com/EspressoSystems/HotShot/issues/1817
                 debug!("Prepare VID shares");
 
                 // TODO Secure SRS for VID

--- a/crates/types/src/block_impl.rs
+++ b/crates/types/src/block_impl.rs
@@ -8,6 +8,7 @@ use crate::{
     data::{test_srs, VidScheme, VidSchemeTrait},
     traits::{block_contents::Transaction, state::TestableBlock, BlockPayload},
 };
+use ark_serialize::CanonicalDeserialize;
 use commit::{Commitment, Committable};
 use serde::{Deserialize, Serialize};
 use sha3::{Digest, Keccak256};
@@ -88,8 +89,8 @@ impl VIDBlockPayload {
 
 impl Committable for VIDBlockPayload {
     fn commit(&self) -> Commitment<Self> {
-        let builder = commit::RawCommitmentBuilder::new("BlockPayload Comm");
-        builder.generic_byte_array(&self.commitment).finalize()
+        <Commitment<Self> as CanonicalDeserialize>::deserialize(&*self.commitment)
+            .expect("conversion from VidScheme::Commit to Commitment should succeed")
     }
 
     fn tag() -> String {

--- a/crates/types/src/certificate.rs
+++ b/crates/types/src/certificate.rs
@@ -207,7 +207,6 @@ impl<TYPES: NodeType, COMMITMENT: CommitmentBounds>
     }
 
     fn genesis() -> Self {
-        // TODO GG need a new way to get fake commit now that we don't have Committable
         Self {
             leaf_commitment: COMMITMENT::default_commitment_no_preimage(),
             view_number: <TYPES::Time as ConsensusTime>::genesis(),

--- a/crates/types/src/data.rs
+++ b/crates/types/src/data.rs
@@ -947,7 +947,6 @@ impl<TYPES: NodeType> Committable for SequencingLeaf<TYPES> {
     fn commit(&self) -> commit::Commitment<Self> {
         // Commit the block commitment, rather than the block, so that the replicas can reconstruct
         // the leaf.
-        // TODO GG why can't we use block.commit() here?
         let block_commitment = match &self.deltas {
             Either::Left(block) => block.commit(),
             Either::Right(commitment) => *commitment,

--- a/crates/types/src/data.rs
+++ b/crates/types/src/data.rs
@@ -947,6 +947,7 @@ impl<TYPES: NodeType> Committable for SequencingLeaf<TYPES> {
     fn commit(&self) -> commit::Commitment<Self> {
         // Commit the block commitment, rather than the block, so that the replicas can reconstruct
         // the leaf.
+        // TODO GG why can't we use block.commit() here?
         let block_commitment = match &self.deltas {
             Either::Left(block) => block.commit(),
             Either::Right(commitment) => *commitment,

--- a/crates/types/src/traits/election.rs
+++ b/crates/types/src/traits/election.rs
@@ -620,6 +620,8 @@ impl<
     ) -> (EncodedPublicKey, EncodedSignature) {
         let signature = TYPES::SignatureKey::sign(
             &self.private_key,
+            // TODO GG why create a VoteData::DA only to discard it immediately?
+            // Why not just have a `sign_commitment()` member?
             VoteData::DA(block_commitment).get_commit().as_ref(),
         );
         (self.public_key.to_bytes(), signature)
@@ -899,12 +901,16 @@ impl<
     /// of information necessary for any user of the subsequently constructed QC to check that this
     /// node voted `Yes` on that leaf. The leaf is expected to be reconstructed based on other
     /// information in the yes vote.
+    ///
+    /// TODO GG: why return the pubkey? Some other sign_xxx methods do not return the pubkey.
     fn sign_yes_vote(
         &self,
         leaf_commitment: Commitment<LEAF>,
     ) -> (EncodedPublicKey, EncodedSignature) {
         let signature = TYPES::SignatureKey::sign(
             &self.private_key,
+            // TODO GG why create a VoteData::Yes only to discard it?
+            // why not just have a sign_commit() method?
             VoteData::Yes(leaf_commitment).get_commit().as_ref(),
         );
         (self.public_key.to_bytes(), signature)
@@ -915,12 +921,15 @@ impl<
     /// The leaf commitment and the type of the vote (no) are signed, which is the minimum amount
     /// of information necessary for any user of the subsequently constructed QC to check that this
     /// node voted `No` on that leaf.
+    /// TODO GG: why return the pubkey? Some other sign_xxx methods do not return the pubkey.
     fn sign_no_vote(
         &self,
         leaf_commitment: Commitment<LEAF>,
     ) -> (EncodedPublicKey, EncodedSignature) {
         let signature = TYPES::SignatureKey::sign(
             &self.private_key,
+            // TODO GG why create a VoteData::No only to discard it?
+            // why not just have a sign_commit() method?
             VoteData::No(leaf_commitment).get_commit().as_ref(),
         );
         (self.public_key.to_bytes(), signature)
@@ -933,9 +942,12 @@ impl<
     ///
     /// This also allows for the high QC included with the vote to be spoofed in a MITM scenario,
     /// but it is outside our threat model.
+    /// TODO GG: why return the pubkey? Some other sign_xxx methods do not return the pubkey.
     fn sign_timeout_vote(&self, view_number: TYPES::Time) -> (EncodedPublicKey, EncodedSignature) {
         let signature = TYPES::SignatureKey::sign(
             &self.private_key,
+            // TODO GG why create a VoteData::Timeout only to discard it?
+            // why not just have a sign_commit() method?
             VoteData::Timeout(view_number.commit())
                 .get_commit()
                 .as_ref(),

--- a/crates/types/src/traits/election.rs
+++ b/crates/types/src/traits/election.rs
@@ -918,7 +918,7 @@ impl<
     /// node voted `Yes` on that leaf. The leaf is expected to be reconstructed based on other
     /// information in the yes vote.
     ///
-    /// TODO GG: why return the pubkey? Some other sign_xxx methods do not return the pubkey.
+    /// TODO GG: why return the pubkey? Some other `sign_xxx` methods do not return the pubkey.
     fn sign_yes_vote(
         &self,
         leaf_commitment: Commitment<LEAF>,
@@ -937,7 +937,7 @@ impl<
     /// The leaf commitment and the type of the vote (no) are signed, which is the minimum amount
     /// of information necessary for any user of the subsequently constructed QC to check that this
     /// node voted `No` on that leaf.
-    /// TODO GG: why return the pubkey? Some other sign_xxx methods do not return the pubkey.
+    /// TODO GG: why return the pubkey? Some other `sign_xxx` methods do not return the pubkey.
     fn sign_no_vote(
         &self,
         leaf_commitment: Commitment<LEAF>,
@@ -958,7 +958,7 @@ impl<
     ///
     /// This also allows for the high QC included with the vote to be spoofed in a MITM scenario,
     /// but it is outside our threat model.
-    /// TODO GG: why return the pubkey? Some other sign_xxx methods do not return the pubkey.
+    /// TODO GG: why return the pubkey? Some other `sign_xxx` methods do not return the pubkey.
     fn sign_timeout_vote(&self, view_number: TYPES::Time) -> (EncodedPublicKey, EncodedSignature) {
         let signature = TYPES::SignatureKey::sign(
             &self.private_key,

--- a/crates/types/src/traits/election.rs
+++ b/crates/types/src/traits/election.rs
@@ -777,6 +777,15 @@ pub trait QuorumExchangeType<TYPES: NodeType, LEAF: LeafType<NodeType = TYPES>, 
         leaf_commitment: &Commitment<LEAF>,
     ) -> EncodedSignature;
 
+    /// Sign a block commitment.
+    ///
+    /// TODO GG: `sign_block_commitment` and `sign_validating_or_commitment_proposal` should be the same function.
+    /// `Commitment<LEAF>` should equal `Commitment<TYPES::BlockType>`.
+    fn sign_block_commitment(
+        &self,
+        block_commitment: Commitment<TYPES::BlockType>,
+    ) -> EncodedSignature;
+
     /// Sign a positive vote on validating or commitment proposal.
     ///
     /// The leaf commitment and the type of the vote (yes) are signed, which is the minimum amount
@@ -893,6 +902,13 @@ impl<
     ) -> EncodedSignature {
         let signature = TYPES::SignatureKey::sign(&self.private_key, leaf_commitment.as_ref());
         signature
+    }
+
+    fn sign_block_commitment(
+        &self,
+        block_commitment: Commitment<<TYPES as NodeType>::BlockType>,
+    ) -> EncodedSignature {
+        TYPES::SignatureKey::sign(&self.private_key, block_commitment.as_ref())
     }
 
     /// Sign a positive vote on validating or commitment proposal.

--- a/crates/types/src/traits/election.rs
+++ b/crates/types/src/traits/election.rs
@@ -94,19 +94,28 @@ where
     ViewSyncFinalize(COMMITMENT),
 }
 
-impl<COMMITMENT> VoteData<COMMITMENT>
+/// Make different types of `VoteData` committable
+impl<COMMITMENT> Committable for VoteData<COMMITMENT>
 where
     COMMITMENT: CommitmentBounds,
 {
-    /// Return the underlying commitment.
-    #[must_use]
-    pub fn get_commit(&self) -> COMMITMENT {
-        #[allow(clippy::enum_glob_use)]
-        use VoteData::*;
-        match self {
-            DA(c) | Yes(c) | No(c) | Timeout(c) | ViewSyncPreCommit(c) | ViewSyncCommit(c)
-            | ViewSyncFinalize(c) => *c,
-        }
+    fn commit(&self) -> Commitment<Self> {
+        let (tag, commit) = match self {
+            VoteData::DA(c) => ("DA BlockPayload Commit", c),
+            VoteData::Yes(c) => ("Yes Vote Commit", c),
+            VoteData::No(c) => ("No Vote Commit", c),
+            VoteData::Timeout(c) => ("Timeout View Number Commit", c),
+            VoteData::ViewSyncPreCommit(c) => ("ViewSyncPreCommit", c),
+            VoteData::ViewSyncCommit(c) => ("ViewSyncCommit", c),
+            VoteData::ViewSyncFinalize(c) => ("ViewSyncFinalize", c),
+        };
+        commit::RawCommitmentBuilder::new(tag)
+            .var_size_bytes(commit.as_ref())
+            .finalize()
+    }
+
+    fn tag() -> String {
+        ("VOTE_DATA_COMMIT").to_string()
     }
 }
 
@@ -345,7 +354,7 @@ pub trait ConsensusExchange<TYPES: NodeType, M: NetworkMsg>: Send + Sync {
 
         match qc.signatures() {
             AssembledSignature::DA(qc) => {
-                let real_commit = VoteData::DA(leaf_commitment).get_commit();
+                let real_commit = VoteData::DA(leaf_commitment).commit();
                 let real_qc_pp = <TYPES::SignatureKey as SignatureKey>::get_public_parameter(
                     self.membership().get_committee_qc_stake_table(),
                     U256::from(self.membership().success_threshold().get()),
@@ -353,7 +362,7 @@ pub trait ConsensusExchange<TYPES: NodeType, M: NetworkMsg>: Send + Sync {
                 <TYPES::SignatureKey as SignatureKey>::check(&real_qc_pp, real_commit.as_ref(), &qc)
             }
             AssembledSignature::Yes(qc) => {
-                let real_commit = VoteData::Yes(leaf_commitment).get_commit();
+                let real_commit = VoteData::Yes(leaf_commitment).commit();
                 let real_qc_pp = <TYPES::SignatureKey as SignatureKey>::get_public_parameter(
                     self.membership().get_committee_qc_stake_table(),
                     U256::from(self.membership().success_threshold().get()),
@@ -361,7 +370,7 @@ pub trait ConsensusExchange<TYPES: NodeType, M: NetworkMsg>: Send + Sync {
                 <TYPES::SignatureKey as SignatureKey>::check(&real_qc_pp, real_commit.as_ref(), &qc)
             }
             AssembledSignature::No(qc) => {
-                let real_commit = VoteData::No(leaf_commitment).get_commit();
+                let real_commit = VoteData::No(leaf_commitment).commit();
                 let real_qc_pp = <TYPES::SignatureKey as SignatureKey>::get_public_parameter(
                     self.membership().get_committee_qc_stake_table(),
                     U256::from(self.membership().success_threshold().get()),
@@ -389,7 +398,7 @@ pub trait ConsensusExchange<TYPES: NodeType, M: NetworkMsg>: Send + Sync {
         let mut is_valid_vote_token = false;
         let mut is_valid_signature = false;
         if let Some(key) = <TYPES::SignatureKey as SignatureKey>::from_bytes(encoded_key) {
-            is_valid_signature = key.validate(encoded_signature, data.get_commit().as_ref());
+            is_valid_signature = key.validate(encoded_signature, data.commit().as_ref());
             let valid_vote_token = self.membership().validate_vote_token(key, vote_token);
             is_valid_vote_token = match valid_vote_token {
                 Err(_) => {
@@ -411,7 +420,7 @@ pub trait ConsensusExchange<TYPES: NodeType, M: NetworkMsg>: Send + Sync {
         data: &VoteData<Self::Commitment>,
         vote_token: &Checked<TYPES::VoteTokenType>,
     ) -> bool {
-        let is_valid_signature = key.validate(encoded_signature, data.get_commit().as_ref());
+        let is_valid_signature = key.validate(encoded_signature, data.commit().as_ref());
         let valid_vote_token = self
             .membership()
             .validate_vote_token(key.clone(), vote_token.clone());
@@ -620,9 +629,7 @@ impl<
     ) -> (EncodedPublicKey, EncodedSignature) {
         let signature = TYPES::SignatureKey::sign(
             &self.private_key,
-            // TODO GG why create a VoteData::DA only to discard it immediately?
-            // Why not just have a `sign_commitment()` member?
-            VoteData::DA(block_commitment).get_commit().as_ref(),
+            VoteData::DA(block_commitment).commit().as_ref(),
         );
         (self.public_key.to_bytes(), signature)
     }
@@ -665,7 +672,7 @@ impl<
     ) -> (EncodedPublicKey, EncodedSignature) {
         let signature = TYPES::SignatureKey::sign(
             &self.private_key,
-            VoteData::DA(block_commitment).get_commit().as_ref(),
+            VoteData::DA(block_commitment).commit().as_ref(),
         );
         (self.public_key.to_bytes(), signature)
     }
@@ -778,9 +785,6 @@ pub trait QuorumExchangeType<TYPES: NodeType, LEAF: LeafType<NodeType = TYPES>, 
     ) -> EncodedSignature;
 
     /// Sign a block commitment.
-    ///
-    /// TODO GG: `sign_block_commitment` and `sign_validating_or_commitment_proposal` should be the same function.
-    /// `Commitment<LEAF>` should equal `Commitment<TYPES::BlockType>`.
     fn sign_block_commitment(
         &self,
         block_commitment: Commitment<TYPES::BlockType>,
@@ -925,9 +929,7 @@ impl<
     ) -> (EncodedPublicKey, EncodedSignature) {
         let signature = TYPES::SignatureKey::sign(
             &self.private_key,
-            // TODO GG why create a VoteData::Yes only to discard it?
-            // why not just have a sign_commit() method?
-            VoteData::Yes(leaf_commitment).get_commit().as_ref(),
+            VoteData::Yes(leaf_commitment).commit().as_ref(),
         );
         (self.public_key.to_bytes(), signature)
     }
@@ -944,9 +946,7 @@ impl<
     ) -> (EncodedPublicKey, EncodedSignature) {
         let signature = TYPES::SignatureKey::sign(
             &self.private_key,
-            // TODO GG why create a VoteData::No only to discard it?
-            // why not just have a sign_commit() method?
-            VoteData::No(leaf_commitment).get_commit().as_ref(),
+            VoteData::No(leaf_commitment).commit().as_ref(),
         );
         (self.public_key.to_bytes(), signature)
     }
@@ -962,11 +962,7 @@ impl<
     fn sign_timeout_vote(&self, view_number: TYPES::Time) -> (EncodedPublicKey, EncodedSignature) {
         let signature = TYPES::SignatureKey::sign(
             &self.private_key,
-            // TODO GG why create a VoteData::Timeout only to discard it?
-            // why not just have a sign_commit() method?
-            VoteData::Timeout(view_number.commit())
-                .get_commit()
-                .as_ref(),
+            VoteData::Timeout(view_number.commit()).commit().as_ref(),
         );
         (self.public_key.to_bytes(), signature)
     }
@@ -1215,9 +1211,7 @@ impl<
     ) -> (EncodedPublicKey, EncodedSignature) {
         let signature = TYPES::SignatureKey::sign(
             &self.private_key,
-            VoteData::ViewSyncPreCommit(commitment)
-                .get_commit()
-                .as_ref(),
+            VoteData::ViewSyncPreCommit(commitment).commit().as_ref(),
         );
 
         (self.public_key.to_bytes(), signature)
@@ -1258,7 +1252,7 @@ impl<
     ) -> (EncodedPublicKey, EncodedSignature) {
         let signature = TYPES::SignatureKey::sign(
             &self.private_key,
-            VoteData::ViewSyncCommit(commitment).get_commit().as_ref(),
+            VoteData::ViewSyncCommit(commitment).commit().as_ref(),
         );
 
         (self.public_key.to_bytes(), signature)
@@ -1299,7 +1293,7 @@ impl<
     ) -> (EncodedPublicKey, EncodedSignature) {
         let signature = TYPES::SignatureKey::sign(
             &self.private_key,
-            VoteData::ViewSyncFinalize(commitment).get_commit().as_ref(),
+            VoteData::ViewSyncFinalize(commitment).commit().as_ref(),
         );
 
         (self.public_key.to_bytes(), signature)
@@ -1330,7 +1324,7 @@ impl<
         };
         match certificate_internal.signatures {
             AssembledSignature::ViewSyncPreCommit(raw_signatures) => {
-                let real_commit = VoteData::ViewSyncPreCommit(vote_data.commit()).get_commit();
+                let real_commit = VoteData::ViewSyncPreCommit(vote_data.commit()).commit();
                 let real_qc_pp = <TYPES::SignatureKey as SignatureKey>::get_public_parameter(
                     self.membership().get_committee_qc_stake_table(),
                     U256::from(self.membership().failure_threshold().get()),
@@ -1342,7 +1336,7 @@ impl<
                 )
             }
             AssembledSignature::ViewSyncCommit(raw_signatures) => {
-                let real_commit = VoteData::ViewSyncCommit(vote_data.commit()).get_commit();
+                let real_commit = VoteData::ViewSyncCommit(vote_data.commit()).commit();
                 let real_qc_pp = <TYPES::SignatureKey as SignatureKey>::get_public_parameter(
                     self.membership().get_committee_qc_stake_table(),
                     U256::from(self.membership().success_threshold().get()),
@@ -1354,7 +1348,7 @@ impl<
                 )
             }
             AssembledSignature::ViewSyncFinalize(raw_signatures) => {
-                let real_commit = VoteData::ViewSyncFinalize(vote_data.commit()).get_commit();
+                let real_commit = VoteData::ViewSyncFinalize(vote_data.commit()).commit();
                 let real_qc_pp = <TYPES::SignatureKey as SignatureKey>::get_public_parameter(
                     self.membership().get_committee_qc_stake_table(),
                     U256::from(self.membership().success_threshold().get()),

--- a/justfile
+++ b/justfile
@@ -51,6 +51,11 @@ test_network_task:
   echo Testing the DA task with async std executor
   ASYNC_STD_THREAD_COUNT=1 cargo test --lib --bins --tests --benches --workspace --no-fail-fast test_network_task -- --test-threads=1 --nocapture
 
+test_memory_network:
+  echo Testing the DA task with async std executor
+  ASYNC_STD_THREAD_COUNT=1 cargo test --lib --bins --tests --benches --workspace --no-fail-fast memory_network -- --test-threads=1 --nocapture
+
+
 test_consensus_task:
   echo Testing with async std executor
   ASYNC_STD_THREAD_COUNT=1 cargo test  --lib --bins --tests --benches --workspace --no-fail-fast test_consensus -- --test-threads=1 --nocapture


### PR DESCRIPTION
close #1693 

Change the transactions task to use `quorum_exchange` instead of `committee_exchange` so that VID can retrieve the number of storage nodes.

The VID erasure code rate is still hard-coded. That's a separate issue #1734 .

## Other things in this PR beyond #1693

- Edit `Committable` impl for `VIDBlockPayload` to re-use the commitment bytes instead of computing another commitment of the commitment.
- Add `test_memory_network` to justfile.
- A few questions embedded in code comments. Search for `TODO GG`.