### PR TITLE
check liveness checkeven if we cannot find the parent in storage

### DIFF
--- a/crates/hotshot/examples/infra/mod.rs
+++ b/crates/hotshot/examples/infra/mod.rs
@@ -413,7 +413,7 @@ pub trait RunDA<
                             block_size,
                         } => {
                             // this might be a obob
-                            if let Some(leaf) = leaf_chain.get(0) {
+                            if let Some(leaf) = leaf_chain.first() {
                                 info!("Decide event for leaf: {}", *leaf.view_number);
 
                                 let new_anchor = leaf.view_number;

--- a/crates/hotshot/src/traits/networking.rs
+++ b/crates/hotshot/src/traits/networking.rs
@@ -17,8 +17,7 @@ use std::{
 use custom_debug::Debug;
 use hotshot_types::traits::metrics::{Counter, Gauge, Histogram, Label, Metrics, NoMetrics};
 pub use hotshot_types::traits::network::{
-    ChannelSendSnafu, CouldNotDeliverSnafu, FailedToDeserializeSnafu, FailedToSerializeSnafu,
-    NetworkError, NetworkReliability, NoSuchNodeSnafu, ShutDownSnafu,
+    FailedToSerializeSnafu, NetworkError, NetworkReliability,
 };
 
 /// Contains several `NetworkingMetrics` that we're interested in from the networking interfaces

--- a/crates/hotshot/src/traits/networking/combined_network.rs
+++ b/crates/hotshot/src/traits/networking/combined_network.rs
@@ -44,6 +44,7 @@ struct Cache {
     /// The maximum number of items to store in the cache
     capacity: usize,
     /// The cache itself
+    #[allow(clippy::struct_field_names)]
     cache: HashSet<u64>,
     /// The hashes of the messages in the cache, in order of insertion
     hashes: Vec<u64>,

--- a/crates/libp2p-networking/src/network/behaviours/dht/cache.rs
+++ b/crates/libp2p-networking/src/network/behaviours/dht/cache.rs
@@ -65,6 +65,7 @@ pub struct Cache {
     config: Config,
 
     /// the cache for records (key -> value)
+    #[allow(clippy::struct_field_names)]
     cache: Arc<DashMap<Vec<u8>, Vec<u8>>>,
     /// the expiries for the dht cache, in order (expiry time -> key)
     expiries: Arc<RwLock<BTreeMap<SystemTime, Vec<u8>>>>,

--- a/crates/libp2p-networking/src/network/node.rs
+++ b/crates/libp2p-networking/src/network/node.rs
@@ -5,9 +5,7 @@ pub use self::{
     config::{
         MeshParams, NetworkNodeConfig, NetworkNodeConfigBuilder, NetworkNodeConfigBuilderError,
     },
-    handle::{
-        network_node_handle_error, NetworkNodeHandle, NetworkNodeHandleError, NetworkNodeReceiver,
-    },
+    handle::{network_node_handle_error, NetworkNodeHandle, NetworkNodeHandleError},
 };
 
 use super::{

--- a/crates/libp2p-networking/tests/common/mod.rs
+++ b/crates/libp2p-networking/tests/common/mod.rs
@@ -189,7 +189,7 @@ pub async fn spin_up_swarms<S: Debug + Default>(
             .map(|(a, b)| (Some(*a), b.clone()))
             .collect::<Vec<_>>()
     );
-
+    #[allow(clippy::unused_enumerate_index)]
     for (_idx, handle) in handles[0..num_of_nodes].iter().enumerate() {
         let to_share = bootstrap_addrs.clone();
         handle

--- a/crates/libp2p-networking/tests/counter.rs
+++ b/crates/libp2p-networking/tests/counter.rs
@@ -371,6 +371,7 @@ async fn run_request_response_increment_all(
     requestee_handle.modify_state(|s| *s += 1).await;
     info!("RR REQUESTEE IS {:?}", requestee_handle.peer_id());
     let mut futs = Vec::new();
+    #[allow(clippy::unused_enumerate_index)]
     for (_i, h) in handles.iter().enumerate() {
         if h.lookup_pid(requestee_handle.peer_id()).await.is_err() {
             error!("ERROR LOOKING UP REQUESTEE ADDRS");

--- a/crates/task-impls/src/consensus.rs
+++ b/crates/task-impls/src/consensus.rs
@@ -546,6 +546,8 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                     let liveness_check = justify_qc.get_view_number() > consensus.locked_view;
 
                     let high_qc = consensus.high_qc.clone();
+                    let locked_view = consensus.locked_view.clone(); 
+                
 
                     drop(consensus);
 
@@ -571,7 +573,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                             self.current_proposal = None;
                         }
                     }
-                    warn!("Failed liveneess check; cannot find parent either");
+                    warn!("Failed liveneess check; cannot find parent either\n High QC is {:?}  Proposal QC is {:?}  Locked view is {:?}", high_qc, proposal.data.clone(), locked_view);
 
                     return;
                 };
@@ -623,7 +625,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
 
                 // Skip if both saftey and liveness checks fail.
                 if !safety_check && !liveness_check {
-                    error!("Failed safety check and liveness check");
+                    error!("Failed safety and liveness check \n High QC is {:?}  Proposal QC is {:?}  Locked view is {:?}", consensus.high_qc, proposal.data.clone(), consensus.locked_view);
                     return;
                 }
 

--- a/crates/task-impls/src/consensus.rs
+++ b/crates/task-impls/src/consensus.rs
@@ -625,7 +625,6 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
 
                 self.current_proposal = Some(proposal.data.clone());
 
-                let high_qc = leaf.justify_qc.clone();
                 let mut new_anchor_view = consensus.last_decided_view;
                 let mut new_locked_view = consensus.locked_view;
                 let mut last_view_number_visited = view;

--- a/crates/task-impls/src/consensus.rs
+++ b/crates/task-impls/src/consensus.rs
@@ -560,7 +560,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                     view_number: view,
                     justify_qc: justify_qc.clone(),
                     parent_commitment,
-                    block_header: proposal.data.block_header,
+                    block_header: proposal.data.block_header.clone(),
                     block_payload: None,
                     rejected: Vec::new(),
                     timestamp: time::OffsetDateTime::now_utc().unix_timestamp_nanos(),

--- a/crates/task-impls/src/consensus.rs
+++ b/crates/task-impls/src/consensus.rs
@@ -711,10 +711,6 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                     HashSet::new()
                 };
 
-                // promote lock here to add proposal to statemap
-                if high_qc.view_number > consensus.high_qc.view_number {
-                    consensus.high_qc = high_qc;
-                }
                 consensus.state_map.insert(
                     view,
                     View {

--- a/crates/task-impls/src/consensus.rs
+++ b/crates/task-impls/src/consensus.rs
@@ -571,6 +571,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                             self.current_proposal = None;
                         }
                     }
+                    warn!("Failed liveneess check; cannot find parent either");
 
                     return;
                 };

--- a/crates/task-impls/src/consensus.rs
+++ b/crates/task-impls/src/consensus.rs
@@ -543,6 +543,15 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                         consensus.high_qc = justify_qc;
                     }
 
+                    let new_view = self.current_proposal.clone().unwrap().view_number + 1;
+
+                    // This is for the case where we form a QC but have not yet seen the previous proposal ourselves
+                    let should_propose = self.quorum_membership.get_leader(new_view)
+                        == self.public_key
+                        && consensus.high_qc.view_number
+                            == self.current_proposal.clone().unwrap().view_number;
+                    let qc = consensus.high_qc.clone();
+
                     drop(consensus);
 
                     if liveness_check {
@@ -551,6 +560,15 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                         if self.vote_if_able().await {
                             self.current_proposal = None;
                         }
+                    }
+
+                    if should_propose {
+                        debug!(
+                            "Attempting to publish proposal after voting; now in view: {}",
+                            *new_view
+                        );
+                        self.publish_proposal_if_able(qc.view_number + 1, None)
+                            .await;
                     }
 
                     return;

--- a/crates/task-impls/src/consensus.rs
+++ b/crates/task-impls/src/consensus.rs
@@ -546,7 +546,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                     let liveness_check = justify_qc.get_view_number() > consensus.locked_view;
 
                     let high_qc = consensus.high_qc.clone();
-                    let locked_view = consensus.locked_view.clone(); 
+                    let locked_view = consensus.locked_view; 
                 
 
                     drop(consensus);


### PR DESCRIPTION
Closes #<ISSUE_NUMBER>
<!-- See here for keywords in Github -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

### This PR: 
Previously, if we received a proposal for which we didn't have the parent in storage, we would throw away the proposal and not vote.  This PR changes this behavior so that we still vote if we pass the liveness check. 
<!-- Describe what this PR adds to HotSHot -->
<!-- E.g. -->
<!-- * Implements feature 1 -->
<!-- * Implements feature 2 -->
<!-- * Fixes bug 3 -->

### This PR does not: 
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->
Properly fix the libp2p clippy lint.  This is already fixed in main. 

### Key places to review: 
consensus.rs
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
