### PR TITLE
View Sync Fixes for PreCommit Threshold, Timeout Logic, and Relay Vote Accumulation

### DIFF
--- a/crates/task-impls/src/view_sync.rs
+++ b/crates/task-impls/src/view_sync.rs
@@ -901,7 +901,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                         .await;
                     self.relay += 1;
                     match self.phase {
-                        ViewSyncPhase::None => {
+                        ViewSyncPhase::None | ViewSyncPhase::PreCommit | ViewSyncPhase::Commit => {
                             let vote = ViewSyncPreCommitVote::<TYPES>::create_signed_vote(
                                 ViewSyncPreCommitData {
                                     relay: self.relay,
@@ -917,44 +917,6 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                             if let GeneralConsensusMessage::ViewSyncPreCommitVote(vote) = message {
                                 self.event_stream
                                     .publish(HotShotEvent::ViewSyncPreCommitVoteSend(vote))
-                                    .await;
-                            }
-                        }
-                        ViewSyncPhase::PreCommit => {
-                            let vote = ViewSyncCommitVote::<TYPES>::create_signed_vote(
-                                ViewSyncCommitData {
-                                    relay: self.relay,
-                                    round: self.next_view,
-                                },
-                                self.next_view,
-                                &self.public_key,
-                                &self.private_key,
-                            );
-                            let message =
-                                GeneralConsensusMessage::<TYPES>::ViewSyncCommitVote(vote);
-
-                            if let GeneralConsensusMessage::ViewSyncCommitVote(vote) = message {
-                                self.event_stream
-                                    .publish(HotShotEvent::ViewSyncCommitVoteSend(vote))
-                                    .await;
-                            }
-                        }
-                        ViewSyncPhase::Commit => {
-                            let vote = ViewSyncFinalizeVote::<TYPES>::create_signed_vote(
-                                ViewSyncFinalizeData {
-                                    relay: self.relay,
-                                    round: self.next_view,
-                                },
-                                self.next_view,
-                                &self.public_key,
-                                &self.private_key,
-                            );
-                            let message =
-                                GeneralConsensusMessage::<TYPES>::ViewSyncFinalizeVote(vote);
-
-                            if let GeneralConsensusMessage::ViewSyncFinalizeVote(vote) = message {
-                                self.event_stream
-                                    .publish(HotShotEvent::ViewSyncFinalizeVoteSend(vote))
                                     .await;
                             }
                         }

--- a/crates/types/src/simple_certificate.rs
+++ b/crates/types/src/simple_certificate.rs
@@ -24,9 +24,35 @@ use crate::{
 
 use serde::{Deserialize, Serialize};
 
+/// Trait which allows use to inject different threshold calculations into a Certificate type
+pub trait Threshhold<TYPES: NodeType> {
+    /// Calculate a threshold based on the membership
+    fn threshold<MEMBERSHIP: Membership<TYPES>>(membership: &MEMBERSHIP) -> u64;
+}
+
+/// Defines a threshold which is 2f + 1 (Amount needed for Quorum)
+#[derive(Serialize, Deserialize, Eq, Hash, PartialEq, Debug, Clone)]
+pub struct SuccessThreshhold {}
+
+impl<TYPES: NodeType> Threshhold<TYPES> for SuccessThreshhold {
+    fn threshold<MEMBERSHIP: Membership<TYPES>>(membership: &MEMBERSHIP) -> u64 {
+        membership.success_threshold().into()
+    }
+}
+
+/// Defines a threshold which is f + 1 (i.e at least one of the stake is honest)
+#[derive(Serialize, Deserialize, Eq, Hash, PartialEq, Debug, Clone)]
+pub struct OneHonestThreshhold {}
+
+impl<TYPES: NodeType> Threshhold<TYPES> for OneHonestThreshhold {
+    fn threshold<MEMBERSHIP: Membership<TYPES>>(membership: &MEMBERSHIP) -> u64 {
+        membership.failure_threshold().into()
+    }
+}
+
 /// A certificate which can be created by aggregating many simple votes on the commitment.
 #[derive(Serialize, Deserialize, Eq, Hash, PartialEq, Debug, Clone)]
-pub struct SimpleCertificate<TYPES: NodeType, VOTEABLE: Voteable> {
+pub struct SimpleCertificate<TYPES: NodeType, VOTEABLE: Voteable, THRESHHOLD: Threshhold<TYPES>> {
     /// The data this certificate is for.  I.e the thing that was voted on to create this Certificate
     pub data: VOTEABLE,
     /// commitment of all the votes this cert should be signed over
@@ -37,14 +63,15 @@ pub struct SimpleCertificate<TYPES: NodeType, VOTEABLE: Voteable> {
     pub signatures: Option<<TYPES::SignatureKey as SignatureKey>::QCType>,
     /// If this QC is for the genesis block
     pub is_genesis: bool,
-    /// phantom data for `MEMBERSHIP` and `TYPES`
-    pub _pd: PhantomData<TYPES>,
+    /// phantom data for `THRESHHOLD` and `TYPES`
+    pub _pd: PhantomData<(TYPES, THRESHHOLD)>,
 }
 
-impl<TYPES: NodeType, VOTEABLE: Voteable + 'static> Certificate<TYPES>
-    for SimpleCertificate<TYPES, VOTEABLE>
+impl<TYPES: NodeType, VOTEABLE: Voteable + 'static, THRESHHOLD: Threshhold<TYPES>>
+    Certificate<TYPES> for SimpleCertificate<TYPES, VOTEABLE, THRESHHOLD>
 {
     type Voteable = VOTEABLE;
+    type Threshhold = THRESHHOLD;
 
     fn create_signed_certificate(
         vote_commitment: Commitment<VOTEABLE>,
@@ -76,7 +103,7 @@ impl<TYPES: NodeType, VOTEABLE: Voteable + 'static> Certificate<TYPES>
         )
     }
     fn threshold<MEMBERSHIP: Membership<TYPES>>(membership: &MEMBERSHIP) -> u64 {
-        membership.success_threshold().into()
+        THRESHHOLD::threshold(membership)
     }
     fn get_data(&self) -> &Self::Voteable {
         &self.data
@@ -86,8 +113,8 @@ impl<TYPES: NodeType, VOTEABLE: Voteable + 'static> Certificate<TYPES>
     }
 }
 
-impl<TYPES: NodeType, VOTEABLE: Voteable + 'static> HasViewNumber<TYPES>
-    for SimpleCertificate<TYPES, VOTEABLE>
+impl<TYPES: NodeType, VOTEABLE: Voteable + 'static, THRESHHOLD: Threshhold<TYPES>>
+    HasViewNumber<TYPES> for SimpleCertificate<TYPES, VOTEABLE, THRESHHOLD>
 {
     fn get_view_number(&self) -> TYPES::Time {
         self.view_number
@@ -123,18 +150,20 @@ impl<TYPES: NodeType> QuorumCertificate<TYPES> {
 }
 
 /// Type alias for a `QuorumCertificate`, which is a `SimpleCertificate` of `QuorumVotes`
-pub type QuorumCertificate<TYPES> = SimpleCertificate<TYPES, QuorumData<TYPES>>;
+pub type QuorumCertificate<TYPES> = SimpleCertificate<TYPES, QuorumData<TYPES>, SuccessThreshhold>;
 /// Type alias for a DA certificate over `DAData`
-pub type DACertificate<TYPES> = SimpleCertificate<TYPES, DAData>;
+pub type DACertificate<TYPES> = SimpleCertificate<TYPES, DAData, SuccessThreshhold>;
 /// Type alias for a Timeout certificate over a view number
-pub type TimeoutCertificate<TYPES> = SimpleCertificate<TYPES, TimeoutData<TYPES>>;
+pub type TimeoutCertificate<TYPES> =
+    SimpleCertificate<TYPES, TimeoutData<TYPES>, SuccessThreshhold>;
 
 // TODO ED Update this to use the correct threshold instead of the default `success_threshold`
 /// Type alias for a `ViewSyncPreCommit` certificate over a view number
 pub type ViewSyncPreCommitCertificate2<TYPES> =
-    SimpleCertificate<TYPES, ViewSyncPreCommitData<TYPES>>;
+    SimpleCertificate<TYPES, ViewSyncPreCommitData<TYPES>, OneHonestThreshhold>;
 /// Type alias for a `ViewSyncCommit` certificate over a view number
-pub type ViewSyncCommitCertificate2<TYPES> = SimpleCertificate<TYPES, ViewSyncCommitData<TYPES>>;
+pub type ViewSyncCommitCertificate2<TYPES> =
+    SimpleCertificate<TYPES, ViewSyncCommitData<TYPES>, SuccessThreshhold>;
 /// Type alias for a `ViewSyncFinalize` certificate over a view number
 pub type ViewSyncFinalizeCertificate2<TYPES> =
-    SimpleCertificate<TYPES, ViewSyncFinalizeData<TYPES>>;
+    SimpleCertificate<TYPES, ViewSyncFinalizeData<TYPES>, SuccessThreshhold>;

--- a/crates/types/src/simple_certificate.rs
+++ b/crates/types/src/simple_certificate.rs
@@ -155,8 +155,6 @@ pub type QuorumCertificate<TYPES> = SimpleCertificate<TYPES, QuorumData<TYPES>, 
 pub type DACertificate<TYPES> = SimpleCertificate<TYPES, DAData, SuccessThreshold>;
 /// Type alias for a Timeout certificate over a view number
 pub type TimeoutCertificate<TYPES> = SimpleCertificate<TYPES, TimeoutData<TYPES>, SuccessThreshold>;
-
-// TODO ED Update this to use the correct threshold instead of the default `success_threshold`
 /// Type alias for a `ViewSyncPreCommit` certificate over a view number
 pub type ViewSyncPreCommitCertificate2<TYPES> =
     SimpleCertificate<TYPES, ViewSyncPreCommitData<TYPES>, OneHonestThreshold>;

--- a/crates/types/src/simple_certificate.rs
+++ b/crates/types/src/simple_certificate.rs
@@ -94,7 +94,7 @@ impl<TYPES: NodeType, VOTEABLE: Voteable + 'static, THRESHHOLD: Threshhold<TYPES
         }
         let real_qc_pp = <TYPES::SignatureKey as SignatureKey>::get_public_parameter(
             membership.get_committee_qc_stake_table(),
-            U256::from(membership.success_threshold().get()),
+            U256::from(Self::threshold(membership)),
         );
         <TYPES::SignatureKey as SignatureKey>::check(
             &real_qc_pp,

--- a/crates/types/src/vote.rs
+++ b/crates/types/src/vote.rs
@@ -14,7 +14,7 @@ use hotshot_utils::bincode::bincode_opts;
 use tracing::error;
 
 use crate::{
-    simple_certificate::Threshhold,
+    simple_certificate::Threshold,
     simple_vote::Voteable,
     traits::{
         election::Membership,
@@ -55,7 +55,7 @@ pub trait Certificate<TYPES: NodeType>: HasViewNumber<TYPES> {
     type Voteable: Voteable;
 
     /// Threshold Functions
-    type Threshhold: Threshhold<TYPES>;
+    type Threshold: Threshold<TYPES>;
 
     /// Build a certificate from the data commitment and the quorum of signers
     fn create_signed_certificate(

--- a/crates/types/src/vote.rs
+++ b/crates/types/src/vote.rs
@@ -14,6 +14,7 @@ use hotshot_utils::bincode::bincode_opts;
 use tracing::error;
 
 use crate::{
+    simple_certificate::Threshhold,
     simple_vote::Voteable,
     traits::{
         election::Membership,
@@ -52,6 +53,9 @@ The votes all must be over the `Commitment` associated type.
 pub trait Certificate<TYPES: NodeType>: HasViewNumber<TYPES> {
     /// The data commitment this certificate certifies.
     type Voteable: Voteable;
+
+    /// Threshold Functions
+    type Threshhold: Threshhold<TYPES>;
 
     /// Build a certificate from the data commitment and the quorum of signers
     fn create_signed_certificate(


### PR DESCRIPTION
Closes #2243 

### This PR: 
- Adds two structures to swap between different thresholds in `SimpleCertificate`
- Makes the ViewSyncPreCommitCertificate type use the threshold of f+1 and the rest us 2f+1
- Use the `Certificate::threshold` function in `is_valid_cert`
- Always send a pre commit vote after a timeout to the next relay, unless we are already finalized
- Fixes a bug where only one vote accumulator is spawned for a relay, now one is spawned for each phase in a view
- Get rid of `ViewSyncRelayTaskState` - it was not in current use and it was just a wrapper around vote accumulation anyways
- Removes phase checks in the replica tasks because we should respond to all certificates with a vote (if relay 1 gets to commit, but we timeout we don't want to ignore the next pre-commit cert)

### This PR does not: 

Fix the issue with duplicate events being sent through the view sync task

### Key places to review: 

The changes to the view_sync.rs file should be looked at closely since some logic does change

