### PR TITLE
Make Test Stricter

### DIFF
--- a/crates/testing/src/overall_safety_task.rs
+++ b/crates/testing/src/overall_safety_task.rs
@@ -367,7 +367,7 @@ impl Default for OverallSafetyPropertiesDescription {
             check_leaf: false,
             check_state: true,
             check_block: true,
-            num_failed_views: 10,
+            num_failed_views: 0,
             transaction_threshold: 0,
             // very strict
             threshold_calculator: Arc::new(|_num_live, num_total| 2 * num_total / 3 + 1),

--- a/crates/testing/src/test_builder.rs
+++ b/crates/testing/src/test_builder.rs
@@ -66,12 +66,12 @@ pub struct TestMetadata {
 impl Default for TimingData {
     fn default() -> Self {
         Self {
-            next_view_timeout: 10000,
+            next_view_timeout: 1000,
             timeout_ratio: (11, 10),
-            round_start_delay: 1,
-            start_delay: 1,
+            round_start_delay: 100,
+            start_delay: 100,
             propose_min_round_time: Duration::new(0, 0),
-            propose_max_round_time: Duration::new(5, 0),
+            propose_max_round_time: Duration::from_millis(100),
         }
     }
 }
@@ -125,7 +125,7 @@ impl TestMetadata {
     }
 
     /// Default setting with 20 nodes and 10 views of successful views.
-    pub fn default_more_nodes_less_success() -> TestMetadata {
+    pub fn default_more_nodes() -> TestMetadata {
         TestMetadata {
             total_nodes: 20,
             start_nodes: 20,
@@ -139,12 +139,13 @@ impl TestMetadata {
             completion_task_description: CompletionTaskDescription::TimeBasedCompletionTaskBuilder(
                 TimeBasedCompletionTaskDescription {
                     // Increase the duration to get the expected number of successful views.
-                    duration: Duration::new(40, 0),
+                    duration: Duration::new(140, 0),
                 },
             ),
-            overall_safety_properties: OverallSafetyPropertiesDescription {
-                num_successful_views: 10,
-                ..Default::default()
+            overall_safety_properties: Default::default(),
+            timing_data: TimingData {
+                next_view_timeout: 1000,
+                ..TimingData::default()
             },
             ..TestMetadata::default()
         }

--- a/crates/testing/tests/basic.rs
+++ b/crates/testing/tests/basic.rs
@@ -38,7 +38,7 @@ async fn test_with_failures_one() {
 
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
-    let mut metadata = TestMetadata::default_more_nodes_less_success();
+    let mut metadata = TestMetadata::default_more_nodes();
     // The first 14 (i.e., 20 - f) nodes are in the DA committee and we may shutdown the
     // remaining 6 (i.e., f) nodes. We could remove this restriction after fixing the
     // following issue.
@@ -50,8 +50,9 @@ async fn test_with_failures_one() {
     }];
 
     metadata.spinning_properties = SpinningTaskDescription {
-        node_changes: vec![(Duration::new(4, 0), dead_nodes)],
+        node_changes: vec![(Duration::new(1, 0), dead_nodes)],
     };
+    metadata.overall_safety_properties.num_failed_views = 2;
     metadata
         .gen_launcher::<SequencingTestTypes, SequencingMemoryImpl>()
         .launch()
@@ -77,7 +78,7 @@ async fn test_with_failures_half_f() {
 
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
-    let mut metadata = TestMetadata::default_more_nodes_less_success();
+    let mut metadata = TestMetadata::default_more_nodes();
     // The first 14 (i.e., 20 - f) nodes are in the DA committee and we may shutdown the
     // remaining 6 (i.e., f) nodes. We could remove this restriction after fixing the
     // following issue.
@@ -99,8 +100,9 @@ async fn test_with_failures_half_f() {
     ];
 
     metadata.spinning_properties = SpinningTaskDescription {
-        node_changes: vec![(Duration::new(4, 0), dead_nodes)],
+        node_changes: vec![(Duration::new(1, 0), dead_nodes)],
     };
+    metadata.overall_safety_properties.num_failed_views = 6;
     metadata
         .gen_launcher::<SequencingTestTypes, SequencingMemoryImpl>()
         .launch()
@@ -126,7 +128,10 @@ async fn test_with_failures_f() {
 
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
-    let mut metadata = TestMetadata::default_more_nodes_less_success();
+    let mut metadata = TestMetadata::default_more_nodes();
+    metadata.overall_safety_properties.num_failed_views = 6;
+    // Make sure we keep commiting rounds after the bad leaders, but not the full 50 because of the numerous timeouts
+    metadata.overall_safety_properties.num_successful_views = 22;
     // The first 14 (i.e., 20 - f) nodes are in the DA committee and we may shutdown the
     // remaining 6 (i.e., f) nodes. We could remove this restriction after fixing the
     // following issue.
@@ -160,7 +165,7 @@ async fn test_with_failures_f() {
     ];
 
     metadata.spinning_properties = SpinningTaskDescription {
-        node_changes: vec![(Duration::new(4, 0), dead_nodes)],
+        node_changes: vec![(Duration::new(1, 0), dead_nodes)],
     };
     metadata
         .gen_launcher::<SequencingTestTypes, SequencingMemoryImpl>()


### PR DESCRIPTION
- Increase the expected view success for the failure tests.  At 10 they were not really testing what happened after a bad node
- Increase duration of failure tests to allow for timeouts and view sync to happen
- Decrease default failures and expect the correct number of failures based on specific tests.
- Tighten up the default timings.  Makes propose time much shorter which allows for timeout to be decreased significantly.  Rounds should complete faster in general now, and the for tests wit expected timeouts they should run 5 times as fast.
- Add more delay at startup.  I noticed the first leader was proposing before we spun up all nodes triggering weird behavior which isn't realistic (or what the tests want to test).  This fixes that.