### PR TITLE
[Stability] Cancel polling for old votes

### DIFF
--- a/crates/hotshot/src/tasks/mod.rs
+++ b/crates/hotshot/src/tasks/mod.rs
@@ -246,10 +246,6 @@ pub async fn add_consensus_task<TYPES: NodeType, I: NodeImplementation<TYPES>>(
         .quorum_network
         .inject_consensus_info(ConsensusIntentEvent::PollForCurrentProposal)
         .await;
-    consensus_state
-        .quorum_network
-        .inject_consensus_info(ConsensusIntentEvent::PollForProposal(1))
-        .await;
     let filter = FilterEvent(Arc::new(consensus_event_filter));
     let consensus_name = "Consensus Task";
     let consensus_event_handler = HandleEvent(Arc::new(

--- a/crates/task-impls/src/consensus.rs
+++ b/crates/task-impls/src/consensus.rs
@@ -998,6 +998,11 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                     .inject_consensus_info(ConsensusIntentEvent::CancelPollForVotes(*view))
                     .await;
 
+                // cancel poll for proposal
+                self.quorum_network
+                    .inject_consensus_info(ConsensusIntentEvent::CancelPollForProposal(*view))
+                    .await;
+
                 let vote = TimeoutVote::create_signed_vote(
                     TimeoutData { view },
                     view,

--- a/crates/task-impls/src/view_sync.rs
+++ b/crates/task-impls/src/view_sync.rs
@@ -465,6 +465,11 @@ impl<
                     return;
                 }
 
+                // cancel poll for votes
+                self.network
+                    .inject_consensus_info(ConsensusIntentEvent::CancelPollForVotes(*view_number))
+                    .await;
+
                 self.num_timeouts_tracked += 1;
                 error!(
                     "Num timeouts tracked since last view change is {}. View {} timed out",
@@ -781,6 +786,13 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                 if last_seen_certificate <= self.phase {
                     return (None, self);
                 }
+
+                // cancel poll for votes
+                self.network
+                    .inject_consensus_info(ConsensusIntentEvent::CancelPollForVotes(
+                        *certificate.view_number,
+                    ))
+                    .await;
 
                 self.phase = last_seen_certificate;
 

--- a/crates/task-impls/src/view_sync.rs
+++ b/crates/task-impls/src/view_sync.rs
@@ -467,7 +467,9 @@ impl<
 
                 // cancel poll for votes
                 self.network
-                    .inject_consensus_info(ConsensusIntentEvent::CancelPollForVotes(*view_number))
+                    .inject_consensus_info(ConsensusIntentEvent::CancelPollForViewSyncVotes(
+                        *view_number,
+                    ))
                     .await;
 
                 self.num_timeouts_tracked += 1;
@@ -789,7 +791,14 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
 
                 // cancel poll for votes
                 self.network
-                    .inject_consensus_info(ConsensusIntentEvent::CancelPollForVotes(
+                    .inject_consensus_info(ConsensusIntentEvent::CancelPollForViewSyncVotes(
+                        *certificate.view_number,
+                    ))
+                    .await;
+
+                // cancel poll for view sync cert
+                self.network
+                    .inject_consensus_info(ConsensusIntentEvent::CancelPollForViewSyncCertificate(
                         *certificate.view_number,
                     ))
                     .await;

--- a/crates/task-impls/src/view_sync.rs
+++ b/crates/task-impls/src/view_sync.rs
@@ -467,9 +467,7 @@ impl<
 
                 // cancel poll for votes
                 self.network
-                    .inject_consensus_info(ConsensusIntentEvent::CancelPollForViewSyncVotes(
-                        *view_number,
-                    ))
+                    .inject_consensus_info(ConsensusIntentEvent::CancelPollForVotes(*view_number))
                     .await;
 
                 self.num_timeouts_tracked += 1;


### PR DESCRIPTION
Closes #2222 
<!-- See here for keywords in Github -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

### This PR: 
<!-- Describe what this PR adds to HotSHot -->
<!-- E.g. -->
<!-- * Implements feature 1 -->
<!-- * Implements feature 2 -->
<!-- * Fixes bug 3 -->

Fixes a bug wherein we are not cancelling old polls for votes.

Cancels polls for votes in the following places:
- when we receive a timeout in view sync or a finalized view sync cert 
- when we form a QC or DAC 
- when we time out for both the quorum and view sync (DA already had this)

Also cancels a poll for proposals for view 1, as this is covered by the latest proposal mechanism. For a node finishing catchup, it would constantly try to pull the first proposal.


### This PR does not: 
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->

Add any GC improvements/more advanced proposal logic/cancelling as discussed. This will be in another PR.


### Key places to review: 
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->
`da.rs`, `consensus.rs`, `view_sync.rs` to make sure all the cancels are in a good spot.

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
