### PR TITLE
Updates orchestrator and web to use url instead of IP address or hostname

### DIFF
--- a/crates/hotshot/examples/combined/all.rs
+++ b/crates/hotshot/examples/combined/all.rs
@@ -45,7 +45,11 @@ async fn main() {
     async_spawn(async move {
         if let Err(e) = hotshot_web_server::run_web_server::<
             <DemoTypes as hotshot_types::traits::node_implementation::NodeType>::SignatureKey,
-        >(Some(server_shutdown_cdn), 9000)
+        >(
+            Some(server_shutdown_cdn),
+            "http://localhost".to_string(),
+            9000,
+        )
         .await
         {
             error!("Problem starting cdn web server: {:?}", e);
@@ -54,7 +58,11 @@ async fn main() {
     async_spawn(async move {
         if let Err(e) = hotshot_web_server::run_web_server::<
             <DemoTypes as hotshot_types::traits::node_implementation::NodeType>::SignatureKey,
-        >(Some(server_shutdown_da), 9001)
+        >(
+            Some(server_shutdown_da),
+            "http://localhost".to_string(),
+            9001,
+        )
         .await
         {
             error!("Problem starting da web server: {:?}", e);
@@ -70,7 +78,7 @@ async fn main() {
         VIDNetwork,
         NodeImpl,
     >(OrchestratorArgs {
-        host: IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+        url: "http://localhost".to_string(),
         port: 4444,
         config_file: args.config_file.clone(),
     }));
@@ -92,7 +100,7 @@ async fn main() {
                 NodeImpl,
                 ThisRun,
             >(ValidatorArgs {
-                host: "127.0.0.1".to_string(),
+                url: "http://localhost".to_string(),
                 port: 4444,
                 public_ip: Some(IpAddr::V4(Ipv4Addr::LOCALHOST)),
             })

--- a/crates/hotshot/examples/combined/multi-validator.rs
+++ b/crates/hotshot/examples/combined/multi-validator.rs
@@ -21,7 +21,7 @@ struct MultiValidatorArgs {
     /// Number of validators to run
     pub num_nodes: u16,
     /// The address the orchestrator runs on
-    pub host: IpAddr,
+    pub url: String,
     /// The port the orchestrator runs on
     pub port: u16,
     /// This node's public IP address, for libp2p
@@ -41,11 +41,13 @@ async fn main() {
     let args = MultiValidatorArgs::parse();
     tracing::error!(
         "connecting to orchestrator at {:?}:{:?}",
-        args.host,
+        args.url,
         args.port
     );
     let mut nodes = Vec::new();
     for _ in 0..args.num_nodes {
+        let url: String = args.url.clone();
+
         let node = async_spawn(async move {
             infra::main_entry_point::<
                 DemoTypes,
@@ -56,7 +58,7 @@ async fn main() {
                 NodeImpl,
                 ThisRun,
             >(ValidatorArgs {
-                host: args.host.to_string(),
+                url,
                 port: args.port,
                 public_ip: args.public_ip,
             })

--- a/crates/hotshot/examples/combined/validator.rs
+++ b/crates/hotshot/examples/combined/validator.rs
@@ -25,7 +25,7 @@ async fn main() {
     let args = ValidatorArgs::parse();
     info!(
         "connecting to orchestrator at {:?}:{:?}",
-        args.host, args.port
+        args.url, args.port
     );
     infra::main_entry_point::<
         DemoTypes,

--- a/crates/hotshot/examples/infra/mod.rs
+++ b/crates/hotshot/examples/infra/mod.rs
@@ -78,8 +78,8 @@ use tracing::{error, info, warn};
 )]
 /// Arguments passed to the orchestrator
 pub struct OrchestratorArgs {
-    /// The address the orchestrator runs on
-    pub host: IpAddr,
+    /// The url the orchestrator runs on; this should be in the form of `http://localhost` or `http://0.0.0.0`
+    pub url: String,
     /// The port the orchestrator runs on
     pub port: u16,
     /// The configuration file to be used for this run
@@ -138,7 +138,7 @@ pub async fn run_orchestrator<
     NODE: NodeImplementation<TYPES, Storage = MemoryStorage<TYPES>>,
 >(
     OrchestratorArgs {
-        host,
+        url,
         port,
         config_file,
     }: OrchestratorArgs,
@@ -148,7 +148,7 @@ pub async fn run_orchestrator<
     let _result = hotshot_orchestrator::run_orchestrator::<
         TYPES::SignatureKey,
         TYPES::ElectionConfigType,
-    >(run_config, host, port)
+    >(run_config, url, port)
     .await;
 }
 
@@ -169,13 +169,13 @@ async fn webserver_network_from_config<TYPES: NodeType>(
 ) -> WebServerNetwork<TYPES> {
     // Get the configuration for the web server
     let WebServerConfig {
-        host,
+        url,
         port,
         wait_between_polls,
     }: WebServerConfig = config.clone().web_server_config.unwrap();
 
     WebServerNetwork::create(
-        &host.to_string(),
+        url,
         port,
         wait_between_polls,
         pub_key.clone(),
@@ -550,7 +550,7 @@ where
 
         // extract values from config (for DA network)
         let WebServerConfig {
-            host,
+            url,
             port,
             wait_between_polls,
         }: WebServerConfig = config.clone().da_web_server_config.unwrap();
@@ -570,7 +570,7 @@ where
 
         let da_channel: WebCommChannel<TYPES> = WebCommChannel::new(
             WebServerNetwork::create(
-                &host.to_string(),
+                url.clone(),
                 port,
                 wait_between_polls,
                 pub_key.clone(),
@@ -580,7 +580,7 @@ where
         );
 
         let vid_channel: WebCommChannel<TYPES> = WebCommChannel::new(
-            WebServerNetwork::create(&host.to_string(), port, wait_between_polls, pub_key, true)
+            WebServerNetwork::create(url, port, wait_between_polls, pub_key, true)
                 .into(),
         );
 
@@ -764,7 +764,7 @@ where
 
         // extract values from config (for webserver DA network)
         let WebServerConfig {
-            host,
+            url,
             port,
             wait_between_polls,
         }: WebServerConfig = config.clone().da_web_server_config.unwrap();
@@ -774,7 +774,7 @@ where
             webserver_network_from_config::<TYPES>(config.clone(), pub_key.clone()).await;
 
         let webserver_underlying_da_network =
-            WebServerNetwork::create(&host.to_string(), port, wait_between_polls, pub_key, true);
+            WebServerNetwork::create(url, port, wait_between_polls, pub_key, true);
 
         webserver_underlying_quorum_network.wait_for_ready().await;
 

--- a/crates/hotshot/examples/infra/mod.rs
+++ b/crates/hotshot/examples/infra/mod.rs
@@ -55,20 +55,8 @@ use std::{collections::BTreeSet, sync::Arc};
 use std::{num::NonZeroUsize, str::FromStr};
 
 use libp2p_identity::PeerId;
-// use libp2p_networking::network::{MeshParams, NetworkNodeConfigBuilder, NetworkNodeType};
 use std::fmt::Debug;
-use std::{
-    //collections::{BTreeSet, VecDeque},
-    fs,
-    net::IpAddr,
-    //num::NonZeroUsize,
-    //str::FromStr,
-    //sync::Arc,
-    //time::{Duration, Instant},
-    time::Instant,
-};
-//use surf_disco::error::ClientError;
-//use surf_disco::Client;
+use std::{fs, time::Instant};
 use tracing::{error, info, warn};
 
 #[derive(Parser, Debug, Clone)]
@@ -174,13 +162,7 @@ async fn webserver_network_from_config<TYPES: NodeType>(
         wait_between_polls,
     }: WebServerConfig = config.clone().web_server_config.unwrap();
 
-    WebServerNetwork::create(
-        url,
-        port,
-        wait_between_polls,
-        pub_key.clone(),
-        false,
-    )
+    WebServerNetwork::create(&url, port, wait_between_polls, pub_key.clone(), false)
 }
 
 async fn libp2p_network_from_config<TYPES: NodeType>(
@@ -569,19 +551,11 @@ where
             WebCommChannel::new(underlying_quorum_network.into());
 
         let da_channel: WebCommChannel<TYPES> = WebCommChannel::new(
-            WebServerNetwork::create(
-                url.clone(),
-                port,
-                wait_between_polls,
-                pub_key.clone(),
-                true,
-            )
-            .into(),
+            WebServerNetwork::create(&url, port, wait_between_polls, pub_key.clone(), true).into(),
         );
 
         let vid_channel: WebCommChannel<TYPES> = WebCommChannel::new(
-            WebServerNetwork::create(url, port, wait_between_polls, pub_key, true)
-                .into(),
+            WebServerNetwork::create(&url, port, wait_between_polls, pub_key, true).into(),
         );
 
         WebServerDARun {
@@ -774,7 +748,7 @@ where
             webserver_network_from_config::<TYPES>(config.clone(), pub_key.clone()).await;
 
         let webserver_underlying_da_network =
-            WebServerNetwork::create(url, port, wait_between_polls, pub_key, true);
+            WebServerNetwork::create(&url, port, wait_between_polls, pub_key, true);
 
         webserver_underlying_quorum_network.wait_for_ready().await;
 

--- a/crates/hotshot/examples/libp2p/all.rs
+++ b/crates/hotshot/examples/libp2p/all.rs
@@ -43,7 +43,7 @@ async fn main() {
         VIDNetwork,
         NodeImpl,
     >(OrchestratorArgs {
-        host: IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+        url: "http://localhost".to_string(),
         port: 4444,
         config_file: args.config_file.clone(),
     }));
@@ -65,7 +65,7 @@ async fn main() {
                 NodeImpl,
                 ThisRun,
             >(ValidatorArgs {
-                host: "127.0.0.1".to_string(),
+                url: "http://localhost".to_string(),
                 port: 4444,
                 public_ip: Some(IpAddr::V4(Ipv4Addr::LOCALHOST)),
             })

--- a/crates/hotshot/examples/libp2p/multi-validator.rs
+++ b/crates/hotshot/examples/libp2p/multi-validator.rs
@@ -21,7 +21,7 @@ struct MultiValidatorArgs {
     /// Number of validators to run
     pub num_nodes: u16,
     /// The address the orchestrator runs on
-    pub host: IpAddr,
+    pub url: String,
     /// The port the orchestrator runs on
     pub port: u16,
     /// This node's public IP address, for libp2p
@@ -41,11 +41,13 @@ async fn main() {
     let args = MultiValidatorArgs::parse();
     tracing::error!(
         "connecting to orchestrator at {:?}:{:?}",
-        args.host,
+        args.url,
         args.port
     );
     let mut nodes = Vec::new();
     for _ in 0..args.num_nodes {
+        let url: String = args.url.clone();
+
         let node = async_spawn(async move {
             infra::main_entry_point::<
                 DemoTypes,
@@ -56,7 +58,7 @@ async fn main() {
                 NodeImpl,
                 ThisRun,
             >(ValidatorArgs {
-                host: args.host.to_string(),
+                url,
                 port: args.port,
                 public_ip: args.public_ip,
             })

--- a/crates/hotshot/examples/libp2p/validator.rs
+++ b/crates/hotshot/examples/libp2p/validator.rs
@@ -25,7 +25,7 @@ async fn main() {
     let args = ValidatorArgs::parse();
     info!(
         "connecting to orchestrator at {:?}:{:?}",
-        args.host, args.port
+        args.url, args.port
     );
     infra::main_entry_point::<
         DemoTypes,

--- a/crates/hotshot/examples/webserver/README.md
+++ b/crates/hotshot/examples/webserver/README.md
@@ -1,29 +1,28 @@
 Commands to run da examples: 
 1a)Start web servers by either running 3 servers:
-just async_std example webserver -- <PORT_FOR_CDN> 
-just async_std example webserver -- <PORT_FOR_DA> 
-just async_std example webserver -- <PORT_FOR_VIEW_SYNC> 
+just async_std example webserver -- <URL_FOR_CDN> <PORT_FOR_CDN>
+just async_std example webserver -- <URL_FOR_DA> <PORT_FOR_DA> 
 
 1b)Or use multi-webserver to spin up all three:
-just async_std example multi-webserver -- <PORT_FOR_CDN> <PORT_FOR_DA> <PORT_FOR_VIEW_SYNC> 
+just async_std example multi-webserver -- <URL_FOR_CDN> <URL_FOR_DA> <PORT_FOR_CDN> <PORT_FOR_DA>
 
 2) Start orchestrator:
-just async_std example orchestrator-webserver -- <ORCHESTRATOR_ADDR> <ORCHESTRATOR_PORT> <ORCHESTRATOR_CONFIG_FILE> 
+just async_std example orchestrator-webserver -- <ORCHESTRATOR_URL> <ORCHESTRATOR_PORT> <ORCHESTRATOR_CONFIG_FILE> 
 
 3a) Start validator:
-just async_std example validator-webserver -- <ORCHESTRATOR_ADDR> <ORCHESTRATOR_PORT>
+just async_std example validator-webserver -- <ORCHESTRATOR_URL> <ORCHESTRATOR_PORT>
 
 3b) Or start multiple validators:
-just async_std example multi-validator-webserver -- <NUM_VALIDATORS> <ORCHESTRATOR_ADDR> <ORCHESTRATOR_PORT>
+just async_std example multi-validator-webserver -- <NUM_VALIDATORS> <ORCHESTRATOR_URL> <ORCHESTRATOR_PORT>
 
 I.e. 
-just async_std example webserver -- 9000 
-just async_std example webserver -- 9001 
-just async_std example webserver -- 9002
-just async_std example orchestrator-webserver -- 0.0.0.0 4444 ./orchestrator/default-run-config.toml 
-just async_std example validator-webserver -- 2 0.0.0.0 4444
+just async_std example webserver -- http://127.0.0.1 9000 
+just async_std example webserver -- http://127.0.0.1 9001 
+just async_std example webserver -- http://127.0.0.1 9002
+just async_std example orchestrator-webserver -- http://127.0.0.1 4444 ./orchestrator/default-run-config.toml 
+just async_std example validator-webserver -- 2 http://127.0.0.1 4444
 
 OR: 
 just async_std example multi-webserver -- 9000 9001 9002
-just async_std example orchestrator-webserver -- 0.0.0.0 4444 ./orchestrator/default-run-config.toml 
-just async_std example multi-validator-webserver -- 10 0.0.0.0 4444
+just async_std example orchestrator-webserver -- http://127.0.0.1 4444 ./orchestrator/default-run-config.toml 
+just async_std example multi-validator-webserver -- 10 http://127.0.0.1 4444

--- a/crates/hotshot/examples/webserver/all.rs
+++ b/crates/hotshot/examples/webserver/all.rs
@@ -37,7 +37,11 @@ async fn main() {
     async_spawn(async move {
         if let Err(e) = hotshot_web_server::run_web_server::<
             <DemoTypes as hotshot_types::traits::node_implementation::NodeType>::SignatureKey,
-        >(Some(server_shutdown_cdn), 9000)
+        >(
+            Some(server_shutdown_cdn),
+            "http://localhost".to_string(),
+            9000,
+        )
         .await
         {
             error!("Problem starting cdn web server: {:?}", e);
@@ -46,7 +50,11 @@ async fn main() {
     async_spawn(async move {
         if let Err(e) = hotshot_web_server::run_web_server::<
             <DemoTypes as hotshot_types::traits::node_implementation::NodeType>::SignatureKey,
-        >(Some(server_shutdown_da), 9001)
+        >(
+            Some(server_shutdown_da),
+            "http://localhost".to_string(),
+            9001,
+        )
         .await
         {
             error!("Problem starting da web server: {:?}", e);
@@ -62,7 +70,7 @@ async fn main() {
         VIDNetwork,
         NodeImpl,
     >(OrchestratorArgs {
-        host: IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+        url: "http://localhost".to_string(),
         port: 4444,
         config_file: args.config_file.clone(),
     }));
@@ -84,7 +92,7 @@ async fn main() {
                 NodeImpl,
                 ThisRun,
             >(ValidatorArgs {
-                host: "127.0.0.1".to_string(),
+                url: "http://localhost".to_string(),
                 port: 4444,
                 public_ip: Some(IpAddr::V4(Ipv4Addr::LOCALHOST)),
             })

--- a/crates/hotshot/examples/webserver/multi-validator.rs
+++ b/crates/hotshot/examples/webserver/multi-validator.rs
@@ -21,7 +21,7 @@ struct MultiValidatorArgs {
     /// Number of validators to run
     pub num_nodes: u16,
     /// The address the orchestrator runs on
-    pub host: IpAddr,
+    pub url: String,
     /// The port the orchestrator runs on
     pub port: u16,
     /// This node's public IP address, for libp2p
@@ -41,11 +41,12 @@ async fn main() {
     let args = MultiValidatorArgs::parse();
     tracing::error!(
         "connecting to orchestrator at {:?}:{:?}",
-        args.host,
+        args.url,
         args.port
     );
     let mut nodes = Vec::new();
     for _ in 0..args.num_nodes {
+        let url = args.url.clone();
         let node = async_spawn(async move {
             infra::main_entry_point::<
                 DemoTypes,
@@ -56,7 +57,7 @@ async fn main() {
                 NodeImpl,
                 ThisRun,
             >(ValidatorArgs {
-                host: args.host.to_string(),
+                url,
                 port: args.port,
                 public_ip: args.public_ip,
             })

--- a/crates/hotshot/examples/webserver/multi-webserver.rs
+++ b/crates/hotshot/examples/webserver/multi-webserver.rs
@@ -11,7 +11,9 @@ use tracing::error;
 
 #[derive(Parser, Debug)]
 struct MultiWebServerArgs {
-    cdn_port: u16,
+    consensus_url: String,
+    da_url: String,
+    consensus_port: u16,
     da_port: u16,
     view_sync_port: u16,
 }
@@ -28,10 +30,14 @@ async fn main() {
     let _sender = Arc::new(server_shutdown_sender_cdn);
     let _sender = Arc::new(server_shutdown_sender_da);
 
-    let cdn_server = async_spawn(async move {
+    let consensus_server = async_spawn(async move {
         if let Err(e) = hotshot_web_server::run_web_server::<
             <DemoTypes as hotshot_types::traits::node_implementation::NodeType>::SignatureKey,
-        >(Some(server_shutdown_cdn), args.cdn_port)
+        >(
+            Some(server_shutdown_cdn),
+            args.consensus_url.to_string(),
+            args.consensus_port,
+        )
         .await
         {
             error!("Problem starting cdn web server: {:?}", e);
@@ -40,12 +46,16 @@ async fn main() {
     let da_server = async_spawn(async move {
         if let Err(e) = hotshot_web_server::run_web_server::<
             <DemoTypes as hotshot_types::traits::node_implementation::NodeType>::SignatureKey,
-        >(Some(server_shutdown_da), args.da_port)
+        >(
+            Some(server_shutdown_da),
+            args.da_url.to_string(),
+            args.da_port,
+        )
         .await
         {
             error!("Problem starting da web server: {:?}", e);
         }
     });
 
-    let _result = futures::future::join_all(vec![cdn_server, da_server]).await;
+    let _result = futures::future::join_all(vec![consensus_server, da_server]).await;
 }

--- a/crates/hotshot/examples/webserver/multi-webserver.rs
+++ b/crates/hotshot/examples/webserver/multi-webserver.rs
@@ -15,7 +15,6 @@ struct MultiWebServerArgs {
     da_url: String,
     consensus_port: u16,
     da_port: u16,
-    view_sync_port: u16,
 }
 
 #[cfg_attr(async_executor_impl = "tokio", tokio::main)]

--- a/crates/hotshot/examples/webserver/validator.rs
+++ b/crates/hotshot/examples/webserver/validator.rs
@@ -25,7 +25,7 @@ async fn main() {
     let args = ValidatorArgs::parse();
     info!(
         "connecting to orchestrator at {:?}:{:?}",
-        args.host, args.port
+        args.url, args.port
     );
     infra::main_entry_point::<
         DemoTypes,

--- a/crates/hotshot/examples/webserver/webserver.rs
+++ b/crates/hotshot/examples/webserver/webserver.rs
@@ -9,6 +9,7 @@ use clap::Parser;
 
 #[derive(Parser, Debug)]
 struct WebServerArgs {
+    url: String, 
     port: u16,
 }
 
@@ -22,6 +23,6 @@ async fn main() {
     let _sender = Arc::new(server_shutdown_sender);
     let _result = hotshot_web_server::run_web_server::<
         <DemoTypes as hotshot_types::traits::node_implementation::NodeType>::SignatureKey,
-    >(Some(server_shutdown), args.port)
+    >(Some(server_shutdown), args.url, args.port)
     .await;
 }

--- a/crates/hotshot/examples/webserver/webserver.rs
+++ b/crates/hotshot/examples/webserver/webserver.rs
@@ -9,7 +9,7 @@ use clap::Parser;
 
 #[derive(Parser, Debug)]
 struct WebServerArgs {
-    url: String, 
+    url: String,
     port: u16,
 }
 

--- a/crates/hotshot/src/traits/networking/web_server_network.rs
+++ b/crates/hotshot/src/traits/networking/web_server_network.rs
@@ -506,7 +506,7 @@ impl<TYPES: NodeType + 'static> WebServerNetwork<TYPES> {
     /// # Panics
     /// if the web server url is malformed
     pub fn create(
-        url: String,
+        url: &str,
         port: u16,
         wait_between_polls: Duration,
         key: TYPES::SignatureKey,
@@ -1238,7 +1238,7 @@ impl<TYPES: NodeType> TestableNetworkingImplementation<TYPES> for WebServerNetwo
         // Start web server
         async_spawn(hotshot_web_server::run_web_server::<TYPES::SignatureKey>(
             Some(server_shutdown),
-            url.to_owned(), 
+            url.to_owned(),
             port,
         ));
 
@@ -1255,7 +1255,7 @@ impl<TYPES: NodeType> TestableNetworkingImplementation<TYPES> for WebServerNetwo
         Box::new(move |id| {
             let sender = Arc::clone(&sender);
             let mut network = WebServerNetwork::create(
-                "http://localhost".to_string(),
+                "http://localhost",
                 port,
                 Duration::from_millis(100),
                 known_nodes[id as usize].clone(),

--- a/crates/hotshot/src/traits/networking/web_server_network.rs
+++ b/crates/hotshot/src/traits/networking/web_server_network.rs
@@ -506,13 +506,13 @@ impl<TYPES: NodeType + 'static> WebServerNetwork<TYPES> {
     /// # Panics
     /// if the web server url is malformed
     pub fn create(
-        host: &str,
+        url: String,
         port: u16,
         wait_between_polls: Duration,
         key: TYPES::SignatureKey,
         is_da_server: bool,
     ) -> Self {
-        let base_url_string = format!("http://{host}:{port}");
+        let base_url_string = format!("{url}:{port}");
         info!("Connecting to web server at {base_url_string:?} is da: {is_da_server}");
 
         let base_url = base_url_string.parse();
@@ -1231,12 +1231,14 @@ impl<TYPES: NodeType> TestableNetworkingImplementation<TYPES> for WebServerNetwo
     ) -> Box<dyn Fn(u64) -> Self + 'static> {
         let (server_shutdown_sender, server_shutdown) = oneshot();
         let sender = Arc::new(server_shutdown_sender);
+        let url = "http://localhost";
         // TODO ED Restrict this to be an open port using portpicker
         let port = random::<u16>();
         info!("Launching web server on port {port}");
         // Start web server
         async_spawn(hotshot_web_server::run_web_server::<TYPES::SignatureKey>(
             Some(server_shutdown),
+            url.to_owned(), 
             port,
         ));
 
@@ -1253,7 +1255,7 @@ impl<TYPES: NodeType> TestableNetworkingImplementation<TYPES> for WebServerNetwo
         Box::new(move |id| {
             let sender = Arc::clone(&sender);
             let mut network = WebServerNetwork::create(
-                "0.0.0.0",
+                "http://localhost".to_string(),
                 port,
                 Duration::from_millis(100),
                 known_nodes[id as usize].clone(),

--- a/crates/orchestrator/run-config.toml
+++ b/crates/orchestrator/run-config.toml
@@ -66,11 +66,11 @@ online_time = 10
 base_port = 9000
 
 [web_server_config]
-host = "127.0.0.1"
+url = "http://localhost"
 port = 9000
 
 [da_web_server_config]
-host = "127.0.0.1"
+url = "http://localhost"
 port = 9001
 
 [web_server_config.wait_between_polls]

--- a/crates/orchestrator/src/client.rs
+++ b/crates/orchestrator/src/client.rs
@@ -23,7 +23,7 @@ pub struct OrchestratorClient {
 /// Arguments passed to the validator
 pub struct ValidatorArgs {
     /// The address the orchestrator runs on
-    pub host: String,
+    pub url: String,
     /// The port the orchestrator runs on
     pub port: u16,
     /// This node's public IP address, for libp2p
@@ -34,8 +34,7 @@ pub struct ValidatorArgs {
 impl OrchestratorClient {
     /// Creates the client that connects to the orchestrator
     pub async fn connect_to_orchestrator(args: ValidatorArgs) -> Self {
-        let base_url = format!("{0}:{1}", args.host, args.port);
-        let base_url = format!("http://{base_url}").parse().unwrap();
+        let base_url = format!("{0}:{1}", args.url, args.port).parse().unwrap();
         let client = surf_disco::Client::<ClientError>::new(base_url);
         // TODO ED: Add healthcheck wait here
         OrchestratorClient { client }

--- a/crates/orchestrator/src/config.rs
+++ b/crates/orchestrator/src/config.rs
@@ -52,7 +52,7 @@ pub struct Libp2pConfigFile {
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
 pub struct WebServerConfig {
-    pub host: IpAddr,
+    pub url: String,
     pub port: u16,
     pub wait_between_polls: Duration,
 }

--- a/crates/orchestrator/src/lib.rs
+++ b/crates/orchestrator/src/lib.rs
@@ -237,7 +237,7 @@ where
 /// Runs the orchestrator
 pub async fn run_orchestrator<KEY, ELECTION>(
     network_config: NetworkConfig<KEY, ELECTION>,
-    host: IpAddr,
+    url: String,
     port: u16,
 ) -> io::Result<()>
 where
@@ -252,6 +252,6 @@ where
     let mut app = App::<RwLock<OrchestratorState<KEY, ELECTION>>, ServerError>::with_state(state);
     app.register_module("api", api.unwrap())
         .expect("Error registering api");
-    tracing::error!("lisening on {:?}:{:?}", host, port);
-    app.serve(format!("http://{host}:{port}")).await
+    tracing::error!("lisening on {:?}:{:?}", url, port);
+    app.serve(format!("{url}:{port}")).await
 }

--- a/crates/orchestrator/src/lib.rs
+++ b/crates/orchestrator/src/lib.rs
@@ -252,6 +252,6 @@ where
     let mut app = App::<RwLock<OrchestratorState<KEY, ELECTION>>, ServerError>::with_state(state);
     app.register_module("api", api.unwrap())
         .expect("Error registering api");
-    tracing::error!("lisening on {:?}:{:?}", url, port);
+    tracing::error!("listening on {:?}:{:?}", url, port);
     app.serve(format!("{url}:{port}")).await
 }

--- a/crates/task-impls/src/network.rs
+++ b/crates/task-impls/src/network.rs
@@ -157,7 +157,7 @@ impl<TYPES: NodeType, COMMCHANNEL: CommunicationChannel<TYPES>>
     /// # Panics
     /// Panic sif a direct message event is received with no recipient
     #[allow(clippy::too_many_lines)] // TODO https://github.com/EspressoSystems/HotShot/issues/1704
-    #[instrument(skip_all, fields(view = *self.view), name = "Newtork Task", level = "error")]
+    #[instrument(skip_all, fields(view = *self.view), name = "Network Task", level = "error")]
 
     pub async fn handle_event(
         &mut self,

--- a/crates/web_server/src/lib.rs
+++ b/crates/web_server/src/lib.rs
@@ -854,6 +854,7 @@ where
 
 pub async fn run_web_server<KEY: SignatureKey + 'static>(
     shutdown_listener: Option<OneShotReceiver<()>>,
+    url: String, 
     port: u16,
 ) -> io::Result<()> {
     let options = Options::default();
@@ -864,7 +865,7 @@ pub async fn run_web_server<KEY: SignatureKey + 'static>(
 
     app.register_module("api", api).unwrap();
 
-    let app_future = app.serve(format!("http://0.0.0.0:{port}"));
+    let app_future = app.serve(format!("{url}:{port}"));
 
     info!("Web server started on port {port}");
 

--- a/crates/web_server/src/lib.rs
+++ b/crates/web_server/src/lib.rs
@@ -854,7 +854,7 @@ where
 
 pub async fn run_web_server<KEY: SignatureKey + 'static>(
     shutdown_listener: Option<OneShotReceiver<()>>,
-    url: String, 
+    url: String,
     port: u16,
 ) -> io::Result<()> {
     let options = Options::default();


### PR DESCRIPTION
Closes #2142

### This PR: 
* Updates the orchestrator and web server to take `url` arguments instead of `host` arguments.  The `url` arguments include the network protocol, such as HTTP or HTTPS.  Previously everything was hard-coded to always use `HTTP`.  
* Updates the network configuration file accordingly so that it also takes in url instead of hostname or IP address.  

### This PR does not: 
* Fix other tech debt issues in the web server and orchestrator

### Key places to review: 
* orchestrator/lib.rs
* web_server/lib.rs
* examples/infra/mod.rs

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
