### PR TITLE
refactor: allow configurable stake table capacity

### DIFF
--- a/crates/hotshot-state-prover/src/utils.rs
+++ b/crates/hotshot-state-prover/src/utils.rs
@@ -32,10 +32,11 @@ pub(crate) fn key_pairs_for_testing<R: CryptoRng + RngCore>(
 
 /// Helper function for test
 pub(crate) fn stake_table_for_testing(
+    capacity: usize,
     bls_keys: &[BLSVerKey],
     schnorr_keys: &[(SchnorrSignKey, SchnorrVerKey)],
 ) -> StakeTable<BLSVerKey, SchnorrVerKey, F> {
-    let mut st = StakeTable::<BLSVerKey, SchnorrVerKey, F>::new();
+    let mut st = StakeTable::<BLSVerKey, SchnorrVerKey, F>::new(capacity);
     // Registering keys
     bls_keys
         .iter()


### PR DESCRIPTION
As part of https://github.com/EspressoSystems/espresso-sequencer/issues/706, we realized that having a hardcoded `STAKE_TABLE_CAPACITY = 200` is a pain as it results in a million gates circuit and slow down unit tests significantly. 


### This PR: 

We introduce configurability of this hyperparameter via generic constant in `state-prover`'s API and `StakeTable::new(capacity)` in `stake-table` crate.

### Key places to review: 

API changes are sensible, as they are breaking changes (which is fine since we are not using in any testnet yet). 

