### PR TITLE
[CI] - Separate lints into separate CI step

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,4 +1,4 @@
-name: Build, Lint, and Test
+name: Build and Test
 
 on:
   push:
@@ -44,10 +44,6 @@ jobs:
           wget https://github.com/casey/just/releases/download/1.14.0/just-1.14.0-x86_64-unknown-linux-musl.tar.gz
           tar -vxf just-1.14.0-x86_64-unknown-linux-musl.tar.gz just
           sudo cp just /usr/bin/just
-
-      - name: Run linting
-        run: |
-          just ${{ matrix.just_variants }} lint
 
       - name: Build all crates in workspace
         run: just ${{ matrix.just_variants }} build
@@ -231,7 +227,7 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.validator-webserver.outputs.tags }}
           labels: ${{ steps.validator-webserver.outputs.labels }}
-      
+
   test-crypto:
     strategy:
       matrix:

--- a/.github/workflows/lint-self-hosted.yml
+++ b/.github/workflows/lint-self-hosted.yml
@@ -1,4 +1,4 @@
-name: Build, Lint, and Test (self-hosted)
+name: Lint (self-hosted)
 
 on:
   push:
@@ -31,12 +31,6 @@ jobs:
         with:
           prefix-key: ${{ matrix.just_variants }}
 
-      - name: Build all crates in workspace
-        run: just ${{ matrix.just_variants }} build
-
-      - name: Unit and integration tests for all crates in workspace
+      - name: Run linting
         run: |
-          just ${{ matrix.just_variants }} test
-        timeout-minutes: 60
-        env:
-          RUST_BACKTRACE: full
+          just ${{ matrix.just_variants }} lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,50 @@
+name: Lint
+
+on:
+  push:
+    branches:
+      - 'develop'
+      - 'main'
+  pull_request:
+  schedule:
+    - cron: '0 0 * * 1'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-test:
+    strategy:
+      matrix:
+        just_variants:
+          - async_std
+          - tokio
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        name: Checkout Repository
+
+      - run: rustup toolchain install stable --profile minimal
+
+      - uses: Swatinem/rust-cache@v2
+        name: Enable Rust Caching
+        with:
+          shared-key: ""
+          prefix-key: ${{ matrix.just_variants }}
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
+
+      - name: Install Just
+        run: |
+          wget https://github.com/casey/just/releases/download/1.14.0/just-1.14.0-x86_64-unknown-linux-musl.tar.gz
+          tar -vxf just-1.14.0-x86_64-unknown-linux-musl.tar.gz just
+          sudo cp just /usr/bin/just
+
+      - name: Run linting
+        run: |
+          just ${{ matrix.just_variants }} lint


### PR DESCRIPTION
Closes #2154 

### This PR: 
Moves linting into a separate CI step for both locally hosted runners and github runners.

### This PR does not: 
This PR does not make the build-and-test jobs dependent on linting. Not sure if we want this.

### Key places to review: 
