### PR TITLE
Make hotshot_example a feature flag

### DIFF
--- a/crates/testing/src/lib.rs
+++ b/crates/testing/src/lib.rs
@@ -1,6 +1,6 @@
 #![cfg_attr(
     // hotshot_example option is set manually in justfile when running examples
-    not(any(test, debug_assertions, hotshot_example)),
+    not(any(test, debug_assertions, feature="hotshot_example")),
     deprecated = "suspicious usage of testing/demo implementations in non-test/non-debug build"
 )]
 

--- a/justfile
+++ b/justfile
@@ -2,8 +2,8 @@ default: run_ci
 
 set export
 
-original_rustflags := env_var_or_default('RUSTFLAGS', '--cfg hotshot_example')
-original_rustdocflags := env_var_or_default('RUSTDOCFLAGS', '--cfg hotshot_example')
+original_rustflags := env_var_or_default('RUSTFLAGS', '--cfg feature="hotshot_example"')
+original_rustdocflags := env_var_or_default('RUSTDOCFLAGS', '--cfg feature="hotshot_example"')
 
 run_ci: lint build test
 


### PR DESCRIPTION
Closes #2179

### This PR: 
Converts hotshot_example to a feature flag. Note that we still use RUSTFLAGS to enable the feature for our tests (see: https://github.com/rust-lang/cargo/issues/4942), but crates importing HotShot as dependency should be able to set the feature.

### This PR does not: 

### Key places to review: 
