### PR TITLE
[Stability] Rework spinning task to be function of view

### DIFF
--- a/crates/testing/src/spinning_task.rs
+++ b/crates/testing/src/spinning_task.rs
@@ -1,40 +1,35 @@
-use std::{
-    collections::HashMap,
-    sync::{atomic::AtomicUsize, Arc},
-    time::Duration,
-};
+use either::Either;
+use hotshot_task::Merge;
+use hotshot_task_impls::events::HotShotEvent;
+use std::{collections::HashMap, sync::Arc};
 
-use crate::{test_launcher::TaskGenerator, test_runner::Node, GlobalTestEvent};
-use async_compatibility_layer::art::async_sleep;
+use async_compatibility_layer::channel::UnboundedStream;
 use futures::FutureExt;
 use hotshot::{traits::TestableNodeImplementation, HotShotType, SystemContext};
 use hotshot_task::{
-    boxed_sync,
     event_stream::ChannelStream,
     task::{FilterEvent, HandleEvent, HandleMessage, HotShotTaskCompleted, HotShotTaskTypes, TS},
     task_impls::{HSTWithEventAndMessage, TaskBuilder},
-    GeneratedStream,
+    MergeN,
 };
-
-use hotshot_types::traits::{network::CommunicationChannel, node_implementation::NodeType};
+use hotshot_types::traits::network::CommunicationChannel;
+use hotshot_types::{event::Event, traits::node_implementation::NodeType};
 use snafu::Snafu;
+
+use crate::{test_launcher::TaskGenerator, test_runner::Node};
+pub type StateAndBlock<S, B> = (Vec<S>, Vec<B>);
+
+use super::GlobalTestEvent;
+
 #[derive(Snafu, Debug)]
 pub struct SpinningTaskErr {}
 
-/// Completion task types
-pub type SpinningTaskTypes<TYPES, I> = HSTWithEventAndMessage<
-    SpinningTaskErr,
-    GlobalTestEvent,
-    ChannelStream<GlobalTestEvent>,
-    (),
-    GeneratedStream<()>,
-    SpinningTask<TYPES, I>,
->;
-
+/// Spinning task state
 pub struct SpinningTask<TYPES: NodeType, I: TestableNodeImplementation<TYPES>> {
     pub(crate) handles: Vec<Node<TYPES, I>>,
     pub(crate) late_start: HashMap<u64, SystemContext<TYPES, I>>,
-    pub(crate) changes: Vec<Vec<ChangeNode>>,
+    pub(crate) changes: HashMap<TYPES::Time, Vec<ChangeNode>>,
+    pub(crate) latest_view: Option<TYPES::Time>,
 }
 
 impl<TYPES: NodeType, I: TestableNodeImplementation<TYPES>> TS for SpinningTask<TYPES, I> {}
@@ -63,17 +58,15 @@ pub struct ChangeNode {
 
 #[derive(Clone, Debug)]
 pub struct SpinningTaskDescription {
-    pub node_changes: Vec<(Duration, Vec<ChangeNode>)>,
+    pub node_changes: Vec<(u64, Vec<ChangeNode>)>,
 }
 
 impl SpinningTaskDescription {
+    /// build a task
     pub fn build<TYPES: NodeType, I: TestableNodeImplementation<TYPES>>(
         self,
-    ) -> TaskGenerator<SpinningTask<TYPES, I>>
-    where
-        SystemContext<TYPES, I>: HotShotType<TYPES, I>,
-    {
-        Box::new(move |state, mut registry, test_event_stream| {
+    ) -> TaskGenerator<SpinningTask<TYPES, I>> {
+        Box::new(move |mut state, mut registry, test_event_stream| {
             async move {
                 let event_handler =
                     HandleEvent::<SpinningTaskTypes<TYPES, I>>(Arc::new(move |event, state| {
@@ -86,65 +79,95 @@ impl SpinningTaskDescription {
                         }
                         .boxed()
                     }));
-                let atomic_idx = Arc::new(AtomicUsize::new(0));
-                let sleep_durations = Arc::new(
-                    self.node_changes
-                        .clone()
-                        .into_iter()
-                        .map(|(d, _)| d)
-                        .collect::<Vec<_>>(),
-                );
-                let stream_generator = GeneratedStream::new(Arc::new(move || {
-                    let atomic_idx = atomic_idx.clone();
-                    let sleep_durations = sleep_durations.clone();
-                    let atomic_idx = atomic_idx.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-                    sleep_durations.get(atomic_idx).copied().map(|duration| {
-                        let fut = async move {
-                            async_sleep(duration).await;
-                        };
-                        boxed_sync(fut)
-                    })
-                }));
+
                 let message_handler = HandleMessage::<SpinningTaskTypes<TYPES, I>>(Arc::new(
-                    move |_msg, mut state| {
+                    move |msg, mut state| {
                         async move {
-                            if let Some(nodes_to_change) = state.changes.pop() {
-                                for ChangeNode { idx, updown } in nodes_to_change {
-                                    match updown {
-                                        UpDown::Up => {
-                                            if let Some(node) =
-                                                state.late_start.remove(&idx.try_into().unwrap())
-                                            {
-                                                tracing::error!("Spinning up node late");
-                                                let handle = node.run_tasks().await;
-                                                handle.hotshot.start_consensus().await;
-                                            }
-                                        }
-                                        UpDown::Down => {
-                                            if let Some(node) = state.handles.get_mut(idx) {
-                                                node.handle.shut_down().await;
-                                            }
-                                        }
-                                        UpDown::NetworkUp => {
-                                            if let Some(handle) = state.handles.get(idx) {
-                                                handle.networks.0.resume();
-                                                handle.networks.1.resume();
-                                            }
-                                        }
-                                        UpDown::NetworkDown => {
-                                            if let Some(handle) = state.handles.get(idx) {
-                                                handle.networks.0.pause();
-                                                handle.networks.1.pause();
+                            let (_, maybe_event): (usize, Either<_, _>) = msg;
+                            if let Either::Left(Event {
+                                view_number,
+                                event: _,
+                            }) = maybe_event
+                            {
+                                // if we have not seen this view before
+                                if state.latest_view.is_none()
+                                    || view_number > state.latest_view.unwrap()
+                                {
+                                    // perform operations on the nodes
+                                    if let Some(operations) = state.changes.remove(&view_number) {
+                                        for ChangeNode { idx, updown } in operations {
+                                            match updown {
+                                                UpDown::Up => {
+                                                    if let Some(node) = state
+                                                        .late_start
+                                                        .remove(&idx.try_into().unwrap())
+                                                    {
+                                                        tracing::error!(
+                                                            "Node {} spinning up late",
+                                                            idx
+                                                        );
+                                                        let handle = node.run_tasks().await;
+                                                        handle.hotshot.start_consensus().await;
+                                                    }
+                                                }
+                                                UpDown::Down => {
+                                                    if let Some(node) = state.handles.get_mut(idx) {
+                                                        tracing::error!(
+                                                            "Node {} shutting down",
+                                                            idx
+                                                        );
+                                                        node.handle.shut_down().await;
+                                                    }
+                                                }
+                                                UpDown::NetworkUp => {
+                                                    if let Some(handle) = state.handles.get(idx) {
+                                                        tracing::error!(
+                                                            "Node {} networks resuming",
+                                                            idx
+                                                        );
+                                                        handle.networks.0.resume();
+                                                        handle.networks.1.resume();
+                                                    }
+                                                }
+                                                UpDown::NetworkDown => {
+                                                    if let Some(handle) = state.handles.get(idx) {
+                                                        tracing::error!(
+                                                            "Node {} networks pausing",
+                                                            idx
+                                                        );
+                                                        handle.networks.0.pause();
+                                                        handle.networks.1.pause();
+                                                    }
+                                                }
                                             }
                                         }
                                     }
+
+                                    // update our latest view
+                                    state.latest_view = Some(view_number);
                                 }
                             }
+
                             (None, state)
                         }
                         .boxed()
                     },
                 ));
+
+                let mut streams = vec![];
+                for handle in &mut state.handles {
+                    let s1 = handle
+                        .handle
+                        .get_event_stream_known_impl(FilterEvent::default())
+                        .await
+                        .0;
+                    let s2 = handle
+                        .handle
+                        .get_internal_event_stream_known_impl(FilterEvent::default())
+                        .await
+                        .0;
+                    streams.push(Merge::new(s1, s2));
+                }
                 let builder = TaskBuilder::<SpinningTaskTypes<TYPES, I>>::new(
                     "Test Spinning Task".to_string(),
                 )
@@ -152,10 +175,10 @@ impl SpinningTaskDescription {
                 .await
                 .register_registry(&mut registry)
                 .await
-                .register_state(state)
-                .register_event_handler(event_handler)
                 .register_message_handler(message_handler)
-                .register_message_stream(stream_generator);
+                .register_message_stream(MergeN::new(streams))
+                .register_event_handler(event_handler)
+                .register_state(state);
                 let task_id = builder.get_task_id().unwrap();
                 (task_id, SpinningTaskTypes::build(builder).launch())
             }
@@ -163,3 +186,13 @@ impl SpinningTaskDescription {
         })
     }
 }
+
+/// types for safety task
+pub type SpinningTaskTypes<TYPES, I> = HSTWithEventAndMessage<
+    SpinningTaskErr,
+    GlobalTestEvent,
+    ChannelStream<GlobalTestEvent>,
+    (usize, Either<Event<TYPES>, HotShotEvent<TYPES>>),
+    MergeN<Merge<UnboundedStream<Event<TYPES>>, UnboundedStream<HotShotEvent<TYPES>>>>,
+    SpinningTask<TYPES, I>,
+>;

--- a/crates/testing/src/test_runner.rs
+++ b/crates/testing/src/test_runner.rs
@@ -4,7 +4,7 @@ use super::{
     txn_task::TxnTask,
 };
 use crate::{
-    spinning_task::UpDown,
+    spinning_task::{ChangeNode, UpDown},
     test_launcher::{Networks, TestLauncher},
 };
 use hotshot::{types::SystemContextHandle, Memberships};
@@ -16,7 +16,7 @@ use hotshot_task::{
 use hotshot_types::traits::network::CommunicationChannel;
 use hotshot_types::{
     consensus::ConsensusMetricsValue,
-    traits::{election::Membership, node_implementation::NodeType},
+    traits::{election::Membership, node_implementation::NodeType, state::ConsensusTime},
     HotShotConfig, ValidatorConfig,
 };
 use std::{
@@ -114,10 +114,20 @@ where
         task_runner = task_runner.add_task(id, "Test Completion Task".to_string(), task);
 
         // add spinning task
+        // map spinning to view
+        let mut changes: HashMap<TYPES::Time, Vec<ChangeNode>> = HashMap::new();
+        for (view, mut change) in spinning_changes {
+            changes
+                .entry(TYPES::Time::new(view))
+                .or_insert_with(Vec::new)
+                .append(&mut change);
+        }
+
         let spinning_task_state = crate::spinning_task::SpinningTask {
             handles: nodes.clone(),
             late_start,
-            changes: spinning_changes.into_iter().map(|(_, b)| b).collect(),
+            latest_view: None,
+            changes,
         };
 
         let (id, task) = (launcher.spinning_task_generator)(

--- a/crates/testing/tests/basic.rs
+++ b/crates/testing/tests/basic.rs
@@ -38,8 +38,6 @@ async fn test_success() {
 )]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 async fn test_with_failures_one() {
-    use std::time::Duration;
-
     use hotshot_testing::{
         node_types::{MemoryImpl, TestTypes},
         spinning_task::{ChangeNode, SpinningTaskDescription, UpDown},
@@ -60,7 +58,7 @@ async fn test_with_failures_one() {
     }];
 
     metadata.spinning_properties = SpinningTaskDescription {
-        node_changes: vec![(Duration::new(1, 0), dead_nodes)],
+        node_changes: vec![(5, dead_nodes)],
     };
     metadata
         .gen_launcher::<TestTypes, MemoryImpl>(0)
@@ -77,8 +75,6 @@ async fn test_with_failures_one() {
 )]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 async fn test_with_failures_half_f() {
-    use std::time::Duration;
-
     use hotshot_testing::{
         node_types::{MemoryImpl, TestTypes},
         spinning_task::{ChangeNode, SpinningTaskDescription, UpDown},
@@ -109,7 +105,7 @@ async fn test_with_failures_half_f() {
     ];
 
     metadata.spinning_properties = SpinningTaskDescription {
-        node_changes: vec![(Duration::new(1, 0), dead_nodes)],
+        node_changes: vec![(5, dead_nodes)],
     };
     metadata.overall_safety_properties.num_failed_views = 6;
     metadata
@@ -127,8 +123,6 @@ async fn test_with_failures_half_f() {
 )]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 async fn test_with_failures_f() {
-    use std::time::Duration;
-
     use hotshot_testing::{
         node_types::{MemoryImpl, TestTypes},
         spinning_task::{ChangeNode, SpinningTaskDescription, UpDown},
@@ -174,7 +168,7 @@ async fn test_with_failures_f() {
     ];
 
     metadata.spinning_properties = SpinningTaskDescription {
-        node_changes: vec![(Duration::new(1, 0), dead_nodes)],
+        node_changes: vec![(5, dead_nodes)],
     };
     metadata
         .gen_launcher::<TestTypes, MemoryImpl>(0)

--- a/crates/testing/tests/catchup.rs
+++ b/crates/testing/tests/catchup.rs
@@ -38,7 +38,7 @@ async fn test_catchup() {
     metadata.total_nodes = 20;
 
     metadata.spinning_properties = SpinningTaskDescription {
-        node_changes: vec![(Duration::new(1, 0), catchup_nodes)],
+        node_changes: vec![(25, catchup_nodes)],
     };
 
     metadata.completion_task_description =
@@ -93,7 +93,7 @@ async fn test_catchup_web() {
     metadata.total_nodes = 20;
 
     metadata.spinning_properties = SpinningTaskDescription {
-        node_changes: vec![(Duration::from_millis(400), catchup_nodes)],
+        node_changes: vec![(25, catchup_nodes)],
     };
 
     metadata.completion_task_description =
@@ -150,7 +150,7 @@ async fn test_catchup_one_node() {
     metadata.total_nodes = 20;
 
     metadata.spinning_properties = SpinningTaskDescription {
-        node_changes: vec![(Duration::from_millis(400), catchup_nodes)],
+        node_changes: vec![(25, catchup_nodes)],
     };
 
     metadata.completion_task_description =
@@ -216,7 +216,7 @@ async fn test_catchup_in_view_sync() {
     metadata.total_nodes = 20;
 
     metadata.spinning_properties = SpinningTaskDescription {
-        node_changes: vec![(Duration::new(5, 0), catchup_nodes)],
+        node_changes: vec![(25, catchup_nodes)],
     };
 
     metadata.completion_task_description =

--- a/crates/testing/tests/combined_network.rs
+++ b/crates/testing/tests/combined_network.rs
@@ -94,7 +94,7 @@ async fn test_combined_network_webserver_crash() {
     }
 
     metadata.spinning_properties = SpinningTaskDescription {
-        node_changes: vec![(Duration::new(1, 0), all_nodes)],
+        node_changes: vec![(5, all_nodes)],
     };
 
     metadata
@@ -154,10 +154,7 @@ async fn test_combined_network_reup() {
     }
 
     metadata.spinning_properties = SpinningTaskDescription {
-        node_changes: vec![
-            (Duration::from_millis(500), all_up),
-            (Duration::from_millis(500), all_down),
-        ],
+        node_changes: vec![(13, all_up), (5, all_down)],
     };
 
     metadata
@@ -211,7 +208,7 @@ async fn test_combined_network_half_dc() {
     }
 
     metadata.spinning_properties = SpinningTaskDescription {
-        node_changes: vec![(Duration::new(1, 0), half)],
+        node_changes: vec![(5, half)],
     };
 
     metadata
@@ -225,7 +222,10 @@ async fn test_combined_network_half_dc() {
     async_std::task::sleep(Duration::from_secs(ASYNC_STD_LIBP2P_LISTENER_SPINDOWN_TIME)).await;
 }
 
-fn generate_random_node_changes(total_nodes: usize) -> Vec<(Duration, Vec<ChangeNode>)> {
+fn generate_random_node_changes(
+    total_nodes: usize,
+    total_num_rounds: usize,
+) -> Vec<(u64, Vec<ChangeNode>)> {
     let mut rng = rand::thread_rng();
     let mut node_changes = vec![];
 
@@ -241,9 +241,9 @@ fn generate_random_node_changes(total_nodes: usize) -> Vec<(Duration, Vec<Change
             updown,
         };
 
-        let duration = Duration::new(rng.gen_range(1..3), 0);
+        let round = rng.gen_range(1..total_num_rounds) as u64;
 
-        node_changes.push((duration, vec![node_change]));
+        node_changes.push((round, vec![node_change]));
     }
 
     node_changes
@@ -282,7 +282,7 @@ async fn test_stress_combined_network_fuzzy() {
     };
 
     metadata.spinning_properties = SpinningTaskDescription {
-        node_changes: generate_random_node_changes(metadata.total_nodes),
+        node_changes: generate_random_node_changes(metadata.total_nodes, 100),
     };
 
     metadata

--- a/crates/testing/tests/timeout.rs
+++ b/crates/testing/tests/timeout.rs
@@ -44,7 +44,7 @@ async fn test_timeout_web() {
     };
 
     metadata.spinning_properties = SpinningTaskDescription {
-        node_changes: vec![(Duration::from_millis(500), dead_nodes)],
+        node_changes: vec![(5, dead_nodes)],
     };
 
     metadata.completion_task_description =
@@ -107,7 +107,7 @@ async fn test_timeout_libp2p() {
     };
 
     metadata.spinning_properties = SpinningTaskDescription {
-        node_changes: vec![(Duration::from_millis(2000), dead_nodes)],
+        node_changes: vec![(2, dead_nodes)],
     };
 
     metadata.completion_task_description =


### PR DESCRIPTION
Closes issue: #2094 

### This PR: 
<!-- Describe what this PR adds to HotSHot -->
<!-- E.g. -->
<!-- * Implements feature 1 -->
<!-- * Implements feature 2 -->
<!-- * Fixes bug 3 -->
- Reworks the spinning task to be a function of the latest view
- Changes the tests to work under this new description

### This PR does not: 
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->
- Change any other functionality
- Address any test failures

### Key places to review: 
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->
- `spinning_task.rs`: where the functionality is changed
- the tests, to make sure they are (re)configured properly

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
