### PR TITLE
Unified clippy lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -160,3 +160,15 @@ debug = 1
 inherits = "release"
 lto = "off"
 incremental = true
+
+[workspace.lints.clippy]
+all = "warn"
+pedantic = "warn"
+missing_docs_in_private_items = "warn"
+panic = "warn"
+
+module_name_repetitions = "allow"
+
+[workspace.lints.rust]
+rust_2018_idioms = "warn"
+missing_docs = "warn"

--- a/crates/constants/Cargo.toml
+++ b/crates/constants/Cargo.toml
@@ -3,3 +3,6 @@ name = "hotshot-constants"
 version.workspace = true
 
 [dependencies]
+
+[lints]
+workspace = true

--- a/crates/hotshot-qc/Cargo.toml
+++ b/crates/hotshot-qc/Cargo.toml
@@ -34,3 +34,6 @@ hotshot-stake-table = { path = "../hotshot-stake-table" }
 default = ["parallel"]
 std = ["ark-std/std"]
 parallel = ["jf-primitives/parallel", "jf-utils/parallel"]
+
+[lints]
+workspace = true

--- a/crates/hotshot-signature-key/Cargo.toml
+++ b/crates/hotshot-signature-key/Cargo.toml
@@ -21,3 +21,6 @@ rand_chacha = { workspace = true }
 serde = { workspace = true }
 tracing = { workspace = true }
 typenum = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/hotshot-stake-table/Cargo.toml
+++ b/crates/hotshot-stake-table/Cargo.toml
@@ -33,3 +33,6 @@ rand_chacha = { workspace = true }
 default = ["parallel"]
 std = ["ark-std/std", "ark-serialize/std", "ark-ff/std"]
 parallel = ["jf-primitives/parallel", "jf-utils/parallel", "ark-ff/parallel"]
+
+[lints]
+workspace = true

--- a/crates/hotshot-state-prover/Cargo.toml
+++ b/crates/hotshot-state-prover/Cargo.toml
@@ -33,3 +33,6 @@ hotshot-stake-table = { path = "../hotshot-stake-table" }
 default = ["parallel"]
 std = ["ark-std/std", "ark-serialize/std", "ark-ff/std"]
 parallel = ["jf-primitives/parallel", "jf-utils/parallel", "ark-ff/parallel"]
+
+[lints]
+workspace = true

--- a/crates/hotshot/Cargo.toml
+++ b/crates/hotshot/Cargo.toml
@@ -131,3 +131,6 @@ clap = { version = "4.4", features = ["derive", "env"] }
 serde_json = "1.0.109"
 toml = { workspace = true }
 hotshot-testing = { path = "../testing" }
+
+[lints]
+workspace = true

--- a/crates/hotshot/src/lib.rs
+++ b/crates/hotshot/src/lib.rs
@@ -1,12 +1,3 @@
-#![warn(
-    clippy::all,
-    clippy::pedantic,
-    rust_2018_idioms,
-    missing_docs,
-    clippy::missing_docs_in_private_items,
-    clippy::panic
-)]
-#![allow(clippy::module_name_repetitions)]
 // Temporary
 #![allow(clippy::cast_possible_truncation)]
 // Temporary, should be disabled after the completion of the NodeImplementation refactor

--- a/crates/libp2p-networking/Cargo.toml
+++ b/crates/libp2p-networking/Cargo.toml
@@ -75,3 +75,5 @@ netlink-sys = { git = "https://github.com/espressosystems/netlink.git", version 
 ], optional = true }
 netlink-packet-generic = { git = "https://github.com/espressosystems/netlink.git", version = "0.2.0", optional = true }
 
+[lints]
+workspace = true

--- a/crates/libp2p-networking/src/lib.rs
+++ b/crates/libp2p-networking/src/lib.rs
@@ -1,11 +1,3 @@
-#![warn(
-    clippy::all,
-    clippy::pedantic,
-    rust_2018_idioms,
-    missing_docs,
-    clippy::panic
-)]
-#![allow(clippy::module_name_repetitions)]
 //! Library for p2p communication
 
 /// Example message used by the UI library

--- a/crates/orchestrator/Cargo.toml
+++ b/crates/orchestrator/Cargo.toml
@@ -30,3 +30,6 @@ thiserror = "1.0.50"
 tokio = { workspace = true }
 [target.'cfg(all(async_executor_impl = "async-std"))'.dependencies]
 async-std = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/task-impls/Cargo.toml
+++ b/crates/task-impls/Cargo.toml
@@ -32,3 +32,6 @@ sha2 = { workspace = true }
 tokio = { workspace = true }
 [target.'cfg(all(async_executor_impl = "async-std"))'.dependencies]
 async-std = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/task-impls/src/lib.rs
+++ b/crates/task-impls/src/lib.rs
@@ -1,16 +1,6 @@
 //! The consensus layer for hotshot. This currently implements sequencing
 //! consensus in an event driven way
 
-#![warn(
-    clippy::all,
-    clippy::pedantic,
-    rust_2018_idioms,
-    missing_docs,
-    clippy::missing_docs_in_private_items,
-    clippy::panic
-)]
-#![allow(clippy::module_name_repetitions)]
-
 /// the task which implements the main parts of consensus
 pub mod consensus;
 

--- a/crates/task/Cargo.toml
+++ b/crates/task/Cargo.toml
@@ -22,3 +22,6 @@ tokio = { workspace = true }
 
 [target.'cfg(all(async_executor_impl = "async-std"))'.dependencies]
 async-std = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/task/src/lib.rs
+++ b/crates/task/src/lib.rs
@@ -1,13 +1,5 @@
 //! Abstractions meant for usage with long running consensus tasks
 //! and testing harness
-#![warn(
-    clippy::all,
-    clippy::pedantic,
-    rust_2018_idioms,
-    missing_docs,
-    clippy::missing_docs_in_private_items,
-    clippy::panic
-)]
 
 use crate::task::PassType;
 use either::Either;

--- a/crates/testing/Cargo.toml
+++ b/crates/testing/Cargo.toml
@@ -54,3 +54,6 @@ bincode = { workspace = true }    # GG any better options for serialization?
 tokio = { workspace = true }
 [target.'cfg(all(async_executor_impl = "async-std"))'.dependencies]
 async-std = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -58,3 +58,6 @@ async-std = { workspace = true }
 
 [target.'cfg(all(async_executor_impl = "tokio"))'.dependencies]
 tokio = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -1,13 +1,4 @@
 //! Types and Traits for the `HotShot` consensus module
-#![warn(
-    clippy::all,
-    clippy::pedantic,
-    rust_2018_idioms,
-    missing_docs,
-    clippy::missing_docs_in_private_items,
-    clippy::panic
-)]
-#![allow(clippy::module_name_repetitions)]
 
 use displaydoc::Display;
 use std::{num::NonZeroUsize, time::Duration};

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -8,3 +8,6 @@ version = "0.1.0"
 
 [dependencies]
 bincode = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -1,13 +1,4 @@
 //! Contains general utility structures and methods
 
-#![warn(
-    clippy::all,
-    clippy::pedantic,
-    rust_2018_idioms,
-    missing_docs,
-    clippy::missing_docs_in_private_items,
-    clippy::panic
-)]
-
 /// Provides bincode options
 pub mod bincode;

--- a/crates/web_server/Cargo.toml
+++ b/crates/web_server/Cargo.toml
@@ -33,3 +33,6 @@ hotshot-types = { path = "../types", default-features = false }
 tokio = { workspace = true }
 [target.'cfg(all(async_executor_impl = "async-std"))'.dependencies]
 async-std = { workspace = true }
+
+[lints]
+workspace = true


### PR DESCRIPTION
Closes #2291

### This PR: 
Moves clippy lints to the Cargo.toml in the workspace root, and enables lints for all crates.

### This PR does not: 
Fix any linter warnings.

### Key places to review: 
