### PR TITLE
[BUILDER] Add external events for builder

### DIFF
--- a/crates/hotshot/src/lib.rs
+++ b/crates/hotshot/src/lib.rs
@@ -325,8 +325,8 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> SystemContext<TYPES, I> {
     /// Emit an external event
     // A copypasta of `ConsensusApi::send_event`
     // TODO: remove with https://github.com/EspressoSystems/HotShot/issues/2407
-    async fn send_event(&self, event: Event<TYPES>) {
-        debug!(?event, "send_event");
+    async fn send_external_event(&self, event: Event<TYPES>) {
+        debug!(?event, "send_external_event");
         let mut event_sender = self.inner.event_sender.write().await;
         if let Some(sender) = &*event_sender {
             if let Err(e) = sender.send_async(event).await {
@@ -372,7 +372,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> SystemContext<TYPES, I> {
                         da_membership,
                     ),
                 api
-                    .send_event(Event {
+                    .send_external_event(Event {
                         view_number: api.inner.consensus.read().await.cur_view,
                         event: EventType::Transactions {
                             transactions: vec![transaction],

--- a/crates/task-impls/src/consensus.rs
+++ b/crates/task-impls/src/consensus.rs
@@ -1211,21 +1211,13 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                 leaf.view_number, ""
             );
 
-            futures::join! {
-                self.event_stream
-                    .publish(HotShotEvent::QuorumProposalSend(
-                        message.clone(),
-                        self.public_key.clone(),
-                    )),
-                self.api
-                    .send_event(Event {
-                        view_number: self.cur_view,
-                        event: EventType::QuorumProposal {
-                            proposal: message,
-                            sender: self.public_key.clone(),
-                        },
-                    })
-            };
+            self.event_stream
+                .publish(HotShotEvent::QuorumProposalSend(
+                    message.clone(),
+                    self.public_key.clone(),
+                ))
+                .await;
+
             self.payload_commitment_and_metadata = None;
             return true;
         }

--- a/crates/task-impls/src/da.rs
+++ b/crates/task-impls/src/da.rs
@@ -4,7 +4,6 @@ use crate::{
 };
 use async_lock::RwLock;
 
-use futures::join;
 use hotshot_task::{
     event_stream::{ChannelStream, EventStream},
     global_registry::GlobalRegistry,
@@ -312,20 +311,12 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                     _pd: PhantomData,
                 };
 
-                join! {
-                    self.event_stream
-                        .publish(HotShotEvent::DAProposalSend(
-                            message.clone(),
-                            self.public_key.clone(),
-                        )),
-                    self.api.send_event(Event {
-                        view_number: self.cur_view,
-                        event: EventType::DAProposal {
-                            proposal: message,
-                            sender: self.public_key.clone()
-                        },
-                    }),
-                };
+                self.event_stream
+                    .publish(HotShotEvent::DAProposalSend(
+                        message.clone(),
+                        self.public_key.clone(),
+                    ))
+                    .await;
             }
 
             HotShotEvent::Timeout(view) => {

--- a/crates/types/src/event.rs
+++ b/crates/types/src/event.rs
@@ -1,7 +1,10 @@
 //! Events that a `HotShot` instance can emit
 
 use crate::{
-    data::Leaf, error::HotShotError, simple_certificate::QuorumCertificate,
+    data::{DAProposal, Leaf, QuorumProposal},
+    error::HotShotError,
+    message::Proposal,
+    simple_certificate::QuorumCertificate,
     traits::node_implementation::NodeType,
 };
 
@@ -61,5 +64,27 @@ pub enum EventType<TYPES: NodeType> {
     ViewFinished {
         /// The view number that has just finished
         view_number: TYPES::Time,
+    },
+    /// New transactions were received from the network
+    /// or submitted to the network by us
+    Transactions {
+        /// The list of transactions
+        transactions: Vec<TYPES::Transaction>,
+    },
+    /// DA proposal was received from the network
+    /// or submitted to the network by us
+    DAProposal {
+        /// Contents of the proposal
+        proposal: Proposal<TYPES, DAProposal<TYPES>>,
+        /// Public key of the leader submitting the proposal
+        sender: TYPES::SignatureKey,
+    },
+    /// Quorum proposal was received from the network
+    /// or submitted to the network by us
+    QuorumProposal {
+        /// Contents of the proposal
+        proposal: Proposal<TYPES, QuorumProposal<TYPES>>,
+        /// Public key of the leader submitting the proposal
+        sender: TYPES::SignatureKey,
     },
 }


### PR DESCRIPTION
Added external events for `Transaction`, `DAProposal` and `QuorumProposal`

Closes #2371 

### This PR: 
Adds external events and logic to emit those.

### This PR does not: 
Change consensus logic.

### Key places to review: 
All changed files.