### PR TITLE
[HotShot Stability] Fix genesis commitment

### DIFF
--- a/crates/testing/src/block_types.rs
+++ b/crates/testing/src/block_types.rs
@@ -70,16 +70,14 @@ pub struct TestBlockPayload {
 }
 
 impl TestBlockPayload {
-    /// Create a genesis block payload with transaction bytes `vec![0]`, to be used for
+    /// Create a genesis block payload with bytes `vec![0]`, to be used for
     /// consensus task initiation.
     /// # Panics
     /// If the `VidScheme` construction fails.
     #[must_use]
     pub fn genesis() -> Self {
-        let txns: Vec<u8> = vec![0];
-        // It's impossible for `encode` to fail because the transaciton length is very small.
         TestBlockPayload {
-            transactions: vec![TestTransaction(txns)],
+            transactions: vec![],
         }
     }
 }

--- a/crates/types/src/traits/block_contents.rs
+++ b/crates/types/src/traits/block_contents.rs
@@ -98,6 +98,10 @@ pub fn vid_commitment(
 }
 
 /// Computes the (empty) genesis VID commitment
+/// The number of storage nodes does not do anything, unless in the future we add fake transactions
+/// to the genesis payload.
+/// 
+/// In that case, the payloads may mismatch and cause problems.
 #[must_use]
 pub fn genesis_vid_commitment() -> <VidScheme as VidSchemeTrait>::Commit {
     vid_commitment(&vec![], 8)


### PR DESCRIPTION
### This PR: 
<!-- Describe what this PR adds to HotSHot -->
<!-- E.g. -->
<!-- * Implements feature 1 -->
<!-- * Implements feature 2 -->
<!-- * Fixes bug 3 -->

Fixes a bug where a mismatch in genesis block commitment causes it not to store relevant blocks; introduces a regression in the query service tests. Does this by removing the test transaction from the genesis payload initializer.

### This PR does not: 
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   --

Change anything consensus-related

### Key places to review: 
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->

Both files.

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
