### PR TITLE
[FIX_CI] - Fix nondeterministic result for the network task test

### DIFF
--- a/crates/task-impls/src/harness.rs
+++ b/crates/task-impls/src/harness.rs
@@ -10,7 +10,7 @@ use hotshot_task::{
 };
 use hotshot_types::traits::node_implementation::NodeType;
 use snafu::Snafu;
-use std::{collections::HashMap, future::Future, sync::Arc};
+use std::{collections::HashMap, future::Future, sync::Arc, thread::sleep, time::Duration};
 
 /// The state for the test harness task. Keeps track of which events and how many we expect to get
 pub struct TestHarnessState<TYPES: NodeType> {
@@ -107,6 +107,8 @@ pub fn handle_event<TYPES: NodeType>(
     }
 
     if state.expected_output.is_empty() {
+        // Sleep before the shutdown in case other tasks are still running.
+        sleep(Duration::from_millis(100));
         return (Some(HotShotTaskCompleted::ShutDown), state);
     }
 

--- a/crates/testing/tests/consensus_task.rs
+++ b/crates/testing/tests/consensus_task.rs
@@ -127,7 +127,7 @@ async fn test_consensus_task() {
         add_consensus_task(task_runner, event_stream, ChannelStream::new(), handle)
     };
 
-    run_harness(input, output, None, build_fn).await;
+    run_harness(input, output, None, build_fn, false).await;
 }
 
 #[cfg(test)]
@@ -177,5 +177,5 @@ async fn test_consensus_vote() {
         add_consensus_task(task_runner, event_stream, ChannelStream::new(), handle)
     };
 
-    run_harness(input, output, None, build_fn).await;
+    run_harness(input, output, None, build_fn, false).await;
 }

--- a/crates/testing/tests/da_task.rs
+++ b/crates/testing/tests/da_task.rs
@@ -103,5 +103,5 @@ async fn test_da_task() {
 
     let build_fn = |task_runner, event_stream| add_da_task(task_runner, event_stream, handle);
 
-    run_harness(input, output, None, build_fn).await;
+    run_harness(input, output, None, build_fn, false).await;
 }

--- a/crates/testing/tests/network_task.rs
+++ b/crates/testing/tests/network_task.rs
@@ -97,7 +97,9 @@ async fn test_network_task() {
         quorum_proposal.clone(),
         pub_key,
     ));
-    input.push(HotShotEvent::Shutdown);
+    // Don't send `Shutdown` as other task unit tests do, to avoid nondeterministic behaviors due
+    // to some tasks shut down earlier than the testing harness and we don't get all the expected
+    // events.
 
     output.insert(HotShotEvent::ViewChange(ViewNumber::new(1)), 2);
     output.insert(
@@ -110,7 +112,7 @@ async fn test_network_task() {
     );
     output.insert(
         HotShotEvent::DAProposalSend(da_proposal.clone(), pub_key),
-        2, // 2 occurrences: 1 from `input`, 1 from the DA task
+        3, // 2 occurrences: 1 from `input`, 2 from the DA task
     );
     output.insert(
         HotShotEvent::VidDisperseSend(vid_proposal.clone(), pub_key),
@@ -128,7 +130,7 @@ async fn test_network_task() {
     output.insert(HotShotEvent::ViewChange(ViewNumber::new(2)), 2);
     output.insert(
         HotShotEvent::SendPayloadCommitmentAndMetadata(payload_commitment, ()),
-        1,
+        2, // 2 occurrences: both from the VID task
     );
     output.insert(
         HotShotEvent::QuorumProposalRecv(quorum_proposal, pub_key),
@@ -136,8 +138,11 @@ async fn test_network_task() {
     );
     output.insert(HotShotEvent::VidDisperseRecv(vid_proposal, pub_key), 1);
     output.insert(HotShotEvent::DAProposalRecv(da_proposal, pub_key), 1);
-    output.insert(HotShotEvent::Shutdown, 1);
 
     let build_fn = |task_runner, _| async { task_runner };
-    run_harness(input, output, Some(event_stream), build_fn).await;
+    // There may be extra outputs not in the expected set, e.g., a second `VidDisperseRecv` if the
+    // VID task runs fast. All event types we want to test should be seen by this point, so waiting
+    // for more events will not help us test more cases for now. Therefore, we set
+    // `allow_extra_output` to `true` for deterministic test result.
+    run_harness(input, output, Some(event_stream), build_fn, true).await;
 }

--- a/crates/testing/tests/vid_task.rs
+++ b/crates/testing/tests/vid_task.rs
@@ -113,5 +113,5 @@ async fn test_vid_task() {
 
     let build_fn = |task_runner, event_stream| add_vid_task(task_runner, event_stream, handle);
 
-    run_harness(input, output, None, build_fn).await;
+    run_harness(input, output, None, build_fn, false).await;
 }

--- a/crates/testing/tests/view_sync_task.rs
+++ b/crates/testing/tests/view_sync_task.rs
@@ -58,5 +58,5 @@ async fn test_view_sync_task() {
     let build_fn =
         |task_runner, event_stream| add_view_sync_task(task_runner, event_stream, handle);
 
-    run_harness(input, output, None, build_fn).await;
+    run_harness(input, output, None, build_fn, false).await;
 }


### PR DESCRIPTION
Closes https://github.com/EspressoSystems/HotShot/issues/2214.

### This PR: 
* Removes `Shutdown` from the network task test, to run tasks until the testing harness shuts down.
* Increases the expected count of `DAProposalSend` and `SendPayloadCommitmentAndMetadata` due to allowing tasks to run longer.
* Adds a boolean parameter to the testing harness to allow extra outputs after receiving all expected ones.

### This PR does not: 
Fix other CI failures if any.

### Key places to review: 
All changes.
