### PR TITLE
Update view sync for 2 timeouts

### DIFF
--- a/crates/task-impls/src/view_sync.rs
+++ b/crates/task-impls/src/view_sync.rs
@@ -500,9 +500,9 @@ impl<
                     let subscribe_view = if self.membership.get_leader(TYPES::Time::new(next_view))
                         == self.public_key
                     {
-                        next_view
-                    } else {
                         next_view + 1
+                    } else {
+                        next_view
                     };
                     // Subscribe to the next view just in case there is progress being made
                     self.network

--- a/crates/task-impls/src/view_sync.rs
+++ b/crates/task-impls/src/view_sync.rs
@@ -476,11 +476,12 @@ impl<
                     self.num_timeouts_tracked, *view_number
                 );
 
-                if self.num_timeouts_tracked > 3 {
+                if self.num_timeouts_tracked >= 3 {
                     error!("Too many consecutive timeouts!  This shouldn't happen");
                 }
 
-                if self.num_timeouts_tracked > 2 {
+                if self.num_timeouts_tracked >= 2 {
+                    error!("Starting view sync protocol for view {}", *view_number + 1);
                     // Start polling for view sync certificates
                     self.network
                         .inject_consensus_info(ConsensusIntentEvent::PollForViewSyncCertificate(
@@ -743,6 +744,12 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                         .publish(HotShotEvent::ViewSyncFinalizeVoteSend(vote))
                         .await;
                 }
+
+                error!(
+                    "View sync protocol has received view sync evidence to update the view to {}",
+                    *self.next_view
+                );
+
                 self.event_stream
                     .publish(HotShotEvent::ViewChange(self.next_view))
                     .await;

--- a/crates/testing/tests/view_sync_task.rs
+++ b/crates/testing/tests/view_sync_task.rs
@@ -27,11 +27,11 @@ async fn test_view_sync_task() {
 
     let vote_data = ViewSyncPreCommitData {
         relay: 0,
-        round: <TestTypes as hotshot_types::traits::node_implementation::NodeType>::Time::new(5),
+        round: <TestTypes as hotshot_types::traits::node_implementation::NodeType>::Time::new(4),
     };
     let vote = hotshot_types::simple_vote::ViewSyncPreCommitVote::<TestTypes>::create_signed_vote(
         vote_data,
-        <TestTypes as hotshot_types::traits::node_implementation::NodeType>::Time::new(5),
+        <TestTypes as hotshot_types::traits::node_implementation::NodeType>::Time::new(4),
         hotshot_types::traits::consensus_api::ConsensusApi::public_key(&api),
         hotshot_types::traits::consensus_api::ConsensusApi::private_key(&api),
     );
@@ -44,16 +44,13 @@ async fn test_view_sync_task() {
 
     input.push(HotShotEvent::Timeout(ViewNumber::new(2)));
     input.push(HotShotEvent::Timeout(ViewNumber::new(3)));
-    input.push(HotShotEvent::Timeout(ViewNumber::new(4)));
 
     input.push(HotShotEvent::Shutdown);
 
     output.insert(HotShotEvent::Timeout(ViewNumber::new(2)), 1);
     output.insert(HotShotEvent::Timeout(ViewNumber::new(3)), 1);
-    output.insert(HotShotEvent::Timeout(ViewNumber::new(4)), 1);
 
     output.insert(HotShotEvent::ViewChange(ViewNumber::new(2)), 1);
-    output.insert(HotShotEvent::ViewChange(ViewNumber::new(3)), 1);
     output.insert(HotShotEvent::ViewSyncPreCommitVoteSend(vote.clone()), 1);
 
     output.insert(HotShotEvent::Shutdown, 1);


### PR DESCRIPTION
Closes #<ISSUE_NUMBER>
<!-- See here for keywords in Github -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

### This PR: 
* Fixes a bug where view sync waited for 3 views to trigger instead of 2 views. 
<!-- Describe what this PR adds to HotSHot -->
<!-- E.g. -->
<!-- * Implements feature 1 -->
<!-- * Implements feature 2 -->
<!-- * Fixes bug 3 -->

### This PR does not: 
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->

### Key places to review: 
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
