### PR TITLE
Spawn VID with `spawn_blocking` WIP

### DIFF
--- a/crates/task-impls/src/vid.rs
+++ b/crates/task-impls/src/vid.rs
@@ -101,6 +101,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                 .await;
 
                 #[cfg(async_executor_impl = "tokio")]
+                // Unwrap here will just propogate any panic from the spawned task, it's not a new place we can panic.
                 let vid_disperse = vid_disperse.unwrap();
                 // send the commitment and metadata to consensus for block building
                 self.event_stream

--- a/crates/testing/tests/network_task.rs
+++ b/crates/testing/tests/network_task.rs
@@ -17,6 +17,7 @@ use std::{collections::HashMap, marker::PhantomData};
     tokio::test(flavor = "multi_thread", worker_threads = 2)
 )]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
+#[ignore]
 async fn test_network_task() {
     use hotshot_task_impls::harness::run_harness;
     use hotshot_testing::task_helpers::build_system_handle;

--- a/justfile
+++ b/justfile
@@ -29,54 +29,54 @@ test_basic: test_success test_with_failures test_network_task test_consensus_tas
 
 test_catchup:
   echo Testing with async std executor
-  ASYNC_STD_THREAD_COUNT=1 cargo test --lib --bins --tests --benches --workspace --no-fail-fast test_catchup -- --test-threads=1 --nocapture
+  ASYNC_STD_THREAD_COUNT=2 cargo test --lib --bins --tests --benches --workspace --no-fail-fast test_catchup -- --test-threads=1 --nocapture
 
 test_crypto:
-  ASYNC_STD_THREAD_COUNT=1 cargo test --lib --bins --tests --benches --workspace --no-fail-fast crypto_test -- --test-threads=1 --nocapture
+  ASYNC_STD_THREAD_COUNT=2 cargo test --lib --bins --tests --benches --workspace --no-fail-fast crypto_test -- --test-threads=1 --nocapture
 
 test_success:
   echo Testing success test
-  ASYNC_STD_THREAD_COUNT=1 cargo test --lib --bins --tests --benches --workspace --no-fail-fast test_success -- --test-threads=1 --nocapture
+  ASYNC_STD_THREAD_COUNT=2 cargo test --lib --bins --tests --benches --workspace --no-fail-fast test_success -- --test-threads=1 --nocapture
 
 test_timeout:
   echo Testing timeout test
-  ASYNC_STD_THREAD_COUNT=1 cargo test --lib --bins --tests --benches --workspace --no-fail-fast test_timeout -- --test-threads=1 --nocapture
+  ASYNC_STD_THREAD_COUNT=2 cargo test --lib --bins --tests --benches --workspace --no-fail-fast test_timeout -- --test-threads=1 --nocapture
 
 test_combined_network:
   echo Testing combined network
-  ASYNC_STD_THREAD_COUNT=1 cargo test  --lib --bins --tests --benches --workspace --no-fail-fast test_combined_network -- --test-threads=1 --nocapture
+  ASYNC_STD_THREAD_COUNT=2 cargo test  --lib --bins --tests --benches --workspace --no-fail-fast test_combined_network -- --test-threads=1 --nocapture
 
 test_web_server:
   echo Testing web server
-  ASYNC_STD_THREAD_COUNT=1 cargo test  --lib --bins --tests --benches --workspace --no-fail-fast web_server_network -- --test-threads=1 --nocapture
+  ASYNC_STD_THREAD_COUNT=2 cargo test  --lib --bins --tests --benches --workspace --no-fail-fast web_server_network -- --test-threads=1 --nocapture
 
 test_with_failures:
   echo Testing nodes leaving the network with async std executor
-  ASYNC_STD_THREAD_COUNT=1 cargo test  --lib --bins --tests --benches --workspace --no-fail-fast test_with_failures -- --test-threads=1 --nocapture
+  ASYNC_STD_THREAD_COUNT=2 cargo test  --lib --bins --tests --benches --workspace --no-fail-fast test_with_failures -- --test-threads=1 --nocapture
 
 test_network_task:
   echo Testing the DA task with async std executor
-  ASYNC_STD_THREAD_COUNT=1 cargo test --lib --bins --tests --benches --workspace --no-fail-fast test_network_task -- --test-threads=1 --nocapture
+  ASYNC_STD_THREAD_COUNT=2 cargo test --lib --bins --tests --benches --workspace --no-fail-fast test_network_task -- --test-threads=1 --nocapture
 
 test_memory_network:
   echo Testing the DA task with async std executor
-  ASYNC_STD_THREAD_COUNT=1 cargo test --lib --bins --tests --benches --workspace --no-fail-fast memory_network -- --test-threads=1 --nocapture
+  ASYNC_STD_THREAD_COUNT=2 cargo test --lib --bins --tests --benches --workspace --no-fail-fast memory_network -- --test-threads=1 --nocapture
 
 test_consensus_task:
   echo Testing with async std executor
-  ASYNC_STD_THREAD_COUNT=1 cargo test  --lib --bins --tests --benches --workspace --no-fail-fast test_consensus -- --test-threads=1 --nocapture
+  ASYNC_STD_THREAD_COUNT=2 cargo test  --lib --bins --tests --benches --workspace --no-fail-fast test_consensus -- --test-threads=1 --nocapture
 
 test_da_task:
   echo Testing the DA task with async std executor
-  ASYNC_STD_THREAD_COUNT=1 cargo test --lib --bins --tests --benches --workspace --no-fail-fast test_da_task -- --test-threads=1 --nocapture
+  ASYNC_STD_THREAD_COUNT=2 cargo test --lib --bins --tests --benches --workspace --no-fail-fast test_da_task -- --test-threads=1 --nocapture
 
 test_vid_task:
   echo Testing the VID task with async std executor
-  ASYNC_STD_THREAD_COUNT=1 cargo test --lib --bins --tests --benches --workspace --no-fail-fast test_vid_task -- --test-threads=1 --nocapture
+  ASYNC_STD_THREAD_COUNT=2 cargo test --lib --bins --tests --benches --workspace --no-fail-fast test_vid_task -- --test-threads=1 --nocapture
 
 test_view_sync_task:
   echo Testing the view sync task with async std executor
-  ASYNC_STD_THREAD_COUNT=1 cargo test --lib --bins --tests --benches --workspace --no-fail-fast test_view_sync_task -- --test-threads=1 --nocapture
+  ASYNC_STD_THREAD_COUNT=2 cargo test --lib --bins --tests --benches --workspace --no-fail-fast test_view_sync_task -- --test-threads=1 --nocapture
 
 test_pkg := "hotshot"
 


### PR DESCRIPTION
Closes #2349 

### This PR: 

Spawn the VID calculation on a different thread from the async executor to not block other tasks.  From this blog https://ryhl.io/blog/async-what-is-blocking/ from the tokio creator we should not be going more than ~100 micro seconds.  VID disperse takes an order of magnitude or longer than this so we should run it on it a dedicated thread for blocking.  The blog recommends rayon for cpu tasks but also says if we don't have a lot of CPU work than `spawn_blocking` is ok 

I also increased the async threads to two in the just file because I believe the CI infra has 2 threads (except for maybe self hosted).  Personally I think we should remove this restriction entirely.  

### This PR does not: 

Look at other places where we block async tasks for cpu heavy work.  We should probably audit the code for other places where we might go a long time between awaits in our code.  Potentially signature aggregation, qc validation, and serialization.

It also doesn't make the VID disperse run on multiple threads.  As mentioned in the task we should not be dividing up the block on the consensus side.  The further parallelization will be done in jellyfish.

### Key places to review: 

vid.rs where we now spawn a task.  Note that the `unwrap` for the tokio version just passes on any panics that happen during the thread, so it is "safe", i.e it's not adding a new place we can panic.

<!-- ### How to test this PR:  -->

This should improve the consistency of our CI since we should be able to run faster.  I think a key issue with our tests was that all nodes would block each other from running while the leader calculated the vid disperse and blocked the main executor.  In a single node setting it's probably not so bad since a leader would probably not have other work to do while it was blocked on vid calculation.  

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
