### PR TITLE
[Stability] Fix catchup route

### DIFF
--- a/crates/web_server/api.toml
+++ b/crates/web_server/api.toml
@@ -21,7 +21,7 @@ Return the VID disperse data for a given view number
 
 # GET the proposal for a view, where the view is passed as an argument
 [route.getrecentproposal]
-PATH = ["proposal/"]
+PATH = ["proposal/recent"]
 DOC = """
 Return the proposal for the most recent view the server has
 """

--- a/crates/web_server/src/config.rs
+++ b/crates/web_server/src/config.rs
@@ -18,7 +18,7 @@ pub fn post_proposal_route(view_number: u64) -> String {
 }
 
 pub fn get_recent_proposal_route() -> String {
-    "api/proposal".to_string()
+    "api/proposal/recent".to_string()
 }
 
 pub fn get_da_certificate_route(view_number: u64) -> String {


### PR DESCRIPTION
Closes #2191 
<!-- See here for keywords in Github -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

### This PR: 
<!-- Describe what this PR adds to HotSHot -->
<!-- E.g. -->
<!-- * Implements feature 1 -->
<!-- * Implements feature 2 -->
<!-- * Fixes bug 3 -->

Changes the route for catchup so that the CDN matches the proper one; the correct route for "getrecentproposal" was never getting hit, and stopped catchup from working after the CDN disposed of the first couple of views.

### This PR does not: 
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->

Change any catchup functionality.

### Key places to review: 
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->

Both files

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
