### PR TITLE
[TESTS] - View Sync Testing Harness Callback

### DIFF
--- a/crates/testing/src/completion_task.rs
+++ b/crates/testing/src/completion_task.rs
@@ -19,11 +19,11 @@ use super::{test_launcher::TaskGenerator, GlobalTestEvent};
 
 /// the idea here is to run as long as we want
 
-/// Data Availability task error
+/// Completion Task error
 #[derive(Snafu, Debug)]
 pub struct CompletionTaskErr {}
 
-/// Data availability task state
+/// Completion task state
 pub struct CompletionTask<TYPES: NodeType, I: TestableNodeImplementation<TYPES>> {
     pub(crate) test_event_stream: ChannelStream<GlobalTestEvent>,
     pub(crate) handles: Vec<Node<TYPES, I>>,

--- a/crates/testing/src/lib.rs
+++ b/crates/testing/src/lib.rs
@@ -30,6 +30,9 @@ pub mod completion_task;
 /// task to spin nodes up and down
 pub mod spinning_task;
 
+/// task for checking if view sync got activated
+pub mod view_sync_task;
+
 /// block types
 pub mod block_types;
 

--- a/crates/testing/src/test_builder.rs
+++ b/crates/testing/src/test_builder.rs
@@ -12,7 +12,7 @@ use hotshot_types::{
 use super::completion_task::{CompletionTaskDescription, TimeBasedCompletionTaskDescription};
 use crate::{
     spinning_task::SpinningTaskDescription,
-    test_launcher::{ResourceGenerators, TestLauncher},
+    test_launcher::{ResourceGenerators, TestLauncher}, view_sync_task::ViewSyncTaskDescription,
 };
 
 use super::{
@@ -58,6 +58,8 @@ pub struct TestMetadata {
     pub min_transactions: usize,
     /// timing data
     pub timing_data: TimingData,
+    /// view sync check task
+    pub view_sync_properties: ViewSyncTaskDescription
 }
 
 impl Default for TimingData {
@@ -75,10 +77,11 @@ impl Default for TimingData {
 
 impl TestMetadata {
     pub fn default_stress() -> Self {
+        let num_nodes = 100;
         TestMetadata {
             num_bootstrap_nodes: 15,
-            total_nodes: 100,
-            start_nodes: 100,
+            total_nodes: num_nodes,
+            start_nodes: num_nodes,
             overall_safety_properties: OverallSafetyPropertiesDescription {
                 num_successful_views: 50,
                 check_leaf: true,
@@ -95,14 +98,16 @@ impl TestMetadata {
                 round_start_delay: 25,
                 ..TimingData::default()
             },
+            view_sync_properties: ViewSyncTaskDescription::Threshold(0, num_nodes),
             ..TestMetadata::default()
         }
     }
 
     pub fn default_multiple_rounds() -> TestMetadata {
+        let num_nodes = 10;
         TestMetadata {
-            total_nodes: 10,
-            start_nodes: 10,
+            total_nodes: num_nodes,
+            start_nodes: num_nodes,
             overall_safety_properties: OverallSafetyPropertiesDescription {
                 num_successful_views: 20,
                 check_leaf: true,
@@ -117,15 +122,17 @@ impl TestMetadata {
                 round_start_delay: 25,
                 ..TimingData::default()
             },
+            view_sync_properties: ViewSyncTaskDescription::Threshold(0, num_nodes),
             ..TestMetadata::default()
         }
     }
 
     /// Default setting with 20 nodes and 8 views of successful views.
     pub fn default_more_nodes() -> TestMetadata {
+        let num_nodes = 20;
         TestMetadata {
-            total_nodes: 20,
-            start_nodes: 20,
+            total_nodes: num_nodes,
+            start_nodes: num_nodes,
             num_bootstrap_nodes: 20,
             // The first 14 (i.e., 20 - f) nodes are in the DA committee and we may shutdown the
             // remaining 6 (i.e., f) nodes. We could remove this restriction after fixing the
@@ -146,6 +153,7 @@ impl TestMetadata {
                 next_view_timeout: 5000,
                 ..TimingData::default()
             },
+            view_sync_properties: ViewSyncTaskDescription::Threshold(0, num_nodes),
             ..TestMetadata::default()
         }
     }
@@ -154,11 +162,12 @@ impl TestMetadata {
 impl Default for TestMetadata {
     /// by default, just a single round
     fn default() -> Self {
+        let num_nodes = 5;
         Self {
             timing_data: TimingData::default(),
             min_transactions: 0,
-            total_nodes: 5,
-            start_nodes: 5,
+            total_nodes: num_nodes,
+            start_nodes: num_nodes,
             num_bootstrap_nodes: 5,
             da_committee_size: 5,
             spinning_properties: SpinningTaskDescription {
@@ -173,6 +182,7 @@ impl Default for TestMetadata {
                     duration: Duration::from_millis(10000),
                 },
             ),
+            view_sync_properties: ViewSyncTaskDescription::Threshold(0, num_nodes)
         }
     }
 }
@@ -195,6 +205,7 @@ impl TestMetadata {
             completion_task_description,
             overall_safety_properties,
             spinning_properties,
+            view_sync_properties,
             ..
         } = self.clone();
 
@@ -263,6 +274,7 @@ impl TestMetadata {
         let completion_task_generator = completion_task_description.build_and_launch();
         let overall_safety_task_generator = overall_safety_properties.build();
         let spinning_task_generator = spinning_properties.build();
+        let view_sync_task_generator = view_sync_properties.build();
         TestLauncher {
             resource_generator: ResourceGenerators {
                 channel_generator: <I as TestableNodeImplementation<TYPES>>::gen_comm_channels(
@@ -278,6 +290,7 @@ impl TestMetadata {
             overall_safety_task_generator,
             completion_task_generator,
             spinning_task_generator,
+            view_sync_task_generator,
             hooks: vec![],
         }
         .modify_default_config(mod_config)

--- a/crates/testing/src/test_builder.rs
+++ b/crates/testing/src/test_builder.rs
@@ -12,7 +12,8 @@ use hotshot_types::{
 use super::completion_task::{CompletionTaskDescription, TimeBasedCompletionTaskDescription};
 use crate::{
     spinning_task::SpinningTaskDescription,
-    test_launcher::{ResourceGenerators, TestLauncher}, view_sync_task::ViewSyncTaskDescription,
+    test_launcher::{ResourceGenerators, TestLauncher},
+    view_sync_task::ViewSyncTaskDescription,
 };
 
 use super::{
@@ -59,7 +60,7 @@ pub struct TestMetadata {
     /// timing data
     pub timing_data: TimingData,
     /// view sync check task
-    pub view_sync_properties: ViewSyncTaskDescription
+    pub view_sync_properties: ViewSyncTaskDescription,
 }
 
 impl Default for TimingData {
@@ -182,7 +183,7 @@ impl Default for TestMetadata {
                     duration: Duration::from_millis(10000),
                 },
             ),
-            view_sync_properties: ViewSyncTaskDescription::Threshold(0, num_nodes)
+            view_sync_properties: ViewSyncTaskDescription::Threshold(0, num_nodes),
         }
     }
 }

--- a/crates/testing/src/test_launcher.rs
+++ b/crates/testing/src/test_launcher.rs
@@ -10,7 +10,7 @@ use hotshot_task::{
 };
 use hotshot_types::{traits::node_implementation::NodeType, HotShotConfig};
 
-use crate::spinning_task::SpinningTask;
+use crate::{spinning_task::SpinningTask, view_sync_task::ViewSyncTask};
 
 use super::{
     completion_task::CompletionTask, overall_safety_task::OverallSafetyTask,
@@ -71,9 +71,11 @@ pub struct TestLauncher<TYPES: NodeType, I: TestableNodeImplementation<TYPES>> {
     pub completion_task_generator: TaskGenerator<CompletionTask<TYPES, I>>,
     /// overall safety task generator
     pub overall_safety_task_generator: TaskGenerator<OverallSafetyTask<TYPES, I>>,
-
+    /// task for spinning nodes up/down
     pub spinning_task_generator: TaskGenerator<SpinningTask<TYPES, I>>,
-
+    /// task for view sync
+    pub view_sync_task_generator: TaskGenerator<ViewSyncTask<TYPES, I>>,
+    /// extra hooks in case we want to check additional things
     pub hooks: Vec<Hook>,
 }
 
@@ -129,6 +131,17 @@ impl<TYPES: NodeType, I: TestableNodeImplementation<TYPES>> TestLauncher<TYPES, 
     ) -> Self {
         Self {
             txn_task_generator,
+            ..self
+        }
+    }
+
+    /// override the view sync task generator
+    pub fn with_view_sync_task_generator(
+        self,
+        view_sync_task_generator: TaskGenerator<ViewSyncTask<TYPES, I>>,
+    ) -> Self {
+        Self {
+            view_sync_task_generator,
             ..self
         }
     }

--- a/crates/testing/src/test_runner.rs
+++ b/crates/testing/src/test_runner.rs
@@ -5,7 +5,8 @@ use super::{
 };
 use crate::{
     spinning_task::{ChangeNode, UpDown},
-    test_launcher::{Networks, TestLauncher}, view_sync_task::ViewSyncTask,
+    test_launcher::{Networks, TestLauncher},
+    view_sync_task::ViewSyncTask,
 };
 use hotshot::{types::SystemContextHandle, Memberships};
 
@@ -146,18 +147,18 @@ where
         .await;
         task_runner = task_runner.add_task(id, "Test Overall Safety Task".to_string(), task);
 
-        /// add view sync task
+        // add view sync task
         let view_sync_task_state = ViewSyncTask {
-            test_event_stream: test_event_stream.clone(),
             handles: nodes.clone(),
-            hit_view_sync: HashMap::new(),
+            hit_view_sync: HashSet::new(),
         };
 
         let (id, task) = (launcher.view_sync_task_generator)(
             view_sync_task_state,
             registry.clone(),
             test_event_stream.clone(),
-        ).await;
+        )
+        .await;
         task_runner = task_runner.add_task(id, "View Sync Task".to_string(), task);
 
         // wait for networks to be ready

--- a/crates/testing/src/test_runner.rs
+++ b/crates/testing/src/test_runner.rs
@@ -5,7 +5,7 @@ use super::{
 };
 use crate::{
     spinning_task::{ChangeNode, UpDown},
-    test_launcher::{Networks, TestLauncher},
+    test_launcher::{Networks, TestLauncher}, view_sync_task::ViewSyncTask,
 };
 use hotshot::{types::SystemContextHandle, Memberships};
 
@@ -145,6 +145,20 @@ where
         )
         .await;
         task_runner = task_runner.add_task(id, "Test Overall Safety Task".to_string(), task);
+
+        /// add view sync task
+        let view_sync_task_state = ViewSyncTask {
+            test_event_stream: test_event_stream.clone(),
+            handles: nodes.clone(),
+            hit_view_sync: HashMap::new(),
+        };
+
+        let (id, task) = (launcher.view_sync_task_generator)(
+            view_sync_task_state,
+            registry.clone(),
+            test_event_stream.clone(),
+        ).await;
+        task_runner = task_runner.add_task(id, "View Sync Task".to_string(), task);
 
         // wait for networks to be ready
         for node in &nodes {

--- a/crates/testing/src/view_sync_task.rs
+++ b/crates/testing/src/view_sync_task.rs
@@ -1,0 +1,114 @@
+use std::{sync::Arc, collections::{HashSet, HashMap}};
+use futures::FutureExt;
+use hotshot_task::task::HotShotTaskTypes;
+use async_compatibility_layer::channel::UnboundedStream;
+use hotshot_task::{task_impls::{TaskBuilder, HSTWithEventAndMessage}, task::{FilterEvent, HandleMessage, HandleEvent, TS}, MergeN, event_stream::ChannelStream};
+use hotshot_task_impls::events::HotShotEvent;
+use hotshot_types::traits::node_implementation::{TestableNodeImplementation, NodeType};
+use snafu::Snafu;
+
+use crate::{test_launcher::TaskGenerator, test_runner::Node, GlobalTestEvent};
+
+/// ViewSync Task error
+#[derive(Snafu, Debug)]
+pub struct ViewSyncTaskErr {}
+
+/// ViewSync task state
+pub struct ViewSyncTask<TYPES: NodeType, I: TestableNodeImplementation<TYPES>> {
+    /// the global event stream
+    pub(crate) test_event_stream: ChannelStream<GlobalTestEvent>,
+    /// the node handles
+    pub(crate) handles: Vec<Node<TYPES, I>>,
+    /// nodes that hit view sync
+    pub(crate) hit_view_sync: HashMap<usize, <TYPES as NodeType>::Time>
+}
+
+impl<TYPES: NodeType, I: TestableNodeImplementation<TYPES>> TS for ViewSyncTask<TYPES, I> {}
+
+/// ViewSync task types
+pub type ViewSyncTaskTypes<TYPES, I> = HSTWithEventAndMessage<
+    ViewSyncTaskErr,
+    GlobalTestEvent,
+    ChannelStream<GlobalTestEvent>,
+    (usize, HotShotEvent<TYPES>),
+    MergeN<UnboundedStream<HotShotEvent<TYPES>>>,
+    ViewSyncTask<TYPES, I>,
+>;
+
+#[derive(Clone, Debug, Copy)]
+pub enum ShouldHitViewSync {
+    /// the node should hit view sync
+    Yes,
+    /// the node should not hit view sync
+    No,
+    /// don't care if the node should hit view sync
+    DontCare
+}
+
+/// Description for a view sync task.
+#[derive(Clone, Debug)]
+pub enum ViewSyncTaskDescription {
+    /// (min, max) number nodes that may hit view sync, inclusive
+    Threshold(usize, usize),
+    /// node idx -> whether or not the node should hit view sync
+    /// if node not in map, assumed to be `ShouldHItViewSync::DontCare`
+    Precise(HashMap<usize, ShouldHitViewSync>)
+}
+
+impl ViewSyncTaskDescription {
+    pub fn build<TYPES: NodeType, I: TestableNodeImplementation<TYPES>>(
+        self,
+    ) -> TaskGenerator<ViewSyncTask<TYPES, I>> {
+        Box::new(move |mut state, mut registry, test_event_stream| {
+            async move {
+
+                let event_handler = HandleEvent::<ViewSyncTaskTypes<TYPES, I>>(Arc::new(move |event, state| {
+                    async move {
+                        match event {
+                            GlobalTestEvent::ShutDown => {
+                                todo!()
+                                    // logic checking stuff
+                            }
+                        }
+                    }.boxed()
+
+                }));
+
+                let message_handler = HandleMessage::<ViewSyncTaskTypes<TYPES, I>>(Arc::new(
+                        move |msg, mut state| {
+                            todo!()
+                        }
+                        ));
+                let mut streams = vec![];
+                for handle in &mut state.handles {
+                    let stream = handle.handle.get_internal_event_stream_known_impl(FilterEvent::default()).await.0;
+                    streams.push(stream);
+                }
+
+                let builder = TaskBuilder::<ViewSyncTaskTypes<TYPES, I>>::new(
+                    "Test Completion Task".to_string(),
+                    )
+                    .register_event_stream(test_event_stream, FilterEvent::default())
+                    .await
+                    .register_registry(&mut registry)
+                    .await
+                    .register_state(state)
+                    .register_event_handler(event_handler)
+                    .register_message_handler(message_handler)
+                    .register_message_stream(MergeN::new(streams));
+                let task_id = builder.get_task_id().unwrap();
+                (task_id, ViewSyncTaskTypes::build(builder).launch())
+            }.boxed()
+        })
+
+        // match self {
+        //     ViewSyncTaskDescription::Threshold(threshold) => {
+        //
+        //     },
+        //     ViewSyncTaskDescription::Precise(map) => {
+        //
+        //     }
+        // }
+    }
+
+}

--- a/crates/testing/src/view_sync_task.rs
+++ b/crates/testing/src/view_sync_task.rs
@@ -10,10 +10,7 @@ use hotshot_task::{
 use hotshot_task_impls::events::HotShotEvent;
 use hotshot_types::traits::node_implementation::{NodeType, TestableNodeImplementation};
 use snafu::Snafu;
-use std::{
-    collections::{HashMap, HashSet},
-    sync::Arc,
-};
+use std::{collections::HashSet, sync::Arc};
 
 use crate::{test_launcher::TaskGenerator, test_runner::Node, GlobalTestEvent};
 
@@ -58,9 +55,6 @@ pub enum ShouldHitViewSync {
 pub enum ViewSyncTaskDescription {
     /// (min, max) number nodes that may hit view sync, inclusive
     Threshold(usize, usize),
-    /// node idx -> whether or not the node should hit view sync
-    /// if node not in map, assumed to be `ShouldHItViewSync::DontCare`
-    Precise(HashMap<usize, ShouldHitViewSync>),
 }
 
 impl ViewSyncTaskDescription {
@@ -89,42 +83,6 @@ impl ViewSyncTaskDescription {
                                                 state,
                                             )
                                         }
-                                    }
-                                    ViewSyncTaskDescription::Precise(map) => {
-                                        for (id, should_hit) in map {
-                                            match should_hit {
-                                                ShouldHitViewSync::Yes => {
-                                                    if !state.hit_view_sync.contains(&id) {
-                                                        return (
-                                                            Some(HotShotTaskCompleted::Error(
-                                                                Box::new(ViewSyncTaskErr {
-                                                                    hit_view_sync: state
-                                                                        .hit_view_sync
-                                                                        .clone(),
-                                                                }),
-                                                            )),
-                                                            state,
-                                                        );
-                                                    }
-                                                }
-                                                ShouldHitViewSync::No => {
-                                                    if state.hit_view_sync.contains(&id) {
-                                                        return (
-                                                            Some(HotShotTaskCompleted::Error(
-                                                                Box::new(ViewSyncTaskErr {
-                                                                    hit_view_sync: state
-                                                                        .hit_view_sync
-                                                                        .clone(),
-                                                                }),
-                                                            )),
-                                                            state,
-                                                        );
-                                                    }
-                                                }
-                                                ShouldHitViewSync::Ignore => {}
-                                            }
-                                        }
-                                        (Some(HotShotTaskCompleted::ShutDown), state)
                                     }
                                 },
                             }
@@ -189,14 +147,5 @@ impl ViewSyncTaskDescription {
             }
             .boxed()
         })
-
-        // match self {
-        //     ViewSyncTaskDescription::Threshold(threshold) => {
-        //
-        //     },
-        //     ViewSyncTaskDescription::Precise(map) => {
-        //
-        //     }
-        // }
     }
 }

--- a/crates/testing/tests/catchup.rs
+++ b/crates/testing/tests/catchup.rs
@@ -37,6 +37,9 @@ async fn test_catchup() {
     metadata.start_nodes = 18;
     metadata.total_nodes = 20;
 
+    metadata.view_sync_properties =
+        hotshot_testing::view_sync_task::ViewSyncTaskDescription::Threshold(0, 20);
+
     metadata.spinning_properties = SpinningTaskDescription {
         // Start the nodes before their leadership.
         node_changes: vec![(15, catchup_nodes)],

--- a/crates/testing/tests/catchup.rs
+++ b/crates/testing/tests/catchup.rs
@@ -218,6 +218,8 @@ async fn test_catchup_in_view_sync() {
     metadata.timing_data = timing_data;
     metadata.start_nodes = 18;
     metadata.total_nodes = 20;
+    metadata.view_sync_properties =
+        hotshot_testing::view_sync_task::ViewSyncTaskDescription::Threshold(0, 20);
 
     metadata.spinning_properties = SpinningTaskDescription {
         node_changes: vec![(25, catchup_nodes)],


### PR DESCRIPTION
Closes #2285 

### This PR: 
This PR adds a view sync check to ensure that certain nodes did have view sync activated during the test run.

### This PR does not: 
Add any substantial tests using this feature. It would be worth discussing what sort of tests should make use of this feature.

### Key places to review: 
Worth confirming that `ViewSyncTaskDescription` matches the sort of API we want to specify nodes hitting view sync
