### PR TITLE
Fix `test_with_failures` and update logging

### DIFF
--- a/crates/task-impls/src/consensus.rs
+++ b/crates/task-impls/src/consensus.rs
@@ -1009,10 +1009,13 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
         timeout_certificate: Option<TimeoutCertificate<TYPES>>,
     ) -> bool {
         if self.quorum_membership.get_leader(view) != self.public_key {
-            error!(
-                "Somehow we formed a QC but are not the leader for the next view {:?}",
-                view
-            );
+            // This is expected for view 1, so skipping the logging.
+            if view != TYPES::Time::new(1) {
+                error!(
+                    "Somehow we formed a QC but are not the leader for the next view {:?}",
+                    view
+                );
+            }
             return false;
         }
 

--- a/crates/testing/tests/basic.rs
+++ b/crates/testing/tests/basic.rs
@@ -109,6 +109,8 @@ async fn test_with_failures_half_f() {
         node_changes: vec![(5, dead_nodes)],
     };
     metadata.overall_safety_properties.num_failed_views = 6;
+    // Make sure we keep commiting rounds after the bad leaders, but not the full 50 because of the numerous timeouts
+    metadata.overall_safety_properties.num_successful_views = 22;
     metadata
         .gen_launcher::<TestTypes, MemoryImpl>(0)
         .launch()

--- a/crates/types/src/traits/block_contents.rs
+++ b/crates/types/src/traits/block_contents.rs
@@ -100,7 +100,7 @@ pub fn vid_commitment(
 /// Computes the (empty) genesis VID commitment
 /// The number of storage nodes does not do anything, unless in the future we add fake transactions
 /// to the genesis payload.
-/// 
+///
 /// In that case, the payloads may mismatch and cause problems.
 #[must_use]
 pub fn genesis_vid_commitment() -> <VidScheme as VidSchemeTrait>::Commit {


### PR DESCRIPTION
Closes https://github.com/EspressoSystems/HotShot/issues/2213.

### This PR: 
* Makes `test_with_failures` pass deterministically.
* Updates the leadership check to log `error!` only for non-genesis blocks.

### This PR does not: 
Change default test parameters to make other `NotEnoughDecides` tests pass--will fix them separately.