### PR TITLE
[Stability] Garbage collect polls for all views < latest-2

### DIFF
--- a/crates/hotshot/src/tasks/mod.rs
+++ b/crates/hotshot/src/tasks/mod.rs
@@ -246,6 +246,10 @@ pub async fn add_consensus_task<TYPES: NodeType, I: NodeImplementation<TYPES>>(
         .quorum_network
         .inject_consensus_info(ConsensusIntentEvent::PollForCurrentProposal)
         .await;
+    consensus_state
+        .quorum_network
+        .inject_consensus_info(ConsensusIntentEvent::PollForProposal(1))
+        .await;
     let filter = FilterEvent(Arc::new(consensus_event_filter));
     let consensus_name = "Consensus Task";
     let consensus_event_handler = HandleEvent(Arc::new(

--- a/crates/hotshot/src/tasks/mod.rs
+++ b/crates/hotshot/src/tasks/mod.rs
@@ -246,10 +246,6 @@ pub async fn add_consensus_task<TYPES: NodeType, I: NodeImplementation<TYPES>>(
         .quorum_network
         .inject_consensus_info(ConsensusIntentEvent::PollForCurrentProposal)
         .await;
-    consensus_state
-        .quorum_network
-        .inject_consensus_info(ConsensusIntentEvent::PollForProposal(1))
-        .await;
     let filter = FilterEvent(Arc::new(consensus_event_filter));
     let consensus_name = "Consensus Task";
     let consensus_event_handler = HandleEvent(Arc::new(

--- a/crates/hotshot/src/traits/networking/web_server_network.rs
+++ b/crates/hotshot/src/traits/networking/web_server_network.rs
@@ -331,6 +331,7 @@ impl<TYPES: NodeType> Inner<TYPES> {
                         ConsensusIntentEvent::CancelPollForVotes(event_view)
                         | ConsensusIntentEvent::CancelPollForProposal(event_view)
                         | ConsensusIntentEvent::CancelPollForDAC(event_view)
+                        | ConsensusIntentEvent::CancelPollForViewSyncCertificate(event_view)
                         | ConsensusIntentEvent::CancelPollForVIDDisperse(event_view)
                         | ConsensusIntentEvent::CancelPollForViewSyncVotes(event_view) => {
                             if view_number == event_view {

--- a/crates/hotshot/src/traits/networking/web_server_network.rs
+++ b/crates/hotshot/src/traits/networking/web_server_network.rs
@@ -175,8 +175,6 @@ impl<TYPES: NodeType> Inner<TYPES> {
                 MessagePurpose::VidDisperse => config::get_vid_disperse_route(view_number), // like `Proposal`
             };
 
-            println!("getting {}", endpoint);
-
             if message_purpose == MessagePurpose::Data {
                 let possible_message = self.get_txs_from_web_server(endpoint).await;
                 match possible_message {
@@ -801,9 +799,9 @@ impl<TYPES: NodeType + 'static> ConnectedNetwork<Message<TYPES>, TYPES::Signatur
                 }
 
                 // Remove all entries in the task map that are polling for a view less than or equal to `view_number - 2`.
-                let view_minus_2 = view_number.checked_sub(2).unwrap_or(0);
-                let mut range = task_map.range(..view_minus_2);
-                while let Some((view, task)) = range.next() {
+                let view_minus_2 = view_number.saturating_sub(2);
+                let range = task_map.range(..view_minus_2);
+                for (view, task) in range {
                     // Cancel the old task by sending a message to it. If the task already exited we expect an error
                     let _res = task
                         .send(ConsensusIntentEvent::CancelPollForProposal(*view))
@@ -839,9 +837,9 @@ impl<TYPES: NodeType + 'static> ConnectedNetwork<Message<TYPES>, TYPES::Signatur
                 }
 
                 // Remove all entries in the task map that are polling for a view less than or equal to `view_number - 2`.
-                let view_minus_2 = view_number.checked_sub(2).unwrap_or(0);
-                let mut range = task_map.range(..view_minus_2);
-                while let Some((view, task)) = range.next() {
+                let view_minus_2 = view_number.saturating_sub(2);
+                let range = task_map.range(..view_minus_2);
+                for (view, task) in range {
                     // Cancel the old task by sending a message to it. If the task already exited we expect an error
                     let _res = task
                         .send(ConsensusIntentEvent::CancelPollForVIDDisperse(*view))
@@ -892,9 +890,9 @@ impl<TYPES: NodeType + 'static> ConnectedNetwork<Message<TYPES>, TYPES::Signatur
                 }
 
                 // Remove all entries in the task map that are polling for a view less than or equal to `view_number - 2`.
-                let view_minus_2 = view_number.checked_sub(2).unwrap_or(0);
-                let mut range = task_map.range(..view_minus_2);
-                while let Some((view, task)) = range.next() {
+                let view_minus_2 = view_number.saturating_sub(2);
+                let range = task_map.range(..view_minus_2);
+                for (view, task) in range {
                     // Cancel the old task by sending a message to it. If the task already exited we expect an error
                     let _res = task
                         .send(ConsensusIntentEvent::CancelPollForVotes(*view))
@@ -927,9 +925,9 @@ impl<TYPES: NodeType + 'static> ConnectedNetwork<Message<TYPES>, TYPES::Signatur
                 }
 
                 // Remove all entries in the task map that are polling for a view less than or equal to `view_number - 2`.
-                let view_minus_2 = view_number.checked_sub(2).unwrap_or(0);
-                let mut range = task_map.range(..view_minus_2);
-                while let Some((view, task)) = range.next() {
+                let view_minus_2 = view_number.saturating_sub(2);
+                let range = task_map.range(..view_minus_2);
+                for (view, task) in range {
                     // Cancel the old task by sending a message to it. If the task already exited we expect an error
                     let _res = task
                         .send(ConsensusIntentEvent::CancelPollForDAC(*view))
@@ -979,9 +977,9 @@ impl<TYPES: NodeType + 'static> ConnectedNetwork<Message<TYPES>, TYPES::Signatur
                 }
 
                 // Remove all entries in the task map that are polling for a view less than or equal to `view_number - 2`.
-                let view_minus_2 = view_number.checked_sub(2).unwrap_or(0);
-                let mut range = task_map.range(..view_minus_2);
-                while let Some((view, task)) = range.next() {
+                let view_minus_2 = view_number.saturating_sub(2);
+                let range = task_map.range(..view_minus_2);
+                for (view, task) in range {
                     // Cancel the old task by sending a message to it. If the task already exited we expect an error
                     let _res = task
                         .send(ConsensusIntentEvent::CancelPollForViewSyncCertificate(
@@ -1019,9 +1017,9 @@ impl<TYPES: NodeType + 'static> ConnectedNetwork<Message<TYPES>, TYPES::Signatur
                 }
 
                 // Remove all entries in the task map that are polling for a view less than or equal to `view_number - 2`.
-                let view_minus_2 = view_number.checked_sub(2).unwrap_or(0);
-                let mut range = task_map.range(..view_minus_2);
-                while let Some((view, task)) = range.next() {
+                let view_minus_2 = view_number.saturating_sub(2);
+                let range = task_map.range(..view_minus_2);
+                for (view, task) in range {
                     // Cancel the old task by sending a message to it. If the task already exited we expect an error
                     let _res = task
                         .send(ConsensusIntentEvent::CancelPollForViewSyncVotes(*view))
@@ -1082,9 +1080,9 @@ impl<TYPES: NodeType + 'static> ConnectedNetwork<Message<TYPES>, TYPES::Signatur
                 }
 
                 // Remove all entries in the task map that are polling for a view less than or equal to `view_number - 2`.
-                let view_minus_2 = view_number.checked_sub(2).unwrap_or(0);
-                let mut range = task_map.range(..view_minus_2);
-                while let Some((view, task)) = range.next() {
+                let view_minus_2 = view_number.saturating_sub(2);
+                let range = task_map.range(..view_minus_2);
+                for (view, task) in range {
                     // Cancel the old task by sending a message to it. If the task already exited we expect an error
                     let _res = task
                         .send(ConsensusIntentEvent::CancelPollForTransactions(*view))

--- a/crates/hotshot/src/traits/networking/web_server_network.rs
+++ b/crates/hotshot/src/traits/networking/web_server_network.rs
@@ -30,8 +30,9 @@ use serde::{Deserialize, Serialize};
 use surf_disco::Url;
 
 use hotshot_types::traits::network::ViewMessage;
+use std::collections::BTreeMap;
 use std::{
-    collections::{hash_map::Entry, BTreeSet, HashMap},
+    collections::{btree_map::Entry, BTreeSet},
     sync::{
         atomic::{AtomicBool, Ordering},
         Arc,
@@ -119,25 +120,25 @@ struct Inner<TYPES: NodeType> {
 
     /// Task map for quorum proposals.
     proposal_task_map:
-        Arc<RwLock<HashMap<u64, UnboundedSender<ConsensusIntentEvent<TYPES::SignatureKey>>>>>,
+        Arc<RwLock<BTreeMap<u64, UnboundedSender<ConsensusIntentEvent<TYPES::SignatureKey>>>>>,
     /// Task map for quorum votes.
     vote_task_map:
-        Arc<RwLock<HashMap<u64, UnboundedSender<ConsensusIntentEvent<TYPES::SignatureKey>>>>>,
+        Arc<RwLock<BTreeMap<u64, UnboundedSender<ConsensusIntentEvent<TYPES::SignatureKey>>>>>,
     /// Task map for VID disperse data
     vid_disperse_task_map:
-        Arc<RwLock<HashMap<u64, UnboundedSender<ConsensusIntentEvent<TYPES::SignatureKey>>>>>,
+        Arc<RwLock<BTreeMap<u64, UnboundedSender<ConsensusIntentEvent<TYPES::SignatureKey>>>>>,
     /// Task map for DACs.
     dac_task_map:
-        Arc<RwLock<HashMap<u64, UnboundedSender<ConsensusIntentEvent<TYPES::SignatureKey>>>>>,
+        Arc<RwLock<BTreeMap<u64, UnboundedSender<ConsensusIntentEvent<TYPES::SignatureKey>>>>>,
     /// Task map for view sync certificates.
     view_sync_cert_task_map:
-        Arc<RwLock<HashMap<u64, UnboundedSender<ConsensusIntentEvent<TYPES::SignatureKey>>>>>,
+        Arc<RwLock<BTreeMap<u64, UnboundedSender<ConsensusIntentEvent<TYPES::SignatureKey>>>>>,
     /// Task map for view sync votes.
     view_sync_vote_task_map:
-        Arc<RwLock<HashMap<u64, UnboundedSender<ConsensusIntentEvent<TYPES::SignatureKey>>>>>,
+        Arc<RwLock<BTreeMap<u64, UnboundedSender<ConsensusIntentEvent<TYPES::SignatureKey>>>>>,
     /// Task map for transactions
     txn_task_map:
-        Arc<RwLock<HashMap<u64, UnboundedSender<ConsensusIntentEvent<TYPES::SignatureKey>>>>>,
+        Arc<RwLock<BTreeMap<u64, UnboundedSender<ConsensusIntentEvent<TYPES::SignatureKey>>>>>,
 }
 
 impl<TYPES: NodeType> Inner<TYPES> {
@@ -173,6 +174,8 @@ impl<TYPES: NodeType> Inner<TYPES> {
                 MessagePurpose::DAC => config::get_da_certificate_route(view_number),
                 MessagePurpose::VidDisperse => config::get_vid_disperse_route(view_number), // like `Proposal`
             };
+
+            println!("getting {}", endpoint);
 
             if message_purpose == MessagePurpose::Data {
                 let possible_message = self.get_txs_from_web_server(endpoint).await;
@@ -768,8 +771,6 @@ impl<TYPES: NodeType + 'static> ConnectedNetwork<Message<TYPES>, TYPES::Signatur
         );
 
         // TODO ED Need to handle canceling tasks that don't receive their expected output (such a proposal that never comes)
-        // TODO ED Need to GC all old views, not just singular views, could lead to a network leak
-
         match event {
             ConsensusIntentEvent::PollForProposal(view_number) => {
                 // Check if we already have a task for this (we shouldn't)
@@ -799,15 +800,13 @@ impl<TYPES: NodeType + 'static> ConnectedNetwork<Message<TYPES>, TYPES::Signatur
                     debug!("Somehow task already existed!");
                 }
 
-                // GC proposal collection if we are two views in the future
-                if let Some((_, sender)) = task_map.remove_entry(&view_number.wrapping_sub(2)) {
-                    // Send task cancel message to old task
-
-                    // If task already exited we expect an error
-                    let _res = sender
-                        .send(ConsensusIntentEvent::CancelPollForProposal(
-                            view_number.wrapping_sub(2),
-                        ))
+                // Remove all entries in the task map that are polling for a view less than or equal to `view_number - 2`.
+                let view_minus_2 = view_number.checked_sub(2).unwrap_or(0);
+                let mut range = task_map.range(..view_minus_2);
+                while let Some((view, task)) = range.next() {
+                    // Cancel the old task by sending a message to it. If the task already exited we expect an error
+                    let _res = task
+                        .send(ConsensusIntentEvent::CancelPollForProposal(*view))
                         .await;
                 }
             }
@@ -839,15 +838,13 @@ impl<TYPES: NodeType + 'static> ConnectedNetwork<Message<TYPES>, TYPES::Signatur
                     debug!("Somehow task already existed!");
                 }
 
-                // GC proposal collection if we are two views in the future
-                if let Some((_, sender)) = task_map.remove_entry(&view_number.wrapping_sub(2)) {
-                    // Send task cancel message to old task
-
-                    // If task already exited we expect an error
-                    let _res = sender
-                        .send(ConsensusIntentEvent::CancelPollForVIDDisperse(
-                            view_number.wrapping_sub(2),
-                        ))
+                // Remove all entries in the task map that are polling for a view less than or equal to `view_number - 2`.
+                let view_minus_2 = view_number.checked_sub(2).unwrap_or(0);
+                let mut range = task_map.range(..view_minus_2);
+                while let Some((view, task)) = range.next() {
+                    // Cancel the old task by sending a message to it. If the task already exited we expect an error
+                    let _res = task
+                        .send(ConsensusIntentEvent::CancelPollForVIDDisperse(*view))
                         .await;
                 }
             }
@@ -894,16 +891,13 @@ impl<TYPES: NodeType + 'static> ConnectedNetwork<Message<TYPES>, TYPES::Signatur
                     debug!("Somehow task already existed!");
                 }
 
-                // GC proposal collection if we are two views in the future
-                // TODO ED This won't work for vote collection, last task is more than 2 view ago depending on size of network, will need to rely on cancel task from consensus
-                if let Some((_, sender)) = task_map.remove_entry(&(view_number.wrapping_sub(2))) {
-                    // Send task cancel message to old task
-
-                    // If task already exited we expect an error
-                    let _res = sender
-                        .send(ConsensusIntentEvent::CancelPollForVotes(
-                            view_number.wrapping_sub(2),
-                        ))
+                // Remove all entries in the task map that are polling for a view less than or equal to `view_number - 2`.
+                let view_minus_2 = view_number.checked_sub(2).unwrap_or(0);
+                let mut range = task_map.range(..view_minus_2);
+                while let Some((view, task)) = range.next() {
+                    // Cancel the old task by sending a message to it. If the task already exited we expect an error
+                    let _res = task
+                        .send(ConsensusIntentEvent::CancelPollForVotes(*view))
                         .await;
                 }
             }
@@ -932,15 +926,13 @@ impl<TYPES: NodeType + 'static> ConnectedNetwork<Message<TYPES>, TYPES::Signatur
                     debug!("Somehow task already existed!");
                 }
 
-                // GC proposal collection if we are two views in the future
-                if let Some((_, sender)) = task_map.remove_entry(&(view_number.wrapping_sub(2))) {
-                    // Send task cancel message to old task
-
-                    // If task already exited we expect an error
-                    let _res = sender
-                        .send(ConsensusIntentEvent::CancelPollForDAC(
-                            view_number.wrapping_sub(2),
-                        ))
+                // Remove all entries in the task map that are polling for a view less than or equal to `view_number - 2`.
+                let view_minus_2 = view_number.checked_sub(2).unwrap_or(0);
+                let mut range = task_map.range(..view_minus_2);
+                while let Some((view, task)) = range.next() {
+                    // Cancel the old task by sending a message to it. If the task already exited we expect an error
+                    let _res = task
+                        .send(ConsensusIntentEvent::CancelPollForDAC(*view))
                         .await;
                 }
             }
@@ -986,7 +978,17 @@ impl<TYPES: NodeType + 'static> ConnectedNetwork<Message<TYPES>, TYPES::Signatur
                     debug!("Somehow task already existed!");
                 }
 
-                // TODO ED Do we need to GC before returning?  Or will view sync task handle that?
+                // Remove all entries in the task map that are polling for a view less than or equal to `view_number - 2`.
+                let view_minus_2 = view_number.checked_sub(2).unwrap_or(0);
+                let mut range = task_map.range(..view_minus_2);
+                while let Some((view, task)) = range.next() {
+                    // Cancel the old task by sending a message to it. If the task already exited we expect an error
+                    let _res = task
+                        .send(ConsensusIntentEvent::CancelPollForViewSyncCertificate(
+                            *view,
+                        ))
+                        .await;
+                }
             }
             ConsensusIntentEvent::PollForViewSyncVotes(view_number) => {
                 let mut task_map = self.inner.view_sync_vote_task_map.write().await;
@@ -1014,6 +1016,16 @@ impl<TYPES: NodeType + 'static> ConnectedNetwork<Message<TYPES>, TYPES::Signatur
                     });
                 } else {
                     debug!("Somehow task already existed!");
+                }
+
+                // Remove all entries in the task map that are polling for a view less than or equal to `view_number - 2`.
+                let view_minus_2 = view_number.checked_sub(2).unwrap_or(0);
+                let mut range = task_map.range(..view_minus_2);
+                while let Some((view, task)) = range.next() {
+                    // Cancel the old task by sending a message to it. If the task already exited we expect an error
+                    let _res = task
+                        .send(ConsensusIntentEvent::CancelPollForViewSyncVotes(*view))
+                        .await;
                 }
             }
 
@@ -1047,7 +1059,7 @@ impl<TYPES: NodeType + 'static> ConnectedNetwork<Message<TYPES>, TYPES::Signatur
             }
             ConsensusIntentEvent::PollForTransactions(view_number) => {
                 let mut task_map = self.inner.txn_task_map.write().await;
-                if let std::collections::hash_map::Entry::Vacant(e) = task_map.entry(view_number) {
+                if let Entry::Vacant(e) = task_map.entry(view_number) {
                     // create new task
                     let (sender, receiver) = unbounded();
                     e.insert(sender);
@@ -1069,7 +1081,15 @@ impl<TYPES: NodeType + 'static> ConnectedNetwork<Message<TYPES>, TYPES::Signatur
                     debug!("Somehow task already existed!");
                 }
 
-                // TODO ED Do we need to GC before returning?  Or will view sync task handle that?
+                // Remove all entries in the task map that are polling for a view less than or equal to `view_number - 2`.
+                let view_minus_2 = view_number.checked_sub(2).unwrap_or(0);
+                let mut range = task_map.range(..view_minus_2);
+                while let Some((view, task)) = range.next() {
+                    // Cancel the old task by sending a message to it. If the task already exited we expect an error
+                    let _res = task
+                        .send(ConsensusIntentEvent::CancelPollForTransactions(*view))
+                        .await;
+                }
             }
             ConsensusIntentEvent::CancelPollForTransactions(view_number) => {
                 let mut task_map = self.inner.txn_task_map.write().await;

--- a/crates/task-impls/src/consensus.rs
+++ b/crates/task-impls/src/consensus.rs
@@ -997,7 +997,8 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                 let high_qc = self.consensus.read().await.high_qc.clone();
                 let leader_view = high_qc.get_view_number() + 1;
                 if self.quorum_membership.get_leader(leader_view) == self.public_key {
-                    self.publish_proposal_if_able(high_qc, leader_view, None).await;
+                    self.publish_proposal_if_able(high_qc, leader_view, None)
+                        .await;
                 }
             }
             _ => {}

--- a/crates/task-impls/src/view_sync.rs
+++ b/crates/task-impls/src/view_sync.rs
@@ -509,6 +509,11 @@ impl<
                             subscribe_view,
                         ))
                         .await;
+                    // Also subscribe to the latest view for the same reason. The GC will remove the above poll
+                    // in the case that one doesn't resolve but this one does.
+                    self.network
+                        .inject_consensus_info(ConsensusIntentEvent::PollForCurrentProposal)
+                        .await;
 
                     self.network
                         .inject_consensus_info(ConsensusIntentEvent::PollForDAC(subscribe_view))

--- a/crates/task-impls/src/view_sync.rs
+++ b/crates/task-impls/src/view_sync.rs
@@ -465,11 +465,6 @@ impl<
                     return;
                 }
 
-                // cancel poll for votes
-                self.network
-                    .inject_consensus_info(ConsensusIntentEvent::CancelPollForVotes(*view_number))
-                    .await;
-
                 self.num_timeouts_tracked += 1;
                 error!(
                     "Num timeouts tracked since last view change is {}. View {} timed out",
@@ -791,13 +786,6 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                 if last_seen_certificate <= self.phase {
                     return (None, self);
                 }
-
-                // cancel poll for votes
-                self.network
-                    .inject_consensus_info(ConsensusIntentEvent::CancelPollForVotes(
-                        *certificate.view_number,
-                    ))
-                    .await;
 
                 self.phase = last_seen_certificate;
 

--- a/crates/task-impls/src/view_sync.rs
+++ b/crates/task-impls/src/view_sync.rs
@@ -465,6 +465,11 @@ impl<
                     return;
                 }
 
+                // cancel poll for votes
+                self.network
+                    .inject_consensus_info(ConsensusIntentEvent::CancelPollForVotes(*view_number))
+                    .await;
+
                 self.num_timeouts_tracked += 1;
                 error!(
                     "Num timeouts tracked since last view change is {}. View {} timed out",
@@ -781,6 +786,13 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                 if last_seen_certificate <= self.phase {
                     return (None, self);
                 }
+
+                // cancel poll for votes
+                self.network
+                    .inject_consensus_info(ConsensusIntentEvent::CancelPollForVotes(
+                        *certificate.view_number,
+                    ))
+                    .await;
 
                 self.phase = last_seen_certificate;
 


### PR DESCRIPTION
Closes #2225 
<!-- See here for keywords in Github -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

### This PR: 
<!-- Describe what this PR adds to HotSHot -->
<!-- E.g. -->
<!-- * Implements feature 1 -->
<!-- * Implements feature 2 -->
<!-- * Fixes bug 3 -->

- Adds better garbage collection for all old tasks. Specifically:
    - It changes the `TaskMap` for all data types to be a `BTreeMap` (which is ordered)
    - For every new poll, it uses our new ordered "list" to cancel polls less than or equal to the current poll - 2
- After view sync, adds a poll for the current (most recent) proposal per the webserver.

### This PR does not: 
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->

Address any other webserver-related errors or bugs.

### Key places to review: 
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->

Both files ! (minus the one which just got linted)

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
