### PR TITLE
[CI Stability] Immediately fail test on Libp2p panic

### DIFF
--- a/crates/libp2p-networking/tests/counter.rs
+++ b/crates/libp2p-networking/tests/counter.rs
@@ -27,7 +27,7 @@ const NUM_ROUNDS: usize = 100;
 
 const TOTAL_NUM_PEERS_COVERAGE: usize = 10;
 const NUM_OF_BOOTSTRAP_COVERAGE: usize = 5;
-const TIMEOUT_COVERAGE: Duration = Duration::from_secs(20);
+const TIMEOUT_COVERAGE: Duration = Duration::from_secs(120);
 
 const TOTAL_NUM_PEERS_STRESS: usize = 100;
 const NUM_OF_BOOTSTRAP_STRESS: usize = 25;

--- a/crates/libp2p-networking/tests/counter.rs
+++ b/crates/libp2p-networking/tests/counter.rs
@@ -144,7 +144,7 @@ async fn run_request_response_increment<'a>(
 
         match stream.next().await.unwrap() {
             Ok(()) => {}
-            Err(e) => {error!("timed out waiting for {requestee_pid:?} to update state");
+            Err(e) => {error!("timed out waiting for {requestee_pid:?} to update state: {e}");
             std::process::exit(-1)},
         }
         requester_handle

--- a/crates/libp2p-networking/tests/counter.rs
+++ b/crates/libp2p-networking/tests/counter.rs
@@ -27,7 +27,7 @@ const NUM_ROUNDS: usize = 100;
 
 const TOTAL_NUM_PEERS_COVERAGE: usize = 10;
 const NUM_OF_BOOTSTRAP_COVERAGE: usize = 5;
-const TIMEOUT_COVERAGE: Duration = Duration::from_secs(120);
+const TIMEOUT_COVERAGE: Duration = Duration::from_secs(20);
 
 const TOTAL_NUM_PEERS_STRESS: usize = 100;
 const NUM_OF_BOOTSTRAP_STRESS: usize = 25;
@@ -144,7 +144,8 @@ async fn run_request_response_increment<'a>(
 
         match stream.next().await.unwrap() {
             Ok(()) => {}
-            Err(e) => panic!("timeout : {e:?} waiting handle {requestee_pid:?} to update state"),
+            Err(e) => {error!("timed out waiting for {requestee_pid:?} to update state");
+            std::process::exit(-1)},
         }
         requester_handle
             .direct_request(requestee_pid, &CounterMessage::AskForCounter)
@@ -152,8 +153,8 @@ async fn run_request_response_increment<'a>(
             .context(HandleSnafu)?;
         match stream.next().await.unwrap() {
             Ok(()) => {}
-            Err(e) => panic!("timeout : {e:?} waiting handle {requestee_pid:?} to update state"),
-        }
+            Err(e) => {error!("timed out waiting for {requestee_pid:?} to update state");
+            std::process::exit(-1)},        }
 
         let s1 = requester_handle.state().await;
 
@@ -208,7 +209,10 @@ async fn run_gossip_round(
         // unwrap is okay because stream must have 2 * (len - 1) elements
         match merged_streams.next().await.unwrap() {
             Ok(()) => {}
-            Err(e) => panic!("timeout : {e:?} waiting handle {i:?} to subscribe to state events"),
+            Err(e) => {
+                error!("timed out waiting for handle {i:?} to subscribe to state events");
+                std::process::exit(-1)
+            }
         }
     }
 
@@ -326,7 +330,8 @@ async fn run_dht_rounds(
                 handle.get_record_timeout(&key, timeout).await;
             match result {
                 Err(e) => {
-                    panic!("DHT error {e:?} during GET");
+                    error!("DHT error {e:?} during GET");
+                    std::process::exit(-1);
                 }
                 Ok(v) => {
                     assert_eq!(v, value);
@@ -417,7 +422,8 @@ async fn run_request_response_increment_all(
         for handle in handles {
             states.push(handle.state().await);
         }
-        panic!("states: {states:?}");
+        error!("states: {states:?}");
+        std::process::exit(-1);
     }
 }
 

--- a/crates/libp2p-networking/tests/counter.rs
+++ b/crates/libp2p-networking/tests/counter.rs
@@ -153,7 +153,7 @@ async fn run_request_response_increment<'a>(
             .context(HandleSnafu)?;
         match stream.next().await.unwrap() {
             Ok(()) => {}
-            Err(e) => {error!("timed out waiting for {requestee_pid:?} to update state");
+            Err(e) => {error!("timed out waiting for {requestee_pid:?} to update state: {e}");
             std::process::exit(-1)},        }
 
         let s1 = requester_handle.state().await;
@@ -210,7 +210,7 @@ async fn run_gossip_round(
         match merged_streams.next().await.unwrap() {
             Ok(()) => {}
             Err(e) => {
-                error!("timed out waiting for handle {i:?} to subscribe to state events");
+                error!("timed out waiting for handle {i:?} to subscribe to state events: {e}");
                 std::process::exit(-1)
             }
         }


### PR DESCRIPTION
Closes #2440
<!-- See here for keywords in Github -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

### This PR: 
<!-- Describe what this PR adds to HotSHot -->
<!-- E.g. -->
<!-- * Implements feature 1 -->
<!-- * Implements feature 2 -->
<!-- * Fixes bug 3 -->
Makes libp2p counter tests fail immediately, instead of deadlocking until the test times out.

### This PR does not: 
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->
Fix the underlying issue. It just makes it much easier to debug.

### Key places to review: 
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
