### PR TITLE
Sishan/fix ci views timeout

### DIFF
--- a/crates/hotshot/src/tasks/mod.rs
+++ b/crates/hotshot/src/tasks/mod.rs
@@ -540,7 +540,7 @@ where
         num_timeouts_tracked: 0,
         replica_task_map: HashMap::default(),
         relay_task_map: HashMap::default(),
-        view_sync_timeout: Duration::new(5, 0),
+        view_sync_timeout: Duration::new(10, 0),
         id: handle.hotshot.inner.id,
         last_garbage_collected_view: TYPES::Time::new(0),
     };

--- a/crates/hotshot/src/traits/networking/libp2p_network.rs
+++ b/crates/hotshot/src/traits/networking/libp2p_network.rs
@@ -140,6 +140,7 @@ where
     /// - An invalid configuration
     ///   (probably an issue with the defaults of this function)
     /// - An inability to spin up the replica's network
+    #[allow(clippy::panic)]
     fn generator(
         expected_node_count: usize,
         num_bootstrap: usize,
@@ -228,7 +229,7 @@ where
                 let keys = all_keys.clone();
                 let da = da_keys.clone();
                 async_block_on(async move {
-                    Libp2pNetwork::new(
+                    match Libp2pNetwork::new(
                         NetworkingMetricsValue::new(),
                         config,
                         pubkey.clone(),
@@ -240,7 +241,12 @@ where
                         da.contains(&pubkey),
                     )
                     .await
-                    .unwrap()
+                    {
+                        Ok(network) => network,
+                        Err(err) => {
+                            panic!("Failed to create network: {err}");
+                        }
+                    }
                 })
             }
         })

--- a/crates/libp2p-networking/tests/counter.rs
+++ b/crates/libp2p-networking/tests/counter.rs
@@ -142,12 +142,18 @@ async fn run_request_response_increment<'a>(
 
         let requestee_pid = requestee_handle.peer_id();
 
-        stream.next().await.unwrap().unwrap();
+        match stream.next().await.unwrap() {
+            Ok(()) => {}
+            Err(e) => panic!("timeout : {e:?} waiting handle {requestee_pid:?} to update state"),
+        }
         requester_handle
             .direct_request(requestee_pid, &CounterMessage::AskForCounter)
             .await
             .context(HandleSnafu)?;
-        stream.next().await.unwrap().unwrap();
+        match stream.next().await.unwrap() {
+            Ok(()) => {}
+            Err(e) => panic!("timeout : {e:?} waiting handle {requestee_pid:?} to update state"),
+        }
 
         let s1 = requester_handle.state().await;
 

--- a/crates/task-impls/src/consensus.rs
+++ b/crates/task-impls/src/consensus.rs
@@ -610,6 +610,7 @@ where
                 // Nuance: We timeout on the view + 1 here because that means that we have
                 // not seen evidence to transition to this new view
                 let view_number = self.cur_view + 1;
+                error!("Timeout task spawned for view {}", *view_number);
                 async move {
                     async_sleep(Duration::from_millis(timeout)).await;
                     stream

--- a/crates/task-impls/src/consensus.rs
+++ b/crates/task-impls/src/consensus.rs
@@ -610,7 +610,6 @@ where
                 // Nuance: We timeout on the view + 1 here because that means that we have
                 // not seen evidence to transition to this new view
                 let view_number = self.cur_view + 1;
-                error!("Timeout task spawned for view {}", *view_number);
                 async move {
                     async_sleep(Duration::from_millis(timeout)).await;
                     stream

--- a/crates/task-impls/src/view_sync.rs
+++ b/crates/task-impls/src/view_sync.rs
@@ -472,7 +472,7 @@ where
 
                 self.num_timeouts_tracked += 1;
                 error!(
-                    "Num timeouts tracked is {}. View {} timed out",
+                    "Num timeouts tracked since last view change is {}. View {} timed out",
                     self.num_timeouts_tracked, *view_number
                 );
 

--- a/crates/task-impls/src/view_sync.rs
+++ b/crates/task-impls/src/view_sync.rs
@@ -477,7 +477,7 @@ where
                 );
 
                 if self.num_timeouts_tracked > 3 {
-                    error!("Too many timeouts!  This shouldn't happen");
+                    error!("Too many consecutive timeouts!  This shouldn't happen");
                 }
 
                 // TODO ED Make this a configurable variable

--- a/crates/testing/src/overall_safety_task.rs
+++ b/crates/testing/src/overall_safety_task.rs
@@ -371,7 +371,7 @@ impl Default for OverallSafetyPropertiesDescription {
             check_leaf: false,
             check_state: true,
             check_block: true,
-            num_failed_views: 10,
+            num_failed_views: 0,
             transaction_threshold: 0,
             // very strict
             threshold_calculator: Arc::new(|_num_live, num_total| 2 * num_total / 3 + 1),

--- a/crates/testing/src/test_builder.rs
+++ b/crates/testing/src/test_builder.rs
@@ -66,12 +66,12 @@ pub struct TestMetadata {
 impl Default for TimingData {
     fn default() -> Self {
         Self {
-            next_view_timeout: 10000,
+            next_view_timeout: 1000,
             timeout_ratio: (11, 10),
-            round_start_delay: 1,
-            start_delay: 1,
+            round_start_delay: 100,
+            start_delay: 100,
             propose_min_round_time: Duration::new(0, 0),
-            propose_max_round_time: Duration::new(5, 0),
+            propose_max_round_time: Duration::from_millis(100),
         }
     }
 }
@@ -125,7 +125,7 @@ impl TestMetadata {
     }
 
     /// Default setting with 20 nodes and 8 views of successful views.
-    pub fn default_more_nodes_less_success() -> TestMetadata {
+    pub fn default_more_nodes() -> TestMetadata {
         TestMetadata {
             total_nodes: 20,
             start_nodes: 20,
@@ -143,8 +143,11 @@ impl TestMetadata {
                 },
             ),
             overall_safety_properties: OverallSafetyPropertiesDescription {
-                num_successful_views: 8,
                 ..Default::default()
+            },
+            timing_data: TimingData {
+                next_view_timeout: 1000,
+                ..TimingData::default()
             },
             ..TestMetadata::default()
         }

--- a/crates/testing/tests/basic.rs
+++ b/crates/testing/tests/basic.rs
@@ -48,7 +48,7 @@ async fn test_with_failures_one() {
 
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
-    let mut metadata = TestMetadata::default_more_nodes_less_success();
+    let mut metadata = TestMetadata::default_more_nodes();
     // The first 14 (i.e., 20 - f) nodes are in the DA committee and we may shutdown the
     // remaining 6 (i.e., f) nodes. We could remove this restriction after fixing the
     // following issue.
@@ -60,7 +60,7 @@ async fn test_with_failures_one() {
     }];
 
     metadata.spinning_properties = SpinningTaskDescription {
-        node_changes: vec![(Duration::new(4, 0), dead_nodes)],
+        node_changes: vec![(Duration::new(1, 0), dead_nodes)],
     };
     metadata
         .gen_launcher::<TestTypes, MemoryImpl>(0)
@@ -87,7 +87,7 @@ async fn test_with_failures_half_f() {
 
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
-    let mut metadata = TestMetadata::default_more_nodes_less_success();
+    let mut metadata = TestMetadata::default_more_nodes();
     // The first 14 (i.e., 20 - f) nodes are in the DA committee and we may shutdown the
     // remaining 6 (i.e., f) nodes. We could remove this restriction after fixing the
     // following issue.
@@ -109,8 +109,9 @@ async fn test_with_failures_half_f() {
     ];
 
     metadata.spinning_properties = SpinningTaskDescription {
-        node_changes: vec![(Duration::new(4, 0), dead_nodes)],
+        node_changes: vec![(Duration::new(1, 0), dead_nodes)],
     };
+    metadata.overall_safety_properties.num_failed_views = 6;
     metadata
         .gen_launcher::<TestTypes, MemoryImpl>(0)
         .launch()
@@ -136,7 +137,10 @@ async fn test_with_failures_f() {
 
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
-    let mut metadata = TestMetadata::default_more_nodes_less_success();
+    let mut metadata = TestMetadata::default_more_nodes();
+    metadata.overall_safety_properties.num_failed_views = 6;
+    // Make sure we keep commiting rounds after the bad leaders, but not the full 50 because of the numerous timeouts
+    metadata.overall_safety_properties.num_successful_views = 22;
     // The first 14 (i.e., 20 - f) nodes are in the DA committee and we may shutdown the
     // remaining 6 (i.e., f) nodes. We could remove this restriction after fixing the
     // following issue.
@@ -170,7 +174,7 @@ async fn test_with_failures_f() {
     ];
 
     metadata.spinning_properties = SpinningTaskDescription {
-        node_changes: vec![(Duration::new(4, 0), dead_nodes)],
+        node_changes: vec![(Duration::new(1, 0), dead_nodes)],
     };
     metadata
         .gen_launcher::<TestTypes, MemoryImpl>(0)

--- a/crates/testing/tests/web_server.rs
+++ b/crates/testing/tests/web_server.rs
@@ -28,7 +28,7 @@ async fn web_server_network() {
             ..Default::default()
         },
         overall_safety_properties: OverallSafetyPropertiesDescription {
-            num_successful_views: 35,
+            num_successful_views: 30,
             ..Default::default()
         },
         completion_task_description: CompletionTaskDescription::TimeBasedCompletionTaskBuilder(

--- a/crates/testing/tests/web_server.rs
+++ b/crates/testing/tests/web_server.rs
@@ -33,7 +33,7 @@ async fn web_server_network() {
         },
         completion_task_description: CompletionTaskDescription::TimeBasedCompletionTaskBuilder(
             TimeBasedCompletionTaskDescription {
-                duration: Duration::from_secs(20),
+                duration: Duration::from_secs(60),
             },
         ),
         ..TestMetadata::default()

--- a/crates/testing/tests/web_server.rs
+++ b/crates/testing/tests/web_server.rs
@@ -28,7 +28,7 @@ async fn web_server_network() {
             ..Default::default()
         },
         overall_safety_properties: OverallSafetyPropertiesDescription {
-            num_successful_views: 30,
+            num_successful_views: 35,
             ..Default::default()
         },
         completion_task_description: CompletionTaskDescription::TimeBasedCompletionTaskBuilder(


### PR DESCRIPTION
This PR:
- Dealt with some unsafe `unwrap()` which I encountered during testing.
- Poll changes of https://github.com/EspressoSystems/HotShot/pull/1917 from `main` to `develop`.
- Reset parameters for the tests. Like task completion time for `web_server_network` is increased, it helps with the error [“Failed to send message from network task”](https://github.com/EspressoSystems/HotShot/actions/runs/6869130335/job/18681245291?pr=2029#step:8:9290) although not sure how.