### PR TITLE
[FIX_CI] Increase view timeout for libp2p_network test

### DIFF
--- a/crates/testing/tests/libp2p.rs
+++ b/crates/testing/tests/libp2p.rs
@@ -29,6 +29,7 @@ async fn libp2p_network() {
             },
         ),
         timing_data: TimingData {
+            next_view_timeout: 5000,
             round_start_delay: 100,
             ..Default::default()
         },


### PR DESCRIPTION
Partially addresses #2216


### This PR: 
Adds a next_view_timeout of 5s to libp2p_network test.

### This PR does not: 
Change anything else

### Key places to review: 
`crates/testing/tests/libp2p.rs`

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
