### PR TITLE
[A2A Network] - Add A2A Test

### DIFF
--- a/crates/hotshot/examples/infra/mod.rs
+++ b/crates/hotshot/examples/infra/mod.rs
@@ -8,7 +8,7 @@ use hotshot::traits::implementations::{CombinedCommChannel, CombinedNetworks};
 use hotshot::{
     traits::{
         implementations::{
-            Libp2pCommChannel, Libp2pNetwork, MemoryStorage, NetworkingMetricsValue,
+            Libp2pNetworkRegular, Libp2pRegularCommChannel, MemoryStorage, NetworkingMetricsValue,
             WebCommChannel, WebServerNetwork,
         },
         NodeImplementation,
@@ -162,7 +162,7 @@ async fn webserver_network_from_config<TYPES: NodeType>(
 async fn libp2p_network_from_config<TYPES: NodeType>(
     config: NetworkConfig<TYPES::SignatureKey, TYPES::ElectionConfigType>,
     pub_key: TYPES::SignatureKey,
-) -> Libp2pNetwork<Message<TYPES>, TYPES::SignatureKey> {
+) -> Libp2pNetworkRegular<Message<TYPES>, TYPES::SignatureKey> {
     let mut config = config;
     let libp2p_config = config
         .libp2p_config
@@ -252,7 +252,7 @@ match node_type {
     }
     let node_config = config_builder.build().unwrap();
 
-    Libp2pNetwork::new(
+    Libp2pNetworkRegular::new(
         NetworkingMetricsValue::default(),
         node_config,
         pub_key.clone(),
@@ -585,10 +585,10 @@ where
 /// Represents a libp2p-based run
 pub struct Libp2pDARun<TYPES: NodeType> {
     config: NetworkConfig<TYPES::SignatureKey, TYPES::ElectionConfigType>,
-    quorum_channel: Libp2pCommChannel<TYPES>,
-    da_channel: Libp2pCommChannel<TYPES>,
-    view_sync_channel: Libp2pCommChannel<TYPES>,
-    vid_channel: Libp2pCommChannel<TYPES>,
+    quorum_channel: Libp2pRegularCommChannel<TYPES>,
+    da_channel: Libp2pRegularCommChannel<TYPES>,
+    view_sync_channel: Libp2pRegularCommChannel<TYPES>,
+    vid_channel: Libp2pRegularCommChannel<TYPES>,
 }
 
 #[async_trait]
@@ -600,17 +600,17 @@ impl<
         >,
         NODE: NodeImplementation<
             TYPES,
-            QuorumNetwork = Libp2pCommChannel<TYPES>,
-            CommitteeNetwork = Libp2pCommChannel<TYPES>,
+            QuorumNetwork = Libp2pRegularCommChannel<TYPES>,
+            CommitteeNetwork = Libp2pRegularCommChannel<TYPES>,
             Storage = MemoryStorage<TYPES>,
         >,
     >
     RunDA<
         TYPES,
-        Libp2pCommChannel<TYPES>,
-        Libp2pCommChannel<TYPES>,
-        Libp2pCommChannel<TYPES>,
-        Libp2pCommChannel<TYPES>,
+        Libp2pRegularCommChannel<TYPES>,
+        Libp2pRegularCommChannel<TYPES>,
+        Libp2pRegularCommChannel<TYPES>,
+        Libp2pRegularCommChannel<TYPES>,
         NODE,
     > for Libp2pDARun<TYPES>
 where
@@ -631,17 +631,17 @@ where
         underlying_quorum_network.wait_for_ready().await;
 
         // create communication channels
-        let quorum_channel: Libp2pCommChannel<TYPES> =
-            Libp2pCommChannel::new(underlying_quorum_network.clone().into());
+        let quorum_channel: Libp2pRegularCommChannel<TYPES> =
+            Libp2pRegularCommChannel::new(underlying_quorum_network.clone().into());
 
-        let view_sync_channel: Libp2pCommChannel<TYPES> =
-            Libp2pCommChannel::new(underlying_quorum_network.clone().into());
+        let view_sync_channel: Libp2pRegularCommChannel<TYPES> =
+            Libp2pRegularCommChannel::new(underlying_quorum_network.clone().into());
 
-        let da_channel: Libp2pCommChannel<TYPES> =
-            Libp2pCommChannel::new(underlying_quorum_network.clone().into());
+        let da_channel: Libp2pRegularCommChannel<TYPES> =
+            Libp2pRegularCommChannel::new(underlying_quorum_network.clone().into());
 
-        let vid_channel: Libp2pCommChannel<TYPES> =
-            Libp2pCommChannel::new(underlying_quorum_network.clone().into());
+        let vid_channel: Libp2pRegularCommChannel<TYPES> =
+            Libp2pRegularCommChannel::new(underlying_quorum_network.clone().into());
 
         Libp2pDARun {
             config,
@@ -652,19 +652,19 @@ where
         }
     }
 
-    fn get_da_channel(&self) -> Libp2pCommChannel<TYPES> {
+    fn get_da_channel(&self) -> Libp2pRegularCommChannel<TYPES> {
         self.da_channel.clone()
     }
 
-    fn get_quorum_channel(&self) -> Libp2pCommChannel<TYPES> {
+    fn get_quorum_channel(&self) -> Libp2pRegularCommChannel<TYPES> {
         self.quorum_channel.clone()
     }
 
-    fn get_view_sync_channel(&self) -> Libp2pCommChannel<TYPES> {
+    fn get_view_sync_channel(&self) -> Libp2pRegularCommChannel<TYPES> {
         self.view_sync_channel.clone()
     }
 
-    fn get_vid_channel(&self) -> Libp2pCommChannel<TYPES> {
+    fn get_vid_channel(&self) -> Libp2pRegularCommChannel<TYPES> {
         self.vid_channel.clone()
     }
 

--- a/crates/hotshot/examples/libp2p/types.rs
+++ b/crates/hotshot/examples/libp2p/types.rs
@@ -1,5 +1,5 @@
 use crate::infra::Libp2pDARun;
-use hotshot::traits::implementations::{Libp2pCommChannel, MemoryStorage};
+use hotshot::traits::implementations::{Libp2pRegularCommChannel, MemoryStorage};
 use hotshot_testing::state_types::TestTypes;
 use hotshot_types::traits::node_implementation::{ChannelMaps, NodeImplementation, NodeType};
 use serde::{Deserialize, Serialize};
@@ -8,10 +8,10 @@ use std::fmt::Debug;
 #[derive(Clone, Debug, Deserialize, Serialize, Hash, PartialEq, Eq)]
 pub struct NodeImpl {}
 
-pub type DANetwork = Libp2pCommChannel<TestTypes>;
-pub type VIDNetwork = Libp2pCommChannel<TestTypes>;
-pub type QuorumNetwork = Libp2pCommChannel<TestTypes>;
-pub type ViewSyncNetwork = Libp2pCommChannel<TestTypes>;
+pub type DANetwork = Libp2pRegularCommChannel<TestTypes>;
+pub type VIDNetwork = Libp2pRegularCommChannel<TestTypes>;
+pub type QuorumNetwork = Libp2pRegularCommChannel<TestTypes>;
+pub type ViewSyncNetwork = Libp2pRegularCommChannel<TestTypes>;
 
 impl NodeImplementation<TestTypes> for NodeImpl {
     type Storage = MemoryStorage<TestTypes>;

--- a/crates/hotshot/src/traits.rs
+++ b/crates/hotshot/src/traits.rs
@@ -14,7 +14,10 @@ pub mod implementations {
     pub use super::{
         networking::{
             combined_network::{CombinedCommChannel, CombinedNetworks},
-            libp2p_network::{Libp2pCommChannel, Libp2pNetwork, PeerInfoVec},
+            libp2p_network::{
+                Libp2pAllToAllCommChannel, Libp2pNetworkRegular, Libp2pRegularCommChannel,
+                PeerInfoVec,
+            },
             memory_network::{MasterMap, MemoryCommChannel, MemoryNetwork},
             web_server_network::{WebCommChannel, WebServerNetwork},
             NetworkingMetricsValue,

--- a/crates/hotshot/src/traits/networking/combined_network.rs
+++ b/crates/hotshot/src/traits/networking/combined_network.rs
@@ -1,7 +1,7 @@
 //! Networking Implementation that has a primary and a fallback newtork.  If the primary
 //! Errors we will use the backup to send or receive
 use super::NetworkError;
-use crate::traits::implementations::{Libp2pNetwork, WebServerNetwork};
+use crate::traits::implementations::{Libp2pNetworkRegular, WebServerNetwork};
 use async_lock::RwLock;
 use hotshot_constants::{
     COMBINED_NETWORK_CACHE_SIZE, COMBINED_NETWORK_MIN_PRIMARY_FAILURES,
@@ -130,18 +130,18 @@ impl<TYPES: NodeType> CombinedCommChannel<TYPES> {
 
     /// Get a ref to the backup network
     #[must_use]
-    pub fn secondary(&self) -> &Libp2pNetwork<Message<TYPES>, TYPES::SignatureKey> {
+    pub fn secondary(&self) -> &Libp2pNetworkRegular<Message<TYPES>, TYPES::SignatureKey> {
         &self.networks.1
     }
 }
 
-/// Wrapper for the tuple of `WebServerNetwork` and `Libp2pNetwork`
+/// Wrapper for the tuple of `WebServerNetwork` and `Libp2pNetworkRegular`
 /// We need this so we can impl `TestableNetworkingImplementation`
 /// on the tuple
 #[derive(Debug, Clone)]
 pub struct CombinedNetworks<TYPES: NodeType>(
     pub WebServerNetwork<TYPES>,
-    pub Libp2pNetwork<Message<TYPES>, TYPES::SignatureKey>,
+    pub Libp2pNetworkRegular<Message<TYPES>, TYPES::SignatureKey>,
 );
 
 impl<TYPES: NodeType> TestableNetworkingImplementation<TYPES> for CombinedNetworks<TYPES> {
@@ -162,7 +162,7 @@ impl<TYPES: NodeType> TestableNetworkingImplementation<TYPES> for CombinedNetwor
                 da_committee_size,
                 is_da
             ),
-            <Libp2pNetwork<Message<TYPES>, TYPES::SignatureKey> as TestableNetworkingImplementation<_>>::generator(
+            <Libp2pNetworkRegular<Message<TYPES>, TYPES::SignatureKey> as TestableNetworkingImplementation<_>>::generator(
                 expected_node_count,
                 num_bootstrap,
                 network_id,
@@ -362,7 +362,7 @@ impl<TYPES: NodeType> CommunicationChannel<TYPES> for CombinedCommChannel<TYPES>
         <WebServerNetwork<_> as ConnectedNetwork<Message<TYPES>,TYPES::SignatureKey>>::
             inject_consensus_info(self.primary(), event.clone()).await;
 
-        <Libp2pNetwork<_, _> as ConnectedNetwork<Message<TYPES>,TYPES::SignatureKey>>::
+        <Libp2pNetworkRegular<_, _> as ConnectedNetwork<Message<TYPES>,TYPES::SignatureKey>>::
             inject_consensus_info(self.secondary(), event).await;
     }
 }

--- a/crates/testing/src/node_types.rs
+++ b/crates/testing/src/node_types.rs
@@ -9,8 +9,8 @@ use hotshot::{
     traits::{
         election::static_committee::{StaticCommittee, StaticElectionConfig},
         implementations::{
-            CombinedCommChannel, Libp2pCommChannel, MemoryCommChannel, MemoryStorage,
-            WebCommChannel,
+            CombinedCommChannel, Libp2pAllToAllCommChannel, Libp2pRegularCommChannel,
+            MemoryCommChannel, MemoryStorage, WebCommChannel,
         },
         NodeImplementation,
     },
@@ -54,6 +54,9 @@ pub struct MemoryImpl;
 pub struct Libp2pImpl;
 
 #[derive(Clone, Debug, Deserialize, Serialize, Hash, Eq, PartialEq)]
+pub struct Libp2pAllToAllImpl;
+
+#[derive(Clone, Debug, Deserialize, Serialize, Hash, Eq, PartialEq)]
 pub struct WebImpl;
 
 #[derive(Clone, Debug, Deserialize, Serialize, Hash, Eq, PartialEq)]
@@ -63,7 +66,7 @@ pub type StaticMembership = StaticCommittee<TestTypes>;
 
 pub type StaticMemoryDAComm = MemoryCommChannel<TestTypes>;
 
-type StaticLibp2pDAComm = Libp2pCommChannel<TestTypes>;
+type StaticLibp2pDAComm = Libp2pRegularCommChannel<TestTypes>;
 
 type StaticWebDAComm = WebCommChannel<TestTypes>;
 
@@ -71,7 +74,7 @@ type StaticCombinedDAComm = CombinedCommChannel<TestTypes>;
 
 pub type StaticMemoryQuorumComm = MemoryCommChannel<TestTypes>;
 
-type StaticLibp2pQuorumComm = Libp2pCommChannel<TestTypes>;
+type StaticLibp2pQuorumComm = Libp2pRegularCommChannel<TestTypes>;
 
 type StaticWebQuorumComm = WebCommChannel<TestTypes>;
 
@@ -85,6 +88,21 @@ impl NodeImplementation<TestTypes> for Libp2pImpl {
     type Storage = MemoryStorage<TestTypes>;
     type QuorumNetwork = StaticLibp2pQuorumComm;
     type CommitteeNetwork = StaticLibp2pDAComm;
+
+    fn new_channel_maps(
+        start_view: <TestTypes as NodeType>::Time,
+    ) -> (ChannelMaps<TestTypes>, Option<ChannelMaps<TestTypes>>) {
+        (
+            ChannelMaps::new(start_view),
+            Some(ChannelMaps::new(start_view)),
+        )
+    }
+}
+
+impl NodeImplementation<TestTypes> for Libp2pAllToAllImpl {
+    type Storage = MemoryStorage<TestTypes>;
+    type QuorumNetwork = Libp2pAllToAllCommChannel<TestTypes>;
+    type CommitteeNetwork = Libp2pAllToAllCommChannel<TestTypes>;
 
     fn new_channel_maps(
         start_view: <TestTypes as NodeType>::Time,

--- a/crates/testing/tests/libp2p.rs
+++ b/crates/testing/tests/libp2p.rs
@@ -67,6 +67,7 @@ async fn test_stress_libp2p_network() {
     tokio::test(flavor = "multi_thread", worker_threads = 2)
 )]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
+#[ignore]
 #[instrument]
 async fn libp2p_network_all_to_all() {
     async_compatibility_layer::logging::setup_logging();

--- a/crates/testing/tests/libp2p.rs
+++ b/crates/testing/tests/libp2p.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use hotshot_testing::{
     completion_task::{CompletionTaskDescription, TimeBasedCompletionTaskDescription},
-    node_types::{Libp2pImpl, TestTypes},
+    node_types::{Libp2pAllToAllImpl, Libp2pImpl, TestTypes},
     overall_safety_task::OverallSafetyPropertiesDescription,
     test_builder::{TestMetadata, TimingData},
 };
@@ -56,6 +56,40 @@ async fn test_stress_libp2p_network() {
     let metadata = TestMetadata::default_stress();
     metadata
         .gen_launcher::<TestTypes, Libp2pImpl>(0)
+        .launch()
+        .run_test()
+        .await
+}
+
+/// libp2p all to all network test
+#[cfg_attr(
+    async_executor_impl = "tokio",
+    tokio::test(flavor = "multi_thread", worker_threads = 2)
+)]
+#[cfg_attr(async_executor_impl = "async-std", async_std::test)]
+#[instrument]
+async fn libp2p_network_all_to_all() {
+    async_compatibility_layer::logging::setup_logging();
+    async_compatibility_layer::logging::setup_backtrace();
+    let metadata = TestMetadata {
+        overall_safety_properties: OverallSafetyPropertiesDescription {
+            check_leaf: true,
+            ..Default::default()
+        },
+        completion_task_description: CompletionTaskDescription::TimeBasedCompletionTaskBuilder(
+            TimeBasedCompletionTaskDescription {
+                duration: Duration::new(240, 0),
+            },
+        ),
+        timing_data: TimingData {
+            round_start_delay: 100,
+            ..Default::default()
+        },
+        ..TestMetadata::default_multiple_rounds()
+    };
+
+    metadata
+        .gen_launcher::<TestTypes, Libp2pAllToAllImpl>(0)
         .launch()
         .run_test()
         .await

--- a/testing-macros/src/lib.rs
+++ b/testing-macros/src/lib.rs
@@ -598,7 +598,7 @@ pub fn cross_all_types(input: TokenStream) -> TokenStream {
     let tokens = quote! {
             DemoType: [ /* (Consensus, hotshot_testing::demo::DemoState), */ (hotshot::demos::vdemo::VDemoState) ],
             SignatureKey: [ hotshot_types::traits::signature_key::bn254::BLSPubKey ],
-            CommChannel: [ hotshot::traits::implementations::Libp2pCommChannel, hotshot::traits::implementations::CentralizedCommChannel ],
+            CommChannel: [ hotshot::traits::implementations::{Libp2pRegularCommChannel, Libp2pAllToAllCommChannel}, hotshot::traits::implementations::CentralizedCommChannel ],
             Time: [ hotshot_types::data::ViewNumber ],
             Storage: [ hotshot::traits::implementations::MemoryStorage ],
             TestName: #test_name,


### PR DESCRIPTION
Closes #2302 

### This PR: 
Adds an `AllToAll` network for libp2p and corresponding test. It's a lot of copy-pasta but it *does* work. I couldn't think of a simpler way to do this without modifying the `Testable` traits to a special case libp2p. This instead maintains the same traits while creating a new network that we can plug in to timeboost.

### This PR does not: 
Implement an all to all broadcast. That will be done in #2303 


### Key places to review: 
N/A

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
