### PR TITLE
VID: Reorganize and create new events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2914,6 +2914,7 @@ dependencies = [
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "serde",
+ "sha2 0.10.8",
  "snafu",
  "tokio",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2880,6 +2880,7 @@ dependencies = [
  "pin-project",
  "rand_chacha 0.3.1",
  "serde",
+ "sha2 0.10.8",
  "snafu",
  "time 0.3.30",
  "tokio",

--- a/crates/hotshot/src/tasks/mod.rs
+++ b/crates/hotshot/src/tasks/mod.rs
@@ -206,7 +206,7 @@ pub async fn add_consensus_task<TYPES: NodeType, I: NodeImplementation<TYPES>>(
     let registry = task_runner.registry.clone();
     let (payload, metadata) = <TYPES::BlockPayload as BlockPayload>::genesis();
     // Impossible for `unwrap` to fail on the genesis payload.
-    let payload_commitment = vid_commitment(payload.encode().unwrap().collect());
+    let payload_commitment = vid_commitment(&payload.encode().unwrap().collect());
     // build the consensus task
     let consensus_state = ConsensusTaskState {
         registry: registry.clone(),

--- a/crates/task-impls/Cargo.toml
+++ b/crates/task-impls/Cargo.toml
@@ -26,6 +26,7 @@ rand_chacha = { workspace = true }
 hotshot-utils = { path = "../utils" }
 bincode = { workspace = true }
 bitvec = { workspace = true }
+sha2 = { workspace = true }
 
 [target.'cfg(all(async_executor_impl = "tokio"))'.dependencies]
 tokio = { workspace = true }

--- a/crates/task-impls/src/da.rs
+++ b/crates/task-impls/src/da.rs
@@ -371,7 +371,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
 
                 return None;
             }
-            HotShotEvent::TransactionsSequenced(payload, _metadata, view) => {
+            HotShotEvent::BlockReady(payload, metadata, view) => {
                 self.da_network
                     .inject_consensus_info(ConsensusIntentEvent::CancelPollForTransactions(*view))
                     .await;
@@ -394,6 +394,12 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                     _pd: PhantomData,
                 };
 
+                self.event_stream
+                    .publish(HotShotEvent::SendPayloadCommitmentAndMetadata(
+                        payload_commitment,
+                        metadata,
+                    ))
+                    .await;
                 self.event_stream
                     .publish(HotShotEvent::DAProposalSend(
                         message.clone(),
@@ -426,7 +432,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
             HotShotEvent::DAProposalRecv(_, _)
                 | HotShotEvent::DAVoteRecv(_)
                 | HotShotEvent::Shutdown
-                | HotShotEvent::TransactionsSequenced(_, _, _)
+                | HotShotEvent::BlockReady(_, _, _)
                 | HotShotEvent::Timeout(_)
                 | HotShotEvent::ViewChange(_)
         )

--- a/crates/task-impls/src/da.rs
+++ b/crates/task-impls/src/da.rs
@@ -364,7 +364,12 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
 
                 return None;
             }
-            HotShotEvent::TransactionsSequenced(encoded_transactions, payload_commitment, metadata, view) => {
+            HotShotEvent::TransactionsSequenced(
+                encoded_transactions,
+                payload_commitment,
+                metadata,
+                view,
+            ) => {
                 self.da_network
                     .inject_consensus_info(ConsensusIntentEvent::CancelPollForTransactions(*view))
                     .await;

--- a/crates/task-impls/src/da.rs
+++ b/crates/task-impls/src/da.rs
@@ -30,6 +30,7 @@ use hotshot_types::{
     vote::HasViewNumber,
     vote::VoteAccumulator,
 };
+use sha2::{Digest, Sha256};
 
 use snafu::Snafu;
 use std::{collections::HashMap, marker::PhantomData, sync::Arc};
@@ -158,6 +159,15 @@ async fn vote_handle<TYPES: NodeType, I: NodeImplementation<TYPES>>(
     (None, state)
 }
 
+/// Helper function to calculate a sha256 hash
+/// Used primarily for signing and verifying the encoded transactions
+#[must_use]
+pub fn sha256_hash(data: &Vec<u8>) -> [u8; 32] {
+    let mut hasher = Sha256::new();
+    hasher.update(data);
+    hasher.finalize().into()
+}
+
 impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 'static>
     DATaskState<TYPES, I, A>
 {
@@ -196,6 +206,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                 }
 
                 let payload_commitment = vid_commitment(proposal.data.encoded_transactions.clone());
+                let encoded_transactions_hash = sha256_hash(&proposal.data.encoded_transactions);
 
                 // ED Is this the right leader?
                 let view_leader_key = self.da_membership.get_leader(view);
@@ -204,7 +215,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                     return None;
                 }
 
-                if !view_leader_key.validate(&proposal.signature, payload_commitment.as_ref()) {
+                if !view_leader_key.validate(&proposal.signature, &encoded_transactions_hash) {
                     error!("Could not verify proposal.");
                     return None;
                 }
@@ -364,18 +375,17 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
 
                 return None;
             }
-            HotShotEvent::TransactionsSequenced(
-                encoded_transactions,
-                payload_commitment,
-                metadata,
-                view,
-            ) => {
+            HotShotEvent::TransactionsSequenced(encoded_transactions, metadata, view) => {
                 self.da_network
                     .inject_consensus_info(ConsensusIntentEvent::CancelPollForTransactions(*view))
                     .await;
 
+                // quick hash the encoded txns with sha256
+                let encoded_transactions_hash = sha256_hash(&encoded_transactions);
+
+                // sign the encoded transactions as opposed to the VID commitment
                 let signature =
-                    TYPES::SignatureKey::sign(&self.private_key, payload_commitment.as_ref());
+                    TYPES::SignatureKey::sign(&self.private_key, &encoded_transactions_hash);
                 let data: DAProposal<TYPES> = DAProposal {
                     encoded_transactions,
                     metadata: metadata.clone(),
@@ -422,7 +432,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
             HotShotEvent::DAProposalRecv(_, _)
                 | HotShotEvent::DAVoteRecv(_)
                 | HotShotEvent::Shutdown
-                | HotShotEvent::TransactionsSequenced(_, _, _, _)
+                | HotShotEvent::TransactionsSequenced(_, _, _)
                 | HotShotEvent::Timeout(_)
                 | HotShotEvent::ViewChange(_)
         )

--- a/crates/task-impls/src/da.rs
+++ b/crates/task-impls/src/da.rs
@@ -159,15 +159,6 @@ async fn vote_handle<TYPES: NodeType, I: NodeImplementation<TYPES>>(
     (None, state)
 }
 
-/// Helper function to calculate a sha256 hash
-/// Used primarily for signing and verifying the encoded transactions
-#[must_use]
-pub fn sha256_hash(data: &Vec<u8>) -> [u8; 32] {
-    let mut hasher = Sha256::new();
-    hasher.update(data);
-    hasher.finalize().into()
-}
-
 impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 'static>
     DATaskState<TYPES, I, A>
 {
@@ -205,8 +196,8 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                     return None;
                 }
 
-                let payload_commitment = vid_commitment(proposal.data.encoded_transactions.clone());
-                let encoded_transactions_hash = sha256_hash(&proposal.data.encoded_transactions);
+                let payload_commitment = vid_commitment(&proposal.data.encoded_transactions);
+                let encoded_transactions_hash = Sha256::digest(&proposal.data.encoded_transactions);
 
                 // ED Is this the right leader?
                 let view_leader_key = self.da_membership.get_leader(view);
@@ -381,7 +372,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                     .await;
 
                 // quick hash the encoded txns with sha256
-                let encoded_transactions_hash = sha256_hash(&encoded_transactions);
+                let encoded_transactions_hash = Sha256::digest(&encoded_transactions);
 
                 // sign the encoded transactions as opposed to the VID commitment
                 let signature =

--- a/crates/task-impls/src/da.rs
+++ b/crates/task-impls/src/da.rs
@@ -371,16 +371,10 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
 
                 return None;
             }
-            HotShotEvent::TransactionsSequenced(encoded_txns, metadata, view) => {
+            HotShotEvent::TransactionsSequenced(payload, _metadata, view) => {
                 self.da_network
                     .inject_consensus_info(ConsensusIntentEvent::CancelPollForTransactions(*view))
                     .await;
-
-                // calculate payload from encoded transactions and metadata
-                let payload = <TYPES::BlockPayload as BlockPayload>::from_bytes(
-                    encoded_txns.into_iter(),
-                    metadata,
-                );
 
                 let payload_commitment = payload.commit();
                 let signature =

--- a/crates/task-impls/src/da.rs
+++ b/crates/task-impls/src/da.rs
@@ -371,10 +371,16 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
 
                 return None;
             }
-            HotShotEvent::TransactionsSequenced(payload, _metadata, view) => {
+            HotShotEvent::TransactionsSequenced(encoded_txns, metadata, view) => {
                 self.da_network
                     .inject_consensus_info(ConsensusIntentEvent::CancelPollForTransactions(*view))
                     .await;
+
+                // calculate payload from encoded transactions and metadata
+                let payload = <TYPES::BlockPayload as BlockPayload>::from_bytes(
+                    encoded_txns.into_iter(),
+                    metadata,
+                );
 
                 let payload_commitment = payload.commit();
                 let signature =

--- a/crates/task-impls/src/da.rs
+++ b/crates/task-impls/src/da.rs
@@ -371,7 +371,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
 
                 return None;
             }
-            HotShotEvent::BlockReady(payload, metadata, view) => {
+            HotShotEvent::TransactionsSequenced(payload, _metadata, view) => {
                 self.da_network
                     .inject_consensus_info(ConsensusIntentEvent::CancelPollForTransactions(*view))
                     .await;
@@ -394,12 +394,6 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                     _pd: PhantomData,
                 };
 
-                self.event_stream
-                    .publish(HotShotEvent::SendPayloadCommitmentAndMetadata(
-                        payload_commitment,
-                        metadata,
-                    ))
-                    .await;
                 self.event_stream
                     .publish(HotShotEvent::DAProposalSend(
                         message.clone(),
@@ -432,7 +426,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
             HotShotEvent::DAProposalRecv(_, _)
                 | HotShotEvent::DAVoteRecv(_)
                 | HotShotEvent::Shutdown
-                | HotShotEvent::BlockReady(_, _, _)
+                | HotShotEvent::TransactionsSequenced(_, _, _)
                 | HotShotEvent::Timeout(_)
                 | HotShotEvent::ViewChange(_)
         )

--- a/crates/task-impls/src/events.rs
+++ b/crates/task-impls/src/events.rs
@@ -95,7 +95,7 @@ pub enum HotShotEvent<TYPES: NodeType> {
     ),
     /// Event when the transactions task has sequenced transactions. Contains the encoded transactions
     TransactionsSequenced(
-        TYPES::BlockPayload,
+        Vec<u8>,
         <TYPES::BlockPayload as BlockPayload>::Metadata,
         TYPES::Time,
     ),

--- a/crates/task-impls/src/events.rs
+++ b/crates/task-impls/src/events.rs
@@ -95,7 +95,6 @@ pub enum HotShotEvent<TYPES: NodeType> {
     /// Event when the transactions task has sequenced transactions. Contains the encoded transactions
     TransactionsSequenced(
         Vec<u8>,
-        VidCommitment,
         <TYPES::BlockPayload as BlockPayload>::Metadata,
         TYPES::Time,
     ),

--- a/crates/task-impls/src/events.rs
+++ b/crates/task-impls/src/events.rs
@@ -93,10 +93,16 @@ pub enum HotShotEvent<TYPES: NodeType> {
         Commitment<TYPES::BlockPayload>,
         <TYPES::BlockPayload as BlockPayload>::Metadata,
     ),
-    /// Event when the transactions task has a block formed
-    BlockReady(
+    /// Event when the transactions task has sequenced transactions. Contains the encoded transactions
+    TransactionsSequenced(
         TYPES::BlockPayload,
         <TYPES::BlockPayload as BlockPayload>::Metadata,
+        TYPES::Time,
+    ),
+    /// Event when the VID task has formed a block
+    BlockReady(
+        Commitment<TYPES::BlockPayload>,
+        VidDisperse<TYPES>,
         TYPES::Time,
     ),
     /// Event when consensus decided on a leaf

--- a/crates/task-impls/src/events.rs
+++ b/crates/task-impls/src/events.rs
@@ -1,6 +1,5 @@
 use crate::view_sync::ViewSyncPhase;
 
-use commit::Commitment;
 use either::Either;
 use hotshot_types::{
     data::{DAProposal, Leaf, QuorumProposal, VidCommitment, VidDisperse},
@@ -101,11 +100,7 @@ pub enum HotShotEvent<TYPES: NodeType> {
         TYPES::Time,
     ),
     /// Event when the transactions task has a block formed
-    BlockReady(
-        VidDisperse<TYPES>,
-        VidCommitment,
-        TYPES::Time,
-    ),
+    BlockReady(VidDisperse<TYPES>, VidCommitment, TYPES::Time),
     /// Event when consensus decided on a leaf
     LeafDecided(Vec<Leaf<TYPES>>),
     /// Send VID shares to VID storage nodes; emitted by the DA leader

--- a/crates/task-impls/src/events.rs
+++ b/crates/task-impls/src/events.rs
@@ -99,7 +99,7 @@ pub enum HotShotEvent<TYPES: NodeType> {
         TYPES::Time,
     ),
     /// Event when the transactions task has a block formed
-    BlockReady(VidDisperse<TYPES>, VidCommitment, TYPES::Time),
+    BlockReady(VidDisperse<TYPES>, TYPES::Time),
     /// Event when consensus decided on a leaf
     LeafDecided(Vec<Leaf<TYPES>>),
     /// Send VID shares to VID storage nodes; emitted by the DA leader

--- a/crates/task-impls/src/events.rs
+++ b/crates/task-impls/src/events.rs
@@ -95,7 +95,7 @@ pub enum HotShotEvent<TYPES: NodeType> {
     ),
     /// Event when the transactions task has sequenced transactions. Contains the encoded transactions
     TransactionsSequenced(
-        Vec<u8>,
+        TYPES::BlockPayload,
         <TYPES::BlockPayload as BlockPayload>::Metadata,
         TYPES::Time,
     ),

--- a/crates/task-impls/src/events.rs
+++ b/crates/task-impls/src/events.rs
@@ -1,5 +1,6 @@
 use crate::view_sync::ViewSyncPhase;
 
+use commit::Commitment;
 use either::Either;
 use hotshot_types::{
     data::{DAProposal, Leaf, QuorumProposal, VidCommitment, VidDisperse},
@@ -92,10 +93,17 @@ pub enum HotShotEvent<TYPES: NodeType> {
         VidCommitment,
         <TYPES::BlockPayload as BlockPayload>::Metadata,
     ),
+    /// Event when the transactions task has sequenced transactions. Contains the encoded transactions
+    TransactionsSequenced(
+        Vec<u8>,
+        VidCommitment,
+        <TYPES::BlockPayload as BlockPayload>::Metadata,
+        TYPES::Time,
+    ),
     /// Event when the transactions task has a block formed
     BlockReady(
-        Vec<u8>,
-        <TYPES::BlockPayload as BlockPayload>::Metadata,
+        VidDisperse<TYPES>,
+        VidCommitment,
         TYPES::Time,
     ),
     /// Event when consensus decided on a leaf

--- a/crates/task-impls/src/events.rs
+++ b/crates/task-impls/src/events.rs
@@ -93,16 +93,10 @@ pub enum HotShotEvent<TYPES: NodeType> {
         Commitment<TYPES::BlockPayload>,
         <TYPES::BlockPayload as BlockPayload>::Metadata,
     ),
-    /// Event when the transactions task has sequenced transactions. Contains the encoded transactions
-    TransactionsSequenced(
+    /// Event when the transactions task has a block formed
+    BlockReady(
         TYPES::BlockPayload,
         <TYPES::BlockPayload as BlockPayload>::Metadata,
-        TYPES::Time,
-    ),
-    /// Event when the VID task has formed a block
-    BlockReady(
-        Commitment<TYPES::BlockPayload>,
-        VidDisperse<TYPES>,
         TYPES::Time,
     ),
     /// Event when consensus decided on a leaf

--- a/crates/task-impls/src/network.rs
+++ b/crates/task-impls/src/network.rs
@@ -267,7 +267,7 @@ impl<TYPES: NodeType, COMMCHANNEL: CommunicationChannel<TYPES>>
             HotShotEvent::ViewSyncCommitCertificate2Send(certificate, sender) => (
                 sender,
                 MessageKind::<TYPES>::from_consensus_message(SequencingMessage(Left(
-                    GeneralConsensusMessage::ViewSyncCommitCertificate(certificate.clone()),
+                    GeneralConsensusMessage::ViewSyncCommitCertificate(certificate),
                 ))),
                 TransmitType::Broadcast,
                 None,
@@ -276,7 +276,7 @@ impl<TYPES: NodeType, COMMCHANNEL: CommunicationChannel<TYPES>>
             HotShotEvent::ViewSyncFinalizeCertificate2Send(certificate, sender) => (
                 sender,
                 MessageKind::<TYPES>::from_consensus_message(SequencingMessage(Left(
-                    GeneralConsensusMessage::ViewSyncFinalizeCertificate(certificate.clone()),
+                    GeneralConsensusMessage::ViewSyncFinalizeCertificate(certificate),
                 ))),
                 TransmitType::Broadcast,
                 None,

--- a/crates/task-impls/src/transactions.rs
+++ b/crates/task-impls/src/transactions.rs
@@ -13,8 +13,10 @@ use hotshot_task::{
     task_impls::HSTWithEvent,
 };
 use hotshot_types::{
+    block_impl::{NUM_CHUNKS, NUM_STORAGE_NODES},
     consensus::Consensus,
-    data::Leaf,
+    data::{test_srs, Leaf, VidDisperse, VidScheme, VidSchemeTrait},
+    message::Proposal,
     traits::{
         consensus_api::ConsensusApi,
         election::Membership,
@@ -27,10 +29,11 @@ use hotshot_utils::bincode::bincode_opts;
 use snafu::Snafu;
 use std::{
     collections::{HashMap, HashSet},
+    marker::PhantomData,
     sync::Arc,
     time::Instant,
 };
-use tracing::{debug, error, instrument, warn};
+use tracing::{debug, error, info, instrument, warn};
 
 /// A type alias for `HashMap<Commitment<T>, T>`
 type CommitmentMap<T> = HashMap<Commitment<T>, T>;
@@ -217,16 +220,56 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                             return None;
                         }
                     };
+                let encoded_txns = match payload.encode() {
+                    Ok(encoded) => encoded,
+                    Err(e) => {
+                        error!("Failed to encode the block payload: {:?}.", e);
+                        return None;
+                    }
+                };
+                // TODO <https://github.com/EspressoSystems/HotShot/issues/1686>
+                let srs = test_srs(NUM_STORAGE_NODES);
+                // TODO We are using constant numbers for now, but they will change as the quorum size
+                // changes.
+                // TODO <https://github.com/EspressoSystems/HotShot/issues/1693>
+                let vid = VidScheme::new(NUM_CHUNKS, NUM_STORAGE_NODES, &srs).unwrap();
+                let vid_disperse = vid
+                    .disperse(encoded_txns.into_iter().collect::<Vec<u8>>())
+                    .unwrap();
 
-                // Publish encoded transactions to the event stream
+                // TODO never clone a block
+                // https://github.com/EspressoSystems/HotShot/issues/1858
                 self.event_stream
-                    .publish(HotShotEvent::TransactionsSequenced(
-                        payload,
+                    .publish(HotShotEvent::BlockReady(
+                        payload.clone(),
                         metadata,
                         view + 1,
                     ))
                     .await;
 
+                // TODO (Keyao) Determine and update where to publish VidDisperseSend.
+                // <https://github.com/EspressoSystems/HotShot/issues/1817>
+                debug!("publishing VID disperse for view {}", *view + 1);
+                info!("New view: {}", *view);
+                self.event_stream
+                    .publish(HotShotEvent::VidDisperseSend(
+                        Proposal {
+                            data: VidDisperse {
+                                view_number: view + 1,
+                                payload_commitment: payload.commit(),
+                                shares: vid_disperse.shares,
+                                common: vid_disperse.common,
+                            },
+                            // TODO (Keyao) This is also signed in DA task.
+                            signature: TYPES::SignatureKey::sign(
+                                &self.private_key,
+                                payload.commit().as_ref(),
+                            ),
+                            _pd: PhantomData,
+                        },
+                        self.public_key.clone(),
+                    ))
+                    .await;
                 return None;
             }
             HotShotEvent::Shutdown => {

--- a/crates/task-impls/src/transactions.rs
+++ b/crates/task-impls/src/transactions.rs
@@ -17,7 +17,7 @@ use hotshot_types::{
     data::{test_srs, Leaf, VidDisperse, VidScheme, VidSchemeTrait},
     message::Proposal,
     traits::{
-        block_contents::{NUM_CHUNKS, NUM_STORAGE_NODES},
+        block_contents::{vid_commitment, NUM_CHUNKS, NUM_STORAGE_NODES},
         consensus_api::ConsensusApi,
         election::Membership,
         node_implementation::{NodeImplementation, NodeType},
@@ -220,6 +220,8 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                             return None;
                         }
                     };
+
+                // encode the transactions
                 let encoded_transactions = match payload.encode() {
                     Ok(encoded) => encoded.into_iter().collect::<Vec<u8>>(),
                     Err(e) => {
@@ -227,46 +229,29 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                         return None;
                     }
                 };
-                // TODO <https://github.com/EspressoSystems/HotShot/issues/1686>
-                let srs = test_srs(NUM_STORAGE_NODES);
-                // TODO We are using constant numbers for now, but they will change as the quorum size
-                // changes.
-                // TODO <https://github.com/EspressoSystems/HotShot/issues/1693>
-                let vid = VidScheme::new(NUM_CHUNKS, NUM_STORAGE_NODES, &srs).unwrap();
-                let vid_disperse = vid.disperse(encoded_transactions.clone()).unwrap();
 
+                // calculate the payload commitment
                 // TODO never clone a block
                 // https://github.com/EspressoSystems/HotShot/issues/1858
+                let commitment = vid_commitment(encoded_transactions.clone());
+
+                // send the sequenced transactions to VID and DA tasks
                 self.event_stream
-                    .publish(HotShotEvent::BlockReady(
+                    .publish(HotShotEvent::TransactionsSequenced(
                         encoded_transactions,
-                        metadata,
+                        commitment,
+                        metadata.clone(),
                         view + 1,
                     ))
                     .await;
 
-                // TODO (Keyao) Determine and update where to publish VidDisperseSend.
-                // <https://github.com/EspressoSystems/HotShot/issues/1817>
-                debug!("publishing VID disperse for view {}", *view + 1);
-                info!("New view: {}", *view);
+                // send the commitment and metadata to consensus for timeout purposes
                 self.event_stream
-                    .publish(HotShotEvent::VidDisperseSend(
-                        Proposal {
-                            data: VidDisperse {
-                                view_number: view + 1,
-                                payload_commitment: vid_disperse.commit,
-                                shares: vid_disperse.shares,
-                                common: vid_disperse.common,
-                            },
-                            signature: TYPES::SignatureKey::sign(
-                                &self.private_key,
-                                &vid_disperse.commit,
-                            ),
-                            _pd: PhantomData,
-                        },
-                        self.public_key.clone(),
+                    .publish(HotShotEvent::SendPayloadCommitmentAndMetadata(
+                        commitment, metadata,
                     ))
                     .await;
+
                 return None;
             }
             HotShotEvent::Shutdown => {

--- a/crates/task-impls/src/transactions.rs
+++ b/crates/task-impls/src/transactions.rs
@@ -13,10 +13,8 @@ use hotshot_task::{
     task_impls::HSTWithEvent,
 };
 use hotshot_types::{
-    block_impl::{NUM_CHUNKS, NUM_STORAGE_NODES},
     consensus::Consensus,
-    data::{test_srs, Leaf, VidDisperse, VidScheme, VidSchemeTrait},
-    message::Proposal,
+    data::Leaf,
     traits::{
         consensus_api::ConsensusApi,
         election::Membership,
@@ -29,11 +27,10 @@ use hotshot_utils::bincode::bincode_opts;
 use snafu::Snafu;
 use std::{
     collections::{HashMap, HashSet},
-    marker::PhantomData,
     sync::Arc,
     time::Instant,
 };
-use tracing::{debug, error, info, instrument, warn};
+use tracing::{debug, error, instrument, warn};
 
 /// A type alias for `HashMap<Commitment<T>, T>`
 type CommitmentMap<T> = HashMap<Commitment<T>, T>;
@@ -220,56 +217,16 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                             return None;
                         }
                     };
-                let encoded_txns = match payload.encode() {
-                    Ok(encoded) => encoded,
-                    Err(e) => {
-                        error!("Failed to encode the block payload: {:?}.", e);
-                        return None;
-                    }
-                };
-                // TODO <https://github.com/EspressoSystems/HotShot/issues/1686>
-                let srs = test_srs(NUM_STORAGE_NODES);
-                // TODO We are using constant numbers for now, but they will change as the quorum size
-                // changes.
-                // TODO <https://github.com/EspressoSystems/HotShot/issues/1693>
-                let vid = VidScheme::new(NUM_CHUNKS, NUM_STORAGE_NODES, &srs).unwrap();
-                let vid_disperse = vid
-                    .disperse(encoded_txns.into_iter().collect::<Vec<u8>>())
-                    .unwrap();
 
-                // TODO never clone a block
-                // https://github.com/EspressoSystems/HotShot/issues/1858
+                // Publish encoded transactions to the event stream
                 self.event_stream
-                    .publish(HotShotEvent::BlockReady(
-                        payload.clone(),
+                    .publish(HotShotEvent::TransactionsSequenced(
+                        payload,
                         metadata,
                         view + 1,
                     ))
                     .await;
 
-                // TODO (Keyao) Determine and update where to publish VidDisperseSend.
-                // <https://github.com/EspressoSystems/HotShot/issues/1817>
-                debug!("publishing VID disperse for view {}", *view + 1);
-                info!("New view: {}", *view);
-                self.event_stream
-                    .publish(HotShotEvent::VidDisperseSend(
-                        Proposal {
-                            data: VidDisperse {
-                                view_number: view + 1,
-                                payload_commitment: payload.commit(),
-                                shares: vid_disperse.shares,
-                                common: vid_disperse.common,
-                            },
-                            // TODO (Keyao) This is also signed in DA task.
-                            signature: TYPES::SignatureKey::sign(
-                                &self.private_key,
-                                payload.commit().as_ref(),
-                            ),
-                            _pd: PhantomData,
-                        },
-                        self.public_key.clone(),
-                    ))
-                    .await;
                 return None;
             }
             HotShotEvent::Shutdown => {

--- a/crates/task-impls/src/transactions.rs
+++ b/crates/task-impls/src/transactions.rs
@@ -218,10 +218,19 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                         }
                     };
 
+                // Encode the transactions
+                let encoded_txns = match payload.encode() {
+                    Ok(encoded) => encoded,
+                    Err(e) => {
+                        error!("Failed to encode the block payload: {:?}.", e);
+                        return None;
+                    }
+                };
+
                 // Publish encoded transactions to the event stream
                 self.event_stream
                     .publish(HotShotEvent::TransactionsSequenced(
-                        payload,
+                        encoded_txns.collect(),
                         metadata,
                         view + 1,
                     ))

--- a/crates/task-impls/src/transactions.rs
+++ b/crates/task-impls/src/transactions.rs
@@ -218,19 +218,10 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                         }
                     };
 
-                // Encode the transactions
-                let encoded_txns = match payload.encode() {
-                    Ok(encoded) => encoded,
-                    Err(e) => {
-                        error!("Failed to encode the block payload: {:?}.", e);
-                        return None;
-                    }
-                };
-
                 // Publish encoded transactions to the event stream
                 self.event_stream
                     .publish(HotShotEvent::TransactionsSequenced(
-                        encoded_txns.collect(),
+                        payload,
                         metadata,
                         view + 1,
                     ))

--- a/crates/task-impls/src/transactions.rs
+++ b/crates/task-impls/src/transactions.rs
@@ -231,7 +231,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                 self.event_stream
                     .publish(HotShotEvent::TransactionsSequenced(
                         encoded_transactions,
-                        metadata.clone(),
+                        metadata,
                         view + 1,
                     ))
                     .await;

--- a/crates/task-impls/src/transactions.rs
+++ b/crates/task-impls/src/transactions.rs
@@ -14,10 +14,9 @@ use hotshot_task::{
 };
 use hotshot_types::{
     consensus::Consensus,
-    data::{test_srs, Leaf, VidDisperse, VidScheme, VidSchemeTrait},
-    message::Proposal,
+    data::Leaf,
     traits::{
-        block_contents::{vid_commitment, NUM_CHUNKS, NUM_STORAGE_NODES},
+        block_contents::vid_commitment,
         consensus_api::ConsensusApi,
         election::Membership,
         node_implementation::{NodeImplementation, NodeType},
@@ -29,11 +28,10 @@ use hotshot_utils::bincode::bincode_opts;
 use snafu::Snafu;
 use std::{
     collections::{HashMap, HashSet},
-    marker::PhantomData,
     sync::Arc,
     time::Instant,
 };
-use tracing::{debug, error, info, instrument, warn};
+use tracing::{debug, error, instrument, warn};
 
 /// A type alias for `HashMap<Commitment<T>, T>`
 type CommitmentMap<T> = HashMap<Commitment<T>, T>;

--- a/crates/task-impls/src/transactions.rs
+++ b/crates/task-impls/src/transactions.rs
@@ -16,7 +16,6 @@ use hotshot_types::{
     consensus::Consensus,
     data::Leaf,
     traits::{
-        block_contents::vid_commitment,
         consensus_api::ConsensusApi,
         election::Membership,
         node_implementation::{NodeImplementation, NodeType},
@@ -228,25 +227,12 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                     }
                 };
 
-                // calculate the payload commitment
-                // TODO never clone a block
-                // https://github.com/EspressoSystems/HotShot/issues/1858
-                let commitment = vid_commitment(encoded_transactions.clone());
-
                 // send the sequenced transactions to VID and DA tasks
                 self.event_stream
                     .publish(HotShotEvent::TransactionsSequenced(
                         encoded_transactions,
-                        commitment,
                         metadata.clone(),
                         view + 1,
-                    ))
-                    .await;
-
-                // send the commitment and metadata to consensus for timeout purposes
-                self.event_stream
-                    .publish(HotShotEvent::SendPayloadCommitmentAndMetadata(
-                        commitment, metadata,
                     ))
                     .await;
 

--- a/crates/task-impls/src/vid.rs
+++ b/crates/task-impls/src/vid.rs
@@ -345,24 +345,27 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                     .await;
             }
 
-            HotShotEvent::TransactionsSequenced(encoded_txns, metadata, view_number) => {
+            HotShotEvent::TransactionsSequenced(payload, metadata, view_number) => {
+                // Encode the sequenced transactions
+                let encoded_txns = match payload.encode() {
+                    Ok(encoded) => encoded,
+                    Err(e) => {
+                        error!("Failed to encode the block payload: {:?}.", e);
+                        return None;
+                    }
+                };
+
                 // TODO <https://github.com/EspressoSystems/HotShot/issues/1686>
                 let srs = test_srs(NUM_STORAGE_NODES);
                 // TODO We are using constant numbers for now, but they will change as the quorum size
                 // changes.
                 // TODO <https://github.com/EspressoSystems/HotShot/issues/1693>
-                // TODO never clone a block
-                // https://github.com/EspressoSystems/HotShot/issues/1858
                 let vid = VidScheme::new(NUM_CHUNKS, NUM_STORAGE_NODES, &srs).unwrap();
-                let vid_disperse = vid.disperse(encoded_txns.clone()).unwrap();
+                let vid_disperse = vid
+                    .disperse(encoded_txns.into_iter().collect::<Vec<u8>>())
+                    .unwrap();
 
-                // rebuild the payload from the txns and the metadata
-                let payload = <TYPES::BlockPayload as BlockPayload>::from_bytes(
-                    encoded_txns.into_iter(),
-                    metadata.clone(),
-                );
-
-                // commit the payload
+                // Commit the payload
                 let payload_commitment = payload.commit();
 
                 self.event_stream
@@ -392,6 +395,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                     .publish(HotShotEvent::VidDisperseSend(
                         Proposal {
                             data: vid_disperse,
+                            // TODO (Keyao) This is also signed in DA task.
                             signature: TYPES::SignatureKey::sign(
                                 &self.private_key,
                                 payload_commitment.as_ref(),

--- a/crates/task-impls/src/vid.rs
+++ b/crates/task-impls/src/vid.rs
@@ -371,22 +371,21 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                             shares: vid_disperse.shares,
                             common: vid_disperse.common,
                         },
-                        vid_disperse.commit,
                         view_number,
                     ))
                     .await;
             }
 
-            HotShotEvent::BlockReady(vid_disperse, payload_commitment, view_number) => {
+            HotShotEvent::BlockReady(vid_disperse, view_number) => {
                 debug!("publishing VID disperse for view {}", *view_number);
                 self.event_stream
                     .publish(HotShotEvent::VidDisperseSend(
                         Proposal {
-                            data: vid_disperse,
                             signature: TYPES::SignatureKey::sign(
                                 &self.private_key,
-                                &payload_commitment,
+                                &vid_disperse.payload_commitment,
                             ),
+                            data: vid_disperse,
                             _pd: PhantomData,
                         },
                         self.public_key.clone(),
@@ -452,7 +451,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                 | HotShotEvent::VidVoteRecv(_)
                 | HotShotEvent::VidCertRecv(_)
                 | HotShotEvent::TransactionsSequenced(_, _, _)
-                | HotShotEvent::BlockReady(_, _, _)
+                | HotShotEvent::BlockReady(_, _)
                 | HotShotEvent::ViewChange(_)
         )
     }

--- a/crates/task-impls/src/vid.rs
+++ b/crates/task-impls/src/vid.rs
@@ -348,7 +348,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
             HotShotEvent::TransactionsSequenced(
                 encoded_transactions,
                 commitment,
-                metadata,
+                _metadata,
                 view_number,
             ) => {
                 // TODO <https://github.com/EspressoSystems/HotShot/issues/1686>
@@ -379,7 +379,10 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                     .publish(HotShotEvent::VidDisperseSend(
                         Proposal {
                             data: vid_disperse,
-                            signature: TYPES::SignatureKey::sign(&self.private_key, &payload_commitment),
+                            signature: TYPES::SignatureKey::sign(
+                                &self.private_key,
+                                &payload_commitment,
+                            ),
                             _pd: PhantomData,
                         },
                         self.public_key.clone(),

--- a/crates/task-impls/src/vid.rs
+++ b/crates/task-impls/src/vid.rs
@@ -3,7 +3,6 @@ use async_compatibility_layer::art::async_spawn;
 use async_lock::RwLock;
 
 use bitvec::prelude::*;
-use commit::Committable;
 use either::{Either, Left, Right};
 use futures::FutureExt;
 use hotshot_task::{
@@ -12,12 +11,7 @@ use hotshot_task::{
     task::{FilterEvent, HandleEvent, HotShotTaskCompleted, HotShotTaskTypes, TS},
     task_impls::{HSTWithEvent, TaskBuilder},
 };
-use hotshot_types::{
-    block_impl::{NUM_CHUNKS, NUM_STORAGE_NODES},
-    data::{test_srs, VidDisperse, VidScheme, VidSchemeTrait},
-    message::Proposal,
-    traits::{network::ConsensusIntentEvent, BlockPayload},
-};
+use hotshot_types::traits::network::ConsensusIntentEvent;
 use hotshot_types::{
     consensus::{Consensus, View},
     traits::{
@@ -344,69 +338,6 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                     ))
                     .await;
             }
-
-            HotShotEvent::TransactionsSequenced(payload, metadata, view_number) => {
-                // Encode the sequenced transactions
-                let encoded_txns = match payload.encode() {
-                    Ok(encoded) => encoded,
-                    Err(e) => {
-                        error!("Failed to encode the block payload: {:?}.", e);
-                        return None;
-                    }
-                };
-
-                // TODO <https://github.com/EspressoSystems/HotShot/issues/1686>
-                let srs = test_srs(NUM_STORAGE_NODES);
-                // TODO We are using constant numbers for now, but they will change as the quorum size
-                // changes.
-                // TODO <https://github.com/EspressoSystems/HotShot/issues/1693>
-                let vid = VidScheme::new(NUM_CHUNKS, NUM_STORAGE_NODES, &srs).unwrap();
-                let vid_disperse = vid
-                    .disperse(encoded_txns.into_iter().collect::<Vec<u8>>())
-                    .unwrap();
-
-                // Commit the payload
-                let payload_commitment = payload.commit();
-
-                self.event_stream
-                    .publish(HotShotEvent::SendPayloadCommitmentAndMetadata(
-                        payload_commitment,
-                        metadata,
-                    ))
-                    .await;
-
-                self.event_stream
-                    .publish(HotShotEvent::BlockReady(
-                        payload_commitment,
-                        VidDisperse {
-                            view_number,
-                            payload_commitment,
-                            shares: vid_disperse.shares,
-                            common: vid_disperse.common,
-                        },
-                        view_number,
-                    ))
-                    .await;
-            }
-
-            HotShotEvent::BlockReady(payload_commitment, vid_disperse, view_number) => {
-                debug!("publishing VID disperse for view {}", *view_number);
-                self.event_stream
-                    .publish(HotShotEvent::VidDisperseSend(
-                        Proposal {
-                            data: vid_disperse,
-                            // TODO (Keyao) This is also signed in DA task.
-                            signature: TYPES::SignatureKey::sign(
-                                &self.private_key,
-                                payload_commitment.as_ref(),
-                            ),
-                            _pd: PhantomData,
-                        },
-                        self.public_key.clone(),
-                    ))
-                    .await;
-            }
-
             HotShotEvent::ViewChange(view) => {
                 if *self.cur_view >= *view {
                     return None;
@@ -464,8 +395,6 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                 | HotShotEvent::VidDisperseRecv(_, _)
                 | HotShotEvent::VidVoteRecv(_)
                 | HotShotEvent::VidCertRecv(_)
-                | HotShotEvent::TransactionsSequenced(_, _, _)
-                | HotShotEvent::BlockReady(_, _, _)
                 | HotShotEvent::ViewChange(_)
         )
     }

--- a/crates/testing/Cargo.toml
+++ b/crates/testing/Cargo.toml
@@ -39,6 +39,7 @@ tracing = { workspace = true }
 serde = { workspace = true }
 ethereum-types = { workspace = true }
 bitvec = { workspace = true }
+sha2 = { workspace = true }
 
 [dev-dependencies]
 async-lock = { workspace = true }

--- a/crates/testing/src/task_helpers.rs
+++ b/crates/testing/src/task_helpers.rs
@@ -126,7 +126,7 @@ async fn build_quorum_proposal_and_signature(
 
     // every event input is seen on the event stream in the output.
     let block = <VIDBlockPayload as TestableBlock>::genesis();
-    let payload_commitment = vid_commitment(block.encode().unwrap().collect());
+    let payload_commitment = vid_commitment(&block.encode().unwrap().collect());
     let block_header = VIDBlockHeader::new(payload_commitment, (), &parent_leaf.block_header);
     let leaf = Leaf {
         view_number: ViewNumber::new(view),

--- a/crates/testing/tests/da_task.rs
+++ b/crates/testing/tests/da_task.rs
@@ -62,7 +62,7 @@ async fn test_da_task() {
     // In view 1, node 2 is the next leader.
     input.push(HotShotEvent::ViewChange(ViewNumber::new(1)));
     input.push(HotShotEvent::ViewChange(ViewNumber::new(2)));
-    input.push(HotShotEvent::TransactionsSequenced(
+    input.push(HotShotEvent::BlockReady(
         block.clone(),
         (),
         ViewNumber::new(2),
@@ -73,7 +73,11 @@ async fn test_da_task() {
 
     output.insert(HotShotEvent::ViewChange(ViewNumber::new(1)), 1);
     output.insert(
-        HotShotEvent::TransactionsSequenced(block.clone(), (), ViewNumber::new(2)),
+        HotShotEvent::BlockReady(block.clone(), (), ViewNumber::new(2)),
+        1,
+    );
+    output.insert(
+        HotShotEvent::SendPayloadCommitmentAndMetadata(block.commit(), ()),
         1,
     );
     output.insert(HotShotEvent::DAProposalSend(message.clone(), pub_key), 1);

--- a/crates/testing/tests/da_task.rs
+++ b/crates/testing/tests/da_task.rs
@@ -1,5 +1,5 @@
 use hotshot::{types::SignatureKey, HotShotConsensusApi};
-use hotshot_task_impls::{da::sha256_hash, events::HotShotEvent};
+use hotshot_task_impls::events::HotShotEvent;
 use hotshot_testing::node_types::{MemoryImpl, TestTypes};
 use hotshot_types::{
     block_impl::VIDTransaction,
@@ -10,6 +10,7 @@ use hotshot_types::{
         node_implementation::NodeType, state::ConsensusTime,
     },
 };
+use sha2::{Digest, Sha256};
 use std::{collections::HashMap, marker::PhantomData};
 
 #[cfg_attr(
@@ -34,8 +35,8 @@ async fn test_da_task() {
     let pub_key = *api.public_key();
     let transactions = vec![VIDTransaction(vec![0])];
     let encoded_transactions = VIDTransaction::encode(transactions.clone()).unwrap();
-    let payload_commitment = vid_commitment(encoded_transactions.clone());
-    let encoded_transactions_hash = sha256_hash(&encoded_transactions);
+    let payload_commitment = vid_commitment(&encoded_transactions);
+    let encoded_transactions_hash = Sha256::digest(&encoded_transactions);
 
     let signature =
         <TestTypes as NodeType>::SignatureKey::sign(api.private_key(), &encoded_transactions_hash);

--- a/crates/testing/tests/da_task.rs
+++ b/crates/testing/tests/da_task.rs
@@ -59,8 +59,9 @@ async fn test_da_task() {
     // In view 1, node 2 is the next leader.
     input.push(HotShotEvent::ViewChange(ViewNumber::new(1)));
     input.push(HotShotEvent::ViewChange(ViewNumber::new(2)));
-    input.push(HotShotEvent::BlockReady(
+    input.push(HotShotEvent::TransactionsSequenced(
         encoded_transactions.clone(),
+        payload_commitment,
         (),
         ViewNumber::new(2),
     ));
@@ -70,11 +71,12 @@ async fn test_da_task() {
 
     output.insert(HotShotEvent::ViewChange(ViewNumber::new(1)), 1);
     output.insert(
-        HotShotEvent::BlockReady(encoded_transactions, (), ViewNumber::new(2)),
-        1,
-    );
-    output.insert(
-        HotShotEvent::SendPayloadCommitmentAndMetadata(payload_commitment, ()),
+        HotShotEvent::TransactionsSequenced(
+            encoded_transactions,
+            payload_commitment,
+            (),
+            ViewNumber::new(2),
+        ),
         1,
     );
     output.insert(HotShotEvent::DAProposalSend(message.clone(), pub_key), 1);

--- a/crates/testing/tests/da_task.rs
+++ b/crates/testing/tests/da_task.rs
@@ -62,7 +62,7 @@ async fn test_da_task() {
     // In view 1, node 2 is the next leader.
     input.push(HotShotEvent::ViewChange(ViewNumber::new(1)));
     input.push(HotShotEvent::ViewChange(ViewNumber::new(2)));
-    input.push(HotShotEvent::BlockReady(
+    input.push(HotShotEvent::TransactionsSequenced(
         block.clone(),
         (),
         ViewNumber::new(2),
@@ -73,11 +73,7 @@ async fn test_da_task() {
 
     output.insert(HotShotEvent::ViewChange(ViewNumber::new(1)), 1);
     output.insert(
-        HotShotEvent::BlockReady(block.clone(), (), ViewNumber::new(2)),
-        1,
-    );
-    output.insert(
-        HotShotEvent::SendPayloadCommitmentAndMetadata(block.commit(), ()),
+        HotShotEvent::TransactionsSequenced(block.clone(), (), ViewNumber::new(2)),
         1,
     );
     output.insert(HotShotEvent::DAProposalSend(message.clone(), pub_key), 1);

--- a/crates/testing/tests/da_task.rs
+++ b/crates/testing/tests/da_task.rs
@@ -63,7 +63,7 @@ async fn test_da_task() {
     input.push(HotShotEvent::ViewChange(ViewNumber::new(1)));
     input.push(HotShotEvent::ViewChange(ViewNumber::new(2)));
     input.push(HotShotEvent::TransactionsSequenced(
-        encoded_txns.clone(),
+        block.clone(),
         (),
         ViewNumber::new(2),
     ));
@@ -73,7 +73,7 @@ async fn test_da_task() {
 
     output.insert(HotShotEvent::ViewChange(ViewNumber::new(1)), 1);
     output.insert(
-        HotShotEvent::TransactionsSequenced(encoded_txns, (), ViewNumber::new(2)),
+        HotShotEvent::TransactionsSequenced(block.clone(), (), ViewNumber::new(2)),
         1,
     );
     output.insert(HotShotEvent::DAProposalSend(message.clone(), pub_key), 1);

--- a/crates/testing/tests/da_task.rs
+++ b/crates/testing/tests/da_task.rs
@@ -63,7 +63,7 @@ async fn test_da_task() {
     input.push(HotShotEvent::ViewChange(ViewNumber::new(1)));
     input.push(HotShotEvent::ViewChange(ViewNumber::new(2)));
     input.push(HotShotEvent::TransactionsSequenced(
-        block.clone(),
+        encoded_txns.clone(),
         (),
         ViewNumber::new(2),
     ));
@@ -73,7 +73,7 @@ async fn test_da_task() {
 
     output.insert(HotShotEvent::ViewChange(ViewNumber::new(1)), 1);
     output.insert(
-        HotShotEvent::TransactionsSequenced(block.clone(), (), ViewNumber::new(2)),
+        HotShotEvent::TransactionsSequenced(encoded_txns, (), ViewNumber::new(2)),
         1,
     );
     output.insert(HotShotEvent::DAProposalSend(message.clone(), pub_key), 1);

--- a/crates/testing/tests/network_task.rs
+++ b/crates/testing/tests/network_task.rs
@@ -79,7 +79,6 @@ async fn test_network_task() {
     ));
     input.push(HotShotEvent::BlockReady(
         da_vid_disperse_inner.clone(),
-        payload_commitment,
         ViewNumber::new(2),
     ));
     input.push(HotShotEvent::DAProposalSend(da_proposal.clone(), pub_key));
@@ -128,11 +127,7 @@ async fn test_network_task() {
         1,
     );
     output.insert(
-        HotShotEvent::BlockReady(
-            da_vid_disperse_inner,
-            payload_commitment,
-            ViewNumber::new(2),
-        ),
+        HotShotEvent::BlockReady(da_vid_disperse_inner, ViewNumber::new(2)),
         2,
     );
     output.insert(HotShotEvent::DAProposalRecv(da_proposal, pub_key), 1);

--- a/crates/testing/tests/network_task.rs
+++ b/crates/testing/tests/network_task.rs
@@ -79,7 +79,7 @@ async fn test_network_task() {
 
     input.push(HotShotEvent::ViewChange(ViewNumber::new(1)));
     input.push(HotShotEvent::TransactionsSequenced(
-        block.clone(),
+        encoded_txns.clone(),
         (),
         ViewNumber::new(2),
     ));
@@ -106,7 +106,7 @@ async fn test_network_task() {
         2, // 2 occurrences: 1 from `input`, 1 from the DA task
     );
     output.insert(
-        HotShotEvent::TransactionsSequenced(block.clone(), (), ViewNumber::new(2)),
+        HotShotEvent::TransactionsSequenced(encoded_txns, (), ViewNumber::new(2)),
         1,
     );
 

--- a/crates/testing/tests/network_task.rs
+++ b/crates/testing/tests/network_task.rs
@@ -74,7 +74,6 @@ async fn test_network_task() {
     input.push(HotShotEvent::ViewChange(ViewNumber::new(1)));
     input.push(HotShotEvent::TransactionsSequenced(
         encoded_transactions.clone(),
-        payload_commitment,
         (),
         ViewNumber::new(2),
     ));
@@ -101,12 +100,7 @@ async fn test_network_task() {
         2, // 2 occurrences: 1 from `input`, 1 from the DA task
     );
     output.insert(
-        HotShotEvent::TransactionsSequenced(
-            encoded_transactions,
-            payload_commitment,
-            (),
-            ViewNumber::new(2),
-        ),
+        HotShotEvent::TransactionsSequenced(encoded_transactions, (), ViewNumber::new(2)),
         2,
     );
     output.insert(

--- a/crates/testing/tests/network_task.rs
+++ b/crates/testing/tests/network_task.rs
@@ -78,14 +78,9 @@ async fn test_network_task() {
     let mut output = HashMap::new();
 
     input.push(HotShotEvent::ViewChange(ViewNumber::new(1)));
-    input.push(HotShotEvent::TransactionsSequenced(
+    input.push(HotShotEvent::BlockReady(
         block.clone(),
         (),
-        ViewNumber::new(2),
-    ));
-    input.push(HotShotEvent::BlockReady(
-        block.commit(),
-        da_vid_disperse.clone().data,
         ViewNumber::new(2),
     ));
     input.push(HotShotEvent::DAProposalSend(da_proposal.clone(), pub_key));
@@ -106,19 +101,9 @@ async fn test_network_task() {
         2, // 2 occurrences: 1 from `input`, 1 from the DA task
     );
     output.insert(
-        HotShotEvent::TransactionsSequenced(block.clone(), (), ViewNumber::new(2)),
-        1,
-    );
-
-    output.insert(
-        HotShotEvent::BlockReady(
-            block.commit(),
-            da_vid_disperse.clone().data,
-            ViewNumber::new(2),
-        ),
+        HotShotEvent::BlockReady(block.clone(), (), ViewNumber::new(2)),
         2,
     );
-
     output.insert(
         HotShotEvent::VidDisperseRecv(da_vid_disperse.clone(), pub_key),
         1,

--- a/crates/testing/tests/network_task.rs
+++ b/crates/testing/tests/network_task.rs
@@ -78,9 +78,14 @@ async fn test_network_task() {
     let mut output = HashMap::new();
 
     input.push(HotShotEvent::ViewChange(ViewNumber::new(1)));
-    input.push(HotShotEvent::BlockReady(
+    input.push(HotShotEvent::TransactionsSequenced(
         block.clone(),
         (),
+        ViewNumber::new(2),
+    ));
+    input.push(HotShotEvent::BlockReady(
+        block.commit(),
+        da_vid_disperse.clone().data,
         ViewNumber::new(2),
     ));
     input.push(HotShotEvent::DAProposalSend(da_proposal.clone(), pub_key));
@@ -101,9 +106,19 @@ async fn test_network_task() {
         2, // 2 occurrences: 1 from `input`, 1 from the DA task
     );
     output.insert(
-        HotShotEvent::BlockReady(block.clone(), (), ViewNumber::new(2)),
+        HotShotEvent::TransactionsSequenced(block.clone(), (), ViewNumber::new(2)),
+        1,
+    );
+
+    output.insert(
+        HotShotEvent::BlockReady(
+            block.commit(),
+            da_vid_disperse.clone().data,
+            ViewNumber::new(2),
+        ),
         2,
     );
+
     output.insert(
         HotShotEvent::VidDisperseRecv(da_vid_disperse.clone(), pub_key),
         1,

--- a/crates/testing/tests/network_task.rs
+++ b/crates/testing/tests/network_task.rs
@@ -79,7 +79,7 @@ async fn test_network_task() {
 
     input.push(HotShotEvent::ViewChange(ViewNumber::new(1)));
     input.push(HotShotEvent::TransactionsSequenced(
-        encoded_txns.clone(),
+        block.clone(),
         (),
         ViewNumber::new(2),
     ));
@@ -106,7 +106,7 @@ async fn test_network_task() {
         2, // 2 occurrences: 1 from `input`, 1 from the DA task
     );
     output.insert(
-        HotShotEvent::TransactionsSequenced(encoded_txns, (), ViewNumber::new(2)),
+        HotShotEvent::TransactionsSequenced(block.clone(), (), ViewNumber::new(2)),
         1,
     );
 

--- a/crates/testing/tests/vid_task.rs
+++ b/crates/testing/tests/vid_task.rs
@@ -73,42 +73,19 @@ async fn test_vid_task() {
     // In view 1, node 2 is the next leader.
     input.push(HotShotEvent::ViewChange(ViewNumber::new(1)));
     input.push(HotShotEvent::ViewChange(ViewNumber::new(2)));
-    input.push(HotShotEvent::TransactionsSequenced(
+    input.push(HotShotEvent::BlockReady(
         block.clone(),
         (),
         ViewNumber::new(2),
     ));
-    input.push(HotShotEvent::BlockReady(
-        block.commit(),
-        vid_proposal.clone().data,
-        ViewNumber::new(2),
-    ));
 
-    input.push(HotShotEvent::VidDisperseSend(vid_proposal.clone(), pub_key));
     input.push(HotShotEvent::VidDisperseRecv(vid_proposal.clone(), pub_key));
     input.push(HotShotEvent::Shutdown);
 
     output.insert(HotShotEvent::ViewChange(ViewNumber::new(1)), 1);
     output.insert(
-        HotShotEvent::TransactionsSequenced(block.clone(), (), ViewNumber::new(2)),
+        HotShotEvent::BlockReady(block.clone(), (), ViewNumber::new(2)),
         1,
-    );
-    output.insert(
-        HotShotEvent::SendPayloadCommitmentAndMetadata(block.commit(), ()),
-        1,
-    );
-    output.insert(
-        HotShotEvent::BlockReady(
-            block.commit(),
-            vid_proposal.clone().data,
-            ViewNumber::new(2),
-        ),
-        2,
-    );
-
-    output.insert(
-        HotShotEvent::VidDisperseSend(vid_proposal.clone(), pub_key),
-        2, // 2 occurrences: 1 from `input`, 1 from the DA task
     );
 
     let vid_vote = VIDVote::create_signed_vote(

--- a/crates/testing/tests/vid_task.rs
+++ b/crates/testing/tests/vid_task.rs
@@ -77,7 +77,6 @@ async fn test_vid_task() {
     ));
     input.push(HotShotEvent::BlockReady(
         vid_disperse.clone(),
-        payload_commitment,
         ViewNumber::new(2),
     ));
     input.push(HotShotEvent::VidDisperseSend(vid_proposal.clone(), pub_key));
@@ -91,7 +90,7 @@ async fn test_vid_task() {
     );
 
     output.insert(
-        HotShotEvent::BlockReady(vid_disperse, payload_commitment, ViewNumber::new(2)),
+        HotShotEvent::BlockReady(vid_disperse, ViewNumber::new(2)),
         2,
     );
 

--- a/crates/testing/tests/vid_task.rs
+++ b/crates/testing/tests/vid_task.rs
@@ -72,7 +72,6 @@ async fn test_vid_task() {
     input.push(HotShotEvent::ViewChange(ViewNumber::new(2)));
     input.push(HotShotEvent::TransactionsSequenced(
         encoded_transactions.clone(),
-        payload_commitment,
         (),
         ViewNumber::new(2),
     ));
@@ -87,12 +86,7 @@ async fn test_vid_task() {
 
     output.insert(HotShotEvent::ViewChange(ViewNumber::new(1)), 1);
     output.insert(
-        HotShotEvent::TransactionsSequenced(
-            encoded_transactions,
-            payload_commitment,
-            (),
-            ViewNumber::new(2),
-        ),
+        HotShotEvent::TransactionsSequenced(encoded_transactions, (), ViewNumber::new(2)),
         1,
     );
 
@@ -101,6 +95,10 @@ async fn test_vid_task() {
         2,
     );
 
+    output.insert(
+        HotShotEvent::SendPayloadCommitmentAndMetadata(payload_commitment, ()),
+        1,
+    );
     output.insert(
         HotShotEvent::VidDisperseSend(vid_proposal.clone(), pub_key),
         2, // 2 occurrences: 1 from `input`, 1 from the DA task

--- a/crates/testing/tests/vid_task.rs
+++ b/crates/testing/tests/vid_task.rs
@@ -51,13 +51,14 @@ async fn test_vid_task() {
         signature,
         _pd: PhantomData,
     };
+    let vid_disperse = VidDisperse {
+        view_number: message.data.view_number,
+        payload_commitment,
+        shares: vid_disperse.shares,
+        common: vid_disperse.common,
+    };
     let vid_proposal = Proposal {
-        data: VidDisperse {
-            view_number: message.data.view_number,
-            payload_commitment,
-            shares: vid_disperse.shares,
-            common: vid_disperse.common,
-        },
+        data: vid_disperse.clone(),
         signature: message.signature.clone(),
         _pd: PhantomData,
     };
@@ -69,19 +70,40 @@ async fn test_vid_task() {
     // In view 1, node 2 is the next leader.
     input.push(HotShotEvent::ViewChange(ViewNumber::new(1)));
     input.push(HotShotEvent::ViewChange(ViewNumber::new(2)));
-    input.push(HotShotEvent::BlockReady(
+    input.push(HotShotEvent::TransactionsSequenced(
         encoded_transactions.clone(),
+        payload_commitment,
         (),
         ViewNumber::new(2),
     ));
-
+    input.push(HotShotEvent::BlockReady(
+        vid_disperse.clone(),
+        payload_commitment,
+        ViewNumber::new(2),
+    ));
+    input.push(HotShotEvent::VidDisperseSend(vid_proposal.clone(), pub_key));
     input.push(HotShotEvent::VidDisperseRecv(vid_proposal.clone(), pub_key));
     input.push(HotShotEvent::Shutdown);
 
     output.insert(HotShotEvent::ViewChange(ViewNumber::new(1)), 1);
     output.insert(
-        HotShotEvent::BlockReady(encoded_transactions, (), ViewNumber::new(2)),
+        HotShotEvent::TransactionsSequenced(
+            encoded_transactions,
+            payload_commitment,
+            (),
+            ViewNumber::new(2),
+        ),
         1,
+    );
+
+    output.insert(
+        HotShotEvent::BlockReady(vid_disperse, payload_commitment, ViewNumber::new(2)),
+        2,
+    );
+
+    output.insert(
+        HotShotEvent::VidDisperseSend(vid_proposal.clone(), pub_key),
+        2, // 2 occurrences: 1 from `input`, 1 from the DA task
     );
 
     let vid_vote = VIDVote::create_signed_vote(

--- a/crates/testing/tests/vid_task.rs
+++ b/crates/testing/tests/vid_task.rs
@@ -73,19 +73,42 @@ async fn test_vid_task() {
     // In view 1, node 2 is the next leader.
     input.push(HotShotEvent::ViewChange(ViewNumber::new(1)));
     input.push(HotShotEvent::ViewChange(ViewNumber::new(2)));
-    input.push(HotShotEvent::BlockReady(
+    input.push(HotShotEvent::TransactionsSequenced(
         block.clone(),
         (),
         ViewNumber::new(2),
     ));
+    input.push(HotShotEvent::BlockReady(
+        block.commit(),
+        vid_proposal.clone().data,
+        ViewNumber::new(2),
+    ));
 
+    input.push(HotShotEvent::VidDisperseSend(vid_proposal.clone(), pub_key));
     input.push(HotShotEvent::VidDisperseRecv(vid_proposal.clone(), pub_key));
     input.push(HotShotEvent::Shutdown);
 
     output.insert(HotShotEvent::ViewChange(ViewNumber::new(1)), 1);
     output.insert(
-        HotShotEvent::BlockReady(block.clone(), (), ViewNumber::new(2)),
+        HotShotEvent::TransactionsSequenced(block.clone(), (), ViewNumber::new(2)),
         1,
+    );
+    output.insert(
+        HotShotEvent::SendPayloadCommitmentAndMetadata(block.commit(), ()),
+        1,
+    );
+    output.insert(
+        HotShotEvent::BlockReady(
+            block.commit(),
+            vid_proposal.clone().data,
+            ViewNumber::new(2),
+        ),
+        2,
+    );
+
+    output.insert(
+        HotShotEvent::VidDisperseSend(vid_proposal.clone(), pub_key),
+        2, // 2 occurrences: 1 from `input`, 1 from the DA task
     );
 
     let vid_vote = VIDVote::create_signed_vote(

--- a/crates/testing/tests/vid_task.rs
+++ b/crates/testing/tests/vid_task.rs
@@ -74,7 +74,7 @@ async fn test_vid_task() {
     input.push(HotShotEvent::ViewChange(ViewNumber::new(1)));
     input.push(HotShotEvent::ViewChange(ViewNumber::new(2)));
     input.push(HotShotEvent::TransactionsSequenced(
-        encoded_txns.clone(),
+        block.clone(),
         (),
         ViewNumber::new(2),
     ));
@@ -90,7 +90,7 @@ async fn test_vid_task() {
 
     output.insert(HotShotEvent::ViewChange(ViewNumber::new(1)), 1);
     output.insert(
-        HotShotEvent::TransactionsSequenced(encoded_txns, (), ViewNumber::new(2)),
+        HotShotEvent::TransactionsSequenced(block.clone(), (), ViewNumber::new(2)),
         1,
     );
     output.insert(

--- a/crates/testing/tests/vid_task.rs
+++ b/crates/testing/tests/vid_task.rs
@@ -74,7 +74,7 @@ async fn test_vid_task() {
     input.push(HotShotEvent::ViewChange(ViewNumber::new(1)));
     input.push(HotShotEvent::ViewChange(ViewNumber::new(2)));
     input.push(HotShotEvent::TransactionsSequenced(
-        block.clone(),
+        encoded_txns.clone(),
         (),
         ViewNumber::new(2),
     ));
@@ -90,7 +90,7 @@ async fn test_vid_task() {
 
     output.insert(HotShotEvent::ViewChange(ViewNumber::new(1)), 1);
     output.insert(
-        HotShotEvent::TransactionsSequenced(block.clone(), (), ViewNumber::new(2)),
+        HotShotEvent::TransactionsSequenced(encoded_txns, (), ViewNumber::new(2)),
         1,
     );
     output.insert(

--- a/crates/types/src/block_impl.rs
+++ b/crates/types/src/block_impl.rs
@@ -86,7 +86,7 @@ impl VIDBlockPayload {
         let encoded = VIDTransaction::encode(vec![VIDTransaction(txns.clone())]).unwrap();
         VIDBlockPayload {
             transactions: vec![VIDTransaction(txns)],
-            payload_commitment: vid_commitment(encoded),
+            payload_commitment: vid_commitment(&encoded),
         }
     }
 }
@@ -121,7 +121,7 @@ impl BlockPayload for VIDBlockPayload {
         Ok((
             Self {
                 transactions: txns_vec,
-                payload_commitment: vid_commitment(encoded),
+                payload_commitment: vid_commitment(&encoded),
             },
             (),
         ))
@@ -151,7 +151,7 @@ impl BlockPayload for VIDBlockPayload {
 
         Self {
             transactions,
-            payload_commitment: vid_commitment(encoded_vec),
+            payload_commitment: vid_commitment(&encoded_vec),
         }
     }
 

--- a/crates/types/src/data.rs
+++ b/crates/types/src/data.rs
@@ -381,7 +381,7 @@ impl<TYPES: NodeType> Leaf<TYPES> {
             Ok(encoded) => encoded.into_iter().collect(),
             Err(_) => return Err(BlockError::InvalidTransactionLength),
         };
-        let commitment = vid_commitment(encoded_txns);
+        let commitment = vid_commitment(&encoded_txns);
         if commitment != self.block_header.payload_commitment() {
             return Err(BlockError::InconsistentPayloadCommitment);
         }

--- a/crates/types/src/traits/block_contents.rs
+++ b/crates/types/src/traits/block_contents.rs
@@ -83,7 +83,7 @@ pub trait BlockPayload:
 /// # Panics
 /// If the VID computation fails.
 #[must_use]
-pub fn vid_commitment(encoded_transactions: Vec<u8>) -> <VidScheme as VidSchemeTrait>::Commit {
+pub fn vid_commitment(encoded_transactions: &Vec<u8>) -> <VidScheme as VidSchemeTrait>::Commit {
     // TODO <https://github.com/EspressoSystems/HotShot/issues/1686>
     let srs = test_srs(NUM_STORAGE_NODES);
     // TODO We are using constant numbers for now, but they will change as the quorum size

--- a/crates/types/src/traits/node_implementation.rs
+++ b/crates/types/src/traits/node_implementation.rs
@@ -251,9 +251,7 @@ where
             let network = Arc::new(network_generator(id));
             let network_da = Arc::new(da_generator(id));
             let quorum_chan =
-                <I::QuorumNetwork as TestableChannelImplementation<_>>::generate_network()(
-                    network,
-                );
+                <I::QuorumNetwork as TestableChannelImplementation<_>>::generate_network()(network);
             let committee_chan =
                 <I::CommitteeNetwork as TestableChannelImplementation<_>>::generate_network()(
                     network_da,

--- a/crates/types/src/traits/node_implementation.rs
+++ b/crates/types/src/traits/node_implementation.rs
@@ -252,7 +252,7 @@ where
             let network_da = Arc::new(da_generator(id));
             let quorum_chan =
                 <I::QuorumNetwork as TestableChannelImplementation<_>>::generate_network()(
-                    network.clone(),
+                    network,
                 );
             let committee_chan =
                 <I::CommitteeNetwork as TestableChannelImplementation<_>>::generate_network()(


### PR DESCRIPTION
Closes issue: #1817 

### This PR: 
<!-- Describe what this PR adds to HotSHot -->
<!-- E.g. -->
<!-- * Implements feature 1 -->
<!-- * Implements feature 2 -->
<!-- * Fixes bug 3 -->
- Creates a new event `TransactionsSequenced`
- Reorganizes events such that:
    - Transactions task - collects transactions and sequences them. Emits a TransactionsSequenced event that contains the payload and metadata
    - VID task - listens for TransactionsSequenced, calculates the encoded transactions, VID disperse data upon receiving that event. Emits BlockReady event, which contains the commitment and the disperse data.
    - VID task - listens for BlockReady, then sends out the VIDProposalSend event
    - DA task - listens for TransactionsSequenced, creates DA proposal upon receiving that event. Emits DAProposalSend
    
- Moves `SendPayloadCommitmentAndMetadata` to the VID task
- Change the tests to account for the new and moved events

Note that, in reference to the previous PR https://github.com/EspressoSystems/HotShot/pull/2077:
- I chose to pass around the payload and metadata as opposed to the encoded bytes, since the DA task needs access to the payload to create the DA proposal.

### This PR does not: 
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->
- Touch the VID header or payload structure 
- Remove commitment computation (this is in #2102)

### Key places to review: 
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->
The new logic as specified in `da.rs`, `vid.rs`, `transactions.rs`. 

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
