### PR TITLE
[CI] Add a workflow to run `cargo-semver-checks`

### DIFF
--- a/.github/workflows/semver-check.yml
+++ b/.github/workflows/semver-check.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         async_runtimes:
-          - async-std
+          - async_std
           - tokio
     steps:
       - uses: actions/checkout@v4
@@ -32,6 +32,12 @@ jobs:
         with:
           path: baseline
           ref: ${{ inputs.baseline }}
+
+      - name: Install Just
+        run: |
+          wget https://github.com/casey/just/releases/download/1.14.0/just-1.14.0-x86_64-unknown-linux-musl.tar.gz
+          tar -vxf just-1.14.0-x86_64-unknown-linux-musl.tar.gz just
+          sudo cp just /usr/bin/just
 
       - name: Install Rust Stable
         uses: dtolnay/rust-toolchain@stable
@@ -51,13 +57,5 @@ jobs:
       - name: Run cargo-semver-checks
         run: |
           cd current
-          export RUSTFLAGS='--cfg async_executor_impl="${{matrix.async_runtimes}}" --cfg async_channel_impl="${{matrix.async_runtimes}}"'
-          export RUSTDOCFLAGS="${RUSTFLAGS}"
-          # Checking each crate manually, because cargo-semver-checks
-          # exits early if it fails to check one of the crates
-          while IFS= read -r crate; do
-            cargo semver-checks \
-              --package "${crate}" \
-              --baseline-root ../baseline || true
-          done < <(cargo workspaces list)
+          just ${{matrix.async_runtimes}} semver --baseline-root ../baseline
 

--- a/.github/workflows/semver-check.yml
+++ b/.github/workflows/semver-check.yml
@@ -1,0 +1,63 @@
+name: Run semver check
+
+on:
+  workflow_dispatch:
+    inputs:
+      baseline:
+        description: "Baseline git revision to check against"
+        required: true
+        type: string
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test-sequencer:
+    runs-on: ubuntu-latest
+    name: semver
+    strategy:
+      matrix:
+        async_runtimes:
+          - async-std
+          - tokio
+    steps:
+      - uses: actions/checkout@v4
+        name: Checkout Repository
+        with:
+          path: current
+
+      - uses: actions/checkout@v4
+        name: Checkout Baseline
+        with:
+          path: baseline
+          ref: ${{ inputs.baseline }}
+
+      - name: Install Rust Stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        name: Enable Rust Caching
+        with:
+          shared-key: ""
+          prefix-key: semver
+          workspaces: "current -> target"
+
+      - name: Install cargo-semver-checks and cargo-workspaces
+        run: |
+          cargo install cargo-semver-checks --locked
+          cargo install cargo-workspaces
+
+      - name: Run cargo-semver-checks
+        run: |
+          cd current
+          export RUSTFLAGS='--cfg async_executor_impl="${{matrix.async_runtimes}}" --cfg async_channel_impl="${{matrix.async_runtimes}}"'
+          export RUSTDOCFLAGS="${RUSTFLAGS}"
+          # Checking each crate manually, because cargo-semver-checks
+          # exits early if it fails to check one of the crates
+          while IFS= read -r crate; do
+            cargo semver-checks \
+              --package "${crate}" \
+              --baseline-root ../baseline || true
+          done < <(cargo workspaces list)
+

--- a/flake.nix
+++ b/flake.nix
@@ -165,6 +165,7 @@
             cargo-expand
             cargo-workspaces
             cargo-audit
+            cargo-semver-checks
             nixpkgs-fmt
             git-chglog
             protobuf

--- a/justfile
+++ b/justfile
@@ -112,6 +112,14 @@ careful:
   echo Careful-ing with tokio executor
   cargo careful test --verbose --profile careful --lib --bins --tests --benches --workspace --no-fail-fast -- --test-threads=1 --nocapture
 
+semver *ARGS:
+  #!/usr/bin/env bash
+  echo Running cargo-semver-checks
+  while IFS= read -r crate; do
+    cargo semver-checks \
+      --package "${crate}" {{ARGS}} || true;
+  done < <(cargo workspaces list)
+
 fix:
   cargo fix --allow-dirty --allow-staged --workspace --lib --bins --tests --benches
 


### PR DESCRIPTION
### This PR: 
Sort of a companion to #2360, adds a manually-triggered workflow to run `cargo-semver-checks` for all crates in the workspace.

### This PR does not: 
Touch other workflows or introduce any conditions on which this workflow will be automatically run.

### Key places to review: 
`.github/workflows/semver-check.yml`

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
