### PR TITLE
[light-client-integration] add state signature keys to the config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2924,6 +2924,7 @@ version = "0.1.0"
 dependencies = [
  "arbitrary",
  "ark-bls12-381",
+ "ark-ed-on-bn254",
  "ark-ff",
  "ark-serialize 0.3.0",
  "ark-std 0.4.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,10 @@ resolver = "2"
 
 [workspace.dependencies]
 ark-bls12-381 = "0.4"
+ark-bn254 = "0.4"
 ark-ec = "0.4"
+ark-ed-on-bn254 = "0.4"
+ark-ff = "0.4"
 ark-serialize = "0.4" # features = ["derive"]
 ark-std = { version = "0.4", default-features = false }
 async-compatibility-layer = { git = "https://github.com/EspressoSystems/async-compatibility-layer.git", tag = "1.4.1", default-features = false, features = [

--- a/crates/hotshot-stake-table/src/vec_based.rs
+++ b/crates/hotshot-stake-table/src/vec_based.rs
@@ -369,7 +369,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::config::{BLSVerKey, FieldType as F, SchnorrVerKey};
+    use super::config::{FieldType as F, QCVerKey, StateVerKey};
     use super::StakeTable;
     use ark_std::{rand::SeedableRng, vec::Vec};
     use ethereum_types::U256;
@@ -379,7 +379,7 @@ mod tests {
 
     #[test]
     fn test_stake_table() -> Result<(), StakeTableError> {
-        let mut st = StakeTable::<BLSVerKey, SchnorrVerKey, F>::new();
+        let mut st = StakeTable::<QCVerKey, StateVerKey, F>::new();
         let mut prng = jf_utils::test_rng();
         let keys = (0..10)
             .map(|_| {

--- a/crates/hotshot-stake-table/src/vec_based/config.rs
+++ b/crates/hotshot-stake-table/src/vec_based/config.rs
@@ -4,17 +4,17 @@ use ark_ff::PrimeField;
 use ark_std::vec;
 use jf_utils::to_bytes;
 
-/// BLS verification key as indexing key
-pub use jf_primitives::signatures::bls_over_bn254::VerKey as BLSVerKey;
 /// Schnorr verification key as auxiliary information
-pub type SchnorrVerKey = jf_primitives::signatures::schnorr::VerKey<ark_ed_on_bn254::EdwardsConfig>;
+pub use hotshot_types::light_client_state::StateVerKey;
+/// BLS verification key as indexing key
+pub use jf_primitives::signatures::bls_over_bn254::VerKey as QCVerKey;
 /// Type for commitment
 pub type FieldType = ark_ed_on_bn254::Fq;
 
 /// Hashable representation of a key
 /// NOTE: commitment is only used in light client contract.
 /// For this application, we needs only hash the Schnorr verfication key.
-impl ToFields<FieldType> for SchnorrVerKey {
+impl ToFields<FieldType> for StateVerKey {
     const SIZE: usize = 2;
 
     fn to_fields(&self) -> Vec<FieldType> {
@@ -23,7 +23,7 @@ impl ToFields<FieldType> for SchnorrVerKey {
     }
 }
 
-impl ToFields<FieldType> for BLSVerKey {
+impl ToFields<FieldType> for QCVerKey {
     const SIZE: usize = 2;
 
     fn to_fields(&self) -> Vec<FieldType> {

--- a/crates/hotshot-stake-table/src/vec_based/config.rs
+++ b/crates/hotshot-stake-table/src/vec_based/config.rs
@@ -5,7 +5,7 @@ use ark_std::vec;
 use jf_utils::to_bytes;
 
 /// Schnorr verification key as auxiliary information
-pub use hotshot_types::light_client_state::StateVerKey;
+pub use hotshot_types::light_client::StateVerKey;
 /// BLS verification key as indexing key
 pub use jf_primitives::signatures::bls_over_bn254::VerKey as QCVerKey;
 /// Type for commitment

--- a/crates/hotshot-state-prover/Cargo.toml
+++ b/crates/hotshot-state-prover/Cargo.toml
@@ -7,10 +7,10 @@ edition = { workspace = true }
 rust-version = { workspace = true }
 
 [dependencies]
-ark-bn254 = "0.4.0"
-ark-ec = "0.4.0"
-ark-ed-on-bn254 = "0.4.0"
-ark-ff = "0.4.0"
+ark-bn254 = { workspace = true }
+ark-ec = { workspace = true }
+ark-ed-on-bn254 = { workspace = true }
+ark-ff = { workspace = true }
 ark-serialize = { workspace = true }
 ark-std = { workspace = true }
 bincode = { workspace = true }

--- a/crates/hotshot-state-prover/src/circuit.rs
+++ b/crates/hotshot-state-prover/src/circuit.rs
@@ -5,7 +5,7 @@ use ark_ff::PrimeField;
 use ark_std::borrow::Borrow;
 use ethereum_types::U256;
 use hotshot_stake_table::config::STAKE_TABLE_CAPACITY;
-use hotshot_types::light_client_state::LightClientState;
+use hotshot_types::light_client::LightClientState;
 use jf_plonk::errors::PlonkError;
 use jf_primitives::{
     circuit::{

--- a/crates/hotshot-state-prover/src/circuit.rs
+++ b/crates/hotshot-state-prover/src/circuit.rs
@@ -5,7 +5,7 @@ use ark_ff::PrimeField;
 use ark_std::borrow::Borrow;
 use ethereum_types::U256;
 use hotshot_stake_table::config::STAKE_TABLE_CAPACITY;
-use hotshot_types::traits::state::LightClientState;
+use hotshot_types::light_client_state::LightClientState;
 use jf_plonk::errors::PlonkError;
 use jf_primitives::{
     circuit::{
@@ -27,21 +27,21 @@ pub(crate) fn u256_to_field<F: PrimeField>(v: &U256) -> F {
 /// Variable for stake table entry
 #[derive(Clone, Debug)]
 pub struct StakeTableEntryVar {
-    /// Schnorr verification keys
-    pub schnorr_ver_key: VerKeyVar,
+    /// state verification keys
+    pub state_ver_key: VerKeyVar,
     /// Stake amount
     pub stake_amount: Variable,
 }
 
 /// Light client state Variable
-/// The stake table commitment is a triple (bls_keys_comm, schnorr_keys_comm, stake_amount_comm).
+/// The stake table commitment is a triple (qc_keys_comm, state_keys_comm, stake_amount_comm).
 /// Variable for a stake table commitment
 #[derive(Clone, Debug)]
 pub struct StakeTableCommVar {
-    /// Commitment for BLS keys
-    pub bls_keys_comm: Variable,
-    /// Commitment for Schnorr keys
-    pub schnorr_keys_comm: Variable,
+    /// Commitment for QC verification keys
+    pub qc_keys_comm: Variable,
+    /// Commitment for state verification keys
+    pub state_keys_comm: Variable,
     /// Commitment for stake amount
     pub stake_amount_comm: Variable,
 }
@@ -104,13 +104,13 @@ impl<F: PrimeField> PublicInput<F> {
         (self.0[5], self.0[6], self.0[7])
     }
 
-    /// Return the bls key commitment of the light client state
-    pub fn bls_key_comm(&self) -> F {
+    /// Return the qc key commitment of the light client state
+    pub fn qc_key_comm(&self) -> F {
         self.0[5]
     }
 
-    /// Return the schnorr key commitment of the light client state
-    pub fn schnorr_key_comm(&self) -> F {
+    /// Return the state key commitment of the light client state
+    pub fn state_key_comm(&self) -> F {
         self.0[6]
     }
 
@@ -158,8 +158,8 @@ impl LightClientStateVar {
 
     pub fn stake_table_comm(&self) -> StakeTableCommVar {
         StakeTableCommVar {
-            bls_keys_comm: self.vars[4],
-            schnorr_keys_comm: self.vars[5],
+            qc_keys_comm: self.vars[4],
+            state_keys_comm: self.vars[5],
             stake_amount_comm: self.vars[6],
         }
     }
@@ -182,7 +182,7 @@ impl AsRef<[Variable]> for LightClientStateVar {
 /// It checks that
 /// - the signer's accumulated weight exceeds the quorum threshold
 /// - the stake table corresponds to the one committed in the light client state
-/// - all signed schnorr signatures are valid
+/// - all signed Schnorr signatures are valid
 /// and returns
 /// - A circuit for proof generation
 /// - A list of public inputs for verification
@@ -245,10 +245,10 @@ where
     let mut stake_table_var = stake_table_entries
         .map(|item| {
             let item = item.borrow();
-            let schnorr_ver_key = circuit.create_signature_vk_variable(&item.0)?;
+            let state_ver_key = circuit.create_signature_vk_variable(&item.0)?;
             let stake_amount = circuit.create_variable(u256_to_field::<F>(&item.1))?;
             Ok(StakeTableEntryVar {
-                schnorr_ver_key,
+                state_ver_key,
                 stake_amount,
             })
         })
@@ -256,11 +256,11 @@ where
     stake_table_var.extend(
         (0..stake_table_entries_pad_len)
             .map(|_| {
-                let schnorr_ver_key =
+                let state_ver_key =
                     circuit.create_signature_vk_variable(&SchnorrVerKey::<P>::default())?;
                 let stake_amount = circuit.create_variable(F::default())?;
                 Ok(StakeTableEntryVar {
-                    schnorr_ver_key,
+                    state_ver_key,
                     stake_amount,
                 })
             })
@@ -332,20 +332,18 @@ where
     circuit.enforce_leq(threshold_pub_var, acc_amount_var)?;
 
     // checking the commitment for the list of schnorr keys
-    let schnorr_ver_key_preimage_vars = stake_table_var
+    let state_ver_key_preimage_vars = stake_table_var
         .iter()
-        .flat_map(|var| [var.schnorr_ver_key.0.get_x(), var.schnorr_ver_key.0.get_y()])
+        .flat_map(|var| [var.state_ver_key.0.get_x(), var.state_ver_key.0.get_y()])
         .collect::<Vec<_>>();
-    let schnorr_ver_key_comm = RescueNativeGadget::<F>::rescue_sponge_with_padding(
+    let state_ver_key_comm = RescueNativeGadget::<F>::rescue_sponge_with_padding(
         &mut circuit,
-        &schnorr_ver_key_preimage_vars,
+        &state_ver_key_preimage_vars,
         1,
     )?[0];
     circuit.enforce_equal(
-        schnorr_ver_key_comm,
-        lightclient_state_pub_var
-            .stake_table_comm()
-            .schnorr_keys_comm,
+        state_ver_key_comm,
+        lightclient_state_pub_var.stake_table_comm().state_keys_comm,
     )?;
 
     // checking the commitment for the list of stake amounts
@@ -372,7 +370,7 @@ where
         .map(|(entry, sig)| {
             SignatureGadget::<_, P>::check_signature_validity(
                 &mut circuit,
-                &entry.schnorr_ver_key,
+                &entry.state_ver_key,
                 lightclient_state_pub_var.as_ref(),
                 &sig,
             )
@@ -432,13 +430,13 @@ mod tests {
         let num_validators = 10;
         let mut prng = test_rng();
 
-        let (bls_keys, schnorr_keys) = key_pairs_for_testing(num_validators, &mut prng);
-        let st = stake_table_for_testing(&bls_keys, &schnorr_keys);
+        let (qc_keys, state_keys) = key_pairs_for_testing(num_validators, &mut prng);
+        let st = stake_table_for_testing(&qc_keys, &state_keys);
 
         let entries = st
             .try_iter(SnapshotVersion::LastEpochStart)
             .unwrap()
-            .map(|(_, stake_amount, schnorr_key)| (schnorr_key, stake_amount))
+            .map(|(_, stake_amount, state_key)| (state_key, stake_amount))
             .collect::<Vec<_>>();
 
         let block_comm_root =
@@ -457,7 +455,7 @@ mod tests {
         };
         let state_msg: [F; 7] = lightclient_state.clone().into();
 
-        let sigs = schnorr_keys
+        let sigs = state_keys
             .iter()
             .map(|(key, _)| SchnorrSignatureScheme::<Config>::sign(&(), key, state_msg, &mut prng))
             .collect::<Result<Vec<_>, PrimitivesError>>()
@@ -535,7 +533,7 @@ mod tests {
         let mut bad_lightclient_state = lightclient_state.clone();
         bad_lightclient_state.stake_table_comm.1 = F::default();
         let bad_state_msg: [F; 7] = bad_lightclient_state.clone().into();
-        let sig_for_bad_state = schnorr_keys
+        let sig_for_bad_state = state_keys
             .iter()
             .map(|(key, _)| {
                 SchnorrSignatureScheme::<Config>::sign(&(), key, bad_state_msg, &mut prng)
@@ -556,10 +554,10 @@ mod tests {
 
         // bad path: incorrect signatures
         let mut wrong_light_client_state = lightclient_state.clone();
-        // state with a different bls key commitment
+        // state with a different qc key commitment
         wrong_light_client_state.stake_table_comm.0 = F::default();
         let wrong_state_msg: [F; 7] = wrong_light_client_state.into();
-        let wrong_sigs = schnorr_keys
+        let wrong_sigs = state_keys
             .iter()
             .map(|(key, _)| {
                 SchnorrSignatureScheme::<Config>::sign(&(), key, wrong_state_msg, &mut prng)

--- a/crates/hotshot-state-prover/src/lib.rs
+++ b/crates/hotshot-state-prover/src/lib.rs
@@ -15,7 +15,7 @@ use ark_std::{
 use circuit::PublicInput;
 use ethereum_types::U256;
 use hotshot_types::{
-    light_client_state::{LightClientState, StateVerKey},
+    light_client::{LightClientState, StateVerKey},
     traits::stake_table::{SnapshotVersion, StakeTableScheme},
 };
 use jf_plonk::{
@@ -103,7 +103,7 @@ mod tests {
     };
     use ethereum_types::U256;
     use hotshot_types::{
-        light_client_state::LightClientState,
+        light_client::LightClientState,
         traits::stake_table::{SnapshotVersion, StakeTableScheme},
     };
     use jf_plonk::{

--- a/crates/hotshot-state-prover/src/lib.rs
+++ b/crates/hotshot-state-prover/src/lib.rs
@@ -7,15 +7,16 @@ pub mod circuit;
 mod utils;
 
 use ark_bn254::Bn254;
+use ark_ed_on_bn254::EdwardsConfig;
 use ark_std::{
     borrow::Borrow,
     rand::{CryptoRng, RngCore},
 };
 use circuit::PublicInput;
 use ethereum_types::U256;
-use hotshot_types::traits::{
-    stake_table::{SnapshotVersion, StakeTableScheme},
-    state::LightClientState,
+use hotshot_types::{
+    light_client_state::{LightClientState, StateVerKey},
+    traits::stake_table::{SnapshotVersion, StakeTableScheme},
 };
 use jf_plonk::{
     errors::PlonkError,
@@ -25,9 +26,7 @@ use jf_plonk::{
 use jf_primitives::signatures::schnorr::Signature;
 
 /// BLS verification key, base field and Schnorr verification key
-pub use hotshot_stake_table::vec_based::config::{
-    BLSVerKey, FieldType as BaseField, SchnorrVerKey,
-};
+pub use hotshot_stake_table::vec_based::config::{FieldType as BaseField, QCVerKey};
 /// Proving key
 pub type ProvingKey = jf_plonk::proof_system::structs::ProvingKey<Bn254>;
 /// Verifying key
@@ -36,8 +35,6 @@ pub type VerifyingKey = jf_plonk::proof_system::structs::VerifyingKey<Bn254>;
 pub type Proof = jf_plonk::proof_system::structs::Proof<Bn254>;
 /// Universal SRS
 pub type UniversalSrs = jf_plonk::proof_system::structs::UniversalSrs<Bn254>;
-/// Curve config for Schnorr signatures
-pub use ark_ed_on_bn254::EdwardsConfig;
 
 /// Given a SRS, returns the proving key and verifying key for state update
 pub fn preprocess(srs: &UniversalSrs) -> Result<(ProvingKey, VerifyingKey), PlonkError> {
@@ -65,7 +62,7 @@ pub fn generate_state_update_proof<ST, R, BitIter, SigIter>(
     threshold: &U256,
 ) -> Result<(Proof, PublicInput<BaseField>), PlonkError>
 where
-    ST: StakeTableScheme<Key = BLSVerKey, Amount = U256, Aux = SchnorrVerKey>,
+    ST: StakeTableScheme<Key = QCVerKey, Amount = U256, Aux = StateVerKey>,
     ST::IntoIter: ExactSizeIterator,
     R: CryptoRng + RngCore,
     BitIter: IntoIterator,
@@ -105,9 +102,9 @@ mod tests {
         One,
     };
     use ethereum_types::U256;
-    use hotshot_types::traits::{
-        stake_table::{SnapshotVersion, StakeTableScheme},
-        state::LightClientState,
+    use hotshot_types::{
+        light_client_state::LightClientState,
+        traits::stake_table::{SnapshotVersion, StakeTableScheme},
     };
     use jf_plonk::{
         proof_system::{PlonkKzgSnark, UniversalSNARK},

--- a/crates/hotshot/examples/infra/mod.rs
+++ b/crates/hotshot/examples/infra/mod.rs
@@ -884,16 +884,12 @@ pub async fn main_entry_point<
 
     run_config.node_index = node_index.into();
 
-    let (public_key, private_key) =
-        <<TYPES as NodeType>::SignatureKey as SignatureKey>::generated_from_seed_indexed(
+    run_config.config.my_own_validator_config =
+        ValidatorConfig::<<TYPES as NodeType>::SignatureKey>::generated_from_seed_indexed(
             run_config.seed,
             node_index.into(),
+            1,
         );
-    run_config.config.my_own_validator_config = ValidatorConfig {
-        public_key,
-        private_key,
-        stake_value: 1,
-    };
     //run_config.libp2p_config.as_mut().unwrap().public_ip = args.public_ip.unwrap();
 
     error!("Initializing networking");

--- a/crates/orchestrator/src/config.rs
+++ b/crates/orchestrator/src/config.rs
@@ -292,13 +292,7 @@ fn default_transaction_size() -> usize {
 impl<K: SignatureKey> From<ValidatorConfigFile> for ValidatorConfig<K> {
     fn from(val: ValidatorConfigFile) -> Self {
         // here stake_value is set to 1, since we don't input stake_value from ValidatorConfigFile for now
-        let validator_config =
-            ValidatorConfig::generated_from_seed_indexed(val.seed, val.node_id, 1);
-        ValidatorConfig {
-            public_key: validator_config.public_key,
-            private_key: validator_config.private_key,
-            stake_value: validator_config.stake_value,
-        }
+        ValidatorConfig::generated_from_seed_indexed(val.seed, val.node_id, 1)
     }
 }
 impl<KEY: SignatureKey, E: ElectionConfig> From<ValidatorConfigFile> for HotShotConfig<KEY, E> {

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -13,7 +13,8 @@ demo = []
 [dependencies]
 arbitrary = { version = "1.3", features = ["derive"] }
 ark-bls12-381 = { workspace = true }
-ark-ff = "0.4.0"
+ark-ed-on-bn254 = { workspace = true }
+ark-ff = { workspace = true }
 ark-serialize = { version = "0.3", features = [
     "derive",
 ] } # TODO upgrade to 0.4 and inherit this dep from workspace https://github.com/EspressoSystems/HotShot/issues/1700

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -10,6 +10,7 @@
 #![allow(clippy::module_name_repetitions)]
 
 use displaydoc::Display;
+use light_client_state::{generat_key_pair_from_seed_indexed, StateSigKeyPairs};
 use std::{num::NonZeroUsize, time::Duration};
 use traits::{election::ElectionConfig, signature_key::SignatureKey};
 pub mod block_impl;
@@ -17,6 +18,7 @@ pub mod consensus;
 pub mod data;
 pub mod error;
 pub mod event;
+pub mod light_client_state;
 pub mod message;
 pub mod simple_certificate;
 pub mod simple_vote;
@@ -46,6 +48,8 @@ pub struct ValidatorConfig<KEY: SignatureKey> {
     pub private_key: KEY::PrivateKey,
     /// The validator's stake
     pub stake_value: u64,
+    /// the validator's key pairs for state signing/verification
+    pub state_key_pairs: StateSigKeyPairs,
 }
 
 impl<KEY: SignatureKey> ValidatorConfig<KEY> {
@@ -53,10 +57,12 @@ impl<KEY: SignatureKey> ValidatorConfig<KEY> {
     #[must_use]
     pub fn generated_from_seed_indexed(seed: [u8; 32], index: u64, stake_value: u64) -> Self {
         let (public_key, private_key) = KEY::generated_from_seed_indexed(seed, index);
+        let state_key_pairs = generat_key_pair_from_seed_indexed(seed, index);
         Self {
             public_key,
             private_key,
             stake_value,
+            state_key_pairs,
         }
     }
 }

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -10,7 +10,7 @@
 #![allow(clippy::module_name_repetitions)]
 
 use displaydoc::Display;
-use light_client_state::{generat_key_pair_from_seed_indexed, StateSigKeyPairs};
+use light_client_state::{generate_state_key_pair_from_seed_indexed, StateSigKeyPairs};
 use std::{num::NonZeroUsize, time::Duration};
 use traits::{election::ElectionConfig, signature_key::SignatureKey};
 pub mod block_impl;
@@ -57,7 +57,7 @@ impl<KEY: SignatureKey> ValidatorConfig<KEY> {
     #[must_use]
     pub fn generated_from_seed_indexed(seed: [u8; 32], index: u64, stake_value: u64) -> Self {
         let (public_key, private_key) = KEY::generated_from_seed_indexed(seed, index);
-        let state_key_pairs = generat_key_pair_from_seed_indexed(seed, index);
+        let state_key_pairs = generate_state_key_pair_from_seed_indexed(seed, index);
         Self {
             public_key,
             private_key,

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -10,7 +10,6 @@
 #![allow(clippy::module_name_repetitions)]
 
 use displaydoc::Display;
-use light_client_state::{generate_state_key_pair_from_seed_indexed, StateSigKeyPairs};
 use std::{num::NonZeroUsize, time::Duration};
 use traits::{election::ElectionConfig, signature_key::SignatureKey};
 pub mod block_impl;
@@ -18,7 +17,7 @@ pub mod consensus;
 pub mod data;
 pub mod error;
 pub mod event;
-pub mod light_client_state;
+pub mod light_client;
 pub mod message;
 pub mod simple_certificate;
 pub mod simple_vote;
@@ -49,7 +48,7 @@ pub struct ValidatorConfig<KEY: SignatureKey> {
     /// The validator's stake
     pub stake_value: u64,
     /// the validator's key pairs for state signing/verification
-    pub state_key_pairs: StateSigKeyPairs,
+    pub state_key_pair: light_client::StateKeyPair,
 }
 
 impl<KEY: SignatureKey> ValidatorConfig<KEY> {
@@ -57,12 +56,12 @@ impl<KEY: SignatureKey> ValidatorConfig<KEY> {
     #[must_use]
     pub fn generated_from_seed_indexed(seed: [u8; 32], index: u64, stake_value: u64) -> Self {
         let (public_key, private_key) = KEY::generated_from_seed_indexed(seed, index);
-        let state_key_pairs = generate_state_key_pair_from_seed_indexed(seed, index);
+        let state_key_pairs = light_client::StateKeyPair::generate_from_seed_indexed(seed, index);
         Self {
             public_key,
             private_key,
             stake_value,
-            state_key_pairs,
+            state_key_pair: state_key_pairs,
         }
     }
 }

--- a/crates/types/src/light_client_state.rs
+++ b/crates/types/src/light_client_state.rs
@@ -59,16 +59,16 @@ pub type StateSignature = jf_primitives::signatures::schnorr::Signature<Config>;
 
 /// Generate key pairs from seed
 #[must_use]
-pub fn generat_key_pair_from_seed(seed: [u8; 32]) -> StateSigKeyPairs {
+pub fn generate_state_key_pair_from_seed(seed: [u8; 32]) -> StateSigKeyPairs {
     StateSigKeyPairs::generate(&mut ChaCha20Rng::from_seed(seed))
 }
 
 /// Generate key pairs from an index and a seed
 #[must_use]
-pub fn generat_key_pair_from_seed_indexed(seed: [u8; 32], index: u64) -> StateSigKeyPairs {
+pub fn generate_state_key_pair_from_seed_indexed(seed: [u8; 32], index: u64) -> StateSigKeyPairs {
     let mut hasher = blake3::Hasher::new();
     hasher.update(&seed);
     hasher.update(&index.to_le_bytes());
     let new_seed = *hasher.finalize().as_bytes();
-    generat_key_pair_from_seed(new_seed)
+    generate_state_key_pair_from_seed(new_seed)
 }

--- a/crates/types/src/light_client_state.rs
+++ b/crates/types/src/light_client_state.rs
@@ -1,0 +1,74 @@
+//! Types and structs associated with light client state
+
+use ark_ff::PrimeField;
+
+/// A serialized light client state for proof generation
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize, Default)]
+pub struct LightClientState<F: PrimeField> {
+    /// Current view number
+    pub view_number: usize,
+    /// Current block height
+    pub block_height: usize,
+    /// Root of the block commitment tree
+    pub block_comm_root: F,
+    /// Commitment for fee ledger
+    pub fee_ledger_comm: F,
+    /// Commitment for the stake table
+    pub stake_table_comm: (F, F, F),
+}
+
+impl<F: PrimeField> From<LightClientState<F>> for [F; 7] {
+    fn from(state: LightClientState<F>) -> Self {
+        [
+            F::from(state.view_number as u64),
+            F::from(state.block_height as u64),
+            state.block_comm_root,
+            state.fee_ledger_comm,
+            state.stake_table_comm.0,
+            state.stake_table_comm.1,
+            state.stake_table_comm.2,
+        ]
+    }
+}
+impl<F: PrimeField> From<&LightClientState<F>> for [F; 7] {
+    fn from(state: &LightClientState<F>) -> Self {
+        [
+            F::from(state.view_number as u64),
+            F::from(state.block_height as u64),
+            state.block_comm_root,
+            state.fee_ledger_comm,
+            state.stake_table_comm.0,
+            state.stake_table_comm.1,
+            state.stake_table_comm.2,
+        ]
+    }
+}
+
+use ark_ed_on_bn254::EdwardsConfig as Config;
+use rand::SeedableRng;
+use rand_chacha::ChaCha20Rng;
+
+/// Verification key for verifying state signatures
+pub type StateVerKey = jf_primitives::signatures::schnorr::VerKey<Config>;
+/// Signing key for signing a light client state
+pub type StateSignKey = jf_primitives::signatures::schnorr::SignKey<ark_ed_on_bn254::Fr>;
+/// Key pairs for signing/verifying a light client state
+pub type StateSigKeyPairs = jf_primitives::signatures::schnorr::KeyPair<Config>;
+/// Signatures
+pub type StateSignature = jf_primitives::signatures::schnorr::Signature<Config>;
+
+/// Generate key pairs from seed
+#[must_use]
+pub fn generat_key_pair_from_seed(seed: [u8; 32]) -> StateSigKeyPairs {
+    StateSigKeyPairs::generate(&mut ChaCha20Rng::from_seed(seed))
+}
+
+/// Generate key pairs from an index and a seed
+#[must_use]
+pub fn generat_key_pair_from_seed_indexed(seed: [u8; 32], index: u64) -> StateSigKeyPairs {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(&seed);
+    hasher.update(&index.to_le_bytes());
+    let new_seed = *hasher.finalize().as_bytes();
+    generat_key_pair_from_seed(new_seed)
+}

--- a/crates/types/src/traits/state.rs
+++ b/crates/types/src/traits/state.rs
@@ -4,7 +4,6 @@
 //! network state, which is modified by the transactions contained within blocks.
 
 use crate::traits::BlockPayload;
-use ark_ff::PrimeField;
 use commit::Committable;
 use espresso_systems_common::hotshot::tag;
 use serde::{de::DeserializeOwned, Serialize};
@@ -217,47 +216,5 @@ pub mod dummy {
         ) -> VIDTransaction {
             VIDTransaction(vec![0u8])
         }
-    }
-}
-
-/// A serialized light client state for proof generation
-#[derive(Clone, Debug, serde::Serialize, serde::Deserialize, Default)]
-pub struct LightClientState<F: PrimeField> {
-    /// Current view number
-    pub view_number: usize,
-    /// Current block height
-    pub block_height: usize,
-    /// Root of the block commitment tree
-    pub block_comm_root: F,
-    /// Commitment for fee ledger
-    pub fee_ledger_comm: F,
-    /// Commitment for the stake table
-    pub stake_table_comm: (F, F, F),
-}
-
-impl<F: PrimeField> From<LightClientState<F>> for [F; 7] {
-    fn from(state: LightClientState<F>) -> Self {
-        [
-            F::from(state.view_number as u64),
-            F::from(state.block_height as u64),
-            state.block_comm_root,
-            state.fee_ledger_comm,
-            state.stake_table_comm.0,
-            state.stake_table_comm.1,
-            state.stake_table_comm.2,
-        ]
-    }
-}
-impl<F: PrimeField> From<&LightClientState<F>> for [F; 7] {
-    fn from(state: &LightClientState<F>) -> Self {
-        [
-            F::from(state.view_number as u64),
-            F::from(state.block_height as u64),
-            state.block_comm_root,
-            state.fee_ledger_comm,
-            state.stake_table_comm.0,
-            state.stake_table_comm.1,
-            state.stake_table_comm.2,
-        ]
     }
 }


### PR DESCRIPTION
Closes issue: #2119 

### This PR: 

Defines the types for Schnorr signatures of the light client state.


### This PR does not: 
Contains any logic related to signature generations, etc.
Since validators need not verify these Schnorr signatures, didn't add the verification keys to the config file. 

### Key places to review: 
* Types and structs related to schnorr signatures are moved to `crates/types/src/light_client_state.rs`
* Add a `state_sig_key_pair` field inside the `ValidatorConfig` struct, see line 51-52 `crates/types/src/lib.rs`
* Are these modification enough so that the validators will be able to sign a state change?

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->

### Comments requested
* I didn't wrap these key types, nor define any related traits. Because they are pretty isolated and are only used in light client related logics.
* For stake table, I renamed some bls keys to qc keys, and Schnorr keys to state keys. Which ones do you think is better? Does it confuse people?