### PR TITLE
[CI] Sequencer tests in CI

### DIFF
--- a/.github/workflows/test-sequencer.yml
+++ b/.github/workflows/test-sequencer.yml
@@ -1,12 +1,6 @@
 name: Test sequencer
 
 on:
-  push:
-    branches:
-      - 'main'
-  pull_request:
-  schedule:
-    - cron: '0 0 * * 1'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/test-sequencer.yml
+++ b/.github/workflows/test-sequencer.yml
@@ -1,6 +1,9 @@
 name: Test sequencer
 
 on:
+  schedule:
+    # Monday midnight
+    - cron: '0 0 * * 1'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/test-sequencer.yml
+++ b/.github/workflows/test-sequencer.yml
@@ -1,0 +1,79 @@
+name: Test sequencer
+
+on:
+  push:
+    branches:
+      - 'main'
+  pull_request:
+  schedule:
+    - cron: '0 0 * * 1'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test-sequencer:
+    runs-on: ubuntu-latest
+    name: Test sequencer
+    steps:
+      - uses: actions/checkout@v4
+        name: Checkout Repository
+        with:
+          path: hotshot
+
+      - uses: actions/checkout@v4
+        name: Checkout Sequencer Repository
+        with:
+          repository: EspressoSystems/espresso-sequencer
+          path: sequencer
+          submodules: true
+
+      - name: Install Rust Stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        name: Enable Rust Caching
+        with:
+          shared-key: ""
+          prefix-key: sequencer
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        # TODO: remove version pinning once sequencer repository does that
+        with:
+          version: "nightly-60ec00296f00754bc21ed68fd05ab6b54b50e024"
+
+      - name: Patch sequencer dependencies
+        run: |
+          mkdir -p .cargo
+          cat << EOF > .cargo/config.toml
+          [patch.'https://github.com/EspressoSystems/hotshot']
+          hotshot = { path = "${GITHUB_WORKSPACE}/hotshot/crates/hotshot" }
+          hotshot-constants = { path = "${GITHUB_WORKSPACE}/hotshot/crates/constants" }
+          hotshot-qc = { path = "${GITHUB_WORKSPACE}/hotshot/crates/hotshot-qc" }
+          hotshot-signature-key = { path = "${GITHUB_WORKSPACE}/hotshot/crates/hotshot-signature-key" }
+          hotshot-stake-table = { path = "${GITHUB_WORKSPACE}/hotshot/crates/hotshot-stake-table" }
+          hotshot-state-prover = { path = "${GITHUB_WORKSPACE}/hotshot/crates/hotshot-state-prover" }
+          hotshot-orchestrator = { path = "${GITHUB_WORKSPACE}/hotshot/crates/orchestrator" }
+          hotshot-web-server = { path = "${GITHUB_WORKSPACE}/hotshot/crates/web_server" }
+          hotshot-task = { path = "${GITHUB_WORKSPACE}/hotshot/crates/task" }
+          hotshot-task-impls = { path = "${GITHUB_WORKSPACE}/hotshot/crates/task-impls" }
+          hotshot-testing = { path = "${GITHUB_WORKSPACE}/hotshot/crates/testing" }
+          hotshot-types = { path = "${GITHUB_WORKSPACE}/hotshot/crates/types" }
+          hotshot-utils = { path = "${GITHUB_WORKSPACE}/hotshot/crates/utils" }
+          libp2p-networking = { path = "${GITHUB_WORKSPACE}/hotshot/crates/libp2p-networking" }
+          EOF
+
+      - name: Build sequencer tests
+        working-directory: sequencer
+        run: |
+          export RUSTFLAGS='--cfg async_executor_impl="async-std" --cfg async_channel_impl="async-std" --cfg hotshot_example'
+          cargo test --release --workspace --all-features --no-run
+
+      - name: Run sequencer tests
+        working-directory: sequencer
+        run: |
+          export RUSTFLAGS='--cfg async_executor_impl="async-std" --cfg async_channel_impl="async-std" --cfg hotshot_example'
+          cargo test --release --workspace --all-features --verbose -- --test-threads 1 --nocapture


### PR DESCRIPTION
Closes #2337
<!-- See here for keywords in Github -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

### This PR: 
Adds a workflow that builds and runs tests for sequencer with hotshot dependencies patched to the PR being tested

### This PR does not: 
Touch any other workflows.
Do anything clever to skip building in cases where API is obviously going to be broken.

### Key places to review: 
`.github/workflows/test-sequencer.yml`

### How to test this PR:
See CI. This PR fails the check on build stage, since sequencer doesn't build with current `main` due to API breakage.
A sample passing run:  #2361 (revert to hotshot version currently used in sequencer + this workflow)
A sample run with successful build, but failing tests: #2364 (revert to hotshot version currently used in sequencer + a sample commit breaking hotshot + this workflow)


<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
