### PR TITLE
[Stability] Disallow old votes

### DIFF
--- a/crates/web_server/src/lib.rs
+++ b/crates/web_server/src/lib.rs
@@ -391,7 +391,7 @@ impl<KEY: SignatureKey> WebServerDataSource<KEY> for WebServerState<KEY> {
         if self.oldest_vote > view_number {
             return Err(ServerError {
                 status: StatusCode::Gone,
-                message: format!("Posted vote is too old"),
+                message: "Posted vote is too old".to_string(),
             });
         }
 
@@ -420,7 +420,7 @@ impl<KEY: SignatureKey> WebServerDataSource<KEY> for WebServerState<KEY> {
         if self.oldest_vid_vote > view_number {
             return Err(ServerError {
                 status: StatusCode::Gone,
-                message: format!("Posted vid vote is too old"),
+                message: "Posted vid vote is too old".to_string(),
             });
         }
 
@@ -451,7 +451,7 @@ impl<KEY: SignatureKey> WebServerDataSource<KEY> for WebServerState<KEY> {
         if self.oldest_view_sync_vote > view_number {
             return Err(ServerError {
                 status: StatusCode::Gone,
-                message: format!("Posted view sync vote is too old"),
+                message: "Posted view sync vote is too old".to_string(),
             });
         }
 

--- a/crates/web_server/src/lib.rs
+++ b/crates/web_server/src/lib.rs
@@ -386,6 +386,15 @@ impl<KEY: SignatureKey> WebServerDataSource<KEY> for WebServerState<KEY> {
                 self.oldest_vote += 1;
             }
         }
+
+        // don't accept the vote if it is too old
+        if self.oldest_vote > view_number {
+            return Err(ServerError {
+                status: StatusCode::Gone,
+                message: format!("Posted vote is too old"),
+            });
+        }
+
         let next_index = self.vote_index.entry(view_number).or_insert(0);
         self.votes
             .entry(view_number)
@@ -406,6 +415,15 @@ impl<KEY: SignatureKey> WebServerDataSource<KEY> for WebServerState<KEY> {
                 self.oldest_vid_vote += 1;
             }
         }
+
+        // don't accept the vote if it is too old
+        if self.oldest_vid_vote > view_number {
+            return Err(ServerError {
+                status: StatusCode::Gone,
+                message: format!("Posted vid vote is too old"),
+            });
+        }
+
         let next_index = self.vid_vote_index.entry(view_number).or_insert(0);
         self.vid_votes
             .entry(view_number)
@@ -428,6 +446,15 @@ impl<KEY: SignatureKey> WebServerDataSource<KEY> for WebServerState<KEY> {
                 self.oldest_view_sync_vote += 1;
             }
         }
+
+        // don't accept the vote if it is too old
+        if self.oldest_view_sync_vote > view_number {
+            return Err(ServerError {
+                status: StatusCode::Gone,
+                message: format!("Posted view sync vote is too old"),
+            });
+        }
+
         let next_index = self.view_sync_vote_index.entry(view_number).or_insert(0);
         self.view_sync_votes
             .entry(view_number)


### PR DESCRIPTION
Closes issue #2253 

### This PR: 
<!-- Describe what this PR adds to HotSHot -->
<!-- E.g. -->
<!-- * Implements feature 1 -->
<!-- * Implements feature 2 -->
<!-- * Fixes bug 3 -->

Disallows old VID, view sync, and quorum votes from being stored on the webserver. 

An attempt to post an old vote for any of the above three types will return an error.

### This PR does not: 
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->

Change any proposal-related logic.

### Key places to review: 
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->

`lib.rs`

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
