### PR TITLE
[Stability] Fix DA cert leak

### DIFF
--- a/crates/hotshot/src/lib.rs
+++ b/crates/hotshot/src/lib.rs
@@ -245,7 +245,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> SystemContext<TYPES, I> {
             last_decided_view: anchored_leaf.get_view_number(),
             saved_leaves,
             saved_payloads,
-            saved_da_certs: BTreeMap::new(),
+            saved_da_certs: HashMap::new(),
             // TODO this is incorrect
             // https://github.com/EspressoSystems/HotShot/issues/560
             locked_view: anchored_leaf.get_view_number(),

--- a/crates/hotshot/src/lib.rs
+++ b/crates/hotshot/src/lib.rs
@@ -245,6 +245,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> SystemContext<TYPES, I> {
             last_decided_view: anchored_leaf.get_view_number(),
             saved_leaves,
             saved_payloads,
+            saved_da_certs: BTreeMap::new(),
             // TODO this is incorrect
             // https://github.com/EspressoSystems/HotShot/issues/560
             locked_view: anchored_leaf.get_view_number(),

--- a/crates/hotshot/src/tasks/mod.rs
+++ b/crates/hotshot/src/tasks/mod.rs
@@ -230,7 +230,6 @@ pub async fn add_consensus_task<TYPES: NodeType, I: NodeImplementation<TYPES>>(
         timeout_task: None,
         event_stream: event_stream.clone(),
         output_event_stream: output_stream,
-        da_certs: HashMap::new(),
         vid_shares: HashMap::new(),
         current_proposal: None,
         id: handle.hotshot.inner.id,

--- a/crates/task-impls/src/consensus.rs
+++ b/crates/task-impls/src/consensus.rs
@@ -21,7 +21,7 @@ use hotshot_types::{
     data::{Leaf, QuorumProposal, VidCommitment, VidDisperse},
     event::{Event, EventType},
     message::{GeneralConsensusMessage, Proposal},
-    simple_certificate::{DACertificate, QuorumCertificate, TimeoutCertificate},
+    simple_certificate::{QuorumCertificate, TimeoutCertificate},
     simple_vote::{QuorumData, QuorumVote, TimeoutData, TimeoutVote},
     traits::{
         block_contents::BlockHeader,
@@ -113,9 +113,6 @@ pub struct ConsensusTaskState<
 
     /// Event stream to publish events to the application layer
     pub output_event_stream: ChannelStream<Event<TYPES>>,
-
-    /// All the DA certs we've received for current and future views.
-    pub da_certs: HashMap<TYPES::Time, DACertificate<TYPES>>,
 
     /// All the VID shares we've received for current and future views.
     /// In the future we will need a different struct similar to VidDisperse except
@@ -246,7 +243,13 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
 
             // Only vote if you have the DA cert
             // ED Need to update the view number this is stored under?
-            if let Some(cert) = self.da_certs.get(&(proposal.get_view_number())) {
+            if let Some(cert) = self
+                .consensus
+                .read()
+                .await
+                .saved_da_certs
+                .get(&(proposal.get_view_number()))
+            {
                 let view = cert.view_number;
                 // TODO: do some of this logic without the vote token check, only do that when voting.
                 let justify_qc = proposal.justify_qc.clone();
@@ -346,12 +349,6 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
             // cancel the old timeout task
             if let Some(timeout_task) = self.timeout_task.take() {
                 cancel_task(timeout_task).await;
-            }
-
-            // Remove old certs, we won't vote on past views
-            for view in *self.cur_view..*new_view - 1 {
-                let v = TYPES::Time::new(view);
-                self.da_certs.remove(&v);
             }
             self.cur_view = new_view;
 
@@ -739,11 +736,6 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                     return;
                 }
                 self.current_proposal = None;
-
-                for v in (*self.cur_view)..=(*view) {
-                    let time = TYPES::Time::new(v);
-                    self.da_certs.remove(&time);
-                }
             }
             HotShotEvent::QuorumVoteRecv(ref vote) => {
                 debug!("Received quroum vote: {:?}", vote.get_view_number());
@@ -910,7 +902,11 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                     .inject_consensus_info(ConsensusIntentEvent::CancelPollForVotes(*view))
                     .await;
 
-                self.da_certs.insert(view, cert);
+                self.consensus
+                    .write()
+                    .await
+                    .saved_da_certs
+                    .insert(view, cert);
 
                 if self.vote_if_able().await {
                     self.current_proposal = None;


### PR DESCRIPTION
Closes #2262 

### This PR: 
<!-- Describe what this PR adds to HotSHot -->
<!-- E.g. -->
<!-- * Implements feature 1 -->
<!-- * Implements feature 2 -->
<!-- * Fixes bug 3 -->

Fixes the DA cert memory leak by:
- moving DA cert storage to the consensus struct as opposed to the consensus task
- removing DA cert garbage collection routine, reimplementing it in `collect_garbage`

### This PR does not: 
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->

Change any DA cert functionality.

### Key places to review: 
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->
`collect_garbage` in `consensus.rs` 

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->
Local tests are passing ✅ 
Also tested that DA certs are properly GCed now ✅  (we only have 4-8 at any given time)

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
