### PR TITLE
Fix network and consensus unit tests

### DIFF
--- a/crates/hotshot/src/traits/storage/memory_storage.rs
+++ b/crates/hotshot/src/traits/storage/memory_storage.rs
@@ -111,16 +111,13 @@ mod test {
     use super::*;
     use commit::Committable;
     use hotshot_testing::{
-        block_types::{TestBlockHeader, TestBlockPayload},
+        block_types::{genesis_vid_commitment, TestBlockHeader, TestBlockPayload},
         node_types::TestTypes,
     };
     use hotshot_types::{
         data::{fake_commitment, genesis_proposer_id, Leaf},
         simple_certificate::QuorumCertificate,
-        traits::{
-            block_contents::genesis_vid_commitment, node_implementation::NodeType,
-            state::ConsensusTime,
-        },
+        traits::{node_implementation::NodeType, state::ConsensusTime},
     };
     use std::marker::PhantomData;
     use tracing::instrument;

--- a/crates/task-impls/src/consensus.rs
+++ b/crates/task-impls/src/consensus.rs
@@ -997,7 +997,8 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                 let high_qc = self.consensus.read().await.high_qc.clone();
                 let leader_view = high_qc.get_view_number() + 1;
                 if self.quorum_membership.get_leader(leader_view) == self.public_key {
-                    self.publish_proposal_if_able(high_qc, leader_view, None).await;
+                    self.publish_proposal_if_able(high_qc, leader_view, None)
+                        .await;
                 }
             }
             _ => {}

--- a/crates/task-impls/src/harness.rs
+++ b/crates/task-impls/src/harness.rs
@@ -94,24 +94,20 @@ pub fn handle_event<TYPES: NodeType>(
     std::option::Option<HotShotTaskCompleted>,
     TestHarnessState<TYPES>,
 ) {
-    // Skip the output check if we are not expecting any output, to avoid the failure in case the
-    // shutdown signal arrives later than the new event.
-    if !state.expected_output.is_empty() {
-        assert!(
-            state.expected_output.contains_key(&event),
-            "Got an unexpected event: {event:?}",
-        );
+    assert!(
+        state.expected_output.contains_key(&event),
+        "Got an unexpected event: {event:?}",
+    );
 
-        let num_expected = state.expected_output.get_mut(&event).unwrap();
-        if *num_expected == 1 {
-            state.expected_output.remove(&event);
-        } else {
-            *num_expected -= 1;
-        }
+    let num_expected = state.expected_output.get_mut(&event).unwrap();
+    if *num_expected == 1 {
+        state.expected_output.remove(&event);
+    } else {
+        *num_expected -= 1;
+    }
 
-        if state.expected_output.is_empty() {
-            return (Some(HotShotTaskCompleted::ShutDown), state);
-        }
+    if state.expected_output.is_empty() {
+        return (Some(HotShotTaskCompleted::ShutDown), state);
     }
 
     (None, state)

--- a/crates/testing/src/block_types.rs
+++ b/crates/testing/src/block_types.rs
@@ -5,9 +5,9 @@ use std::{
 
 use commit::{Commitment, Committable, RawCommitmentBuilder};
 use hotshot_types::{
-    data::{BlockError, VidCommitment},
+    data::{BlockError, VidCommitment, VidScheme, VidSchemeTrait},
     traits::{
-        block_contents::{genesis_vid_commitment, BlockHeader, Transaction},
+        block_contents::{vid_commitment, BlockHeader, Transaction},
         state::TestableBlock,
         BlockPayload,
     },
@@ -155,6 +155,16 @@ impl BlockPayload for TestBlockPayload {
             .map(commit::Committable::commit)
             .collect()
     }
+}
+
+/// Computes the (empty) genesis VID commitment
+/// The number of storage nodes does not do anything, unless in the future we add fake transactions
+/// to the genesis payload.
+///
+/// In that case, the payloads may mismatch and cause problems.
+#[must_use]
+pub fn genesis_vid_commitment() -> <VidScheme as VidSchemeTrait>::Commit {
+    vid_commitment(&vec![], 8)
 }
 
 /// A [`BlockHeader`] that commits to [`TestBlockPayload`].

--- a/crates/testing/tests/consensus_task.rs
+++ b/crates/testing/tests/consensus_task.rs
@@ -85,7 +85,6 @@ async fn build_vote(
     tokio::test(flavor = "multi_thread", worker_threads = 2)
 )]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
-#[ignore]
 async fn test_consensus_task() {
     use hotshot_task_impls::harness::run_harness;
     use hotshot_testing::task_helpers::build_system_handle;

--- a/crates/testing/tests/network_task.rs
+++ b/crates/testing/tests/network_task.rs
@@ -8,6 +8,7 @@ use hotshot_types::{
     data::{DAProposal, VidSchemeTrait, ViewNumber},
     traits::{consensus_api::ConsensusApi, state::ConsensusTime},
 };
+use sha2::{Digest, Sha256};
 use std::{collections::HashMap, marker::PhantomData};
 
 #[cfg(test)]
@@ -18,7 +19,7 @@ use std::{collections::HashMap, marker::PhantomData};
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 async fn test_network_task() {
     use hotshot_task_impls::harness::run_harness;
-    use hotshot_testing::{block_types::TestTransaction, task_helpers::build_system_handle};
+    use hotshot_testing::task_helpers::build_system_handle;
     use hotshot_types::{data::VidDisperse, message::Proposal};
 
     async_compatibility_layer::logging::setup_logging();
@@ -35,14 +36,14 @@ async fn test_network_task() {
     let quorum_membership = handle.hotshot.inner.memberships.quorum_membership.clone();
 
     let vid = vid_init::<TestTypes>(quorum_membership.clone(), ViewNumber::new(0));
-    let transactions = vec![TestTransaction(vec![0])];
-    let encoded_transactions = TestTransaction::encode(transactions.clone()).unwrap();
+    let encoded_transactions = Vec::new();
+    let encoded_transactions_hash = Sha256::digest(&encoded_transactions);
     let vid_disperse = vid.disperse(&encoded_transactions).unwrap();
     let payload_commitment = vid_disperse.commit;
     let signature =
         <TestTypes as hotshot_types::traits::node_implementation::NodeType>::SignatureKey::sign(
             api.private_key(),
-            payload_commitment.as_ref(),
+            &encoded_transactions_hash,
         );
     let da_proposal = Proposal {
         data: DAProposal {
@@ -55,7 +56,7 @@ async fn test_network_task() {
     };
     let quorum_proposal = build_quorum_proposal(&handle, priv_key, 2).await;
 
-    let da_vid_disperse_inner = VidDisperse::from_membership(
+    let vid_disperse_inner = VidDisperse::from_membership(
         da_proposal.data.view_number,
         vid_disperse,
         &quorum_membership.clone().into(),
@@ -63,8 +64,8 @@ async fn test_network_task() {
 
     // TODO for now reuse the same block payload commitment and signature as DA committee
     // https://github.com/EspressoSystems/jellyfish/issues/369
-    let da_vid_disperse = Proposal {
-        data: da_vid_disperse_inner.clone(),
+    let vid_proposal = Proposal {
+        data: vid_disperse_inner.clone(),
         signature: da_proposal.signature.clone(),
         _pd: PhantomData,
     };
@@ -80,14 +81,11 @@ async fn test_network_task() {
         ViewNumber::new(2),
     ));
     input.push(HotShotEvent::BlockReady(
-        da_vid_disperse_inner.clone(),
+        vid_disperse_inner.clone(),
         ViewNumber::new(2),
     ));
     input.push(HotShotEvent::DAProposalSend(da_proposal.clone(), pub_key));
-    input.push(HotShotEvent::VidDisperseSend(
-        da_vid_disperse.clone(),
-        pub_key,
-    ));
+    input.push(HotShotEvent::VidDisperseSend(vid_proposal.clone(), pub_key));
     input.push(HotShotEvent::QuorumProposalSend(
         quorum_proposal.clone(),
         pub_key,
@@ -97,24 +95,21 @@ async fn test_network_task() {
 
     output.insert(HotShotEvent::ViewChange(ViewNumber::new(1)), 2);
     output.insert(
+        HotShotEvent::TransactionsSequenced(encoded_transactions, (), ViewNumber::new(2)),
+        2, // 2 occurrences: 1 from `input`, 1 from the transactions task
+    );
+    output.insert(
+        HotShotEvent::BlockReady(vid_disperse_inner, ViewNumber::new(2)),
+        2, // 2 occurrences: 1 from `input`, 1 from the VID task
+    );
+    output.insert(
         HotShotEvent::DAProposalSend(da_proposal.clone(), pub_key),
         2, // 2 occurrences: 1 from `input`, 1 from the DA task
     );
     output.insert(
-        HotShotEvent::TransactionsSequenced(encoded_transactions, (), ViewNumber::new(2)),
-        2,
-    );
-    output.insert(
-        HotShotEvent::VidDisperseRecv(da_vid_disperse.clone(), pub_key),
+        HotShotEvent::VidDisperseSend(vid_proposal.clone(), pub_key),
         1,
     );
-    output.insert(
-        HotShotEvent::VidDisperseSend(da_vid_disperse, pub_key),
-        2, // 2 occurrences: 1 from `input`, 1 from the DA task
-    );
-    output.insert(HotShotEvent::Timeout(ViewNumber::new(1)), 1);
-    output.insert(HotShotEvent::Timeout(ViewNumber::new(2)), 1);
-
     // Only one output from the input.
     // The consensus task will fail to send a second proposal, like the DA task does, due to the
     // view number check in `publish_proposal_if_able` in consensus.rs, and we will see an error in
@@ -124,20 +119,17 @@ async fn test_network_task() {
         HotShotEvent::QuorumProposalSend(quorum_proposal.clone(), pub_key),
         1,
     );
+    output.insert(HotShotEvent::ViewChange(ViewNumber::new(2)), 2);
     output.insert(
         HotShotEvent::SendPayloadCommitmentAndMetadata(payload_commitment, ()),
         1,
     );
     output.insert(
-        HotShotEvent::BlockReady(da_vid_disperse_inner, ViewNumber::new(2)),
-        2,
-    );
-    output.insert(HotShotEvent::DAProposalRecv(da_proposal, pub_key), 1);
-    output.insert(
         HotShotEvent::QuorumProposalRecv(quorum_proposal, pub_key),
         1,
     );
-    output.insert(HotShotEvent::ViewChange(ViewNumber::new(2)), 2);
+    output.insert(HotShotEvent::VidDisperseRecv(vid_proposal, pub_key), 1);
+    output.insert(HotShotEvent::DAProposalRecv(da_proposal, pub_key), 1);
     output.insert(HotShotEvent::Shutdown, 1);
 
     let build_fn = |task_runner, _| async { task_runner };

--- a/crates/testing/tests/network_task.rs
+++ b/crates/testing/tests/network_task.rs
@@ -16,7 +16,6 @@ use std::{collections::HashMap, marker::PhantomData};
     tokio::test(flavor = "multi_thread", worker_threads = 2)
 )]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
-#[ignore]
 async fn test_network_task() {
     use hotshot_task_impls::harness::run_harness;
     use hotshot_testing::{block_types::TestTransaction, task_helpers::build_system_handle};

--- a/crates/types/src/traits/block_contents.rs
+++ b/crates/types/src/traits/block_contents.rs
@@ -90,16 +90,6 @@ pub fn vid_commitment(
     vid.commit_only(encoded_transactions).unwrap()
 }
 
-/// Computes the (empty) genesis VID commitment
-/// The number of storage nodes does not do anything, unless in the future we add fake transactions
-/// to the genesis payload.
-///
-/// In that case, the payloads may mismatch and cause problems.
-#[must_use]
-pub fn genesis_vid_commitment() -> <VidScheme as VidSchemeTrait>::Commit {
-    vid_commitment(&vec![], 8)
-}
-
 /// Header of a block, which commits to a [`BlockPayload`].
 pub trait BlockHeader:
     Serialize + Clone + Debug + Hash + PartialEq + Eq + Send + Sync + DeserializeOwned + Committable

--- a/crates/types/src/traits/block_contents.rs
+++ b/crates/types/src/traits/block_contents.rs
@@ -13,13 +13,6 @@ use std::{
     hash::Hash,
 };
 
-// TODO <https://github.com/EspressoSystems/HotShot/issues/1693>
-/// Number of storage nodes for VID initiation.
-pub const NUM_STORAGE_NODES: usize = 8;
-// TODO <https://github.com/EspressoSystems/HotShot/issues/1693>
-/// Number of chunks for VID initiation.
-pub const NUM_CHUNKS: usize = 8;
-
 /// Abstraction over any type of transaction. Used by [`BlockPayload`].
 pub trait Transaction:
     Clone + Serialize + DeserializeOwned + Debug + PartialEq + Eq + Sync + Send + Committable + Hash


### PR DESCRIPTION
Closes https://github.com/EspressoSystems/HotShot/issues/2214.

### This PR: 
* Removes `#[ignore]` on the consensus and network task unit tests.
* Fixes the network task test.
  * Fixes DA and VID signatures.
  * Updates expected events.
* Moves `genesis_vid_commitment` to the testing crate.
* Removes unused const values.

### This PR does not: 
Try to fix other CI failures (if any).

### Key places to review: 
All files.
