### PR TITLE
Indexes Payload store by view number

### DIFF
--- a/crates/hotshot/src/lib.rs
+++ b/crates/hotshot/src/lib.rs
@@ -39,7 +39,7 @@ use hotshot_task::{
 use hotshot_task_impls::{events::HotShotEvent, network::NetworkTaskKind};
 
 use hotshot_types::{
-    consensus::{Consensus, ConsensusMetricsValue, PayloadStore, View, ViewInner, ViewQueue},
+    consensus::{Consensus, ConsensusMetricsValue, View, ViewInner, ViewQueue},
     data::Leaf,
     error::StorageSnafu,
     event::EventType,
@@ -217,9 +217,8 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> SystemContext<TYPES, I> {
         );
 
         let mut saved_leaves = HashMap::new();
-        let mut saved_payloads = PayloadStore::default();
+        let mut saved_payloads = BTreeMap::new();
         saved_leaves.insert(anchored_leaf.commit(), anchored_leaf.clone());
-        let payload_commitment = anchored_leaf.get_payload_commitment();
         if let Some(payload) = anchored_leaf.get_block_payload() {
             let encoded_txns = match payload.encode() {
                 // TODO (Keyao) [VALIDATED_STATE] - Avoid collect/copy on the encoded transaction bytes.
@@ -229,7 +228,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> SystemContext<TYPES, I> {
                     return Err(HotShotError::BlockError { source: e });
                 }
             };
-            saved_payloads.insert(payload_commitment, encoded_txns);
+            saved_payloads.insert(anchored_leaf.get_view_number(), encoded_txns);
         }
 
         let start_view = anchored_leaf.get_view_number();

--- a/crates/hotshot/src/lib.rs
+++ b/crates/hotshot/src/lib.rs
@@ -220,7 +220,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> SystemContext<TYPES, I> {
         let mut saved_payloads = BTreeMap::new();
         saved_leaves.insert(anchored_leaf.commit(), anchored_leaf.clone());
         if let Some(payload) = anchored_leaf.get_block_payload() {
-            let encoded_txns = match payload.encode() {
+            let encoded_txns: Vec<u8> = match payload.encode() {
                 // TODO (Keyao) [VALIDATED_STATE] - Avoid collect/copy on the encoded transaction bytes.
                 // <https://github.com/EspressoSystems/HotShot/issues/2115>
                 Ok(encoded) => encoded.into_iter().collect(),
@@ -228,7 +228,8 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> SystemContext<TYPES, I> {
                     return Err(HotShotError::BlockError { source: e });
                 }
             };
-            saved_payloads.insert(anchored_leaf.get_view_number(), encoded_txns);
+            saved_payloads.insert(anchored_leaf.get_view_number(), encoded_txns.clone());
+            saved_payloads.insert(TYPES::Time::new(1), encoded_txns);
         }
 
         let start_view = anchored_leaf.get_view_number();

--- a/crates/task-impls/src/consensus.rs
+++ b/crates/task-impls/src/consensus.rs
@@ -702,7 +702,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                                 // If the block payload is available for this leaf, include it in
                                 // the leaf chain that we send to the client.
                                 if let Some(encoded_txns) =
-                                    consensus.saved_payloads.get(leaf.get_payload_commitment())
+                                    consensus.saved_payloads.get(&leaf.get_view_number())
                                 {
                                     let payload = BlockPayload::from_bytes(
                                         encoded_txns.clone().into_iter(),

--- a/crates/task-impls/src/consensus.rs
+++ b/crates/task-impls/src/consensus.rs
@@ -558,8 +558,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                     let liveness_check = justify_qc.get_view_number() > consensus.locked_view;
 
                     let high_qc = consensus.high_qc.clone();
-                    let locked_view = consensus.locked_view; 
-                
+                    let locked_view = consensus.locked_view;
 
                     drop(consensus);
 

--- a/crates/task-impls/src/da.rs
+++ b/crates/task-impls/src/da.rs
@@ -192,7 +192,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                 // Record the payload we have promised to make available.
                 consensus
                     .saved_payloads
-                    .insert(payload_commitment, proposal.data.encoded_transactions);
+                    .insert(view, proposal.data.encoded_transactions);
             }
             HotShotEvent::DAVoteRecv(ref vote) => {
                 debug!("DA vote recv, Main Task {:?}", vote.get_view_number());

--- a/crates/testing/tests/unreliable_network.rs
+++ b/crates/testing/tests/unreliable_network.rs
@@ -44,7 +44,7 @@ async fn libp2p_network_sync() {
         .gen_launcher::<TestTypes, Libp2pImpl>(0)
         .launch()
         .run_test()
-        .await
+        .await;
 }
 
 #[cfg(test)]
@@ -122,7 +122,7 @@ async fn libp2p_network_async() {
         .gen_launcher::<TestTypes, Libp2pImpl>(0)
         .launch()
         .run_test()
-        .await
+        .await;
 }
 
 #[cfg(test)]
@@ -260,7 +260,7 @@ async fn libp2p_network_partially_sync() {
         .gen_launcher::<TestTypes, Libp2pImpl>(0)
         .launch()
         .run_test()
-        .await
+        .await;
 }
 
 #[cfg(test)]
@@ -339,5 +339,5 @@ async fn libp2p_network_chaos() {
         .gen_launcher::<TestTypes, Libp2pImpl>(0)
         .launch()
         .run_test()
-        .await
+        .await;
 }

--- a/crates/types/src/consensus.rs
+++ b/crates/types/src/consensus.rs
@@ -55,7 +55,7 @@ pub struct Consensus<TYPES: NodeType> {
     ///
     /// Contains the block payload commitment and encoded transactions for every leaf in
     /// `saved_leaves` if that payload is available.
-    pub saved_payloads: PayloadStore,
+    pub saved_payloads: BTreeMap<TYPES::Time, Vec<u8>>,
 
     /// The `locked_qc` view number
     pub locked_view: TYPES::Time,
@@ -318,19 +318,12 @@ impl<TYPES: NodeType> Consensus<TYPES> {
             .retain(|view_number, _| *view_number >= old_anchor_view);
         self.state_map
             .range(old_anchor_view..new_anchor_view)
-            .filter_map(|(_view_number, view)| view.get_payload_commitment())
-            .for_each(|payload_commitment| {
-                self.saved_payloads.remove(payload_commitment);
-            });
-        self.state_map
-            .range(old_anchor_view..new_anchor_view)
             .filter_map(|(_view_number, view)| view.get_leaf_commitment())
             .for_each(|leaf| {
-                if let Some(removed) = self.saved_leaves.remove(&leaf) {
-                    self.saved_payloads.remove(removed.get_payload_commitment());
-                }
+                self.saved_leaves.remove(&leaf);
             });
         self.state_map = self.state_map.split_off(&new_anchor_view);
+        self.saved_payloads = self.saved_payloads.split_off(&new_anchor_view);
     }
 
     /// Gets the last decided state

--- a/crates/types/src/consensus.rs
+++ b/crates/types/src/consensus.rs
@@ -53,8 +53,7 @@ pub struct Consensus<TYPES: NodeType> {
 
     /// Saved payloads.
     ///
-    /// Contains the block payload commitment and encoded transactions for every leaf in
-    /// `saved_leaves` if that payload is available.
+    /// Encoded transactions for every view if we got a payload for that view.
     pub saved_payloads: BTreeMap<TYPES::Time, Vec<u8>>,
 
     /// The `locked_qc` view number


### PR DESCRIPTION
Closes #2448 

### This PR: 

Stops using our custom `PayloadStore` and just uses BTreeMap.  This means we may have duplicate Payloads in the store, but the store will remain quite small so should not be an issue.  We use `split_off` for GCing the map just like the state map.  This gets rid of all the payloads prior to decide, should be a straight forward way to GC.

### This PR does not: 

This is not the PR which fixes this for the release branch.  Review that one first

### Key places to review: 

Is garbage collection and intialization correct? Am I always indexing with the correct view number


