### PR TITLE
Check for Genesis before Clearing `payload_commitment_and_metadata`

### DIFF
--- a/crates/hotshot/src/tasks/mod.rs
+++ b/crates/hotshot/src/tasks/mod.rs
@@ -12,7 +12,9 @@ use hotshot_task::{
     GeneratedStream, Merge,
 };
 use hotshot_task_impls::{
-    consensus::{consensus_event_filter, ConsensusTaskState, ConsensusTaskTypes},
+    consensus::{
+        consensus_event_filter, CommitmentAndMetadata, ConsensusTaskState, ConsensusTaskTypes,
+    },
     da::{DATaskState, DATaskTypes},
     events::HotShotEvent,
     network::{
@@ -222,7 +224,11 @@ pub async fn add_consensus_task<TYPES: NodeType, I: NodeImplementation<TYPES>>(
         consensus,
         timeout: handle.hotshot.inner.config.next_view_timeout,
         cur_view: TYPES::Time::new(0),
-        payload_commitment_and_metadata: Some((payload_commitment, metadata)),
+        payload_commitment_and_metadata: Some(CommitmentAndMetadata {
+            commitment: payload_commitment,
+            metadata,
+            is_genesis: true,
+        }),
         api: c_api.clone(),
         _pd: PhantomData,
         vote_collector: None.into(),

--- a/crates/task-impls/src/consensus.rs
+++ b/crates/task-impls/src/consensus.rs
@@ -224,17 +224,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                     &self.public_key,
                     &self.private_key,
                 );
-                if let Some((payload_commit, meta)) = &self.payload_commitment_and_metadata {
-                    let (genesis_payload, genesis_meta) =
-                        <TYPES::BlockPayload as BlockPayload>::genesis();
-                    let genesis_commitment = vid_commitment(
-                        &genesis_payload.encode().unwrap().collect(),
-                        self.quorum_membership.total_nodes(),
-                    );
-                    if meta == &genesis_meta && payload_commit == &genesis_commitment {
-                        self.payload_commitment_and_metadata = None;
-                    }
-                }
+
                 let message = GeneralConsensusMessage::<TYPES>::Vote(vote);
 
                 if let GeneralConsensusMessage::Vote(vote) = message {
@@ -245,6 +235,17 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                     self.event_stream
                         .publish(HotShotEvent::QuorumVoteSend(vote))
                         .await;
+                    if let Some((payload_commit, meta)) = &self.payload_commitment_and_metadata {
+                        let (genesis_payload, genesis_meta) =
+                            <TYPES::BlockPayload as BlockPayload>::genesis();
+                        let genesis_commitment = vid_commitment(
+                            &genesis_payload.encode().unwrap().collect(),
+                            self.quorum_membership.total_nodes(),
+                        );
+                        if meta == &genesis_meta && payload_commit == &genesis_commitment {
+                            self.payload_commitment_and_metadata = None;
+                        }
+                    }
                     return true;
                 }
             }


### PR DESCRIPTION
### This PR: 

Fixes a race condition where a node could get it's VID payload commit and metadata before it got the first proposal with genesis qc justification and then would clear the correct data and cause it to not propose.

### This PR does not: 

### Key places to review: 
The fix, and in general if the flow of clearing this variable which is set on task creation makes sense
