### PR TITLE
Add Logging when Missing VID Info to Propose

### DIFF
--- a/crates/task-impls/src/consensus.rs
+++ b/crates/task-impls/src/consensus.rs
@@ -1112,6 +1112,8 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                 .await;
             self.payload_commitment_and_metadata = None;
             return true;
+        } else {
+            warn!("Cannot propose because we don't have the VID payload commitment and metadata");
         }
         debug!("Self block was None");
         false


### PR DESCRIPTION

<!-- See here for keywords in Github -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

### This PR: 

logs when we can't propose because the vid disperse is not completed yet

### This PR does not: 

fix the bug that is preventing us from proposing

