### PR TITLE
Remove `timestamp` field from `Leaf`

### DIFF
--- a/crates/task-impls/src/consensus.rs
+++ b/crates/task-impls/src/consensus.rs
@@ -220,7 +220,6 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                     block_header: proposal.block_header.clone(),
                     block_payload: None,
                     rejected: Vec::new(),
-                    timestamp: time::OffsetDateTime::now_utc().unix_timestamp_nanos(),
                     proposer_id: self.quorum_membership.get_leader(view).to_bytes(),
                 };
                 let vote = QuorumVote::<TYPES>::create_signed_vote(
@@ -304,7 +303,6 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                     block_header: proposal.block_header.clone(),
                     block_payload: None,
                     rejected: Vec::new(),
-                    timestamp: time::OffsetDateTime::now_utc().unix_timestamp_nanos(),
                     proposer_id: self.quorum_membership.get_leader(view).to_bytes(),
                 };
 
@@ -524,7 +522,6 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                         block_header: proposal.data.block_header,
                         block_payload: None,
                         rejected: Vec::new(),
-                        timestamp: time::OffsetDateTime::now_utc().unix_timestamp_nanos(),
                         proposer_id: sender.to_bytes(),
                     };
 
@@ -549,7 +546,6 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                     block_header: proposal.data.block_header,
                     block_payload: None,
                     rejected: Vec::new(),
-                    timestamp: time::OffsetDateTime::now_utc().unix_timestamp_nanos(),
                     proposer_id: sender.to_bytes(),
                 };
                 let leaf_commitment = leaf.commit();
@@ -1156,7 +1152,6 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                 ),
                 block_payload: None,
                 rejected: vec![],
-                timestamp: time::OffsetDateTime::now_utc().unix_timestamp_nanos(),
                 proposer_id: self.api.public_key().to_bytes(),
             };
 

--- a/crates/testing/src/task_helpers.rs
+++ b/crates/testing/src/task_helpers.rs
@@ -143,7 +143,6 @@ async fn build_quorum_proposal_and_signature(
         block_header: block_header.clone(),
         block_payload: None,
         rejected: vec![],
-        timestamp: 0,
         proposer_id: api.public_key().to_bytes(),
     };
     let signature = <BLSPubKey as SignatureKey>::sign(private_key, leaf.commit().as_ref());

--- a/crates/testing/tests/consensus_task.rs
+++ b/crates/testing/tests/consensus_task.rs
@@ -65,7 +65,6 @@ async fn build_vote(
         block_header: proposal.block_header,
         block_payload: None,
         rejected: Vec::new(),
-        timestamp: 0,
         proposer_id: membership.get_leader(view).to_bytes(),
     };
     let vote = QuorumVote::<TestTypes>::create_signed_vote(

--- a/crates/types/src/data.rs
+++ b/crates/types/src/data.rs
@@ -316,10 +316,6 @@ pub struct Leaf<TYPES: NodeType> {
     /// Transactions that were marked for rejection while collecting the block.
     pub rejected: Vec<<TYPES::BlockPayload as BlockPayload>::Transaction>,
 
-    // TODO (Keyao) Remove.
-    /// the timestamp the leaf was constructed at, in nanoseconds. Only exposed for dashboard stats
-    pub timestamp: i128,
-
     /// the proposer id of the leaf
     pub proposer_id: EncodedPublicKey,
 }
@@ -368,7 +364,6 @@ impl<TYPES: NodeType> Leaf<TYPES> {
             block_header,
             block_payload: Some(block_payload),
             rejected: Vec::new(),
-            timestamp: time::OffsetDateTime::now_utc().unix_timestamp_nanos(),
             proposer_id: genesis_proposer_id(),
         }
     }
@@ -442,10 +437,6 @@ impl<TYPES: NodeType> Leaf<TYPES> {
     pub fn get_rejected(&self) -> Vec<<TYPES::BlockPayload as BlockPayload>::Transaction> {
         self.rejected.clone()
     }
-    /// Real-world time when this leaf was created.
-    pub fn get_timestamp(&self) -> i128 {
-        self.timestamp
-    }
     /// Identity of the network participant who proposed this leaf.
     pub fn get_proposer_id(&self) -> EncodedPublicKey {
         self.proposer_id.clone()
@@ -459,7 +450,6 @@ impl<TYPES: NodeType> Leaf<TYPES> {
             block_header: stored_view.block_header,
             block_payload: stored_view.block_payload,
             rejected: stored_view.rejected,
-            timestamp: stored_view.timestamp,
             proposer_id: stored_view.proposer_id,
         }
     }
@@ -561,7 +551,6 @@ where
             block_header: leaf.get_block_header().clone(),
             block_payload: leaf.get_block_payload(),
             rejected: leaf.get_rejected(),
-            timestamp: leaf.get_timestamp(),
             proposer_id: leaf.get_proposer_id(),
         }
     }

--- a/crates/types/src/traits/storage.rs
+++ b/crates/types/src/traits/storage.rs
@@ -132,9 +132,6 @@ pub struct StoredView<TYPES: NodeType> {
     pub block_payload: Option<TYPES::BlockPayload>,
     /// transactions rejected in this view
     pub rejected: Vec<TYPES::Transaction>,
-    /// the timestamp this view was recv-ed in nanonseconds
-    #[derivative(PartialEq = "ignore")]
-    pub timestamp: i128,
     /// the proposer id
     #[derivative(PartialEq = "ignore")]
     pub proposer_id: EncodedPublicKey,
@@ -163,7 +160,6 @@ where
             block_header,
             block_payload,
             rejected,
-            timestamp: time::OffsetDateTime::now_utc().unix_timestamp_nanos(),
             proposer_id,
         }
     }


### PR DESCRIPTION
Closes #2195 

### This PR: 
Removes `timestamp` field from `Leaf` and `StoredView`.

### This PR does not: 
Do anything else

### Key places to review: 
`crates/types/src/data.rs`

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
