### PR TITLE
[CI] - fix cargo careful and code coverage workflows

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -30,7 +30,7 @@ jobs:
         # Use the `release` profile rather than `release-lto` as other workflows do, since `--
         # profile=release-lto` will cause the `failed to generate report` error.
         run: |
-          nix develop .#perfShell -c RUSTFLAGS='--cfg async_executor_impl="tokio" --cfg async_channel_impl="tokio"' cargo-llvm-cov llvm-cov --features=full-ci --lib --bins --tests --benches --release --workspace --lcov --output-path lcov.info -- --test-threads=1
+          nix develop .#perfShell -c just tokio code_coverage
         timeout-minutes: 90
 
       - name: Coveralls upload

--- a/flake.nix
+++ b/flake.nix
@@ -95,7 +95,7 @@
 
           src = cargo-careful;
 
-          cargoSha256 = "sha256-mRfJwNzx0kcW1By6Yt0EijYujtq5KawaWiaPy1cubVs=";
+          cargoSha256 = "sha256-5H6Dp3YANVGYxvphTdnd92+0h0ddFX7u5SWT24YxzV4=";
 
           meta = {
             description = "A cargo undefined behaviour checker";
@@ -178,7 +178,7 @@
             openssl.out
           ] ++ lib.optionals stdenv.isDarwin [
             darwin.apple_sdk.frameworks.Security
-            darwin.apple_sdk.frameworks.CoreServices 
+            darwin.apple_sdk.frameworks.CoreServices
             pkgs.libiconv
             darwin.apple_sdk.frameworks.SystemConfiguration
           ];

--- a/justfile
+++ b/justfile
@@ -133,4 +133,8 @@ gen_key_pair:
 
 test_randomized_leader_election:
   echo Testing
-  cargo test --features "randomized-leader-election" --verbose --lib --bins --tests --benches --workspace --no-fail-fast -- --test-threads=1 --nocapture --skip crypto_test 
+  cargo test --features "randomized-leader-election" --verbose --lib --bins --tests --benches --workspace --no-fail-fast -- --test-threads=1 --nocapture --skip crypto_test
+
+code_coverage:
+  echo "Running code coverage"
+  cargo-llvm-cov llvm-cov --lib --bins --tests --benches --release --workspace --lcov --output-path lcov.info -- --test-threads=1


### PR DESCRIPTION
Closes #2332 

### This PR: 
Updates the careful hash, and changes code coverage workflow to use the justfile

### This PR does not: 
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->

### Key places to review: 
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
