### PR TITLE
Store Genesis Block Payload for view 1

### DIFF
--- a/crates/hotshot/src/lib.rs
+++ b/crates/hotshot/src/lib.rs
@@ -225,7 +225,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> SystemContext<TYPES, I> {
         let mut saved_payloads = BTreeMap::new();
         saved_leaves.insert(anchored_leaf.commit(), anchored_leaf.clone());
         if let Some(payload) = anchored_leaf.get_block_payload() {
-            let encoded_txns = match payload.encode() {
+            let encoded_txns: Vec<u8> = match payload.encode() {
                 // TODO (Keyao) [VALIDATED_STATE] - Avoid collect/copy on the encoded transaction bytes.
                 // <https://github.com/EspressoSystems/HotShot/issues/2115>
                 Ok(encoded) => encoded.into_iter().collect(),
@@ -233,7 +233,9 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> SystemContext<TYPES, I> {
                     return Err(HotShotError::BlockError { source: e });
                 }
             };
-            saved_payloads.insert(anchored_leaf.get_view_number(), encoded_txns);
+            saved_payloads.insert(anchored_leaf.get_view_number(), encoded_txns.clone());
+            // Insert the genesis block for the first view, that's what the first leader will propose
+            saved_payloads.insert(TYPES::Time::new(1), encoded_txns);
         }
 
         let start_view = anchored_leaf.get_view_number();


### PR DESCRIPTION
### This PR: 

Initializes hotshot state with the first block that will be proposed.  It's a hack because we don't go through DA on the first view
and the first leader always proposes and empty block.  

### This PR does not: 

Create a proper genesis workflow.  Eventually we don't want to special case the first view, only the genesis view should be special (view 0).

### Key places to review: 

Is this the write place to init the map?

### How to test this PR: 

To Test I manually logged the decide events in the test harness and saw that always the first view was an empty block (no transactions) and that the payload we initialized the map with logged the exact same thing.

