### PR TITLE
chore: serialization of light client state

### DIFF
--- a/crates/types/src/light_client.rs
+++ b/crates/types/src/light_client.rs
@@ -1,10 +1,16 @@
 //! Types and structs associated with light client state
 
+use ark_ed_on_bn254::EdwardsConfig as Config;
 use ark_ff::PrimeField;
+use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use jf_primitives::signatures::schnorr;
+use rand::SeedableRng;
+use rand_chacha::ChaCha20Rng;
+use tagged_base64::tagged;
 
-/// A serialized light client state for proof generation
-#[derive(Clone, Debug, serde::Serialize, serde::Deserialize, Default)]
+/// A light client state
+#[tagged("LIGHT_CLIENT_STATE")]
+#[derive(Clone, Debug, CanonicalSerialize, CanonicalDeserialize, Default)]
 pub struct LightClientState<F: PrimeField> {
     /// Current view number
     pub view_number: usize,
@@ -44,10 +50,6 @@ impl<F: PrimeField> From<&LightClientState<F>> for [F; 7] {
         ]
     }
 }
-
-use ark_ed_on_bn254::EdwardsConfig as Config;
-use rand::SeedableRng;
-use rand_chacha::ChaCha20Rng;
 
 /// Signatures
 pub type StateSignature = schnorr::Signature<Config>;


### PR DESCRIPTION
Closes #<ISSUE_NUMBER>
<!-- See here for keywords in Github -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

The light client state struct is generic over `F: PrimeField`, which requires `CanonicalSerialize` but not `serde::Serialize`. Original serialization macro will add a trait bound `serde::Serialize` to `F`. This is not ideal, b/c most field types only implement `CanonicalSerialize`.

### This PR: 
<!-- Describe what this PR adds to HotSHot -->
<!-- E.g. -->
<!-- * Implements feature 1 -->
<!-- * Implements feature 2 -->
<!-- * Fixes bug 3 -->
Derive `CanonicalSerialize` and `CanonicalDeserialize` for `LightClientState`. And use `tagged` macro to futher derive `serde`.

### This PR does not: 
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->

### Key places to review: 
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
