### PR TITLE
HOT-FIX: Index Payload Store by View

### DIFF
--- a/crates/hotshot/src/lib.rs
+++ b/crates/hotshot/src/lib.rs
@@ -50,7 +50,7 @@ use hotshot_task::{
 use hotshot_task_impls::{events::HotShotEvent, network::NetworkTaskKind};
 
 use hotshot_types::{
-    consensus::{Consensus, ConsensusMetricsValue, PayloadStore, View, ViewInner, ViewQueue},
+    consensus::{Consensus, ConsensusMetricsValue, View, ViewInner, ViewQueue},
     data::Leaf,
     error::StorageSnafu,
     message::{
@@ -222,9 +222,8 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> SystemContext<TYPES, I> {
         );
 
         let mut saved_leaves = HashMap::new();
-        let mut saved_payloads = PayloadStore::default();
+        let mut saved_payloads = BTreeMap::new();
         saved_leaves.insert(anchored_leaf.commit(), anchored_leaf.clone());
-        let payload_commitment = anchored_leaf.get_payload_commitment();
         if let Some(payload) = anchored_leaf.get_block_payload() {
             let encoded_txns = match payload.encode() {
                 // TODO (Keyao) [VALIDATED_STATE] - Avoid collect/copy on the encoded transaction bytes.
@@ -234,7 +233,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> SystemContext<TYPES, I> {
                     return Err(HotShotError::BlockError { source: e });
                 }
             };
-            saved_payloads.insert(payload_commitment, encoded_txns);
+            saved_payloads.insert(anchored_leaf.get_view_number(), encoded_txns);
         }
 
         let start_view = anchored_leaf.get_view_number();

--- a/crates/task-impls/src/consensus.rs
+++ b/crates/task-impls/src/consensus.rs
@@ -680,7 +680,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                                 // If the block payload is available for this leaf, include it in
                                 // the leaf chain that we send to the client.
                                 if let Some(encoded_txns) =
-                                    consensus.saved_payloads.get(leaf.get_payload_commitment())
+                                    consensus.saved_payloads.get(&leaf.get_view_number())
                                 {
                                     let payload = BlockPayload::from_bytes(
                                         encoded_txns.clone().into_iter(),

--- a/crates/task-impls/src/consensus.rs
+++ b/crates/task-impls/src/consensus.rs
@@ -546,8 +546,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                     let liveness_check = justify_qc.get_view_number() > consensus.locked_view;
 
                     let high_qc = consensus.high_qc.clone();
-                    let locked_view = consensus.locked_view; 
-                
+                    let locked_view = consensus.locked_view;
 
                     drop(consensus);
 

--- a/crates/task-impls/src/da.rs
+++ b/crates/task-impls/src/da.rs
@@ -177,7 +177,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                 // Record the payload we have promised to make available.
                 consensus
                     .saved_payloads
-                    .insert(payload_commitment, proposal.data.encoded_transactions);
+                    .insert(view, proposal.data.encoded_transactions);
             }
             HotShotEvent::DAVoteRecv(ref vote) => {
                 debug!("DA vote recv, Main Task {:?}", vote.get_view_number());

--- a/crates/types/src/consensus.rs
+++ b/crates/types/src/consensus.rs
@@ -320,7 +320,7 @@ impl<TYPES: NodeType> Consensus<TYPES> {
             .range(old_anchor_view..new_anchor_view)
             .filter_map(|(_view_number, view)| view.get_leaf_commitment())
             .for_each(|leaf| {
-                 self.saved_leaves.remove(&leaf);
+                self.saved_leaves.remove(&leaf);
             });
         self.state_map = self.state_map.split_off(&new_anchor_view);
         self.saved_payloads = self.saved_payloads.split_off(&new_anchor_view);

--- a/crates/types/src/consensus.rs
+++ b/crates/types/src/consensus.rs
@@ -53,8 +53,7 @@ pub struct Consensus<TYPES: NodeType> {
 
     /// Saved payloads.
     ///
-    /// Contains the block payload commitment and encoded transactions for every leaf in
-    /// `saved_leaves` if that payload is available.
+    /// Encoded transactions for every view if we got a payload for that view.
     pub saved_payloads: BTreeMap<TYPES::Time, Vec<u8>>,
 
     /// The `locked_qc` view number


### PR DESCRIPTION
Closes #2449 

### This PR: 

Stops using our custom PayloadStore and just uses BTreeMap. This means we may have duplicate Payloads in the store, but the store will remain quite small so should not be an issue. We use split_off for GCing the map just like the state map. This gets rid of all the payloads prior to decide, should be a straight forward way to GC.


### Key places to review: 

Is garbage collection and intialization correct? Am I always indexing with the correct view number
