### PR TITLE
[Stability] Create config path

### DIFF
--- a/crates/hotshot/examples/infra/mod.rs
+++ b/crates/hotshot/examples/infra/mod.rs
@@ -387,7 +387,7 @@ pub trait RunDA<
         error!("Sleeping for {start_delay_seconds} seconds before starting hotshot!");
         async_sleep(Duration::from_secs(start_delay_seconds)).await;
 
-        error!("Starting hotshot!");
+        error!("Starting HotShot example!");
         let start = Instant::now();
 
         let (mut event_stream, _streamid) = context.get_event_stream(FilterEvent::default()).await;


### PR DESCRIPTION
Closes issue #2197

### This PR: 
<!-- Describe what this PR adds to HotSHot -->
<!-- E.g. -->
<!-- * Implements feature 1 -->
<!-- * Implements feature 2 -->
<!-- * Fixes bug 3 -->

Adds to `from_file_or_orchestrator` (as it relates to pulling config files from the orchestrator or filesystem) the ability for it to create the path _to_ the file if it does not exist.

Also slightly changes some error messages.

### This PR does not: 
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->

- Create additional functionality 
- Fix the issue with rejoin

### Key places to review: 
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->
`config.rs`

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
