### PR TITLE
Poll for Current Proposal on View Sync Timeout

### DIFF
--- a/crates/task-impls/src/view_sync.rs
+++ b/crates/task-impls/src/view_sync.rs
@@ -865,6 +865,10 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                     && relay == self.relay
                     && last_seen_certificate == self.phase
                 {
+                    // Keep tyring to get a more recent proposal to catch up to
+                    self.network
+                        .inject_consensus_info(ConsensusIntentEvent::PollForCurrentProposal)
+                        .await;
                     self.relay += 1;
                     match self.phase {
                         ViewSyncPhase::None => {


### PR DESCRIPTION
### This PR: 

- Polls for a proposal on every view sync timeout
- Keeps track of the current proposal polling so there can only be one task spawned at a time


### This PR does not: 

Change any consensus specific logic

### Key places to review: 

all the code changes
