### PR TITLE
Refactor Vote accumulator tasks to one General implementation

### DIFF
--- a/crates/hotshot/src/tasks/mod.rs
+++ b/crates/hotshot/src/tasks/mod.rs
@@ -215,6 +215,7 @@ pub async fn add_consensus_task<TYPES: NodeType, I: NodeImplementation<TYPES>>(
         api: c_api.clone(),
         _pd: PhantomData,
         vote_collector: None,
+        timeout_vote_collector: None,
         timeout_task: async_spawn(async move {}),
         event_stream: event_stream.clone(),
         output_event_stream: output_stream,

--- a/crates/task-impls/src/consensus.rs
+++ b/crates/task-impls/src/consensus.rs
@@ -780,7 +780,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                         id: self.id,
                         registry: self.registry.clone(),
                     };
-                    let name = "Quorum Vote Collection";
+                    let name = "Timeout Vote Collection";
                     self.vote_collector =
                         spawn_vote_accumulator(&info, vote.clone(), event, name.to_string()).await;
                 } else if let Some((_, _, stream_id)) = self.vote_collector {

--- a/crates/task-impls/src/consensus.rs
+++ b/crates/task-impls/src/consensus.rs
@@ -723,6 +723,20 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
             }
             HotShotEvent::QuorumVoteRecv(ref vote) => {
                 debug!("Received quroum vote: {:?}", vote.get_view_number());
+                if self
+                    .quorum_membership
+                    .get_leader(vote.get_view_number() + 1)
+                    != self.public_key
+                {
+                    error!(
+                        "We are not the leader for view {} are we the leader for view + 1? {}",
+                        *vote.get_view_number() + 1,
+                        self.quorum_membership
+                            .get_leader(vote.get_view_number() + 2)
+                            == self.public_key
+                    );
+                    return;
+                }
 
                 let collection_view =
                     if let Some((collection_view, collection_task, _)) = &self.vote_collector {
@@ -761,6 +775,20 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                 }
             }
             HotShotEvent::TimeoutVoteRecv(ref vote) => {
+                if self
+                    .timeout_membership
+                    .get_leader(vote.get_view_number() + 1)
+                    != self.public_key
+                {
+                    error!(
+                        "We are not the leader for view {} are we the leader for view + 1? {}",
+                        *vote.get_view_number() + 1,
+                        self.timeout_membership
+                            .get_leader(vote.get_view_number() + 2)
+                            == self.public_key
+                    );
+                    return;
+                }
                 let collection_view =
                     if let Some((collection_view, collection_task, _)) = &self.vote_collector {
                         if vote.get_view_number() > *collection_view {

--- a/crates/task-impls/src/consensus.rs
+++ b/crates/task-impls/src/consensus.rs
@@ -1,19 +1,19 @@
-use crate::events::HotShotEvent;
+use crate::{
+    events::HotShotEvent,
+    vote::{spawn_vote_accumulator, AccumulatorInfo},
+};
 use async_compatibility_layer::art::{async_sleep, async_spawn};
 use async_lock::{RwLock, RwLockUpgradableReadGuard};
 #[cfg(async_executor_impl = "async-std")]
 use async_std::task::JoinHandle;
-use bitvec::prelude::*;
 use commit::{Commitment, Committable};
 use core::time::Duration;
-use either::Either;
-use futures::FutureExt;
 use hotshot_constants::LOOK_AHEAD;
 use hotshot_task::{
     event_stream::{ChannelStream, EventStream},
     global_registry::GlobalRegistry,
-    task::{FilterEvent, HandleEvent, HotShotTaskCompleted, HotShotTaskTypes, TS},
-    task_impls::{HSTWithEvent, TaskBuilder},
+    task::{HotShotTaskCompleted, TS},
+    task_impls::HSTWithEvent,
 };
 use hotshot_types::{
     consensus::{Consensus, View},
@@ -33,7 +33,7 @@ use hotshot_types::{
         BlockPayload,
     },
     utils::{Terminator, ViewInner},
-    vote::{Certificate, HasViewNumber, VoteAccumulator},
+    vote::{Certificate, HasViewNumber},
 };
 use tracing::warn;
 
@@ -128,145 +128,6 @@ pub struct ConsensusTaskState<
     /// The node's id
     pub id: u64,
 }
-
-// /// State for the vote collection task.  This handles the building of a QC from a votes received
-// pub struct VoteCollectionTaskState<TYPES: NodeType, I: NodeImplementation<TYPES>> {
-//     /// Network for all nodes
-//     pub quorum_network: Arc<I::QuorumNetwork>,
-//     /// Membership for Timeout votes/certs
-//     pub timeout_membership: Arc<TYPES::Membership>,
-//     /// Membership for Quorum Certs/votes
-//     pub quorum_membership: Arc<TYPES::Membership>,
-
-//     #[allow(clippy::type_complexity)]
-//     /// Accumulator for votes
-//     pub accumulator: Either<
-//         VoteAccumulator<TYPES, QuorumVote<TYPES>, QuorumCertificate<TYPES>>,
-//         QuorumCertificate<TYPES>,
-//     >,
-
-//     /// Accumulator for votes
-//     #[allow(clippy::type_complexity)]
-//     pub timeout_accumulator: Either<
-//         VoteAccumulator<TYPES, TimeoutVote<TYPES>, TimeoutCertificate<TYPES>>,
-//         TimeoutCertificate<TYPES>,
-//     >,
-//     /// View which this vote collection task is collecting votes in
-//     pub cur_view: TYPES::Time,
-//     /// The event stream shared by all tasks
-//     pub event_stream: ChannelStream<HotShotEvent<TYPES>>,
-//     /// Node id
-//     pub id: u64,
-// }
-
-// impl<TYPES: NodeType, I: NodeImplementation<TYPES>> TS for VoteCollectionTaskState<TYPES, I> {}
-
-// #[instrument(skip_all, fields(id = state.id, view = *state.cur_view), name = "Quorum Vote Collection Task", level = "error")]
-
-// async fn vote_handle<TYPES: NodeType, I: NodeImplementation<TYPES>>(
-//     mut state: VoteCollectionTaskState<TYPES, I>,
-//     event: HotShotEvent<TYPES>,
-// ) -> (
-//     std::option::Option<HotShotTaskCompleted>,
-//     VoteCollectionTaskState<TYPES, I>,
-// ) {
-//     match event {
-//         HotShotEvent::QuorumVoteRecv(vote) => {
-//             // For the case where we receive votes after we've made a certificate
-//             if state.accumulator.is_right() {
-//                 return (None, state);
-//             }
-
-//             if vote.get_view_number() != state.cur_view {
-//                 error!(
-//                     "Vote view does not match! vote view is {} current view is {}",
-//                     *vote.get_view_number(),
-//                     *state.cur_view
-//                 );
-//                 return (None, state);
-//             }
-
-//             let accumulator = state.accumulator.left().unwrap();
-
-//             match accumulator.accumulate(&vote, &state.quorum_membership) {
-//                 Either::Left(acc) => {
-//                     state.accumulator = Either::Left(acc);
-//                     return (None, state);
-//                 }
-//                 Either::Right(qc) => {
-//                     debug!("QCFormed! {:?}", qc.view_number);
-//                     state
-//                         .event_stream
-//                         .publish(HotShotEvent::QCFormed(either::Left(qc.clone())))
-//                         .await;
-//                     state.accumulator = Either::Right(qc.clone());
-
-//                     // No longer need to poll for votes
-//                     state
-//                         .quorum_network
-//                         .inject_consensus_info(ConsensusIntentEvent::CancelPollForVotes(
-//                             *qc.view_number,
-//                         ))
-//                         .await;
-
-//                     return (Some(HotShotTaskCompleted::ShutDown), state);
-//                 }
-//             }
-//         }
-//         // TODO: Code below is redundant of code above; can be fixed
-//         // during exchange refactor
-//         // https://github.com/EspressoSystems/HotShot/issues/1799
-//         HotShotEvent::TimeoutVoteRecv(vote) => {
-//             debug!("Received timeout vote for view {}", *vote.get_view_number());
-//             if state.timeout_accumulator.is_right() {
-//                 return (None, state);
-//             }
-
-//             if vote.get_view_number() != state.cur_view {
-//                 error!(
-//                     "Vote view does not match! vote view is {} current view is {}",
-//                     *vote.get_view_number(),
-//                     *state.cur_view
-//                 );
-//                 return (None, state);
-//             }
-
-//             let accumulator = state.timeout_accumulator.left().unwrap();
-
-//             match accumulator.accumulate(&vote, &state.timeout_membership) {
-//                 Either::Left(acc) => {
-//                     state.timeout_accumulator = Either::Left(acc);
-//                     return (None, state);
-//                 }
-//                 Either::Right(qc) => {
-//                     debug!("QCFormed! {:?}", qc.view_number);
-//                     state
-//                         .event_stream
-//                         .publish(HotShotEvent::QCFormed(either::Right(qc.clone())))
-//                         .await;
-//                     state.timeout_accumulator = Either::Right(qc.clone());
-
-//                     // No longer need to poll for votes
-//                     state
-//                         .quorum_network
-//                         .inject_consensus_info(ConsensusIntentEvent::CancelPollForVotes(
-//                             *qc.view_number,
-//                         ))
-//                         .await;
-
-//                     return (Some(HotShotTaskCompleted::ShutDown), state);
-//                 }
-//             }
-//         }
-//         HotShotEvent::Shutdown => {
-//             return (Some(HotShotTaskCompleted::ShutDown), state);
-//         }
-//         _ => {
-//             error!("Unexpected event");
-//         }
-//     }
-//     (None, state)
-// }
 
 impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 'static>
     ConsensusTaskState<TYPES, I, A>
@@ -859,27 +720,9 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                     self.da_certs.remove(&time);
                 }
             }
-            HotShotEvent::QuorumVoteRecv(vote) => {
+            HotShotEvent::QuorumVoteRecv(ref vote) => {
                 debug!("Received quroum vote: {:?}", vote.get_view_number());
 
-                if self
-                    .quorum_membership
-                    .get_leader(vote.get_view_number() + 1)
-                    != self.public_key
-                {
-                    error!(
-                        "We are not the leader for view {} are we the leader for view + 1? {}",
-                        *vote.get_view_number() + 1,
-                        self.quorum_membership
-                            .get_leader(vote.get_view_number() + 2)
-                            == self.public_key
-                    );
-                    return;
-                }
-
-                let handle_event = HandleEvent(Arc::new(move |event, state| {
-                    async move { vote_handle(state, event).await }.boxed()
-                }));
                 let collection_view =
                     if let Some((collection_view, collection_task, _)) = &self.vote_collector {
                         if vote.get_view_number() > *collection_view {
@@ -892,86 +735,31 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                     };
 
                 if vote.get_view_number() > collection_view {
-                    // Todo check if we are the leader
-                    let new_accumulator = VoteAccumulator {
-                        vote_outcomes: HashMap::new(),
-                        sig_lists: Vec::new(),
-                        signers: bitvec![0; self.quorum_membership.total_nodes()],
-                        phantom: PhantomData,
-                    };
-
-                    let accumulator =
-                        new_accumulator.accumulate(&vote, self.quorum_membership.as_ref());
-
-                    // TODO Create default functions for accumulators
-                    // https://github.com/EspressoSystems/HotShot/issues/1797
-                    let timeout_accumulator = VoteAccumulator {
-                        vote_outcomes: HashMap::new(),
-                        sig_lists: Vec::new(),
-                        signers: bitvec![0; self.timeout_membership.total_nodes()],
-                        phantom: PhantomData,
-                    };
-
-                    let state = VoteCollectionTaskState {
-                        quorum_network: self.quorum_network.clone(),
-                        quorum_membership: self.quorum_membership.clone(),
-                        timeout_membership: self.timeout_membership.clone(),
-                        accumulator,
-                        timeout_accumulator: either::Left(timeout_accumulator),
-                        cur_view: vote.get_view_number(),
+                    debug!("Starting vote handle for view {:?}", vote.get_view_number());
+                    let info = AccumulatorInfo {
+                        public_key: self.public_key.clone(),
+                        membership: self.quorum_membership.clone(),
+                        view: vote.get_view_number(),
                         event_stream: self.event_stream.clone(),
                         id: self.id,
+                        registry: self.registry.clone(),
                     };
                     let name = "Quorum Vote Collection";
-                    let filter = FilterEvent(Arc::new(|event| {
-                        matches!(
-                            event,
-                            HotShotEvent::QuorumVoteRecv(_) | HotShotEvent::TimeoutVoteRecv(_)
-                        )
-                    }));
-
-                    let builder =
-                        TaskBuilder::<VoteCollectionTypes<TYPES, I>>::new(name.to_string())
-                            .register_event_stream(self.event_stream.clone(), filter)
-                            .await
-                            .register_registry(&mut self.registry.clone())
-                            .await
-                            .register_state(state)
-                            .register_event_handler(handle_event);
-                    let id = builder.get_task_id().unwrap();
-                    let stream_id = builder.get_stream_id().unwrap();
-
-                    self.vote_collector = Some((vote.get_view_number(), id, stream_id));
-
-                    let _task = async_spawn(async move {
-                        VoteCollectionTypes::build(builder).launch().await;
-                    });
-                    debug!("Starting vote handle for view {:?}", vote.get_view_number());
+                    self.vote_collector = spawn_vote_accumulator::<
+                        TYPES,
+                        QuorumVote<TYPES>,
+                        QuorumCertificate<TYPES>,
+                    >(
+                        &info, vote.clone(), event, name.to_string()
+                    )
+                    .await;
                 } else if let Some((_, _, stream_id)) = self.vote_collector {
                     self.event_stream
-                        .direct_message(stream_id, HotShotEvent::QuorumVoteRecv(vote))
+                        .direct_message(stream_id, HotShotEvent::QuorumVoteRecv(vote.clone()))
                         .await;
                 }
             }
-            HotShotEvent::TimeoutVoteRecv(vote) => {
-                if self
-                    .timeout_membership
-                    .get_leader(vote.get_view_number() + 1)
-                    != self.public_key
-                {
-                    error!(
-                        "We are not the leader for view {} are we the leader for view + 1? {}",
-                        *vote.get_view_number() + 1,
-                        self.timeout_membership
-                            .get_leader(vote.get_view_number() + 2)
-                            == self.public_key
-                    );
-                    return;
-                }
-
-                let handle_event = HandleEvent(Arc::new(move |event, state| {
-                    async move { vote_handle(state, event).await }.boxed()
-                }));
+            HotShotEvent::TimeoutVoteRecv(ref vote) => {
                 let collection_view =
                     if let Some((collection_view, collection_task, _)) = &self.vote_collector {
                         if vote.get_view_number() > *collection_view {
@@ -984,64 +772,21 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                     };
 
                 if vote.get_view_number() > collection_view {
-                    // Todo check if we are the leader
-                    let new_accumulator = VoteAccumulator {
-                        vote_outcomes: HashMap::new(),
-                        sig_lists: Vec::new(),
-                        signers: bitvec![0; self.timeout_membership.total_nodes()],
-                        phantom: PhantomData,
-                    };
-
-                    let timeout_accumulator =
-                        new_accumulator.accumulate(&vote, self.quorum_membership.as_ref());
-
-                    let quorum_accumulator = VoteAccumulator {
-                        vote_outcomes: HashMap::new(),
-                        sig_lists: Vec::new(),
-                        signers: bitvec![0; self.quorum_membership.total_nodes()],
-                        phantom: PhantomData,
-                    };
-
-                    // self.timeout_accumulator = accumulator;
-
-                    let state = VoteCollectionTaskState {
-                        quorum_network: self.quorum_network.clone(),
-                        quorum_membership: self.quorum_membership.clone(),
-                        timeout_membership: self.timeout_membership.clone(),
-                        accumulator: either::Left(quorum_accumulator),
-                        timeout_accumulator,
-                        cur_view: vote.get_view_number(),
+                    debug!("Starting vote handle for view {:?}", vote.get_view_number());
+                    let info = AccumulatorInfo {
+                        public_key: self.public_key.clone(),
+                        membership: self.timeout_membership.clone(),
+                        view: vote.get_view_number(),
                         event_stream: self.event_stream.clone(),
                         id: self.id,
+                        registry: self.registry.clone(),
                     };
                     let name = "Quorum Vote Collection";
-                    let filter = FilterEvent(Arc::new(|event| {
-                        matches!(
-                            event,
-                            HotShotEvent::QuorumVoteRecv(_) | HotShotEvent::TimeoutVoteRecv(_)
-                        )
-                    }));
-
-                    let builder =
-                        TaskBuilder::<VoteCollectionTypes<TYPES, I>>::new(name.to_string())
-                            .register_event_stream(self.event_stream.clone(), filter)
-                            .await
-                            .register_registry(&mut self.registry.clone())
-                            .await
-                            .register_state(state)
-                            .register_event_handler(handle_event);
-                    let id = builder.get_task_id().unwrap();
-                    let stream_id = builder.get_stream_id().unwrap();
-
-                    self.vote_collector = Some((vote.get_view_number(), id, stream_id));
-
-                    let _task = async_spawn(async move {
-                        VoteCollectionTypes::build(builder).launch().await;
-                    });
-                    debug!("Starting vote handle for view {:?}", vote.get_view_number());
+                    self.vote_collector =
+                        spawn_vote_accumulator(&info, vote.clone(), event, name.to_string()).await;
                 } else if let Some((_, _, stream_id)) = self.vote_collector {
                     self.event_stream
-                        .direct_message(stream_id, HotShotEvent::TimeoutVoteRecv(vote))
+                        .direct_message(stream_id, HotShotEvent::TimeoutVoteRecv(vote.clone()))
                         .await;
                 }
             }
@@ -1288,14 +1033,6 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I>> T
     for ConsensusTaskState<TYPES, I, A>
 {
 }
-
-/// Type allias for consensus' vote collection task
-pub type VoteCollectionTypes<TYPES, I> = HSTWithEvent<
-    ConsensusTaskError,
-    HotShotEvent<TYPES>,
-    ChannelStream<HotShotEvent<TYPES>>,
-    VoteCollectionTaskState<TYPES, I>,
->;
 
 /// Type alias for Consensus task
 pub type ConsensusTaskTypes<TYPES, I, A> = HSTWithEvent<

--- a/crates/task-impls/src/consensus.rs
+++ b/crates/task-impls/src/consensus.rs
@@ -101,9 +101,8 @@ pub struct ConsensusTaskState<
     /// Current Vote collection task, with it's view.
     pub vote_collector: Option<(TYPES::Time, usize, usize)>,
 
-    /// Have we already sent a proposal for a particular view
-    /// since proposal can be sent either on QCFormed event or ViewChange event
-    // pub proposal_sent: HashMap<TYPES::Time, bool>,
+    /// Current timeout vote collection task with its view
+    pub timeout_vote_collector: Option<(TYPES::Time, usize, usize)>,
 
     /// timeout task handle
     pub timeout_task: JoinHandle<()>,

--- a/crates/task-impls/src/da.rs
+++ b/crates/task-impls/src/da.rs
@@ -200,7 +200,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                         id: self.id,
                         registry: self.registry.clone(),
                     };
-                    let name = "Quorum Vote Collection";
+                    let name = "DA Vote Collection";
                     self.vote_collector =
                         spawn_vote_accumulator(&info, vote.clone(), event, name.to_string()).await;
                 } else if let Some((_, _, stream_id)) = self.vote_collector {

--- a/crates/task-impls/src/lib.rs
+++ b/crates/task-impls/src/lib.rs
@@ -34,3 +34,6 @@ pub mod view_sync;
 
 /// The task which implements verifiable information dispersal
 pub mod vid;
+
+/// Generic task for collecting votes
+pub mod vote;

--- a/crates/task-impls/src/vid.rs
+++ b/crates/task-impls/src/vid.rs
@@ -112,7 +112,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                         id: self.id,
                         registry: self.registry.clone(),
                     };
-                    let name = "Quorum Vote Collection";
+                    let name = "VID Vote Collection";
                     self.vote_collector =
                         spawn_vote_accumulator(&info, vote.clone(), event, name.to_string()).await;
                 } else if let Some((_, _, stream_id)) = self.vote_collector {

--- a/crates/task-impls/src/view_sync.rs
+++ b/crates/task-impls/src/view_sync.rs
@@ -1,18 +1,18 @@
 #![allow(clippy::module_name_repetitions)]
-use crate::events::HotShotEvent;
+use crate::{
+    events::HotShotEvent,
+    vote::{spawn_vote_accumulator, AccumulatorInfo},
+};
 use async_compatibility_layer::art::{async_sleep, async_spawn};
-
-use either::Either::{self, Left, Right};
+use either::Either;
 use futures::FutureExt;
 use hotshot_task::{
     event_stream::{ChannelStream, EventStream},
     task::{FilterEvent, HandleEvent, HotShotTaskCompleted, HotShotTaskTypes, TS},
     task_impls::{HSTWithEvent, TaskBuilder},
 };
+use hotshot_types::{simple_vote::ViewSyncFinalizeData, traits::signature_key::SignatureKey};
 use hotshot_types::{
-    simple_certificate::{
-        ViewSyncCommitCertificate2, ViewSyncFinalizeCertificate2, ViewSyncPreCommitCertificate2,
-    },
     simple_vote::{
         ViewSyncCommitData, ViewSyncCommitVote, ViewSyncFinalizeVote, ViewSyncPreCommitData,
         ViewSyncPreCommitVote,
@@ -20,9 +20,7 @@ use hotshot_types::{
     traits::network::ConsensusIntentEvent,
     vote::{Certificate, HasViewNumber, Vote, VoteAccumulator},
 };
-use hotshot_types::{simple_vote::ViewSyncFinalizeData, traits::signature_key::SignatureKey};
 
-use bitvec::prelude::*;
 use hotshot_task::global_registry::GlobalRegistry;
 use hotshot_types::{
     message::GeneralConsensusMessage,
@@ -35,7 +33,7 @@ use hotshot_types::{
     },
 };
 use snafu::Snafu;
-use std::{collections::HashMap, marker::PhantomData, sync::Arc, time::Duration};
+use std::{collections::HashMap, sync::Arc, time::Duration};
 use tracing::{debug, error, info, instrument};
 #[derive(PartialEq, PartialOrd, Clone, Debug, Eq, Hash)]
 /// Phases of view sync
@@ -307,8 +305,9 @@ impl<
                 });
             }
 
-            HotShotEvent::ViewSyncPreCommitVoteRecv(vote) => {
-                if let Some(relay_task) = self.relay_task_map.get(&vote.get_view_number()) {
+            HotShotEvent::ViewSyncPreCommitVoteRecv(ref vote) => {
+                let vote_view = vote.get_view_number();
+                if let Some(relay_task) = self.relay_task_map.get(&vote_view) {
                     // Forward event then return
                     self.event_stream
                         .direct_message(relay_task.event_stream_id, event)
@@ -319,7 +318,7 @@ impl<
                 // We do not have a relay task already running, so start one
                 if self
                     .membership
-                    .get_leader(vote.get_view_number() + vote.get_data().relay)
+                    .get_leader(vote_view + vote.get_data().relay)
                     != self.public_key
                 {
                     // TODO ED This will occur because everyone is pulling down votes for now. Will be fixed in `https://github.com/EspressoSystems/HotShot/issues/1471`
@@ -327,78 +326,26 @@ impl<
                     return;
                 }
 
-                let new_accumulator = VoteAccumulator {
-                    vote_outcomes: HashMap::new(),
-                    sig_lists: Vec::new(),
-                    signers: bitvec![0; self.membership.total_nodes()],
-                    phantom: PhantomData,
-                };
-
-                let mut relay_state = ViewSyncRelayTaskState::<
-                    TYPES,
-                    I,
-                    ViewSyncPreCommitVote<TYPES>,
-                    ViewSyncPreCommitCertificate2<TYPES>,
-                > {
-                    event_stream: self.event_stream.clone(),
-                    membership: self.membership.clone(),
-                    network: self.network.clone(),
+                let name = format!("View Sync Relay Task for view {vote_view:?}");
+                let info = AccumulatorInfo {
                     public_key: self.public_key.clone(),
-                    private_key: self.private_key.clone(),
-                    accumulator: either::Left(new_accumulator),
+                    membership: self.membership.clone(),
+                    view: vote_view,
+                    event_stream: self.event_stream.clone(),
                     id: self.id,
+                    registry: self.registry.clone(),
                 };
-
-                let result = relay_state.handle_event(event.clone()).await;
-
-                if result.0 == Some(HotShotTaskCompleted::ShutDown) {
-                    // The protocol has finished
-                    return;
+                let vote_collector =
+                    spawn_vote_accumulator(&info, vote.clone(), event, name.to_string()).await;
+                if let Some((_, _, event_stream_id)) = vote_collector {
+                    self.relay_task_map
+                        .insert(vote_view, ViewSyncTaskInfo { event_stream_id });
                 }
-
-                relay_state = result.1;
-
-                let name = format!("View Sync Relay Task for view {:?}", vote.get_view_number());
-
-                let relay_handle_event = HandleEvent(Arc::new(
-                    move |event,
-                          state: ViewSyncRelayTaskState<
-                        TYPES,
-                        I,
-                        ViewSyncPreCommitVote<TYPES>,
-                        ViewSyncPreCommitCertificate2<TYPES>,
-                    >| {
-                        async move { state.handle_event(event).await }.boxed()
-                    },
-                ));
-
-                let filter = FilterEvent::default();
-                let builder = TaskBuilder::<
-                    ViewSyncRelayTaskStateTypes<
-                        TYPES,
-                        I,
-                        ViewSyncPreCommitVote<TYPES>,
-                        ViewSyncPreCommitCertificate2<TYPES>,
-                    >,
-                >::new(name)
-                .register_event_stream(relay_state.event_stream.clone(), filter)
-                .await
-                .register_registry(&mut self.registry.clone())
-                .await
-                .register_state(relay_state)
-                .register_event_handler(relay_handle_event);
-
-                let event_stream_id = builder.get_stream_id().unwrap();
-
-                self.relay_task_map
-                    .insert(vote.get_view_number(), ViewSyncTaskInfo { event_stream_id });
-                let _view_sync_relay_task = async_spawn(async move {
-                    ViewSyncRelayTaskStateTypes::build(builder).launch().await
-                });
             }
 
-            HotShotEvent::ViewSyncCommitVoteRecv(vote) => {
-                if let Some(relay_task) = self.relay_task_map.get(&vote.get_view_number()) {
+            HotShotEvent::ViewSyncCommitVoteRecv(ref vote) => {
+                let vote_view = vote.get_view_number();
+                if let Some(relay_task) = self.relay_task_map.get(&vote_view) {
                     // Forward event then return
                     self.event_stream
                         .direct_message(relay_task.event_stream_id, event)
@@ -409,7 +356,7 @@ impl<
                 // We do not have a relay task already running, so start one
                 if self
                     .membership
-                    .get_leader(vote.get_view_number() + vote.get_data().relay)
+                    .get_leader(vote_view + vote.get_data().relay)
                     != self.public_key
                 {
                     // TODO ED This will occur because everyone is pulling down votes for now. Will be fixed in `https://github.com/EspressoSystems/HotShot/issues/1471`
@@ -417,78 +364,26 @@ impl<
                     return;
                 }
 
-                let new_accumulator = VoteAccumulator {
-                    vote_outcomes: HashMap::new(),
-                    sig_lists: Vec::new(),
-                    signers: bitvec![0; self.membership.total_nodes()],
-                    phantom: PhantomData,
-                };
-
-                let mut relay_state = ViewSyncRelayTaskState::<
-                    TYPES,
-                    I,
-                    ViewSyncCommitVote<TYPES>,
-                    ViewSyncCommitCertificate2<TYPES>,
-                > {
-                    event_stream: self.event_stream.clone(),
-                    membership: self.membership.clone(),
-                    network: self.network.clone(),
+                let name = format!("View Sync Relay Task for view {vote_view:?}");
+                let info = AccumulatorInfo {
                     public_key: self.public_key.clone(),
-                    private_key: self.private_key.clone(),
-                    accumulator: either::Left(new_accumulator),
+                    membership: self.membership.clone(),
+                    view: vote_view,
+                    event_stream: self.event_stream.clone(),
                     id: self.id,
+                    registry: self.registry.clone(),
                 };
-
-                let result = relay_state.handle_event(event.clone()).await;
-
-                if result.0 == Some(HotShotTaskCompleted::ShutDown) {
-                    // The protocol has finished
-                    return;
+                let vote_collector =
+                    spawn_vote_accumulator(&info, vote.clone(), event, name.to_string()).await;
+                if let Some((_, _, event_stream_id)) = vote_collector {
+                    self.relay_task_map
+                        .insert(vote_view, ViewSyncTaskInfo { event_stream_id });
                 }
-
-                relay_state = result.1;
-
-                let name = format!("View Sync Relay Task for view {:?}", vote.get_view_number());
-
-                let relay_handle_event = HandleEvent(Arc::new(
-                    move |event,
-                          state: ViewSyncRelayTaskState<
-                        TYPES,
-                        I,
-                        ViewSyncCommitVote<TYPES>,
-                        ViewSyncCommitCertificate2<TYPES>,
-                    >| {
-                        async move { state.handle_event(event).await }.boxed()
-                    },
-                ));
-
-                let filter = FilterEvent::default();
-                let builder = TaskBuilder::<
-                    ViewSyncRelayTaskStateTypes<
-                        TYPES,
-                        I,
-                        ViewSyncCommitVote<TYPES>,
-                        ViewSyncCommitCertificate2<TYPES>,
-                    >,
-                >::new(name)
-                .register_event_stream(relay_state.event_stream.clone(), filter)
-                .await
-                .register_registry(&mut self.registry.clone())
-                .await
-                .register_state(relay_state)
-                .register_event_handler(relay_handle_event);
-
-                let event_stream_id = builder.get_stream_id().unwrap();
-
-                self.relay_task_map
-                    .insert(vote.get_view_number(), ViewSyncTaskInfo { event_stream_id });
-                let _view_sync_relay_task = async_spawn(async move {
-                    ViewSyncRelayTaskStateTypes::build(builder).launch().await
-                });
             }
 
-            HotShotEvent::ViewSyncFinalizeVoteRecv(vote) => {
-                if let Some(relay_task) = self.relay_task_map.get(&vote.get_view_number()) {
+            HotShotEvent::ViewSyncFinalizeVoteRecv(ref vote) => {
+                let vote_view = vote.get_view_number();
+                if let Some(relay_task) = self.relay_task_map.get(&vote_view) {
                     // Forward event then return
                     self.event_stream
                         .direct_message(relay_task.event_stream_id, event)
@@ -499,7 +394,7 @@ impl<
                 // We do not have a relay task already running, so start one
                 if self
                     .membership
-                    .get_leader(vote.get_view_number() + vote.get_data().relay)
+                    .get_leader(vote_view + vote.get_data().relay)
                     != self.public_key
                 {
                     // TODO ED This will occur because everyone is pulling down votes for now. Will be fixed in `https://github.com/EspressoSystems/HotShot/issues/1471`
@@ -507,74 +402,21 @@ impl<
                     return;
                 }
 
-                let new_accumulator = VoteAccumulator {
-                    vote_outcomes: HashMap::new(),
-                    sig_lists: Vec::new(),
-                    signers: bitvec![0; self.membership.total_nodes()],
-                    phantom: PhantomData,
-                };
-
-                let mut relay_state = ViewSyncRelayTaskState::<
-                    TYPES,
-                    I,
-                    ViewSyncFinalizeVote<TYPES>,
-                    ViewSyncFinalizeCertificate2<TYPES>,
-                > {
-                    event_stream: self.event_stream.clone(),
-                    membership: self.membership.clone(),
-                    network: self.network.clone(),
+                let name = format!("View Sync Relay Task for view {vote_view:?}");
+                let info = AccumulatorInfo {
                     public_key: self.public_key.clone(),
-                    private_key: self.private_key.clone(),
-                    accumulator: either::Left(new_accumulator),
+                    membership: self.membership.clone(),
+                    view: vote.get_view_number(),
+                    event_stream: self.event_stream.clone(),
                     id: self.id,
+                    registry: self.registry.clone(),
                 };
-
-                let result = relay_state.handle_event(event.clone()).await;
-
-                if result.0 == Some(HotShotTaskCompleted::ShutDown) {
-                    // The protocol has finished
-                    return;
+                let vote_collector =
+                    spawn_vote_accumulator(&info, vote.clone(), event, name.to_string()).await;
+                if let Some((_, _, event_stream_id)) = vote_collector {
+                    self.relay_task_map
+                        .insert(vote_view, ViewSyncTaskInfo { event_stream_id });
                 }
-
-                relay_state = result.1;
-
-                let name = format!("View Sync Relay Task for view {:?}", vote.get_view_number());
-
-                let relay_handle_event = HandleEvent(Arc::new(
-                    move |event,
-                          state: ViewSyncRelayTaskState<
-                        TYPES,
-                        I,
-                        ViewSyncFinalizeVote<TYPES>,
-                        ViewSyncFinalizeCertificate2<TYPES>,
-                    >| {
-                        async move { state.handle_event(event).await }.boxed()
-                    },
-                ));
-
-                let filter = FilterEvent::default();
-                let builder = TaskBuilder::<
-                    ViewSyncRelayTaskStateTypes<
-                        TYPES,
-                        I,
-                        ViewSyncFinalizeVote<TYPES>,
-                        ViewSyncFinalizeCertificate2<TYPES>,
-                    >,
-                >::new(name)
-                .register_event_stream(relay_state.event_stream.clone(), filter)
-                .await
-                .register_registry(&mut self.registry.clone())
-                .await
-                .register_state(relay_state)
-                .register_event_handler(relay_handle_event);
-
-                let event_stream_id = builder.get_stream_id().unwrap();
-
-                self.relay_task_map
-                    .insert(vote.get_view_number(), ViewSyncTaskInfo { event_stream_id });
-                let _view_sync_relay_task = async_spawn(async move {
-                    ViewSyncRelayTaskStateTypes::build(builder).launch().await
-                });
             }
 
             &HotShotEvent::ViewChange(new_view) => {
@@ -1085,211 +927,5 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
             _ => return (None, self),
         }
         (None, self)
-    }
-}
-
-impl<TYPES: NodeType, I: NodeImplementation<TYPES>>
-    ViewSyncRelayTaskState<
-        TYPES,
-        I,
-        ViewSyncPreCommitVote<TYPES>,
-        ViewSyncPreCommitCertificate2<TYPES>,
-    >
-{
-    /// Handles incoming events for the view sync relay task
-    #[instrument(skip_all, fields(id = self.id), name = "View Sync Relay Task", level = "error")]
-    #[allow(clippy::type_complexity)]
-    pub async fn handle_event(
-        mut self,
-        event: HotShotEvent<TYPES>,
-    ) -> (
-        std::option::Option<HotShotTaskCompleted>,
-        ViewSyncRelayTaskState<
-            TYPES,
-            I,
-            ViewSyncPreCommitVote<TYPES>,
-            ViewSyncPreCommitCertificate2<TYPES>,
-        >,
-    ) {
-        match event {
-            HotShotEvent::ViewSyncPreCommitVoteRecv(vote) => {
-                // Ignore this vote if we are not the correct relay
-                // TODO ED Replace exchange with membership
-                if self
-                    .membership
-                    .get_leader(vote.get_data().round + vote.get_data().relay)
-                    != self.public_key
-                {
-                    info!("We are not the correct relay for this vote; vote was intended for relay {}", vote.get_data().relay);
-                    return (None, self);
-                }
-
-                debug!(
-                    "Accumulating ViewSyncPreCommitVote for round {} and relay {}",
-                    *vote.get_data().round,
-                    vote.get_data().relay
-                );
-
-                match self.accumulator {
-                    Right(_) => return (Some(HotShotTaskCompleted::ShutDown), self),
-                    Left(accumulator) => {
-                        match accumulator.accumulate(&vote, self.membership.as_ref()) {
-                            Left(new_accumulator) => {
-                                self.accumulator = Either::Left(new_accumulator);
-                            }
-                            Right(certificate) => {
-                                self.event_stream
-                                    .publish(HotShotEvent::ViewSyncPreCommitCertificate2Send(
-                                        certificate.clone(),
-                                        self.public_key.clone(),
-                                    ))
-                                    .await;
-                                self.accumulator = Right(certificate);
-
-                                return (Some(HotShotTaskCompleted::ShutDown), self);
-                            }
-                        }
-                    }
-                };
-                (None, self)
-            }
-
-            _ => (None, self),
-        }
-    }
-}
-
-impl<TYPES: NodeType, I: NodeImplementation<TYPES>>
-    ViewSyncRelayTaskState<TYPES, I, ViewSyncCommitVote<TYPES>, ViewSyncCommitCertificate2<TYPES>>
-{
-    /// Handles incoming events for the view sync relay task
-    #[instrument(skip_all, fields(id = self.id), name = "View Sync Relay Task", level = "error")]
-    #[allow(clippy::type_complexity)]
-    pub async fn handle_event(
-        mut self,
-        event: HotShotEvent<TYPES>,
-    ) -> (
-        std::option::Option<HotShotTaskCompleted>,
-        ViewSyncRelayTaskState<
-            TYPES,
-            I,
-            ViewSyncCommitVote<TYPES>,
-            ViewSyncCommitCertificate2<TYPES>,
-        >,
-    ) {
-        match event {
-            HotShotEvent::ViewSyncCommitVoteRecv(vote) => {
-                // Ignore this vote if we are not the correct relay
-                if self
-                    .membership
-                    .get_leader(vote.get_data().round + vote.get_data().relay)
-                    != self.public_key
-                {
-                    info!("We are not the correct relay for this vote; vote was intended for relay {}", vote.get_data().relay);
-                    return (None, self);
-                }
-
-                debug!(
-                    "Accumulating ViewSyncCommitVote for round {} and relay {}",
-                    *vote.get_data().round,
-                    vote.get_data().relay
-                );
-
-                match self.accumulator {
-                    Right(_) => return (Some(HotShotTaskCompleted::ShutDown), self),
-                    Left(accumulator) => {
-                        match accumulator.accumulate(&vote, self.membership.as_ref()) {
-                            Left(new_accumulator) => {
-                                self.accumulator = Either::Left(new_accumulator);
-                            }
-                            Right(certificate) => {
-                                self.event_stream
-                                    .publish(HotShotEvent::ViewSyncCommitCertificate2Send(
-                                        certificate.clone(),
-                                        self.public_key.clone(),
-                                    ))
-                                    .await;
-                                self.accumulator = Right(certificate);
-
-                                return (Some(HotShotTaskCompleted::ShutDown), self);
-                            }
-                        }
-                    }
-                };
-                (None, self)
-            }
-
-            _ => (None, self),
-        }
-    }
-}
-
-impl<TYPES: NodeType, I: NodeImplementation<TYPES>>
-    ViewSyncRelayTaskState<
-        TYPES,
-        I,
-        ViewSyncFinalizeVote<TYPES>,
-        ViewSyncFinalizeCertificate2<TYPES>,
-    >
-{
-    /// Handles incoming events for the view sync relay task
-    #[instrument(skip_all, fields(id = self.id), name = "View Sync Relay Task", level = "error")]
-    #[allow(clippy::type_complexity)]
-    pub async fn handle_event(
-        mut self,
-        event: HotShotEvent<TYPES>,
-    ) -> (
-        std::option::Option<HotShotTaskCompleted>,
-        ViewSyncRelayTaskState<
-            TYPES,
-            I,
-            ViewSyncFinalizeVote<TYPES>,
-            ViewSyncFinalizeCertificate2<TYPES>,
-        >,
-    ) {
-        match event {
-            HotShotEvent::ViewSyncFinalizeVoteRecv(vote) => {
-                // Ignore this vote if we are not the correct relay
-                if self
-                    .membership
-                    .get_leader(vote.get_data().round + vote.get_data().relay)
-                    != self.public_key
-                {
-                    info!("We are not the correct relay for this vote; vote was intended for relay {}", vote.get_data().relay);
-                    return (None, self);
-                }
-
-                debug!(
-                    "Accumulating ViewSyncFinalizetVote for round {} and relay {}",
-                    *vote.get_data().round,
-                    vote.get_data().relay
-                );
-
-                match self.accumulator {
-                    Right(_) => return (Some(HotShotTaskCompleted::ShutDown), self),
-                    Left(accumulator) => {
-                        match accumulator.accumulate(&vote, self.membership.as_ref()) {
-                            Left(new_accumulator) => {
-                                self.accumulator = Either::Left(new_accumulator);
-                            }
-                            Right(certificate) => {
-                                self.event_stream
-                                    .publish(HotShotEvent::ViewSyncFinalizeCertificate2Send(
-                                        certificate.clone(),
-                                        self.public_key.clone(),
-                                    ))
-                                    .await;
-                                self.accumulator = Right(certificate);
-
-                                return (Some(HotShotTaskCompleted::ShutDown), self);
-                            }
-                        }
-                    }
-                };
-                (None, self)
-            }
-
-            _ => (None, self),
-        }
     }
 }

--- a/crates/task-impls/src/vote.rs
+++ b/crates/task-impls/src/vote.rs
@@ -191,6 +191,7 @@ where
     VoteCollectionTaskState<TYPES, VOTE, CERT>: HandleVoteEvent<TYPES, VOTE, CERT>,
 {
     if vote.get_leader(info.membership.as_ref()) != info.public_key {
+        error!("Vote is not to the leader");
         return None;
     }
 
@@ -339,7 +340,7 @@ impl<TYPES: NodeType>
     for ViewSyncCommitVote<TYPES>
 {
     fn get_leader(&self, membership: &TYPES::Membership) -> TYPES::SignatureKey {
-        membership.get_leader(self.get_view_number())
+        membership.get_leader(self.get_data().round + self.get_data().relay)
     }
     fn make_cert_event(
         certificate: ViewSyncCommitCertificate2<TYPES>,
@@ -354,7 +355,7 @@ impl<TYPES: NodeType>
     for ViewSyncPreCommitVote<TYPES>
 {
     fn get_leader(&self, membership: &TYPES::Membership) -> TYPES::SignatureKey {
-        membership.get_leader(self.get_view_number())
+        membership.get_leader(self.get_data().round + self.get_data().relay)
     }
     fn make_cert_event(
         certificate: ViewSyncPreCommitCertificate2<TYPES>,
@@ -369,7 +370,7 @@ impl<TYPES: NodeType>
     for ViewSyncFinalizeVote<TYPES>
 {
     fn get_leader(&self, membership: &TYPES::Membership) -> TYPES::SignatureKey {
-        membership.get_leader(self.get_view_number())
+        membership.get_leader(self.get_data().round + self.get_data().relay)
     }
     fn make_cert_event(
         certificate: ViewSyncFinalizeCertificate2<TYPES>,

--- a/crates/task-impls/src/vote.rs
+++ b/crates/task-impls/src/vote.rs
@@ -191,7 +191,7 @@ where
     VoteCollectionTaskState<TYPES, VOTE, CERT>: HandleVoteEvent<TYPES, VOTE, CERT>,
 {
     if vote.get_leader(info.membership.as_ref()) != info.public_key {
-        error!("Vote is not to the leader");
+        debug!("Vote is not to the leader");
         return None;
     }
 
@@ -325,7 +325,7 @@ impl<TYPES: NodeType> AggregatableVote<TYPES, VIDVote<TYPES>, VIDCertificate<TYP
     for VIDVote<TYPES>
 {
     fn get_leader(&self, membership: &TYPES::Membership) -> TYPES::SignatureKey {
-        membership.get_leader(self.get_view_number() + 1)
+        membership.get_leader(self.get_view_number())
     }
     fn make_cert_event(
         certificate: VIDCertificate<TYPES>,

--- a/crates/task-impls/src/vote.rs
+++ b/crates/task-impls/src/vote.rs
@@ -1,0 +1,458 @@
+use std::{collections::HashMap, fmt::Debug, marker::PhantomData, sync::Arc};
+
+use crate::events::HotShotEvent;
+use async_compatibility_layer::art::async_spawn;
+use async_trait::async_trait;
+use bitvec::prelude::*;
+use either::Either::{self, Left, Right};
+use futures::FutureExt;
+use hotshot_task::{
+    event_stream::{ChannelStream, EventStream},
+    global_registry::GlobalRegistry,
+    task::{FilterEvent, HandleEvent, HotShotTaskCompleted, HotShotTaskTypes, TS},
+    task_impls::{HSTWithEvent, TaskBuilder},
+};
+use hotshot_types::{
+    simple_certificate::{
+        DACertificate, QuorumCertificate, TimeoutCertificate, ViewSyncCommitCertificate2,
+        ViewSyncFinalizeCertificate2, ViewSyncPreCommitCertificate2,
+    },
+    simple_vote::{
+        DAVote, QuorumVote, TimeoutVote, ViewSyncCommitVote, ViewSyncFinalizeVote,
+        ViewSyncPreCommitVote,
+    },
+    traits::{election::Membership, node_implementation::NodeType},
+    vote::{Certificate, HasViewNumber, Vote, VoteAccumulator},
+};
+use snafu::Snafu;
+use tracing::{debug, error};
+
+#[derive(Snafu, Debug)]
+/// Stub of a vote error
+pub struct VoteTaskError {}
+
+/// Task state for collecting votes of one type and emiting a certificate
+pub struct VoteCollectionTaskState<
+    TYPES: NodeType,
+    VOTE: Vote<TYPES>,
+    CERT: Certificate<TYPES, Voteable = VOTE::Commitment> + Debug,
+> {
+    /// Public key for this node.
+    pub public_key: TYPES::SignatureKey,
+
+    /// Membership for voting
+    pub membership: TYPES::Membership,
+
+    /// accumulator handles aggregating the votes
+    pub accumulator: Option<VoteAccumulator<TYPES, VOTE, CERT>>,
+
+    /// The view which we are collecting votes for
+    pub view: TYPES::Time,
+
+    /// global event stream
+    pub event_stream: ChannelStream<HotShotEvent<TYPES>>,
+
+    /// Node id
+    pub id: u64,
+}
+
+/// Describes the functions a vote must implement for it to be aggregatable by the generic vote collection task
+pub trait AggregatableVote<
+    TYPES: NodeType,
+    VOTE: Vote<TYPES>,
+    CERT: Certificate<TYPES, Voteable = VOTE::Commitment>,
+>
+{
+    /// return the leader for this votes
+    fn get_leader(&self, membership: &TYPES::Membership) -> TYPES::SignatureKey;
+
+    /// return the Hotshot event for the completion of this CERT
+    fn make_cert_event(certificate: CERT, key: &TYPES::SignatureKey) -> HotShotEvent<TYPES>;
+}
+
+impl<
+        TYPES: NodeType,
+        VOTE: Vote<TYPES> + AggregatableVote<TYPES, VOTE, CERT>,
+        CERT: Certificate<TYPES, Voteable = VOTE::Commitment> + Debug,
+    > VoteCollectionTaskState<TYPES, VOTE, CERT>
+{
+    /// Take one vote and accumultate it. Returns either the cert or the updated state
+    /// after the vote is accumulated
+    pub async fn accumulate_vote(mut self, vote: &VOTE) -> (Option<HotShotTaskCompleted>, Self) {
+        if vote.get_leader(&self.membership) != self.public_key {
+            return (None, self);
+        }
+
+        if vote.get_view_number() != self.view {
+            error!(
+                "Vote view does not match! vote view is {} current view is {}",
+                *vote.get_view_number(),
+                *self.view
+            );
+            return (None, self);
+        }
+        let Some(accumulator) = self.accumulator else {
+            return (None, self);
+        };
+        match accumulator.accumulate(vote, &self.membership) {
+            Either::Left(acc) => {
+                self.accumulator = Some(acc);
+                (None, self)
+            }
+            Either::Right(qc) => {
+                debug!("Certificate Formed! {:?}", qc);
+                self.event_stream
+                    .publish(VOTE::make_cert_event(qc, &self.public_key))
+                    .await;
+                self.accumulator = None;
+                (Some(HotShotTaskCompleted::ShutDown), self)
+            }
+        }
+    }
+}
+
+impl<
+        TYPES: NodeType,
+        VOTE: Vote<TYPES>
+            + AggregatableVote<TYPES, VOTE, CERT>
+            + std::marker::Send
+            + std::marker::Sync
+            + 'static,
+        CERT: Certificate<TYPES, Voteable = VOTE::Commitment>
+            + Debug
+            + std::marker::Send
+            + std::marker::Sync
+            + 'static,
+    > TS for VoteCollectionTaskState<TYPES, VOTE, CERT>
+{
+}
+
+/// Types for a vote accumulator Task
+pub type VoteTaskStateTypes<TYPES, VOTE, CERT> = HSTWithEvent<
+    VoteTaskError,
+    HotShotEvent<TYPES>,
+    ChannelStream<HotShotEvent<TYPES>>,
+    VoteCollectionTaskState<TYPES, VOTE, CERT>,
+>;
+
+/// Trait for types which will handle a vote event.
+#[async_trait]
+pub trait HandleVoteEvent<TYPES, VOTE, CERT>
+where
+    TYPES: NodeType,
+    VOTE: Vote<TYPES> + AggregatableVote<TYPES, VOTE, CERT>,
+    CERT: Certificate<TYPES, Voteable = VOTE::Commitment> + Debug,
+{
+    /// Handle a vote event
+    async fn handle_event(
+        self,
+        event: HotShotEvent<TYPES>,
+    ) -> (
+        Option<HotShotTaskCompleted>,
+        VoteCollectionTaskState<TYPES, VOTE, CERT>,
+    );
+}
+
+/// Info needed to create a vote accumulator task
+#[allow(missing_docs)]
+pub struct AccumulatorInfo<'a, TYPES: NodeType> {
+    pub public_key: TYPES::SignatureKey,
+    pub membership: &'a TYPES::Membership,
+    pub view: TYPES::Time,
+    pub event_stream: ChannelStream<HotShotEvent<TYPES>>,
+    pub id: u64,
+    pub registry: GlobalRegistry,
+}
+
+/// Generic function for spawnnig a vote task.  Returns the event stream id of the spawned task if created
+/// # Panics
+/// Calls unwrap but should never panic.
+pub async fn spawn_vote_accumulator<TYPES, VOTE, CERT>(
+    info: &AccumulatorInfo<'_, TYPES>,
+    vote: VOTE,
+    event: HotShotEvent<TYPES>,
+) -> Option<usize>
+where
+    TYPES: NodeType,
+    VOTE: Vote<TYPES>
+        + AggregatableVote<TYPES, VOTE, CERT>
+        + AggregatableVote<TYPES, VOTE, CERT>
+        + std::marker::Send
+        + std::marker::Sync
+        + 'static,
+    CERT: Certificate<TYPES, Voteable = VOTE::Commitment>
+        + Debug
+        + AggregatableVote<TYPES, VOTE, CERT>
+        + std::marker::Send
+        + std::marker::Sync
+        + 'static,
+    VoteCollectionTaskState<TYPES, VOTE, CERT>: HandleVoteEvent<TYPES, VOTE, CERT>,
+{
+    if vote.get_leader(info.membership) != info.public_key {
+        return None;
+    }
+
+    if vote.get_view_number() != info.view {
+        error!(
+            "Vote view does not match! vote view is {} current view is {}",
+            *vote.get_view_number(),
+            *info.view
+        );
+        return None;
+    }
+    let new_accumulator = VoteAccumulator {
+        vote_outcomes: HashMap::new(),
+        sig_lists: Vec::new(),
+        signers: bitvec![0;info. membership.total_nodes()],
+        phantom: PhantomData,
+    };
+
+    let mut state = VoteCollectionTaskState::<TYPES, VOTE, CERT> {
+        event_stream: info.event_stream.clone(),
+        membership: info.membership.clone(),
+        public_key: info.public_key.clone(),
+        accumulator: Some(new_accumulator),
+        view: info.view,
+        id: info.id,
+    };
+
+    let result = state.handle_event(event.clone()).await;
+
+    if result.0 == Some(HotShotTaskCompleted::ShutDown) {
+        // The protocol has finished
+        return None;
+    }
+
+    state = result.1;
+
+    let name = format!("View Sync Relay Task for view {:?}", vote.get_view_number());
+
+    let relay_handle_event = HandleEvent(Arc::new(
+        move |event, state: VoteCollectionTaskState<TYPES, VOTE, CERT>| {
+            async move { state.handle_event(event).await }.boxed()
+        },
+    ));
+
+    let filter = FilterEvent::default();
+    let builder = TaskBuilder::<VoteTaskStateTypes<TYPES, VOTE, CERT>>::new(name)
+        .register_event_stream(state.event_stream.clone(), filter)
+        .await
+        .register_registry(&mut info.registry.clone())
+        .await
+        .register_state(state)
+        .register_event_handler(relay_handle_event);
+
+    let event_stream_id = builder.get_stream_id().unwrap();
+
+    let _task = async_spawn(async move { VoteTaskStateTypes::build(builder).launch().await });
+
+    Some(event_stream_id)
+}
+
+/// Alias for Quorum vote accumulator
+type QuorumVoteState<TYPES> =
+    VoteCollectionTaskState<TYPES, QuorumVote<TYPES>, QuorumCertificate<TYPES>>;
+/// Alias for Quorum vote accumulator
+type DAVoteState<TYPES> = VoteCollectionTaskState<TYPES, DAVote<TYPES>, DACertificate<TYPES>>;
+/// Alias for Quorum vote accumulator
+type TimeoutVoteState<TYPES> =
+    VoteCollectionTaskState<TYPES, TimeoutVote<TYPES>, TimeoutCertificate<TYPES>>;
+/// Alias for Quorum vote accumulator
+type ViewSyncPreCommitState<TYPES> = VoteCollectionTaskState<
+    TYPES,
+    ViewSyncPreCommitVote<TYPES>,
+    ViewSyncPreCommitCertificate2<TYPES>,
+>;
+/// Alias for Quorum vote accumulator
+type ViewSyncCommitVoteState<TYPES> =
+    VoteCollectionTaskState<TYPES, ViewSyncCommitVote<TYPES>, ViewSyncCommitCertificate2<TYPES>>;
+/// Alias for Quorum vote accumulator
+type ViewSyncFinalizeVoteState<TYPES> = VoteCollectionTaskState<
+    TYPES,
+    ViewSyncFinalizeVote<TYPES>,
+    ViewSyncFinalizeCertificate2<TYPES>,
+>;
+
+impl<TYPES: NodeType> AggregatableVote<TYPES, QuorumVote<TYPES>, QuorumCertificate<TYPES>>
+    for QuorumVote<TYPES>
+{
+    fn get_leader(&self, membership: &TYPES::Membership) -> TYPES::SignatureKey {
+        membership.get_leader(self.get_view_number())
+    }
+    fn make_cert_event(
+        certificate: QuorumCertificate<TYPES>,
+        _key: &TYPES::SignatureKey,
+    ) -> HotShotEvent<TYPES> {
+        HotShotEvent::QCFormed(Left(certificate))
+    }
+}
+
+impl<TYPES: NodeType> AggregatableVote<TYPES, DAVote<TYPES>, DACertificate<TYPES>>
+    for DAVote<TYPES>
+{
+    fn get_leader(&self, membership: &TYPES::Membership) -> TYPES::SignatureKey {
+        membership.get_leader(self.get_view_number())
+    }
+    fn make_cert_event(
+        certificate: DACertificate<TYPES>,
+        key: &TYPES::SignatureKey,
+    ) -> HotShotEvent<TYPES> {
+        HotShotEvent::DACSend(certificate, key.clone())
+    }
+}
+
+impl<TYPES: NodeType> AggregatableVote<TYPES, TimeoutVote<TYPES>, TimeoutCertificate<TYPES>>
+    for TimeoutVote<TYPES>
+{
+    fn get_leader(&self, membership: &TYPES::Membership) -> TYPES::SignatureKey {
+        membership.get_leader(self.get_view_number())
+    }
+    fn make_cert_event(
+        certificate: TimeoutCertificate<TYPES>,
+        _key: &TYPES::SignatureKey,
+    ) -> HotShotEvent<TYPES> {
+        HotShotEvent::QCFormed(Right(certificate))
+    }
+}
+
+impl<TYPES: NodeType>
+    AggregatableVote<TYPES, ViewSyncCommitVote<TYPES>, ViewSyncCommitCertificate2<TYPES>>
+    for ViewSyncCommitVote<TYPES>
+{
+    fn get_leader(&self, membership: &TYPES::Membership) -> TYPES::SignatureKey {
+        membership.get_leader(self.get_view_number())
+    }
+    fn make_cert_event(
+        certificate: ViewSyncCommitCertificate2<TYPES>,
+        key: &TYPES::SignatureKey,
+    ) -> HotShotEvent<TYPES> {
+        HotShotEvent::ViewSyncCommitCertificate2Send(certificate, key.clone())
+    }
+}
+
+impl<TYPES: NodeType>
+    AggregatableVote<TYPES, ViewSyncPreCommitVote<TYPES>, ViewSyncPreCommitCertificate2<TYPES>>
+    for ViewSyncPreCommitVote<TYPES>
+{
+    fn get_leader(&self, membership: &TYPES::Membership) -> TYPES::SignatureKey {
+        membership.get_leader(self.get_view_number())
+    }
+    fn make_cert_event(
+        certificate: ViewSyncPreCommitCertificate2<TYPES>,
+        key: &TYPES::SignatureKey,
+    ) -> HotShotEvent<TYPES> {
+        HotShotEvent::ViewSyncPreCommitCertificate2Send(certificate, key.clone())
+    }
+}
+
+impl<TYPES: NodeType>
+    AggregatableVote<TYPES, ViewSyncFinalizeVote<TYPES>, ViewSyncFinalizeCertificate2<TYPES>>
+    for ViewSyncFinalizeVote<TYPES>
+{
+    fn get_leader(&self, membership: &TYPES::Membership) -> TYPES::SignatureKey {
+        membership.get_leader(self.get_view_number())
+    }
+    fn make_cert_event(
+        certificate: ViewSyncFinalizeCertificate2<TYPES>,
+        key: &TYPES::SignatureKey,
+    ) -> HotShotEvent<TYPES> {
+        HotShotEvent::ViewSyncFinalizeCertificate2Send(certificate, key.clone())
+    }
+}
+
+// Handlers for all vote accumulators
+#[async_trait]
+impl<TYPES: NodeType> HandleVoteEvent<TYPES, QuorumVote<TYPES>, QuorumCertificate<TYPES>>
+    for QuorumVoteState<TYPES>
+{
+    async fn handle_event(
+        self,
+        event: HotShotEvent<TYPES>,
+    ) -> (Option<HotShotTaskCompleted>, QuorumVoteState<TYPES>) {
+        match event {
+            HotShotEvent::QuorumVoteRecv(vote) => self.accumulate_vote(&vote).await,
+            _ => (None, self),
+        }
+    }
+}
+
+#[async_trait]
+impl<TYPES: NodeType> HandleVoteEvent<TYPES, DAVote<TYPES>, DACertificate<TYPES>>
+    for DAVoteState<TYPES>
+{
+    async fn handle_event(
+        self,
+        event: HotShotEvent<TYPES>,
+    ) -> (Option<HotShotTaskCompleted>, DAVoteState<TYPES>) {
+        match event {
+            HotShotEvent::DAVoteRecv(vote) => self.accumulate_vote(&vote).await,
+            _ => (None, self),
+        }
+    }
+}
+
+#[async_trait]
+impl<TYPES: NodeType> HandleVoteEvent<TYPES, TimeoutVote<TYPES>, TimeoutCertificate<TYPES>>
+    for TimeoutVoteState<TYPES>
+{
+    async fn handle_event(
+        self,
+        event: HotShotEvent<TYPES>,
+    ) -> (Option<HotShotTaskCompleted>, TimeoutVoteState<TYPES>) {
+        match event {
+            HotShotEvent::TimeoutVoteRecv(vote) => self.accumulate_vote(&vote).await,
+            _ => (None, self),
+        }
+    }
+}
+
+#[async_trait]
+impl<TYPES: NodeType>
+    HandleVoteEvent<TYPES, ViewSyncPreCommitVote<TYPES>, ViewSyncPreCommitCertificate2<TYPES>>
+    for ViewSyncPreCommitState<TYPES>
+{
+    async fn handle_event(
+        self,
+        event: HotShotEvent<TYPES>,
+    ) -> (Option<HotShotTaskCompleted>, ViewSyncPreCommitState<TYPES>) {
+        match event {
+            HotShotEvent::ViewSyncPreCommitVoteRecv(vote) => self.accumulate_vote(&vote).await,
+            _ => (None, self),
+        }
+    }
+}
+
+#[async_trait]
+impl<TYPES: NodeType>
+    HandleVoteEvent<TYPES, ViewSyncCommitVote<TYPES>, ViewSyncCommitCertificate2<TYPES>>
+    for ViewSyncCommitVoteState<TYPES>
+{
+    async fn handle_event(
+        self,
+        event: HotShotEvent<TYPES>,
+    ) -> (Option<HotShotTaskCompleted>, ViewSyncCommitVoteState<TYPES>) {
+        match event {
+            HotShotEvent::ViewSyncCommitVoteRecv(vote) => self.accumulate_vote(&vote).await,
+            _ => (None, self),
+        }
+    }
+}
+
+#[async_trait]
+impl<TYPES: NodeType>
+    HandleVoteEvent<TYPES, ViewSyncFinalizeVote<TYPES>, ViewSyncFinalizeCertificate2<TYPES>>
+    for ViewSyncFinalizeVoteState<TYPES>
+{
+    async fn handle_event(
+        self,
+        event: HotShotEvent<TYPES>,
+    ) -> (
+        Option<HotShotTaskCompleted>,
+        ViewSyncFinalizeVoteState<TYPES>,
+    ) {
+        match event {
+            HotShotEvent::ViewSyncFinalizeVoteRecv(vote) => self.accumulate_vote(&vote).await,
+            _ => (None, self),
+        }
+    }
+}

--- a/crates/web_server/src/lib.rs
+++ b/crates/web_server/src/lib.rs
@@ -278,7 +278,6 @@ impl<KEY: SignatureKey> WebServerDataSource<KEY> for WebServerState<KEY> {
         let votes = self.view_sync_votes.get(&view_number);
         let mut ret_votes = vec![];
         if let Some(votes) = votes {
-            // error!("Passed in index is: {} self index is: {}", index, *self.vote_index.get(&view_number).unwrap());
             for i in index..*self.view_sync_vote_index.get(&view_number).unwrap() {
                 ret_votes.push(votes[i as usize].1.clone());
             }
@@ -433,7 +432,7 @@ impl<KEY: SignatureKey> WebServerDataSource<KEY> for WebServerState<KEY> {
     }
     /// Stores a received proposal in the `WebServerState`
     fn post_proposal(&mut self, view_number: u64, mut proposal: Vec<u8>) -> Result<(), Error> {
-        error!("Received proposal for view {}", view_number);
+        debug!("Received proposal for view {}", view_number);
 
         if view_number > self.recent_proposal {
             self.recent_proposal = view_number;
@@ -454,7 +453,7 @@ impl<KEY: SignatureKey> WebServerDataSource<KEY> for WebServerState<KEY> {
     }
 
     fn post_vid_disperse(&mut self, view_number: u64, mut disperse: Vec<u8>) -> Result<(), Error> {
-        error!("Received VID disperse for view {}", view_number);
+        debug!("Received VID disperse for view {}", view_number);
         if view_number > self.recent_vid_disperse {
             self.recent_vid_disperse = view_number;
         }
@@ -526,7 +525,7 @@ impl<KEY: SignatureKey> WebServerDataSource<KEY> for WebServerState<KEY> {
         view_number: u64,
         mut certificate: Vec<u8>,
     ) -> Result<(), Error> {
-        error!("Received VID Certificate for view {}", view_number);
+        debug!("Received VID Certificate for view {}", view_number);
 
         // Only keep proposal history for MAX_VIEWS number of view
         if self.vid_certificates.len() >= MAX_VIEWS {

--- a/crates/web_server/src/lib.rs
+++ b/crates/web_server/src/lib.rs
@@ -5,7 +5,6 @@ use async_compatibility_layer::channel::OneShotReceiver;
 use async_lock::RwLock;
 use clap::Args;
 use futures::FutureExt;
-use tracing::error;
 
 use hotshot_types::traits::signature_key::{EncodedPublicKey, SignatureKey};
 use rand::{distributions::Alphanumeric, rngs::StdRng, thread_rng, Rng, SeedableRng};


### PR DESCRIPTION
Closes issue: <ISSUE>

### This PR: 

- Creates a generic vote accumulator task
- Creates a function to which generically spawns the task (`spawn_vote_accumulator`)
- Uses traits (`AggregatableVote` and `HandleVoteEvent`) to map input and output events to different vote types
    - `AggregatableVote` - defines how we get the right leader for that vote and maps the certificate formed to the appropriate `HotShotEvent`
    - `HandleVoteEvent` - defines how we map from `HotShotEvent` to the specific Vote type, and defines the event filter
- Replaces the duplicated vote accumulator task and task creation logic in all of the task_impls

### This PR does not: 
Replace any other potential duplicated logic in the View sync task for spawning Replicas

### Key places to review: 
The new code in crates/task_impls/src/vote.rs is the main place to look.  If anyone has ideas how to make that file have less boilerplate that would be great.  Fortunately the boilerplate in that file abstracts away pretty much completely in the other task impls

Closes: [#2040](https://github.com/EspressoSystems/HotShot/issues/2040)
