### PR TITLE
Propose after multiple timeouts

### DIFF
--- a/crates/hotshot/src/tasks/mod.rs
+++ b/crates/hotshot/src/tasks/mod.rs
@@ -228,6 +228,7 @@ pub async fn add_consensus_task<TYPES: NodeType, I: NodeImplementation<TYPES>>(
         vote_collector: None,
         timeout_vote_collector: None,
         timeout_task: None,
+        timeout_cert: None,
         event_stream: event_stream.clone(),
         output_event_stream: output_stream,
         vid_shares: HashMap::new(),

--- a/crates/task-impls/src/consensus.rs
+++ b/crates/task-impls/src/consensus.rs
@@ -852,7 +852,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                         ))
                         .await;
 
-                    error!(
+                    debug!(
                         "Attempting to publish proposal after forming a TC for view {}",
                         *qc.view_number
                     );
@@ -861,7 +861,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
 
                     if self.publish_proposal_if_able(view, Some(qc.clone())).await {
                     } else {
-                        error!("Wasn't able to publish proposal");
+                        warn!("Wasn't able to publish proposal");
                     }
                 }
                 if let either::Left(qc) = cert {
@@ -892,7 +892,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                 }
             }
             HotShotEvent::DACRecv(cert) => {
-                error!("DAC Recved for view ! {}", *cert.view_number);
+                debug!("DAC Recved for view ! {}", *cert.view_number);
                 let view = cert.view_number;
 
                 self.quorum_network
@@ -1035,7 +1035,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                 consensus.metrics.number_of_timeouts.add(1);
             }
             HotShotEvent::SendPayloadCommitmentAndMetadata(payload_commitment, metadata, view) => {
-                error!("got commit and meta {:?}", payload_commitment);
+                debug!("got commit and meta {:?}", payload_commitment);
                 self.payload_commitment_and_metadata = Some((payload_commitment, metadata));
                 if self.quorum_membership.get_leader(view) == self.public_key
                     && self.consensus.read().await.high_qc.get_view_number() == view
@@ -1043,8 +1043,11 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                     self.publish_proposal_if_able(view, None).await;
                 }
                 if let Some(tc) = &self.timeout_cert {
-                    if self.quorum_membership.get_leader(tc.get_view_number() + 1) == self.public_key {
-                        self.publish_proposal_if_able(view, self.timeout_cert.clone()).await;
+                    if self.quorum_membership.get_leader(tc.get_view_number() + 1)
+                        == self.public_key
+                    {
+                        self.publish_proposal_if_able(view, self.timeout_cert.clone())
+                            .await;
                     }
                 }
             }
@@ -1156,7 +1159,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                 signature,
                 _pd: PhantomData,
             };
-            error!(
+            debug!(
                 "Sending proposal for view {:?} \n {:?}",
                 leaf.view_number, ""
             );
@@ -1169,7 +1172,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
             self.payload_commitment_and_metadata = None;
             return true;
         }
-        error!("Cannot propose because we don't have the VID payload commitment and metadata");
+        debug!("Cannot propose because we don't have the VID payload commitment and metadata");
         false
     }
 }

--- a/crates/task-impls/src/consensus.rs
+++ b/crates/task-impls/src/consensus.rs
@@ -422,7 +422,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
     pub async fn handle_event(&mut self, event: HotShotEvent<TYPES>) {
         match event {
             HotShotEvent::QuorumProposalRecv(proposal, sender) => {
-                error!(
+                debug!(
                     "Receved Quorum Proposal for view {}",
                     *proposal.data.view_number
                 );

--- a/crates/task-impls/src/consensus.rs
+++ b/crates/task-impls/src/consensus.rs
@@ -1037,12 +1037,10 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
             HotShotEvent::SendPayloadCommitmentAndMetadata(payload_commitment, metadata, view) => {
                 error!("got commit and meta {:?}", payload_commitment);
                 self.payload_commitment_and_metadata = Some((payload_commitment, metadata));
-                if let Some(proposal) = &self.current_proposal {
-                    if self.quorum_membership.get_leader(view) == self.public_key
-                        && proposal.get_view_number() + 1 == view
-                    {
-                        self.publish_proposal_if_able(view, None).await;
-                    }
+                if self.quorum_membership.get_leader(view) == self.public_key
+                    && self.consensus.read().await.high_qc.get_view_number() == view
+                {
+                    self.publish_proposal_if_able(view, None).await;
                 }
                 if let Some(tc) = &self.timeout_cert {
                     if self.quorum_membership.get_leader(tc.get_view_number() + 1) == self.public_key {

--- a/crates/task-impls/src/consensus.rs
+++ b/crates/task-impls/src/consensus.rs
@@ -1044,6 +1044,11 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                         self.publish_proposal_if_able(view, None).await;
                     }
                 }
+                if let Some(tc) = &self.timeout_cert {
+                    if self.quorum_membership.get_leader(tc.get_view_number() + 1) == self.public_key {
+                        self.publish_proposal_if_able(view, self.timeout_cert.clone()).await;
+                    }
+                }
             }
             _ => {}
         }
@@ -1147,6 +1152,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                 proposer_id: leaf.proposer_id,
             };
 
+            self.timeout_cert = None;
             let message = Proposal {
                 data: proposal,
                 signature,

--- a/crates/task-impls/src/events.rs
+++ b/crates/task-impls/src/events.rs
@@ -91,6 +91,7 @@ pub enum HotShotEvent<TYPES: NodeType> {
     SendPayloadCommitmentAndMetadata(
         VidCommitment,
         <TYPES::BlockPayload as BlockPayload>::Metadata,
+        TYPES::Time,
     ),
     /// Event when the transactions task has sequenced transactions. Contains the encoded transactions, the metadata, and the view number
     TransactionsSequenced(

--- a/crates/task-impls/src/transactions.rs
+++ b/crates/task-impls/src/transactions.rs
@@ -172,7 +172,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                 let mut make_block = false;
                 if *view - *self.cur_view > 1 {
                     error!("View changed by more than 1 going to view {:?}", view);
-                    make_block = self.membership.get_leader(view) == self.public_key
+                    make_block = self.membership.get_leader(view) == self.public_key;
                 }
                 self.cur_view = view;
 
@@ -231,11 +231,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                 };
 
                 // send the sequenced transactions to VID and DA tasks
-                let block_view = if make_block {
-                    view
-                } else {
-                    view + 1
-                };
+                let block_view = if make_block { view } else { view + 1 };
                 self.event_stream
                     .publish(HotShotEvent::TransactionsSequenced(
                         encoded_transactions,

--- a/crates/task-impls/src/transactions.rs
+++ b/crates/task-impls/src/transactions.rs
@@ -169,12 +169,15 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                     return None;
                 }
 
+                let mut make_block = false;
                 if *view - *self.cur_view > 1 {
-                    warn!("View changed by more than 1 going to view {:?}", view);
+                    error!("View changed by more than 1 going to view {:?}", view);
+                    make_block = self.membership.get_leader(view) == self.public_key
                 }
                 self.cur_view = view;
 
-                if self.membership.get_leader(self.cur_view + 1) != self.public_key {
+                // return if we aren't the next leader or we skipped last view and aren't the current leader.
+                if !make_block && self.membership.get_leader(self.cur_view + 1) != self.public_key {
                     return None;
                 }
 
@@ -228,11 +231,16 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                 };
 
                 // send the sequenced transactions to VID and DA tasks
+                let block_view = if make_block {
+                    view
+                } else {
+                    view + 1
+                };
                 self.event_stream
                     .publish(HotShotEvent::TransactionsSequenced(
                         encoded_transactions,
                         metadata,
-                        view + 1,
+                        block_view,
                     ))
                     .await;
 

--- a/crates/task-impls/src/vid.rs
+++ b/crates/task-impls/src/vid.rs
@@ -98,6 +98,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                     .publish(HotShotEvent::SendPayloadCommitmentAndMetadata(
                         vid_disperse.commit,
                         metadata,
+                        view_number,
                     ))
                     .await;
 

--- a/crates/task-impls/src/view_sync.rs
+++ b/crates/task-impls/src/view_sync.rs
@@ -740,7 +740,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                 );
 
                 self.event_stream
-                    .publish(HotShotEvent::ViewChange(self.next_view-1))
+                    .publish(HotShotEvent::ViewChange(self.next_view - 1))
                     .await;
 
                 self.event_stream

--- a/crates/task-impls/src/view_sync.rs
+++ b/crates/task-impls/src/view_sync.rs
@@ -740,6 +740,10 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                 );
 
                 self.event_stream
+                    .publish(HotShotEvent::ViewChange(self.next_view-1))
+                    .await;
+
+                self.event_stream
                     .publish(HotShotEvent::ViewChange(self.next_view))
                     .await;
 

--- a/crates/testing/tests/basic.rs
+++ b/crates/testing/tests/basic.rs
@@ -227,7 +227,7 @@ async fn test_with_failures_2() {
     // Make sure we keep commiting rounds after the bad leaders, but not the full 50 because of the numerous timeouts
     metadata.overall_safety_properties.num_successful_views = 15;
     metadata
-        .gen_launcher::<TestTypes, MemoryImpl>(0)
+        .gen_launcher::<TestTypes, WebImpl>(0)
         .launch()
         .run_test()
         .await;

--- a/crates/testing/tests/basic.rs
+++ b/crates/testing/tests/basic.rs
@@ -110,8 +110,7 @@ async fn test_with_failures_half_f() {
         node_changes: vec![(5, dead_nodes)],
     };
 
-    // TODO: this should only have 3 failures for each down leader, investigate why it fails additional views
-    metadata.overall_safety_properties.num_failed_views = 8;
+    metadata.overall_safety_properties.num_failed_views = 3;
     // Make sure we keep commiting rounds after the bad leaders, but not the full 50 because of the numerous timeouts
     metadata.overall_safety_properties.num_successful_views = 22;
     metadata
@@ -176,6 +175,54 @@ async fn test_with_failures_f() {
     metadata.spinning_properties = SpinningTaskDescription {
         node_changes: vec![(5, dead_nodes)],
     };
+    metadata
+        .gen_launcher::<TestTypes, MemoryImpl>(0)
+        .launch()
+        .run_test()
+        .await;
+}
+
+/// Test that a good leader can succeed in the view directly after view sync
+#[cfg(test)]
+#[cfg_attr(
+    async_executor_impl = "tokio",
+    tokio::test(flavor = "multi_thread", worker_threads = 2)
+)]
+#[cfg_attr(async_executor_impl = "async-std", async_std::test)]
+async fn test_with_failures_2() {
+    use hotshot_testing::{
+        node_types::{MemoryImpl, TestTypes},
+        spinning_task::{ChangeNode, SpinningTaskDescription, UpDown},
+        test_builder::TestMetadata,
+    };
+
+    async_compatibility_layer::logging::setup_logging();
+    async_compatibility_layer::logging::setup_backtrace();
+    let mut metadata = TestMetadata::default_more_nodes();
+    // The first 14 (i.e., 20 - f) nodes are in the DA committee and we may shutdown the
+    // remaining 6 (i.e., f) nodes. We could remove this restriction after fixing the
+    // following issue.
+    // TODO: Update message broadcasting to avoid hanging
+    // <https://github.com/EspressoSystems/HotShot/issues/1567>
+    let dead_nodes = vec![
+        ChangeNode {
+            idx: 17,
+            updown: UpDown::Down,
+        },
+        ChangeNode {
+            idx: 18,
+            updown: UpDown::Down,
+        },
+    ];
+
+    metadata.spinning_properties = SpinningTaskDescription {
+        node_changes: vec![(5, dead_nodes)],
+    };
+
+    // 2 nodes fail triggering view sync, expect no other timeouts
+    metadata.overall_safety_properties.num_failed_views = 2;
+    // Make sure we keep commiting rounds after the bad leaders, but not the full 50 because of the numerous timeouts
+    metadata.overall_safety_properties.num_successful_views = 25;
     metadata
         .gen_launcher::<TestTypes, MemoryImpl>(0)
         .launch()

--- a/crates/testing/tests/basic.rs
+++ b/crates/testing/tests/basic.rs
@@ -191,7 +191,7 @@ async fn test_with_failures_f() {
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 async fn test_with_failures_2() {
     use hotshot_testing::{
-        node_types::{MemoryImpl, TestTypes},
+        node_types::{WebImpl, TestTypes},
         spinning_task::{ChangeNode, SpinningTaskDescription, UpDown},
         test_builder::TestMetadata,
     };
@@ -224,7 +224,7 @@ async fn test_with_failures_2() {
     // Make sure we keep commiting rounds after the bad leaders, but not the full 50 because of the numerous timeouts
     metadata.overall_safety_properties.num_successful_views = 25;
     metadata
-        .gen_launcher::<TestTypes, MemoryImpl>(0)
+        .gen_launcher::<TestTypes, WebImpl>(0)
         .launch()
         .run_test()
         .await;

--- a/crates/testing/tests/basic.rs
+++ b/crates/testing/tests/basic.rs
@@ -1,186 +1,186 @@
-// #[cfg(test)]
-// #[cfg_attr(
-//     async_executor_impl = "tokio",
-//     tokio::test(flavor = "multi_thread", worker_threads = 2)
-// )]
-// #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
-// async fn test_success() {
-//     use hotshot_testing::{
-//         completion_task::{CompletionTaskDescription, TimeBasedCompletionTaskDescription},
-//         node_types::{MemoryImpl, TestTypes},
-//         test_builder::TestMetadata,
-//     };
-//     use std::time::Duration;
+#[cfg(test)]
+#[cfg_attr(
+    async_executor_impl = "tokio",
+    tokio::test(flavor = "multi_thread", worker_threads = 2)
+)]
+#[cfg_attr(async_executor_impl = "async-std", async_std::test)]
+async fn test_success() {
+    use hotshot_testing::{
+        completion_task::{CompletionTaskDescription, TimeBasedCompletionTaskDescription},
+        node_types::{MemoryImpl, TestTypes},
+        test_builder::TestMetadata,
+    };
+    use std::time::Duration;
 
-//     async_compatibility_layer::logging::setup_logging();
-//     async_compatibility_layer::logging::setup_backtrace();
-//     let metadata = TestMetadata {
-//         // allow more time to pass in CI
-//         completion_task_description: CompletionTaskDescription::TimeBasedCompletionTaskBuilder(
-//             TimeBasedCompletionTaskDescription {
-//                 duration: Duration::from_secs(60),
-//             },
-//         ),
-//         ..TestMetadata::default()
-//     };
-//     metadata
-//         .gen_launcher::<TestTypes, MemoryImpl>(0)
-//         .launch()
-//         .run_test()
-//         .await;
-// }
+    async_compatibility_layer::logging::setup_logging();
+    async_compatibility_layer::logging::setup_backtrace();
+    let metadata = TestMetadata {
+        // allow more time to pass in CI
+        completion_task_description: CompletionTaskDescription::TimeBasedCompletionTaskBuilder(
+            TimeBasedCompletionTaskDescription {
+                duration: Duration::from_secs(60),
+            },
+        ),
+        ..TestMetadata::default()
+    };
+    metadata
+        .gen_launcher::<TestTypes, MemoryImpl>(0)
+        .launch()
+        .run_test()
+        .await;
+}
 
-// /// Test one node leaving the network.
-// #[cfg(test)]
-// #[cfg_attr(
-//     async_executor_impl = "tokio",
-//     tokio::test(flavor = "multi_thread", worker_threads = 2)
-// )]
-// #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
-// async fn test_with_failures_one() {
-//     use hotshot_testing::{
-//         node_types::{MemoryImpl, TestTypes},
-//         spinning_task::{ChangeNode, SpinningTaskDescription, UpDown},
-//         test_builder::TestMetadata,
-//     };
+/// Test one node leaving the network.
+#[cfg(test)]
+#[cfg_attr(
+    async_executor_impl = "tokio",
+    tokio::test(flavor = "multi_thread", worker_threads = 2)
+)]
+#[cfg_attr(async_executor_impl = "async-std", async_std::test)]
+async fn test_with_failures_one() {
+    use hotshot_testing::{
+        node_types::{MemoryImpl, TestTypes},
+        spinning_task::{ChangeNode, SpinningTaskDescription, UpDown},
+        test_builder::TestMetadata,
+    };
 
-//     async_compatibility_layer::logging::setup_logging();
-//     async_compatibility_layer::logging::setup_backtrace();
-//     let mut metadata = TestMetadata::default_more_nodes();
-//     // The first 14 (i.e., 20 - f) nodes are in the DA committee and we may shutdown the
-//     // remaining 6 (i.e., f) nodes. We could remove this restriction after fixing the
-//     // following issue.
-//     // TODO: Update message broadcasting to avoid hanging
-//     // <https://github.com/EspressoSystems/HotShot/issues/1567>
-//     let dead_nodes = vec![ChangeNode {
-//         idx: 19,
-//         updown: UpDown::Down,
-//     }];
+    async_compatibility_layer::logging::setup_logging();
+    async_compatibility_layer::logging::setup_backtrace();
+    let mut metadata = TestMetadata::default_more_nodes();
+    // The first 14 (i.e., 20 - f) nodes are in the DA committee and we may shutdown the
+    // remaining 6 (i.e., f) nodes. We could remove this restriction after fixing the
+    // following issue.
+    // TODO: Update message broadcasting to avoid hanging
+    // <https://github.com/EspressoSystems/HotShot/issues/1567>
+    let dead_nodes = vec![ChangeNode {
+        idx: 19,
+        updown: UpDown::Down,
+    }];
 
-//     metadata.spinning_properties = SpinningTaskDescription {
-//         node_changes: vec![(5, dead_nodes)],
-//     };
-//     metadata.overall_safety_properties.num_failed_views = 3;
-//     metadata.overall_safety_properties.num_successful_views = 25;
-//     metadata
-//         .gen_launcher::<TestTypes, MemoryImpl>(0)
-//         .launch()
-//         .run_test()
-//         .await;
-// }
+    metadata.spinning_properties = SpinningTaskDescription {
+        node_changes: vec![(5, dead_nodes)],
+    };
+    metadata.overall_safety_properties.num_failed_views = 3;
+    metadata.overall_safety_properties.num_successful_views = 25;
+    metadata
+        .gen_launcher::<TestTypes, MemoryImpl>(0)
+        .launch()
+        .run_test()
+        .await;
+}
 
-// /// Test f/2 nodes leaving the network.
-// #[cfg(test)]
-// #[cfg_attr(
-//     async_executor_impl = "tokio",
-//     tokio::test(flavor = "multi_thread", worker_threads = 2)
-// )]
-// #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
-// async fn test_with_failures_half_f() {
-//     use hotshot_testing::{
-//         node_types::{MemoryImpl, TestTypes},
-//         spinning_task::{ChangeNode, SpinningTaskDescription, UpDown},
-//         test_builder::TestMetadata,
-//     };
+/// Test f/2 nodes leaving the network.
+#[cfg(test)]
+#[cfg_attr(
+    async_executor_impl = "tokio",
+    tokio::test(flavor = "multi_thread", worker_threads = 2)
+)]
+#[cfg_attr(async_executor_impl = "async-std", async_std::test)]
+async fn test_with_failures_half_f() {
+    use hotshot_testing::{
+        node_types::{MemoryImpl, TestTypes},
+        spinning_task::{ChangeNode, SpinningTaskDescription, UpDown},
+        test_builder::TestMetadata,
+    };
 
-//     async_compatibility_layer::logging::setup_logging();
-//     async_compatibility_layer::logging::setup_backtrace();
-//     let mut metadata = TestMetadata::default_more_nodes();
-//     // The first 14 (i.e., 20 - f) nodes are in the DA committee and we may shutdown the
-//     // remaining 6 (i.e., f) nodes. We could remove this restriction after fixing the
-//     // following issue.
-//     // TODO: Update message broadcasting to avoid hanging
-//     // <https://github.com/EspressoSystems/HotShot/issues/1567>
-//     let dead_nodes = vec![
-//         ChangeNode {
-//             idx: 17,
-//             updown: UpDown::Down,
-//         },
-//         ChangeNode {
-//             idx: 18,
-//             updown: UpDown::Down,
-//         },
-//         ChangeNode {
-//             idx: 19,
-//             updown: UpDown::Down,
-//         },
-//     ];
+    async_compatibility_layer::logging::setup_logging();
+    async_compatibility_layer::logging::setup_backtrace();
+    let mut metadata = TestMetadata::default_more_nodes();
+    // The first 14 (i.e., 20 - f) nodes are in the DA committee and we may shutdown the
+    // remaining 6 (i.e., f) nodes. We could remove this restriction after fixing the
+    // following issue.
+    // TODO: Update message broadcasting to avoid hanging
+    // <https://github.com/EspressoSystems/HotShot/issues/1567>
+    let dead_nodes = vec![
+        ChangeNode {
+            idx: 17,
+            updown: UpDown::Down,
+        },
+        ChangeNode {
+            idx: 18,
+            updown: UpDown::Down,
+        },
+        ChangeNode {
+            idx: 19,
+            updown: UpDown::Down,
+        },
+    ];
 
-//     metadata.spinning_properties = SpinningTaskDescription {
-//         node_changes: vec![(5, dead_nodes)],
-//     };
+    metadata.spinning_properties = SpinningTaskDescription {
+        node_changes: vec![(5, dead_nodes)],
+    };
 
-//     metadata.overall_safety_properties.num_failed_views = 3;
-//     // Make sure we keep commiting rounds after the bad leaders, but not the full 50 because of the numerous timeouts
-//     metadata.overall_safety_properties.num_successful_views = 22;
-//     metadata
-//         .gen_launcher::<TestTypes, MemoryImpl>(0)
-//         .launch()
-//         .run_test()
-//         .await;
-// }
+    metadata.overall_safety_properties.num_failed_views = 3;
+    // Make sure we keep commiting rounds after the bad leaders, but not the full 50 because of the numerous timeouts
+    metadata.overall_safety_properties.num_successful_views = 22;
+    metadata
+        .gen_launcher::<TestTypes, MemoryImpl>(0)
+        .launch()
+        .run_test()
+        .await;
+}
 
-// /// Test f nodes leaving the network.
-// #[cfg(test)]
-// #[cfg_attr(
-//     async_executor_impl = "tokio",
-//     tokio::test(flavor = "multi_thread", worker_threads = 2)
-// )]
-// #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
-// async fn test_with_failures_f() {
-//     use hotshot_testing::{
-//         node_types::{MemoryImpl, TestTypes},
-//         spinning_task::{ChangeNode, SpinningTaskDescription, UpDown},
-//         test_builder::TestMetadata,
-//     };
+/// Test f nodes leaving the network.
+#[cfg(test)]
+#[cfg_attr(
+    async_executor_impl = "tokio",
+    tokio::test(flavor = "multi_thread", worker_threads = 2)
+)]
+#[cfg_attr(async_executor_impl = "async-std", async_std::test)]
+async fn test_with_failures_f() {
+    use hotshot_testing::{
+        node_types::{MemoryImpl, TestTypes},
+        spinning_task::{ChangeNode, SpinningTaskDescription, UpDown},
+        test_builder::TestMetadata,
+    };
 
-//     async_compatibility_layer::logging::setup_logging();
-//     async_compatibility_layer::logging::setup_backtrace();
-//     let mut metadata = TestMetadata::default_more_nodes();
-//     metadata.overall_safety_properties.num_failed_views = 6;
-//     // Make sure we keep commiting rounds after the bad leaders, but not the full 50 because of the numerous timeouts
-//     metadata.overall_safety_properties.num_successful_views = 22;
-//     // The first 14 (i.e., 20 - f) nodes are in the DA committee and we may shutdown the
-//     // remaining 6 (i.e., f) nodes. We could remove this restriction after fixing the
-//     // following issue.
-//     // TODO: Update message broadcasting to avoid hanging
-//     // <https://github.com/EspressoSystems/HotShot/issues/1567>
-//     let dead_nodes = vec![
-//         ChangeNode {
-//             idx: 14,
-//             updown: UpDown::Down,
-//         },
-//         ChangeNode {
-//             idx: 15,
-//             updown: UpDown::Down,
-//         },
-//         ChangeNode {
-//             idx: 16,
-//             updown: UpDown::Down,
-//         },
-//         ChangeNode {
-//             idx: 17,
-//             updown: UpDown::Down,
-//         },
-//         ChangeNode {
-//             idx: 18,
-//             updown: UpDown::Down,
-//         },
-//         ChangeNode {
-//             idx: 19,
-//             updown: UpDown::Down,
-//         },
-//     ];
+    async_compatibility_layer::logging::setup_logging();
+    async_compatibility_layer::logging::setup_backtrace();
+    let mut metadata = TestMetadata::default_more_nodes();
+    metadata.overall_safety_properties.num_failed_views = 6;
+    // Make sure we keep commiting rounds after the bad leaders, but not the full 50 because of the numerous timeouts
+    metadata.overall_safety_properties.num_successful_views = 22;
+    // The first 14 (i.e., 20 - f) nodes are in the DA committee and we may shutdown the
+    // remaining 6 (i.e., f) nodes. We could remove this restriction after fixing the
+    // following issue.
+    // TODO: Update message broadcasting to avoid hanging
+    // <https://github.com/EspressoSystems/HotShot/issues/1567>
+    let dead_nodes = vec![
+        ChangeNode {
+            idx: 14,
+            updown: UpDown::Down,
+        },
+        ChangeNode {
+            idx: 15,
+            updown: UpDown::Down,
+        },
+        ChangeNode {
+            idx: 16,
+            updown: UpDown::Down,
+        },
+        ChangeNode {
+            idx: 17,
+            updown: UpDown::Down,
+        },
+        ChangeNode {
+            idx: 18,
+            updown: UpDown::Down,
+        },
+        ChangeNode {
+            idx: 19,
+            updown: UpDown::Down,
+        },
+    ];
 
-//     metadata.spinning_properties = SpinningTaskDescription {
-//         node_changes: vec![(5, dead_nodes)],
-//     };
-//     metadata
-//         .gen_launcher::<TestTypes, MemoryImpl>(0)
-//         .launch()
-//         .run_test()
-//         .await;
-// }
+    metadata.spinning_properties = SpinningTaskDescription {
+        node_changes: vec![(5, dead_nodes)],
+    };
+    metadata
+        .gen_launcher::<TestTypes, MemoryImpl>(0)
+        .launch()
+        .run_test()
+        .await;
+}
 
 /// Test that a good leader can succeed in the view directly after view sync
 #[cfg(test)]
@@ -191,7 +191,58 @@
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 async fn test_with_failures_2() {
     use hotshot_testing::{
-        node_types::{MemoryImpl, TestTypes, WebImpl},
+        node_types::{MemoryImpl, TestTypes},
+        spinning_task::{ChangeNode, SpinningTaskDescription, UpDown},
+        test_builder::TestMetadata,
+    };
+
+    async_compatibility_layer::logging::setup_logging();
+    async_compatibility_layer::logging::setup_backtrace();
+    let mut metadata = TestMetadata::default_more_nodes();
+    metadata.total_nodes = 12;
+    metadata.da_committee_size = 12;
+    metadata.start_nodes = 12;
+    // The first 14 (i.e., 20 - f) nodes are in the DA committee and we may shutdown the
+    // remaining 6 (i.e., f) nodes. We could remove this restriction after fixing the
+    // following issue.
+    // TODO: Update message broadcasting to avoid hanging
+    // <https://github.com/EspressoSystems/HotShot/issues/1567>
+    let dead_nodes = vec![
+        ChangeNode {
+            idx: 10,
+            updown: UpDown::Down,
+        },
+        ChangeNode {
+            idx: 11,
+            updown: UpDown::Down,
+        },
+    ];
+
+    metadata.spinning_properties = SpinningTaskDescription {
+        node_changes: vec![(5, dead_nodes)],
+    };
+
+    // 2 nodes fail triggering view sync, expect no other timeouts
+    metadata.overall_safety_properties.num_failed_views = 2;
+    // Make sure we keep commiting rounds after the bad leaders, but not the full 50 because of the numerous timeouts
+    metadata.overall_safety_properties.num_successful_views = 15;
+    metadata
+        .gen_launcher::<TestTypes, MemoryImpl>(0)
+        .launch()
+        .run_test()
+        .await;
+}
+
+/// Test that a good leader can succeed in the view directly after view sync
+#[cfg(test)]
+#[cfg_attr(
+    async_executor_impl = "tokio",
+    tokio::test(flavor = "multi_thread", worker_threads = 2)
+)]
+#[cfg_attr(async_executor_impl = "async-std", async_std::test)]
+async fn test_with_failures_2_web() {
+    use hotshot_testing::{
+        node_types::{TestTypes, WebImpl},
         spinning_task::{ChangeNode, SpinningTaskDescription, UpDown},
         test_builder::TestMetadata,
     };

--- a/crates/testing/tests/basic.rs
+++ b/crates/testing/tests/basic.rs
@@ -1,186 +1,186 @@
-#[cfg(test)]
-#[cfg_attr(
-    async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread", worker_threads = 2)
-)]
-#[cfg_attr(async_executor_impl = "async-std", async_std::test)]
-async fn test_success() {
-    use hotshot_testing::{
-        completion_task::{CompletionTaskDescription, TimeBasedCompletionTaskDescription},
-        node_types::{MemoryImpl, TestTypes},
-        test_builder::TestMetadata,
-    };
-    use std::time::Duration;
+// #[cfg(test)]
+// #[cfg_attr(
+//     async_executor_impl = "tokio",
+//     tokio::test(flavor = "multi_thread", worker_threads = 2)
+// )]
+// #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
+// async fn test_success() {
+//     use hotshot_testing::{
+//         completion_task::{CompletionTaskDescription, TimeBasedCompletionTaskDescription},
+//         node_types::{MemoryImpl, TestTypes},
+//         test_builder::TestMetadata,
+//     };
+//     use std::time::Duration;
 
-    async_compatibility_layer::logging::setup_logging();
-    async_compatibility_layer::logging::setup_backtrace();
-    let metadata = TestMetadata {
-        // allow more time to pass in CI
-        completion_task_description: CompletionTaskDescription::TimeBasedCompletionTaskBuilder(
-            TimeBasedCompletionTaskDescription {
-                duration: Duration::from_secs(60),
-            },
-        ),
-        ..TestMetadata::default()
-    };
-    metadata
-        .gen_launcher::<TestTypes, MemoryImpl>(0)
-        .launch()
-        .run_test()
-        .await;
-}
+//     async_compatibility_layer::logging::setup_logging();
+//     async_compatibility_layer::logging::setup_backtrace();
+//     let metadata = TestMetadata {
+//         // allow more time to pass in CI
+//         completion_task_description: CompletionTaskDescription::TimeBasedCompletionTaskBuilder(
+//             TimeBasedCompletionTaskDescription {
+//                 duration: Duration::from_secs(60),
+//             },
+//         ),
+//         ..TestMetadata::default()
+//     };
+//     metadata
+//         .gen_launcher::<TestTypes, MemoryImpl>(0)
+//         .launch()
+//         .run_test()
+//         .await;
+// }
 
-/// Test one node leaving the network.
-#[cfg(test)]
-#[cfg_attr(
-    async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread", worker_threads = 2)
-)]
-#[cfg_attr(async_executor_impl = "async-std", async_std::test)]
-async fn test_with_failures_one() {
-    use hotshot_testing::{
-        node_types::{MemoryImpl, TestTypes},
-        spinning_task::{ChangeNode, SpinningTaskDescription, UpDown},
-        test_builder::TestMetadata,
-    };
+// /// Test one node leaving the network.
+// #[cfg(test)]
+// #[cfg_attr(
+//     async_executor_impl = "tokio",
+//     tokio::test(flavor = "multi_thread", worker_threads = 2)
+// )]
+// #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
+// async fn test_with_failures_one() {
+//     use hotshot_testing::{
+//         node_types::{MemoryImpl, TestTypes},
+//         spinning_task::{ChangeNode, SpinningTaskDescription, UpDown},
+//         test_builder::TestMetadata,
+//     };
 
-    async_compatibility_layer::logging::setup_logging();
-    async_compatibility_layer::logging::setup_backtrace();
-    let mut metadata = TestMetadata::default_more_nodes();
-    // The first 14 (i.e., 20 - f) nodes are in the DA committee and we may shutdown the
-    // remaining 6 (i.e., f) nodes. We could remove this restriction after fixing the
-    // following issue.
-    // TODO: Update message broadcasting to avoid hanging
-    // <https://github.com/EspressoSystems/HotShot/issues/1567>
-    let dead_nodes = vec![ChangeNode {
-        idx: 19,
-        updown: UpDown::Down,
-    }];
+//     async_compatibility_layer::logging::setup_logging();
+//     async_compatibility_layer::logging::setup_backtrace();
+//     let mut metadata = TestMetadata::default_more_nodes();
+//     // The first 14 (i.e., 20 - f) nodes are in the DA committee and we may shutdown the
+//     // remaining 6 (i.e., f) nodes. We could remove this restriction after fixing the
+//     // following issue.
+//     // TODO: Update message broadcasting to avoid hanging
+//     // <https://github.com/EspressoSystems/HotShot/issues/1567>
+//     let dead_nodes = vec![ChangeNode {
+//         idx: 19,
+//         updown: UpDown::Down,
+//     }];
 
-    metadata.spinning_properties = SpinningTaskDescription {
-        node_changes: vec![(5, dead_nodes)],
-    };
-    metadata.overall_safety_properties.num_failed_views = 3;
-    metadata.overall_safety_properties.num_successful_views = 25;
-    metadata
-        .gen_launcher::<TestTypes, MemoryImpl>(0)
-        .launch()
-        .run_test()
-        .await;
-}
+//     metadata.spinning_properties = SpinningTaskDescription {
+//         node_changes: vec![(5, dead_nodes)],
+//     };
+//     metadata.overall_safety_properties.num_failed_views = 3;
+//     metadata.overall_safety_properties.num_successful_views = 25;
+//     metadata
+//         .gen_launcher::<TestTypes, MemoryImpl>(0)
+//         .launch()
+//         .run_test()
+//         .await;
+// }
 
-/// Test f/2 nodes leaving the network.
-#[cfg(test)]
-#[cfg_attr(
-    async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread", worker_threads = 2)
-)]
-#[cfg_attr(async_executor_impl = "async-std", async_std::test)]
-async fn test_with_failures_half_f() {
-    use hotshot_testing::{
-        node_types::{MemoryImpl, TestTypes},
-        spinning_task::{ChangeNode, SpinningTaskDescription, UpDown},
-        test_builder::TestMetadata,
-    };
+// /// Test f/2 nodes leaving the network.
+// #[cfg(test)]
+// #[cfg_attr(
+//     async_executor_impl = "tokio",
+//     tokio::test(flavor = "multi_thread", worker_threads = 2)
+// )]
+// #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
+// async fn test_with_failures_half_f() {
+//     use hotshot_testing::{
+//         node_types::{MemoryImpl, TestTypes},
+//         spinning_task::{ChangeNode, SpinningTaskDescription, UpDown},
+//         test_builder::TestMetadata,
+//     };
 
-    async_compatibility_layer::logging::setup_logging();
-    async_compatibility_layer::logging::setup_backtrace();
-    let mut metadata = TestMetadata::default_more_nodes();
-    // The first 14 (i.e., 20 - f) nodes are in the DA committee and we may shutdown the
-    // remaining 6 (i.e., f) nodes. We could remove this restriction after fixing the
-    // following issue.
-    // TODO: Update message broadcasting to avoid hanging
-    // <https://github.com/EspressoSystems/HotShot/issues/1567>
-    let dead_nodes = vec![
-        ChangeNode {
-            idx: 17,
-            updown: UpDown::Down,
-        },
-        ChangeNode {
-            idx: 18,
-            updown: UpDown::Down,
-        },
-        ChangeNode {
-            idx: 19,
-            updown: UpDown::Down,
-        },
-    ];
+//     async_compatibility_layer::logging::setup_logging();
+//     async_compatibility_layer::logging::setup_backtrace();
+//     let mut metadata = TestMetadata::default_more_nodes();
+//     // The first 14 (i.e., 20 - f) nodes are in the DA committee and we may shutdown the
+//     // remaining 6 (i.e., f) nodes. We could remove this restriction after fixing the
+//     // following issue.
+//     // TODO: Update message broadcasting to avoid hanging
+//     // <https://github.com/EspressoSystems/HotShot/issues/1567>
+//     let dead_nodes = vec![
+//         ChangeNode {
+//             idx: 17,
+//             updown: UpDown::Down,
+//         },
+//         ChangeNode {
+//             idx: 18,
+//             updown: UpDown::Down,
+//         },
+//         ChangeNode {
+//             idx: 19,
+//             updown: UpDown::Down,
+//         },
+//     ];
 
-    metadata.spinning_properties = SpinningTaskDescription {
-        node_changes: vec![(5, dead_nodes)],
-    };
+//     metadata.spinning_properties = SpinningTaskDescription {
+//         node_changes: vec![(5, dead_nodes)],
+//     };
 
-    metadata.overall_safety_properties.num_failed_views = 3;
-    // Make sure we keep commiting rounds after the bad leaders, but not the full 50 because of the numerous timeouts
-    metadata.overall_safety_properties.num_successful_views = 22;
-    metadata
-        .gen_launcher::<TestTypes, MemoryImpl>(0)
-        .launch()
-        .run_test()
-        .await;
-}
+//     metadata.overall_safety_properties.num_failed_views = 3;
+//     // Make sure we keep commiting rounds after the bad leaders, but not the full 50 because of the numerous timeouts
+//     metadata.overall_safety_properties.num_successful_views = 22;
+//     metadata
+//         .gen_launcher::<TestTypes, MemoryImpl>(0)
+//         .launch()
+//         .run_test()
+//         .await;
+// }
 
-/// Test f nodes leaving the network.
-#[cfg(test)]
-#[cfg_attr(
-    async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread", worker_threads = 2)
-)]
-#[cfg_attr(async_executor_impl = "async-std", async_std::test)]
-async fn test_with_failures_f() {
-    use hotshot_testing::{
-        node_types::{MemoryImpl, TestTypes},
-        spinning_task::{ChangeNode, SpinningTaskDescription, UpDown},
-        test_builder::TestMetadata,
-    };
+// /// Test f nodes leaving the network.
+// #[cfg(test)]
+// #[cfg_attr(
+//     async_executor_impl = "tokio",
+//     tokio::test(flavor = "multi_thread", worker_threads = 2)
+// )]
+// #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
+// async fn test_with_failures_f() {
+//     use hotshot_testing::{
+//         node_types::{MemoryImpl, TestTypes},
+//         spinning_task::{ChangeNode, SpinningTaskDescription, UpDown},
+//         test_builder::TestMetadata,
+//     };
 
-    async_compatibility_layer::logging::setup_logging();
-    async_compatibility_layer::logging::setup_backtrace();
-    let mut metadata = TestMetadata::default_more_nodes();
-    metadata.overall_safety_properties.num_failed_views = 6;
-    // Make sure we keep commiting rounds after the bad leaders, but not the full 50 because of the numerous timeouts
-    metadata.overall_safety_properties.num_successful_views = 22;
-    // The first 14 (i.e., 20 - f) nodes are in the DA committee and we may shutdown the
-    // remaining 6 (i.e., f) nodes. We could remove this restriction after fixing the
-    // following issue.
-    // TODO: Update message broadcasting to avoid hanging
-    // <https://github.com/EspressoSystems/HotShot/issues/1567>
-    let dead_nodes = vec![
-        ChangeNode {
-            idx: 14,
-            updown: UpDown::Down,
-        },
-        ChangeNode {
-            idx: 15,
-            updown: UpDown::Down,
-        },
-        ChangeNode {
-            idx: 16,
-            updown: UpDown::Down,
-        },
-        ChangeNode {
-            idx: 17,
-            updown: UpDown::Down,
-        },
-        ChangeNode {
-            idx: 18,
-            updown: UpDown::Down,
-        },
-        ChangeNode {
-            idx: 19,
-            updown: UpDown::Down,
-        },
-    ];
+//     async_compatibility_layer::logging::setup_logging();
+//     async_compatibility_layer::logging::setup_backtrace();
+//     let mut metadata = TestMetadata::default_more_nodes();
+//     metadata.overall_safety_properties.num_failed_views = 6;
+//     // Make sure we keep commiting rounds after the bad leaders, but not the full 50 because of the numerous timeouts
+//     metadata.overall_safety_properties.num_successful_views = 22;
+//     // The first 14 (i.e., 20 - f) nodes are in the DA committee and we may shutdown the
+//     // remaining 6 (i.e., f) nodes. We could remove this restriction after fixing the
+//     // following issue.
+//     // TODO: Update message broadcasting to avoid hanging
+//     // <https://github.com/EspressoSystems/HotShot/issues/1567>
+//     let dead_nodes = vec![
+//         ChangeNode {
+//             idx: 14,
+//             updown: UpDown::Down,
+//         },
+//         ChangeNode {
+//             idx: 15,
+//             updown: UpDown::Down,
+//         },
+//         ChangeNode {
+//             idx: 16,
+//             updown: UpDown::Down,
+//         },
+//         ChangeNode {
+//             idx: 17,
+//             updown: UpDown::Down,
+//         },
+//         ChangeNode {
+//             idx: 18,
+//             updown: UpDown::Down,
+//         },
+//         ChangeNode {
+//             idx: 19,
+//             updown: UpDown::Down,
+//         },
+//     ];
 
-    metadata.spinning_properties = SpinningTaskDescription {
-        node_changes: vec![(5, dead_nodes)],
-    };
-    metadata
-        .gen_launcher::<TestTypes, MemoryImpl>(0)
-        .launch()
-        .run_test()
-        .await;
-}
+//     metadata.spinning_properties = SpinningTaskDescription {
+//         node_changes: vec![(5, dead_nodes)],
+//     };
+//     metadata
+//         .gen_launcher::<TestTypes, MemoryImpl>(0)
+//         .launch()
+//         .run_test()
+//         .await;
+// }
 
 /// Test that a good leader can succeed in the view directly after view sync
 #[cfg(test)]
@@ -191,7 +191,7 @@ async fn test_with_failures_f() {
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 async fn test_with_failures_2() {
     use hotshot_testing::{
-        node_types::{WebImpl, TestTypes},
+        node_types::{MemoryImpl, TestTypes, WebImpl},
         spinning_task::{ChangeNode, SpinningTaskDescription, UpDown},
         test_builder::TestMetadata,
     };
@@ -199,6 +199,9 @@ async fn test_with_failures_2() {
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
     let mut metadata = TestMetadata::default_more_nodes();
+    metadata.total_nodes = 12;
+    metadata.da_committee_size = 12;
+    metadata.start_nodes = 12;
     // The first 14 (i.e., 20 - f) nodes are in the DA committee and we may shutdown the
     // remaining 6 (i.e., f) nodes. We could remove this restriction after fixing the
     // following issue.
@@ -206,11 +209,11 @@ async fn test_with_failures_2() {
     // <https://github.com/EspressoSystems/HotShot/issues/1567>
     let dead_nodes = vec![
         ChangeNode {
-            idx: 17,
+            idx: 10,
             updown: UpDown::Down,
         },
         ChangeNode {
-            idx: 18,
+            idx: 11,
             updown: UpDown::Down,
         },
     ];
@@ -222,9 +225,9 @@ async fn test_with_failures_2() {
     // 2 nodes fail triggering view sync, expect no other timeouts
     metadata.overall_safety_properties.num_failed_views = 2;
     // Make sure we keep commiting rounds after the bad leaders, but not the full 50 because of the numerous timeouts
-    metadata.overall_safety_properties.num_successful_views = 25;
+    metadata.overall_safety_properties.num_successful_views = 15;
     metadata
-        .gen_launcher::<TestTypes, WebImpl>(0)
+        .gen_launcher::<TestTypes, MemoryImpl>(0)
         .launch()
         .run_test()
         .await;

--- a/crates/testing/tests/network_task.rs
+++ b/crates/testing/tests/network_task.rs
@@ -129,7 +129,7 @@ async fn test_network_task() {
     );
     output.insert(HotShotEvent::ViewChange(ViewNumber::new(2)), 2);
     output.insert(
-        HotShotEvent::SendPayloadCommitmentAndMetadata(payload_commitment, ()),
+        HotShotEvent::SendPayloadCommitmentAndMetadata(payload_commitment, (), ViewNumber::new(2)),
         2, // 2 occurrences: both from the VID task
     );
     output.insert(

--- a/crates/testing/tests/vid_task.rs
+++ b/crates/testing/tests/vid_task.rs
@@ -99,7 +99,7 @@ async fn test_vid_task() {
     );
 
     output.insert(
-        HotShotEvent::SendPayloadCommitmentAndMetadata(payload_commitment, ()),
+        HotShotEvent::SendPayloadCommitmentAndMetadata(payload_commitment, (), ViewNumber::new(2)),
         1,
     );
     output.insert(


### PR DESCRIPTION
Closes #2264 

### This PR: 
This fixes a confluence of issues were preventing proposals in some cases.  The main theme was that after a second timeout we can form a TC and not propose because of a few different issues with how we handle views and timeout certificates.  Here is a list of fixes:

- Send a view update for both views we move through during view sync so we don't skip any.  (i.e if view n and n + 1 timeout and we sync to n + 2, first send view change for n +1 then n+2).  This makes sure we don't miss any triggers for polling
- Trigger block building after a skipped view if we are the leader
- Propose in the case where we have a TC for the last view, and we get the `SendPayloadCommitmentAndMetadata` event after the TC was formed
- Don't keep the genesis commitment and metadata in `payload_commitment_and_metadata`.  There were cases where we'd propose with this commitment if a leader didn't have this info in time on their first proposal

We also added two tests which reproduce this additional timeout scenario.  2 nodes are killed and we ensure that the view after them succeeds.  We do the same test with the web server and memory network because the timing of these as well as webserver polling made the two networks uncover different issues.

### This PR does not: 
Fix the case where we exit view sync having never formed a TC.  After this fixes this *should* be exceedingly rare, and progress will still not be halted.

### Key places to review: 
Unfortunately all of it is somewhat important to review closely, besides the addition of the tests.

