### PR TITLE
Propose When if we can When Getting VID Dispersal Info

### DIFF
--- a/crates/task-impls/src/consensus.rs
+++ b/crates/task-impls/src/consensus.rs
@@ -994,11 +994,11 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
             }
             HotShotEvent::SendPayloadCommitmentAndMetadata(payload_commitment, metadata) => {
                 self.payload_commitment_and_metadata = Some((payload_commitment, metadata));
-                // let high_qc = self.consensus.read().await.high_qc.clone();
-                // let leader_view = high_qc.get_view_number() + 1;
-                // if self.quorum_membership.get_leader(leader_view) == self.public_key {
-                //     self.publish_proposal_if_able(high_qc, leader_view, None).await;
-                // }
+                let high_qc = self.consensus.read().await.high_qc.clone();
+                let leader_view = high_qc.get_view_number() + 1;
+                if self.quorum_membership.get_leader(leader_view) == self.public_key {
+                    self.publish_proposal_if_able(high_qc, leader_view, None).await;
+                }
             }
             _ => {}
         }
@@ -1117,9 +1117,8 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                 .await;
             self.payload_commitment_and_metadata = None;
             return true;
-        } else {
-            warn!("Cannot propose because we don't have the VID payload commitment and metadata");
         }
+        warn!("Cannot propose because we don't have the VID payload commitment and metadata");
         debug!("Self block was None");
         false
     }

--- a/crates/task-impls/src/consensus.rs
+++ b/crates/task-impls/src/consensus.rs
@@ -994,6 +994,11 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
             }
             HotShotEvent::SendPayloadCommitmentAndMetadata(payload_commitment, metadata) => {
                 self.payload_commitment_and_metadata = Some((payload_commitment, metadata));
+                // let high_qc = self.consensus.read().await.high_qc.clone();
+                // let leader_view = high_qc.get_view_number() + 1;
+                // if self.quorum_membership.get_leader(leader_view) == self.public_key {
+                //     self.publish_proposal_if_able(high_qc, leader_view, None).await;
+                // }
             }
             _ => {}
         }

--- a/crates/types/src/traits/block_contents.rs
+++ b/crates/types/src/traits/block_contents.rs
@@ -100,7 +100,7 @@ pub fn vid_commitment(
 /// Computes the (empty) genesis VID commitment
 /// The number of storage nodes does not do anything, unless in the future we add fake transactions
 /// to the genesis payload.
-/// 
+///
 /// In that case, the payloads may mismatch and cause problems.
 #[must_use]
 pub fn genesis_vid_commitment() -> <VidScheme as VidSchemeTrait>::Commit {


### PR DESCRIPTION
Closes #2207 

### This PR: 

Fixes a bug where we can't propose because VID disperse is still pending, but then we don't try to propose after it completes.  This adds the logic to propose if we can after the disperse compeltes

### This PR does not: 

### Key places to review: 

The added code in consensus.rs

### How to test this PR: 

I added a short `async_sleep` for 300ms immediately before sending the `SendPayloadCommitmentAndMetadata` event.  This was enough timing disruption to hit the bug in almost every view.  With my fix and warn logs on you should see "Cannot propose because we don't have the VID payload commitment and metadata" but the view won't timeout because the proposer succeeds later when it gets the info it needs
