### PR TITLE
Integrate the New Timeout Cert and Vote

### DIFF
--- a/crates/task-impls/src/events.rs
+++ b/crates/task-impls/src/events.rs
@@ -3,16 +3,16 @@ use crate::view_sync::ViewSyncPhase;
 use commit::Commitment;
 use either::Either;
 use hotshot_types::{
-    certificate::{TimeoutCertificate, VIDCertificate},
+    certificate::VIDCertificate,
     data::{DAProposal, VidDisperse},
     message::Proposal,
-    simple_certificate::{DACertificate2, QuorumCertificate2},
-    simple_vote::{DAVote2, QuorumVote},
+    simple_certificate::{DACertificate2, QuorumCertificate2, TimeoutCertificate2},
+    simple_vote::{DAVote2, QuorumVote, TimeoutVote2},
     traits::node_implementation::{
         CommitteeMembership, NodeImplementation, NodeType, QuorumMembership, QuorumProposalType,
         ViewSyncProposalType,
     },
-    vote::{TimeoutVote, VIDVote, ViewSyncVote},
+    vote::{VIDVote, ViewSyncVote},
 };
 
 /// All of the possible events that can be passed between Sequecning `HotShot` tasks
@@ -25,9 +25,9 @@ pub enum HotShotEvent<TYPES: NodeType, I: NodeImplementation<TYPES>> {
     /// A quorum vote has been received from the network; handled by the consensus task
     QuorumVoteRecv(QuorumVote<TYPES, I::Leaf, QuorumMembership<TYPES, I>>),
     /// A timeout vote recevied from the network; handled by consensus task
-    TimeoutVoteRecv(TimeoutVote<TYPES>),
+    TimeoutVoteRecv(TimeoutVote2<TYPES, QuorumMembership<TYPES, I>>),
     /// Send a timeout vote to the network; emitted by consensus task replicas
-    TimeoutVoteSend(TimeoutVote<TYPES>),
+    TimeoutVoteSend(TimeoutVote2<TYPES, QuorumMembership<TYPES, I>>),
     /// A DA proposal has been received from the network; handled by the DA task
     DAProposalRecv(Proposal<DAProposal<TYPES>>, TYPES::SignatureKey),
     /// A DA vote has been received by the network; handled by the DA task
@@ -43,7 +43,7 @@ pub enum HotShotEvent<TYPES: NodeType, I: NodeImplementation<TYPES>> {
     /// Send a DA vote to the DA leader; emitted by DA committee members in the DA task after seeing a valid DA proposal
     DAVoteSend(DAVote2<TYPES, CommitteeMembership<TYPES, I>>),
     /// The next leader has collected enough votes to form a QC; emitted by the next leader in the consensus task; an internal event only
-    QCFormed(Either<QuorumCertificate2<TYPES, I::Leaf>, TimeoutCertificate<TYPES>>),
+    QCFormed(Either<QuorumCertificate2<TYPES, I::Leaf>, TimeoutCertificate2<TYPES>>),
     /// The DA leader has collected enough votes to form a DAC; emitted by the DA leader in the DA task; sent to the entire network via the networking task
     DACSend(DACertificate2<TYPES>, TYPES::SignatureKey),
     /// The current view has changed; emitted by the replica in the consensus task or replica in the view sync task; received by almost all other tasks

--- a/crates/task-impls/src/network.rs
+++ b/crates/task-impls/src/network.rs
@@ -283,12 +283,12 @@ impl<
                 )
             }
             HotShotEvent::TimeoutVoteSend(vote) => (
-                vote.get_key(),
+                vote.get_signing_key(),
                 MessageKind::<TYPES, I>::from_consensus_message(SequencingMessage(Left(
                     GeneralConsensusMessage::TimeoutVote(vote.clone()),
                 ))),
                 TransmitType::Direct,
-                Some(membership.get_leader(vote.get_view() + 1)),
+                Some(membership.get_leader(vote.get_view_number() + 1)),
             ),
             HotShotEvent::ViewChange(view) => {
                 self.view = view;

--- a/crates/types/src/data.rs
+++ b/crates/types/src/data.rs
@@ -4,8 +4,8 @@
 //! `HotShot`'s version of a block, and proposals, messages upon which to reach the consensus.
 
 use crate::{
-    certificate::{AssembledSignature, TimeoutCertificate, ViewSyncCertificate},
-    simple_certificate::QuorumCertificate2,
+    certificate::{AssembledSignature, ViewSyncCertificate},
+    simple_certificate::{QuorumCertificate2, TimeoutCertificate2},
     traits::{
         block_contents::BlockHeader,
         node_implementation::NodeType,
@@ -176,7 +176,7 @@ pub struct QuorumProposal<TYPES: NodeType, LEAF: LeafType<NodeType = TYPES>> {
     pub justify_qc: QuorumCertificate2<TYPES, LEAF>,
 
     /// Possible timeout certificate.  Only present if the justify_qc is not for the preceding view
-    pub timeout_certificate: Option<TimeoutCertificate<TYPES>>,
+    pub timeout_certificate: Option<TimeoutCertificate2<TYPES>>,
 
     /// the propser id
     pub proposer_id: EncodedPublicKey,

--- a/crates/types/src/message.rs
+++ b/crates/types/src/message.rs
@@ -4,7 +4,7 @@
 //! `HotShot` nodes can send among themselves.
 
 use crate::simple_certificate::DACertificate2;
-use crate::simple_vote::DAVote2;
+use crate::simple_vote::{DAVote2, TimeoutVote2};
 use crate::traits::node_implementation::CommitteeMembership;
 use crate::vote2::HasViewNumber;
 use crate::{
@@ -19,7 +19,7 @@ use crate::{
         },
         signature_key::EncodedSignature,
     },
-    vote::{TimeoutVote, VIDVote, ViewSyncVote, VoteType},
+    vote::{VIDVote, ViewSyncVote, VoteType},
 };
 
 use derivative::Derivative;
@@ -337,7 +337,7 @@ where
     ViewSyncCertificate(Proposal<ViewSyncProposalType<TYPES, I>>),
 
     /// Message with a Timeout vote
-    TimeoutVote(TimeoutVote<TYPES>),
+    TimeoutVote(TimeoutVote2<TYPES, QuorumMembership<TYPES, I>>),
 
     /// Internal ONLY message indicating a view interrupt.
     #[serde(skip)]
@@ -431,7 +431,7 @@ impl<
                     GeneralConsensusMessage::ViewSyncCertificate(message) => {
                         message.data.get_view_number()
                     }
-                    GeneralConsensusMessage::TimeoutVote(message) => message.get_view(),
+                    GeneralConsensusMessage::TimeoutVote(message) => message.get_view_number(),
                 }
             }
             Right(committee_message) => {

--- a/crates/types/src/simple_certificate.rs
+++ b/crates/types/src/simple_certificate.rs
@@ -10,7 +10,7 @@ use commit::{Commitment, CommitmentBoundsArkless, Committable};
 use ethereum_types::U256;
 
 use crate::{
-    simple_vote::{DAData, QuorumData, Voteable},
+    simple_vote::{DAData, QuorumData, TimeoutData, Voteable},
     traits::{
         election::Membership, node_implementation::NodeType, signature_key::SignatureKey,
         state::ConsensusTime,
@@ -129,3 +129,5 @@ pub type QuorumCertificate2<TYPES, LEAF> = SimpleCertificate<TYPES, QuorumData<L
 /// Type alias for a DA certificate over `DAData`
 pub type DACertificate2<TYPES> =
     SimpleCertificate<TYPES, DAData<<TYPES as NodeType>::BlockPayload>>;
+/// Type alias for a Timeout certificate over a view number
+pub type TimeoutCertificate2<TYPES> = SimpleCertificate<TYPES, TimeoutData<TYPES>>;

--- a/crates/types/src/simple_vote.rs
+++ b/crates/types/src/simple_vote.rs
@@ -156,6 +156,14 @@ impl<LEAF: Committable> Committable for QuorumData<LEAF> {
     }
 }
 
+impl<TYPES: NodeType> Committable for TimeoutData<TYPES> {
+    fn commit(&self) -> Commitment<Self> {
+        commit::RawCommitmentBuilder::new("Timeout Vote")
+            .u64(*self.view)
+            .finalize()
+    }
+}
+
 impl<PAYLOAD: Committable> Committable for DAData<PAYLOAD> {
     fn commit(&self) -> Commitment<Self> {
         commit::RawCommitmentBuilder::new("DA Vote")
@@ -214,9 +222,9 @@ pub type QuorumVote<TYPES, LEAF, M> = SimpleVote<TYPES, QuorumData<LEAF>, M>;
 /// DA vote type alias
 pub type DAVote2<TYPES, M> = SimpleVote<TYPES, DAData<<TYPES as NodeType>::BlockPayload>, M>;
 /// VID vote type alias
-pub type VIDVote<TYPES, M> = SimpleVote<TYPES, VIDData<<TYPES as NodeType>::BlockPayload>, M>;
+pub type VIDVote2<TYPES, M> = SimpleVote<TYPES, VIDData<<TYPES as NodeType>::BlockPayload>, M>;
 /// Timeout Vote type alias
-pub type TimeoutVote<TYPES, M> = SimpleVote<TYPES, TimeoutData<TYPES>, M>;
+pub type TimeoutVote2<TYPES, M> = SimpleVote<TYPES, TimeoutData<TYPES>, M>;
 /// View Sync Commit Vote type alias
 pub type ViewSyncCommitVote<TYPES, M> = SimpleVote<TYPES, ViewSyncCommitData<TYPES>, M>;
 /// View Sync Pre Commit Vote type alias


### PR DESCRIPTION
Same as the previous PRs for Quorum and Data Vote/Certs

closes: https://github.com/EspressoSystems/HotShot/issues/2012