### PR TITLE
[FIX_CI] Fix test issues

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -60,15 +60,15 @@ jobs:
         with:
           name: binaries-amd64-${{ matrix.just_variants }}
           path: |
-            target/release/examples/counter
-            target/release/examples/multi-validator-libp2p
-            target/release/examples/orchestrator-libp2p
-            target/release/examples/validator-libp2p
-            target/release/examples/multi-validator-webserver
-            target/release/examples/multi-webserver
-            target/release/examples/webserver
-            target/release/examples/orchestrator-webserver
-            target/release/examples/validator-webserver
+            target/debug/examples/counter
+            target/debug/examples/multi-validator-libp2p
+            target/debug/examples/orchestrator-libp2p
+            target/debug/examples/validator-libp2p
+            target/debug/examples/multi-validator-webserver
+            target/debug/examples/multi-webserver
+            target/debug/examples/webserver
+            target/debug/examples/orchestrator-webserver
+            target/debug/examples/validator-webserver
 
   build-arm:
     strategy:
@@ -98,15 +98,15 @@ jobs:
         with:
           name: binaries-aarch64-${{ matrix.just_variants }}
           path: |
-            target/release/examples/counter
-            target/release/examples/multi-validator-libp2p
-            target/release/examples/orchestrator-libp2p
-            target/release/examples/validator-libp2p
-            target/release/examples/multi-validator-webserver
-            target/release/examples/multi-webserver
-            target/release/examples/webserver
-            target/release/examples/orchestrator-webserver
-            target/release/examples/validator-webserver
+            target/debug/examples/counter
+            target/debug/examples/multi-validator-libp2p
+            target/debug/examples/orchestrator-libp2p
+            target/debug/examples/validator-libp2p
+            target/debug/examples/multi-validator-webserver
+            target/debug/examples/multi-webserver
+            target/debug/examples/webserver
+            target/debug/examples/orchestrator-webserver
+            target/debug/examples/validator-webserver
 
   build-dockers:
     strategy:

--- a/crates/hotshot/src/lib.rs
+++ b/crates/hotshot/src/lib.rs
@@ -386,8 +386,8 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> SystemContext<TYPES, I> {
         self.inner.consensus.read().await.get_decided_leaf()
     }
 
-    /// Synchronously tries to return a copy of the last decided leaf,
-    /// if it is currently available for reading.
+    /// Instantly returns a copy of the last decided leaf if it is currently 
+    /// available for reading. If not, we will return.
     ///
     /// # Panics
     /// Panics if internal state for consensus is inconsistent

--- a/crates/hotshot/src/lib.rs
+++ b/crates/hotshot/src/lib.rs
@@ -399,6 +399,19 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> SystemContext<TYPES, I> {
         self.inner.consensus.read().await.get_decided_leaf()
     }
 
+    /// Synchronously tries to return a copy of the last decided leaf,
+    /// if it is currently available for reading.
+    ///
+    /// # Panics
+    /// Panics if internal state for consensus is inconsistent
+    #[must_use]
+    pub fn try_get_decided_leaf(&self) -> Option<Leaf<TYPES>> {
+        self.inner
+            .consensus
+            .try_read()
+            .map(|guard| guard.get_decided_leaf())
+    }
+
     /// Initializes a new hotshot and does the work of setting up all the background tasks
     ///
     /// Assumes networking implementation is already primed.

--- a/crates/hotshot/src/lib.rs
+++ b/crates/hotshot/src/lib.rs
@@ -386,8 +386,8 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> SystemContext<TYPES, I> {
         self.inner.consensus.read().await.get_decided_leaf()
     }
 
-    /// Instantly returns a copy of the last decided leaf if it is currently 
-    /// available for reading. If not, we will return.
+    /// [Non-blocking] instantly returns a copy of the last decided leaf if
+    /// it is available to be read. If not, we return `None`.
     ///
     /// # Panics
     /// Panics if internal state for consensus is inconsistent

--- a/crates/hotshot/src/tasks/mod.rs
+++ b/crates/hotshot/src/tasks/mod.rs
@@ -11,7 +11,6 @@ use hotshot_task::{
     task_launcher::TaskRunner,
     GeneratedStream, Merge,
 };
-use tracing::error;
 use hotshot_task_impls::{
     consensus::{
         consensus_event_filter, CommitmentAndMetadata, ConsensusTaskState, ConsensusTaskTypes,
@@ -45,6 +44,7 @@ use std::{
     sync::Arc,
     time::Duration,
 };
+use tracing::error;
 
 /// event for global event stream
 #[derive(Clone, Debug)]
@@ -96,7 +96,7 @@ pub async fn add_network_message_task<TYPES: NodeType, NET: CommunicationChannel
                     Ok(msgs) => Messages(msgs),
                     Err(err) => {
                         error!("failed to receive broadcast messages: {err}");
-                        
+
                         // return zero messages so we sleep and try again
                         Messages(vec![])
                     }

--- a/crates/hotshot/src/tasks/mod.rs
+++ b/crates/hotshot/src/tasks/mod.rs
@@ -95,7 +95,7 @@ pub async fn add_network_message_task<TYPES: NodeType, NET: CommunicationChannel
                 let msgs = match network.recv_msgs(TransmitType::Direct).await {
                     Ok(msgs) => Messages(msgs),
                     Err(err) => {
-                        error!("failed to receive broadcast messages: {err}");
+                        error!("failed to receive direct messages: {err}");
 
                         // return zero messages so we sleep and try again
                         Messages(vec![])

--- a/crates/hotshot/src/traits/networking/libp2p_network.rs
+++ b/crates/hotshot/src/traits/networking/libp2p_network.rs
@@ -362,7 +362,7 @@ impl<M: NetworkMsg, K: SignatureKey + 'static> Libp2pNetwork<M, K> {
                 is_ready: Arc::new(AtomicBool::new(false)),
                 // This is optimal for 10-30 nodes. TODO: parameterize this for both tests and examples
                 // https://github.com/EspressoSystems/HotShot/issues/2088
-                dht_timeout: Duration::from_secs(1),
+                dht_timeout: Duration::from_secs(2),
                 is_bootstrapped: Arc::new(AtomicBool::new(false)),
                 metrics,
                 topic_map,

--- a/crates/hotshot/src/types/handle.rs
+++ b/crates/hotshot/src/types/handle.rs
@@ -114,6 +114,15 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static> SystemContextHandl
         self.hotshot.get_decided_leaf().await
     }
 
+    /// Tries to get the most recent decided leaf, returning instantly
+    /// if we can't acquire the lock.
+    ///
+    /// # Panics
+    /// Panics if internal consensus is in an inconsistent state.
+    pub fn try_get_decided_leaf(&self) -> Option<Leaf<TYPES>> {
+        self.hotshot.try_get_decided_leaf()
+    }
+
     /// Submits a transaction to the backing [`SystemContext`] instance.
     ///
     /// The current node broadcasts the transaction to all nodes on the network.

--- a/crates/libp2p-networking/src/network/behaviours/direct_message.rs
+++ b/crates/libp2p-networking/src/network/behaviours/direct_message.rs
@@ -70,7 +70,7 @@ impl DMBehaviour {
             }
             Event::OutboundFailure {
                 peer,
-                request_id: _,
+                request_id,
                 error,
             } => {
                 error!(
@@ -79,10 +79,10 @@ impl DMBehaviour {
                 );
                 // RM TODO: make direct messages have n (and not infinite) retries
                 // issue: https://github.com/EspressoSystems/HotShot/issues/2003
-                // if let Some(mut req) = self.in_progress_rr.remove(&request_id) {
-                //     req.backoff.start_next(false);
-                //     self.failed_rr.push_back(req);
-                // }
+                if let Some(mut req) = self.in_progress_rr.remove(&request_id) {
+                    req.backoff.start_next(false);
+                    self.failed_rr.push_back(req);
+                }
             }
             Event::Message { message, peer, .. } => match message {
                 Message::Request {

--- a/crates/task-impls/src/consensus.rs
+++ b/crates/task-impls/src/consensus.rs
@@ -370,7 +370,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
 
     async fn update_view(&mut self, new_view: TYPES::Time) -> bool {
         if *self.cur_view < *new_view {
-            debug!(
+            error!(
                 "Updating view from {} to {} in consensus task",
                 *self.cur_view, *new_view
             );

--- a/crates/task-impls/src/consensus.rs
+++ b/crates/task-impls/src/consensus.rs
@@ -723,7 +723,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                             true
                         },
                     ) {
-                        error!("publishing view error");
+                        error!("view publish error {e}");
                         self.output_event_stream
                             .publish(Event {
                                 view_number: view,

--- a/crates/task-impls/src/consensus.rs
+++ b/crates/task-impls/src/consensus.rs
@@ -370,7 +370,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
 
     async fn update_view(&mut self, new_view: TYPES::Time) -> bool {
         if *self.cur_view < *new_view {
-            error!(
+            debug!(
                 "Updating view from {} to {} in consensus task",
                 *self.cur_view, *new_view
             );

--- a/crates/task-impls/src/consensus.rs
+++ b/crates/task-impls/src/consensus.rs
@@ -558,8 +558,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                     let liveness_check = justify_qc.get_view_number() > consensus.locked_view;
 
                     let high_qc = consensus.high_qc.clone();
-                    let locked_view = consensus.locked_view; 
-                
+                    let locked_view = consensus.locked_view;
 
                     drop(consensus);
 

--- a/crates/testing/src/test_builder.rs
+++ b/crates/testing/src/test_builder.rs
@@ -84,7 +84,7 @@ impl TestMetadata {
     pub fn default_stress() -> Self {
         let num_nodes = 100;
         TestMetadata {
-            num_bootstrap_nodes: 15,
+            num_bootstrap_nodes: num_nodes,
             total_nodes: num_nodes,
             start_nodes: num_nodes,
             overall_safety_properties: OverallSafetyPropertiesDescription {
@@ -112,6 +112,9 @@ impl TestMetadata {
     pub fn default_multiple_rounds() -> TestMetadata {
         let num_nodes = 10;
         TestMetadata {
+            // TODO: remove once we have fixed the DHT timeout issue
+            // https://github.com/EspressoSystems/HotShot/issues/2088
+            num_bootstrap_nodes: num_nodes,
             total_nodes: num_nodes,
             start_nodes: num_nodes,
             overall_safety_properties: OverallSafetyPropertiesDescription {
@@ -139,7 +142,7 @@ impl TestMetadata {
         TestMetadata {
             total_nodes: num_nodes,
             start_nodes: num_nodes,
-            num_bootstrap_nodes: 20,
+            num_bootstrap_nodes: num_nodes,
             // The first 14 (i.e., 20 - f) nodes are in the DA committee and we may shutdown the
             // remaining 6 (i.e., f) nodes. We could remove this restriction after fixing the
             // following issue.
@@ -174,8 +177,8 @@ impl Default for TestMetadata {
             min_transactions: 0,
             total_nodes: num_nodes,
             start_nodes: num_nodes,
-            num_bootstrap_nodes: 5,
-            da_committee_size: 5,
+            num_bootstrap_nodes: num_nodes,
+            da_committee_size: num_nodes,
             spinning_properties: SpinningTaskDescription {
                 node_changes: vec![],
             },

--- a/crates/testing/src/test_runner.rs
+++ b/crates/testing/src/test_runner.rs
@@ -22,7 +22,7 @@ use hotshot_types::{
     HotShotConfig, ValidatorConfig,
 };
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{BTreeMap, HashMap, HashSet},
     marker::PhantomData,
 };
 
@@ -132,7 +132,7 @@ where
 
         // add spinning task
         // map spinning to view
-        let mut changes: HashMap<TYPES::Time, Vec<ChangeNode>> = HashMap::new();
+        let mut changes: BTreeMap<TYPES::Time, Vec<ChangeNode>> = BTreeMap::new();
         for (view, mut change) in spinning_changes {
             changes
                 .entry(TYPES::Time::new(view))

--- a/crates/testing/tests/catchup.rs
+++ b/crates/testing/tests/catchup.rs
@@ -42,7 +42,7 @@ async fn test_catchup() {
 
     metadata.spinning_properties = SpinningTaskDescription {
         // Start the nodes before their leadership.
-        node_changes: vec![(15, catchup_nodes)],
+        node_changes: vec![(14, catchup_nodes)],
     };
 
     metadata.completion_task_description =

--- a/crates/testing/tests/catchup.rs
+++ b/crates/testing/tests/catchup.rs
@@ -84,18 +84,12 @@ async fn test_catchup_web() {
         ..Default::default()
     };
     let mut metadata = TestMetadata::default();
-    let catchup_nodes = vec![
-        ChangeNode {
-            idx: 18,
-            updown: UpDown::Up,
-        },
-        ChangeNode {
-            idx: 19,
-            updown: UpDown::Up,
-        },
-    ];
+    let catchup_nodes = vec![ChangeNode {
+        idx: 18,
+        updown: UpDown::Up,
+    }];
     metadata.timing_data = timing_data;
-    metadata.start_nodes = 18;
+    metadata.start_nodes = 19;
     metadata.total_nodes = 20;
 
     metadata.spinning_properties = SpinningTaskDescription {
@@ -147,18 +141,12 @@ async fn test_catchup_one_node() {
         ..Default::default()
     };
     let mut metadata = TestMetadata::default();
-    let catchup_nodes = vec![
-        ChangeNode {
-            idx: 18,
-            updown: UpDown::Up,
-        },
-        ChangeNode {
-            idx: 19,
-            updown: UpDown::Up,
-        },
-    ];
+    let catchup_nodes = vec![ChangeNode {
+        idx: 18,
+        updown: UpDown::Up,
+    }];
     metadata.timing_data = timing_data;
-    metadata.start_nodes = 18;
+    metadata.start_nodes = 19;
     metadata.total_nodes = 20;
 
     metadata.spinning_properties = SpinningTaskDescription {

--- a/crates/testing/tests/catchup.rs
+++ b/crates/testing/tests/catchup.rs
@@ -106,7 +106,7 @@ async fn test_catchup_web() {
 
     metadata.spinning_properties = SpinningTaskDescription {
         // Start the nodes before their leadership.
-        node_changes: vec![(13, catchup_nodes)],
+        node_changes: vec![(10, catchup_nodes)],
     };
 
     metadata.completion_task_description =
@@ -169,7 +169,7 @@ async fn test_catchup_one_node() {
 
     metadata.spinning_properties = SpinningTaskDescription {
         // Start the nodes before their leadership.
-        node_changes: vec![(13, catchup_nodes)],
+        node_changes: vec![(10, catchup_nodes)],
     };
 
     metadata.completion_task_description =
@@ -236,7 +236,7 @@ async fn test_catchup_in_view_sync() {
         hotshot_testing::view_sync_task::ViewSyncTaskDescription::Threshold(0, 20);
 
     metadata.spinning_properties = SpinningTaskDescription {
-        node_changes: vec![(18, catchup_nodes)],
+        node_changes: vec![(10, catchup_nodes)],
     };
 
     metadata.completion_task_description =

--- a/crates/testing/tests/catchup.rs
+++ b/crates/testing/tests/catchup.rs
@@ -236,7 +236,7 @@ async fn test_catchup_in_view_sync() {
         hotshot_testing::view_sync_task::ViewSyncTaskDescription::Threshold(0, 20);
 
     metadata.spinning_properties = SpinningTaskDescription {
-        node_changes: vec![(25, catchup_nodes)],
+        node_changes: vec![(18, catchup_nodes)],
     };
 
     metadata.completion_task_description =

--- a/crates/testing/tests/catchup.rs
+++ b/crates/testing/tests/catchup.rs
@@ -22,19 +22,13 @@ async fn test_catchup() {
         ..Default::default()
     };
     let mut metadata = TestMetadata::default();
-    let catchup_nodes = vec![
-        ChangeNode {
-            idx: 18,
-            updown: UpDown::Up,
-        },
-        ChangeNode {
-            idx: 19,
-            updown: UpDown::Up,
-        },
-    ];
+    let catchup_node = vec![ChangeNode {
+        idx: 19,
+        updown: UpDown::Up,
+    }];
 
     metadata.timing_data = timing_data;
-    metadata.start_nodes = 18;
+    metadata.start_nodes = 19;
     metadata.total_nodes = 20;
 
     metadata.view_sync_properties =
@@ -42,7 +36,7 @@ async fn test_catchup() {
 
     metadata.spinning_properties = SpinningTaskDescription {
         // Start the nodes before their leadership.
-        node_changes: vec![(13, catchup_nodes)],
+        node_changes: vec![(13, catchup_node)],
     };
 
     metadata.completion_task_description =

--- a/crates/testing/tests/catchup.rs
+++ b/crates/testing/tests/catchup.rs
@@ -42,7 +42,7 @@ async fn test_catchup() {
 
     metadata.spinning_properties = SpinningTaskDescription {
         // Start the nodes before their leadership.
-        node_changes: vec![(14, catchup_nodes)],
+        node_changes: vec![(13, catchup_nodes)],
     };
 
     metadata.completion_task_description =
@@ -90,17 +90,23 @@ async fn test_catchup_web() {
         ..Default::default()
     };
     let mut metadata = TestMetadata::default();
-    let catchup_nodes = vec![ChangeNode {
-        idx: 18,
-        updown: UpDown::Up,
-    }];
-
+    let catchup_nodes = vec![
+        ChangeNode {
+            idx: 18,
+            updown: UpDown::Up,
+        },
+        ChangeNode {
+            idx: 19,
+            updown: UpDown::Up,
+        },
+    ];
     metadata.timing_data = timing_data;
-    metadata.start_nodes = 19;
+    metadata.start_nodes = 18;
     metadata.total_nodes = 20;
 
     metadata.spinning_properties = SpinningTaskDescription {
-        node_changes: vec![(25, catchup_nodes)],
+        // Start the nodes before their leadership.
+        node_changes: vec![(13, catchup_nodes)],
     };
 
     metadata.completion_task_description =
@@ -147,18 +153,23 @@ async fn test_catchup_one_node() {
         ..Default::default()
     };
     let mut metadata = TestMetadata::default();
-    let catchup_nodes = vec![ChangeNode {
-        idx: 18,
-        updown: UpDown::Up,
-    }];
-
+    let catchup_nodes = vec![
+        ChangeNode {
+            idx: 18,
+            updown: UpDown::Up,
+        },
+        ChangeNode {
+            idx: 19,
+            updown: UpDown::Up,
+        },
+    ];
     metadata.timing_data = timing_data;
-    metadata.start_nodes = 19;
+    metadata.start_nodes = 18;
     metadata.total_nodes = 20;
 
     metadata.spinning_properties = SpinningTaskDescription {
-        // Start the node before its leadership.
-        node_changes: vec![(15, catchup_nodes)],
+        // Start the nodes before their leadership.
+        node_changes: vec![(13, catchup_nodes)],
     };
 
     metadata.completion_task_description =

--- a/crates/testing/tests/libp2p.rs
+++ b/crates/testing/tests/libp2p.rs
@@ -29,7 +29,8 @@ async fn libp2p_network() {
             },
         ),
         timing_data: TimingData {
-            round_start_delay: 100,
+            next_view_timeout: 2500,
+            propose_max_round_time: 300,
             ..Default::default()
         },
         ..TestMetadata::default_multiple_rounds()

--- a/crates/testing/tests/libp2p.rs
+++ b/crates/testing/tests/libp2p.rs
@@ -29,7 +29,7 @@ async fn libp2p_network() {
             },
         ),
         timing_data: TimingData {
-            next_view_timeout: 2500,
+            next_view_timeout: 4000,
             propose_max_round_time: Duration::from_millis(300),
             ..Default::default()
         },

--- a/crates/testing/tests/libp2p.rs
+++ b/crates/testing/tests/libp2p.rs
@@ -30,7 +30,7 @@ async fn libp2p_network() {
         ),
         timing_data: TimingData {
             next_view_timeout: 2500,
-            propose_max_round_time: 300,
+            propose_max_round_time: Duration::from_millis(300),
             ..Default::default()
         },
         ..TestMetadata::default_multiple_rounds()

--- a/crates/testing/tests/unreliable_network.rs
+++ b/crates/testing/tests/unreliable_network.rs
@@ -44,7 +44,7 @@ async fn libp2p_network_sync() {
         .gen_launcher::<TestTypes, Libp2pImpl>(0)
         .launch()
         .run_test()
-        .await
+        .await;
 }
 
 #[cfg(test)]
@@ -122,7 +122,7 @@ async fn libp2p_network_async() {
         .gen_launcher::<TestTypes, Libp2pImpl>(0)
         .launch()
         .run_test()
-        .await
+        .await;
 }
 
 #[cfg(test)]
@@ -260,7 +260,7 @@ async fn libp2p_network_partially_sync() {
         .gen_launcher::<TestTypes, Libp2pImpl>(0)
         .launch()
         .run_test()
-        .await
+        .await;
 }
 
 #[cfg(test)]
@@ -339,5 +339,5 @@ async fn libp2p_network_chaos() {
         .gen_launcher::<TestTypes, Libp2pImpl>(0)
         .launch()
         .run_test()
-        .await
+        .await;
 }

--- a/justfile
+++ b/justfile
@@ -27,10 +27,10 @@ async := "async_std"
   export RUST_MIN_STACK=4194304 RUSTDOCFLAGS='-D warnings --cfg async_executor_impl="async-std" --cfg async_channel_impl="async-std" {{original_rustdocflags}}' RUSTFLAGS='--cfg async_executor_impl="async-std" --cfg async_channel_impl="async-std" {{original_rustflags}}' && just {{target}} {{ARGS}}
 
 build:
-  cargo build --workspace --examples --bins --tests --lib --benches --release
+  cargo build --workspace --examples --bins --tests --lib --benches
 
 build_release:
-  cargo build --package hotshot --no-default-features --features="docs, doc-images"
+  cargo build --package hotshot --profile-=release --no-default-features --features="docs, doc-images"
 
 example *ARGS:
   cargo run --profile=release-lto --example {{ARGS}}

--- a/justfile
+++ b/justfile
@@ -99,10 +99,10 @@ default_test := ""
 test_name := "sequencing_libp2p_test"
 
 run_test test=default_test:
-  cargo test --verbose --release --lib --bins --tests --benches {{test}} --no-fail-fast -- --test-threads=1 --nocapture
+  cargo test --verbose --lib --bins --tests --benches {{test}} --no-fail-fast -- --test-threads=1 --nocapture
 
 test_pkg_all pkg=test_pkg:
-  cargo test --verbose --release --lib --bins --tests --benches --package={{pkg}} --no-fail-fast -- --test-threads=1 --nocapture
+  cargo test --verbose --lib --bins --tests --benches --package={{pkg}} --no-fail-fast -- --test-threads=1 --nocapture
 
 list_tests_json package=test_pkg:
   RUST_LOG=none cargo test --verbose --lib --bins --tests --benches --package={{package}} --no-fail-fast -- --test-threads=1 -Zunstable-options --format json


### PR DESCRIPTION
Closes #2441 
Closes #2211 
<!-- See here for keywords in Github -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

### This PR: 
<!-- Describe what this PR adds to HotSHot -->
<!-- E.g. -->
<!-- * Implements feature 1 -->
<!-- * Implements feature 2 -->
<!-- * Fixes bug 3 -->

Makes a few improvements to reduce the probability of a test failing or hanging.
Namely:
- Adds a way for the late start nodes to force stop. Without it, nodes started late continue running past when they're supposed to be killed. This seems to cause a lot of hanging tests, and could also cause an OOM eventually.

- Changes timings for the catchup tests, like `catchup_test_in_view_sync` to make sure that we more accurately depict what the test should be testing.  

- Fixes the spinning task so that we don't miss spinning up or down any nodes. Before this, if nodes try to start or stop during a timeout or view sync, we don't receive the underlying event. This means the action wouldn't actually execute

- Prevents transaction task deadlock by timing out and using non-blocking operations. This prevents tests from hanging when using the `async_std` executor.

- Tunes some libp2p-specific parameters and re-introduce direct message retries. The "retry forever" issue still exists but that is to be dealt with in a separate issue.

It also switches back the `justfile` to use the debug release profile, which lets us iterate faster. Without it, build times average ~15m instead of 5.

### This PR does not: 
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->

A few improvements I want to make to the testbed, although not sure how time consuming:
- The timing issues can stem from the fact that while we execute spinning events on a specific view, it can sometimes take longer to actually execute on that spin. I wonder if we could get it to a middleware-like layer where all tasks have to finish their operations for a particular view before nodes are allowed to move on. This would make it much more deterministic.

- It does not fix all tests everywhere (like fix the libp2p test always). I'm going to get this one in as an incremental improvement and see where to go from there.


### Key places to review: 
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->
- Want to make sure the `catchup` tests are still configured properly - cc @bfish713 

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
