### PR TITLE
Added feature to randomize leader election

### DIFF
--- a/crates/hotshot/Cargo.toml
+++ b/crates/hotshot/Cargo.toml
@@ -17,6 +17,7 @@ bin-orchestrator = ["clap"]
 docs = []
 doc-images = []
 hotshot-testing = []
+randomized-leader-election = []
 
 # libp2p
 [[example]]

--- a/crates/hotshot/src/traits/election/static_committee.rs
+++ b/crates/hotshot/src/traits/election/static_committee.rs
@@ -10,6 +10,9 @@ use serde::{Deserialize, Serialize};
 use std::{marker::PhantomData, num::NonZeroU64};
 use tracing::debug;
 
+#[cfg(feature = "randomized-leader-election")]
+use rand::{Rng, rngs::StdRng};
+
 /// Dummy implementation of [`Membership`]
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
@@ -56,9 +59,20 @@ where
         self.committee_nodes_with_stake.clone()
     }
 
+    #[cfg(not(feature = "randomized-leader-election"))]
     /// Index the vector of public keys with the current view number
     fn get_leader(&self, view_number: TYPES::Time) -> PUBKEY {
         let index = (*view_number % self.nodes_with_stake.len() as u64) as usize;
+        let res = self.nodes_with_stake[index].clone();
+        TYPES::SignatureKey::get_public_key(&res)
+    }
+
+    #[cfg(feature = "randomized-leader-election")]
+    /// Index the vector of public keys with a random number generated using the current view number as a seed
+    fn get_leader(&self, view_number: TYPES::Time) -> PUBKEY {
+        let mut rng: StdRng = rand::SeedableRng::seed_from_u64(*view_number as u64);
+        let randomized_view_number: u64 = rng.gen();
+        let index = (randomized_view_number % self.nodes_with_stake.len() as u64) as usize;
         let res = self.nodes_with_stake[index].clone();
         TYPES::SignatureKey::get_public_key(&res)
     }

--- a/crates/testing/tests/network_task.rs
+++ b/crates/testing/tests/network_task.rs
@@ -17,7 +17,6 @@ use std::{collections::HashMap, marker::PhantomData};
     tokio::test(flavor = "multi_thread", worker_threads = 2)
 )]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
-#[ignore]
 async fn test_network_task() {
     use hotshot_task_impls::harness::run_harness;
     use hotshot_testing::task_helpers::build_system_handle;

--- a/crates/testing/tests/network_task.rs
+++ b/crates/testing/tests/network_task.rs
@@ -17,6 +17,7 @@ use std::{collections::HashMap, marker::PhantomData};
     tokio::test(flavor = "multi_thread", worker_threads = 2)
 )]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
+#[ignore]
 async fn test_network_task() {
     use hotshot_task_impls::harness::run_harness;
     use hotshot_testing::task_helpers::build_system_handle;

--- a/justfile
+++ b/justfile
@@ -130,3 +130,7 @@ lint_imports:
 gen_key_pair:
   echo Generating key pair from config file in config/
   cargo test --package hotshot-testing --test gen_key_pair -- tests --nocapture
+
+test_randomized_leader_election:
+  echo Testing
+  cargo test --features "randomized-leader-election" --verbose --lib --bins --tests --benches --workspace --no-fail-fast -- --test-threads=1 --nocapture --skip crypto_test 


### PR DESCRIPTION
Closes #2311

### This PR: 
Adds a feature `randomized-leader-election` that performs leader election by indexing into the stake table using a random number seeded with the current `view_number`.

### This PR does not: 

### Key places to review: 

### How to test this PR:
`just async_std test_randomized_leader_election`
