### PR TITLE
Change AssembledSignature variant from Genesis() to Genesis

### DIFF
--- a/crates/hotshot/src/demos/sdemo.rs
+++ b/crates/hotshot/src/demos/sdemo.rs
@@ -357,7 +357,7 @@ pub fn random_quorum_certificate<TYPES: NodeType, LEAF: LeafType<NodeType = TYPE
         // block_commitment: random_commitment(rng),
         leaf_commitment: random_commitment(rng),
         view_number: TYPES::Time::new(rng.gen()),
-        signatures: AssembledSignature::Genesis(),
+        signatures: AssembledSignature::Genesis,
         is_genesis: rng.gen(),
     }
 }

--- a/crates/hotshot/src/traits/storage/memory_storage.rs
+++ b/crates/hotshot/src/traits/storage/memory_storage.rs
@@ -170,7 +170,7 @@ mod test {
                 // block_commitment: dummy_block_commit,
                 is_genesis: view_number == <DummyTypes as NodeType>::Time::genesis(),
                 leaf_commitment: dummy_leaf_commit,
-                signatures: AssembledSignature::Genesis(),
+                signatures: AssembledSignature::Genesis,
                 view_number,
             },
             DummyBlock::random(rng),

--- a/crates/types/src/certificate.rs
+++ b/crates/types/src/certificate.rs
@@ -122,7 +122,7 @@ pub enum AssembledSignature<TYPES: NodeType> {
     /// These signatures are for a 'DA' certificate
     DA(<TYPES::SignatureKey as SignatureKey>::QCType),
     /// These signatures are for genesis certificate
-    Genesis(),
+    Genesis,
     /// These signatures are for ViewSyncPreCommit
     ViewSyncPreCommit(<TYPES::SignatureKey as SignatureKey>::QCType),
     /// These signatures are for ViewSyncCommit
@@ -194,7 +194,7 @@ impl<TYPES: NodeType, LEAF: LeafType<NodeType = TYPES>>
         Self {
             leaf_commitment: fake_commitment::<LEAF>(),
             view_number: <TYPES::Time as ConsensusTime>::genesis(),
-            signatures: AssembledSignature::Genesis(),
+            signatures: AssembledSignature::Genesis,
             is_genesis: true,
         }
     }

--- a/crates/types/src/data.rs
+++ b/crates/types/src/data.rs
@@ -844,7 +844,7 @@ pub fn serialize_signature<TYPES: NodeType>(signature: &AssembledSignature<TYPES
             signatures_bytes.extend("ViewSyncFinalize".as_bytes());
             Some(signatures.clone())
         }
-        AssembledSignature::Genesis() => None,
+        AssembledSignature::Genesis => None,
     };
     if let Some(sig) = signatures {
         let (sig, proof) = TYPES::SignatureKey::get_sig_proof(&sig);

--- a/crates/types/src/traits/election.rs
+++ b/crates/types/src/traits/election.rs
@@ -374,7 +374,7 @@ pub trait ConsensusExchange<TYPES: NodeType, M: NetworkMsg>: Send + Sync {
                 );
                 <TYPES::SignatureKey as SignatureKey>::check(&real_qc_pp, real_commit.as_ref(), &qc)
             }
-            AssembledSignature::Genesis() => true,
+            AssembledSignature::Genesis => true,
             AssembledSignature::ViewSyncPreCommit(_)
             | AssembledSignature::ViewSyncCommit(_)
             | AssembledSignature::ViewSyncFinalize(_) => {


### PR DESCRIPTION
serde_json appears not to handle empty tuple variants correctly, but it does handle unit variants: https://github.com/serde-rs/json/issues/1084