### PR TITLE
[VALIDATED_STATE] - Add state to header and remove metadata getter

### DIFF
--- a/crates/task-impls/src/consensus.rs
+++ b/crates/task-impls/src/consensus.rs
@@ -1174,7 +1174,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
             return false;
         };
         // Leaf hash in view inner does not match high qc hash - Why?
-        let Some(leaf_commitment) = parent_view.get_leaf_commitment() else {
+        let Some((leaf_commitment, state)) = parent_view.get_leaf() else {
             error!(
                 ?parent_view_number,
                 ?parent_view,
@@ -1223,6 +1223,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                 commit_and_metadata.commitment,
                 commit_and_metadata.metadata.clone(),
                 &parent_header,
+                state,
             );
             let leaf = Leaf {
                 view_number: view,

--- a/crates/testing/src/block_types.rs
+++ b/crates/testing/src/block_types.rs
@@ -15,6 +15,8 @@ use hotshot_types::{
 use serde::{Deserialize, Serialize};
 use sha3::{Digest, Keccak256};
 
+use crate::state_types::TestState;
+
 /// The transaction in a [`TestBlockPayload`].
 #[derive(Default, PartialEq, Eq, Hash, Serialize, Deserialize, Clone, Debug)]
 pub struct TestTransaction(pub Vec<u8>);
@@ -181,11 +183,13 @@ pub struct TestBlockHeader {
 
 impl BlockHeader for TestBlockHeader {
     type Payload = TestBlockPayload;
+    type State = TestState;
 
     fn new(
         payload_commitment: VidCommitment,
         _metadata: <Self::Payload as BlockPayload>::Metadata,
         parent_header: &Self,
+        _parent_state: &Self::State,
     ) -> Self {
         Self {
             block_number: parent_header.block_number + 1,

--- a/crates/testing/src/state_types.rs
+++ b/crates/testing/src/state_types.rs
@@ -90,8 +90,6 @@ impl State for TestState {
     }
 
     fn on_commit(&self) {}
-
-    fn metadata(&self) -> Self::Metadata {}
 }
 
 impl TestableState for TestState {

--- a/crates/testing/src/state_types.rs
+++ b/crates/testing/src/state_types.rs
@@ -60,8 +60,6 @@ impl State for TestState {
 
     type Time = ViewNumber;
 
-    type Metadata = ();
-
     fn validate_and_apply_header(
         &self,
         _proposed_header: &Self::BlockHeader,

--- a/crates/testing/src/task_helpers.rs
+++ b/crates/testing/src/task_helpers.rs
@@ -239,7 +239,13 @@ async fn build_quorum_proposal_and_signature(
             .quorum_membership
             .total_nodes(),
     );
-    let block_header = TestBlockHeader::new(payload_commitment, (), &parent_leaf.block_header);
+    let mut parent_state = <TestState as State>::from_header(&parent_leaf.block_header);
+    let block_header = TestBlockHeader::new(
+        payload_commitment,
+        (),
+        &parent_leaf.block_header,
+        &parent_state,
+    );
     // current leaf that can be re-assigned everytime when entering a new view
     let mut leaf = Leaf {
         view_number: ViewNumber::new(1),
@@ -250,7 +256,6 @@ async fn build_quorum_proposal_and_signature(
         rejected: vec![],
         proposer_id: *api.public_key(),
     };
-    let mut parent_state = <TestState as State>::from_header(&parent_leaf.block_header);
 
     let mut signature = <BLSPubKey as SignatureKey>::sign(private_key, leaf.commit().as_ref())
         .expect("Failed to sign leaf commitment!");

--- a/crates/types/src/traits/block_contents.rs
+++ b/crates/types/src/traits/block_contents.rs
@@ -3,7 +3,10 @@
 //! This module provides the [`Transaction`], [`BlockPayload`], and [`BlockHeader`] traits, which
 //! describe the behaviors that a block is expected to have.
 
-use crate::data::{test_srs, VidCommitment, VidScheme, VidSchemeTrait};
+use crate::{
+    data::{test_srs, VidCommitment, VidScheme, VidSchemeTrait},
+    traits::State,
+};
 use commit::{Commitment, Committable};
 use serde::{de::DeserializeOwned, Serialize};
 
@@ -100,11 +103,15 @@ pub trait BlockHeader:
     /// Block payload associated with the commitment.
     type Payload: BlockPayload;
 
-    /// Build a header with the payload commitment, metadata, and parent header.
+    /// Validated state.
+    type State: State<BlockHeader = Self>;
+
+    /// Build a header with the payload commitment, metadata, parent header, and parent state.
     fn new(
         payload_commitment: VidCommitment,
         metadata: <Self::Payload as BlockPayload>::Metadata,
         parent_header: &Self,
+        parent_state: &Self::State,
     ) -> Self;
 
     /// Build the genesis header, payload, and metadata.

--- a/crates/types/src/traits/node_implementation.rs
+++ b/crates/types/src/traits/node_implementation.rs
@@ -286,7 +286,7 @@ pub trait NodeType:
     /// This should be the same `Time` that `StateType::Time` is using.
     type Time: ConsensusTime;
     /// The block header type that this hotshot setup is using.
-    type BlockHeader: BlockHeader<Payload = Self::BlockPayload>;
+    type BlockHeader: BlockHeader<Payload = Self::BlockPayload, State = Self::StateType>;
     /// The block type that this hotshot setup is using.
     ///
     /// This should be the same block that `StateType::BlockPayload` is using.

--- a/crates/types/src/traits/state.rs
+++ b/crates/types/src/traits/state.rs
@@ -75,9 +75,6 @@ pub trait State:
 
     /// Gets called to notify the persistence backend that this state has been committed
     fn on_commit(&self);
-
-    /// Get the application-specific data.
-    fn metadata(&self) -> Self::Metadata;
 }
 
 // TODO Seuqnecing here means involving DA in consensus

--- a/crates/types/src/traits/state.rs
+++ b/crates/types/src/traits/state.rs
@@ -45,8 +45,6 @@ pub trait State:
     type BlockPayload: BlockPayload;
     /// Time compatibility needed for reward collection
     type Time: ConsensusTime;
-    /// Application-specific data.
-    type Metadata: Debug + Send + Sync;
 
     /// Check if the proposed block header is valid and apply it to the state if so.
     ///

--- a/crates/types/src/utils.rs
+++ b/crates/types/src/utils.rs
@@ -31,6 +31,15 @@ pub enum ViewInner<TYPES: NodeType> {
 }
 
 impl<TYPES: NodeType> ViewInner<TYPES> {
+    /// Return the underlying undecide leaf view if it exists.
+    pub fn get_leaf(&self) -> Option<(Commitment<Leaf<TYPES>>, &TYPES::StateType)> {
+        if let Self::Leaf { leaf, state } = self {
+            Some((*leaf, state))
+        } else {
+            None
+        }
+    }
+
     /// return the underlying leaf hash if it exists
     #[must_use]
     pub fn get_leaf_commitment(&self) -> Option<Commitment<Leaf<TYPES>>> {


### PR DESCRIPTION
Closes https://github.com/EspressoSystems/HotShot/issues/2463.

### This PR: 
* Adds the parent state to the `BlockHeader` construction.
* Removes the metadata getter function from the `State` trait.

### This PR does not: 
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->

### Key places to review: 
* crates/testing/src/block_types.rs

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
