### PR TITLE
[HOTFIX] Check Relay Number when Accumulating View Sync Votes

### DIFF
--- a/crates/task-impls/src/view_sync.rs
+++ b/crates/task-impls/src/view_sync.rs
@@ -41,7 +41,7 @@ use hotshot_types::{
     },
 };
 use snafu::Snafu;
-use std::{collections::HashMap, fmt::Debug, sync::Arc, time::Duration};
+use std::{collections::BTreeMap, collections::HashMap, fmt::Debug, sync::Arc, time::Duration};
 #[cfg(async_executor_impl = "tokio")]
 use tokio::task::JoinHandle;
 use tracing::{debug, error, info, instrument, warn};
@@ -62,9 +62,9 @@ pub enum ViewSyncPhase {
 /// Stub of a view sync error
 pub struct ViewSyncTaskError {}
 
-/// Type alias for a map from View Number to Vote Task
+/// Type alias for a map from View Number to Relay to Vote Task
 type RelayMap<TYPES, VOTE, CERT> =
-    HashMap<<TYPES as NodeType>::Time, VoteCollectionTaskState<TYPES, VOTE, CERT>>;
+    HashMap<<TYPES as NodeType>::Time, BTreeMap<u64, VoteCollectionTaskState<TYPES, VOTE, CERT>>>;
 
 /// Main view sync task state
 pub struct ViewSyncTaskState<
@@ -198,11 +198,12 @@ impl<
     ) {
         // This certificate is old, we can throw it away
         // If next view = cert round, then that means we should already have a task running for it
-        let mut task_map = self.replica_task_map.write().await;
         if self.current_view > view {
             debug!("Already in a higher view than the view sync message");
             return;
         }
+
+        let mut task_map = self.replica_task_map.write().await;
 
         if let Some(replica_task) = task_map.remove(&view) {
             // Forward event then return
@@ -277,7 +278,9 @@ impl<
             HotShotEvent::ViewSyncPreCommitVoteRecv(ref vote) => {
                 let mut map = self.pre_commit_relay_map.write().await;
                 let vote_view = vote.get_view_number();
-                if let Some(relay_task) = map.remove(&vote_view) {
+                let relay = vote.get_data().relay;
+                let relay_map = map.entry(vote_view).or_insert(BTreeMap::new());
+                if let Some(relay_task) = relay_map.remove(&relay) {
                     debug!("Forwarding message");
                     let result = relay_task.handle_event(event.clone()).await;
 
@@ -285,17 +288,12 @@ impl<
                         // The protocol has finished
                         return;
                     }
-
-                    map.insert(vote_view, result.1);
+                    relay_map.insert(relay, result.1);
                     return;
                 }
 
                 // We do not have a relay task already running, so start one
-                if self
-                    .membership
-                    .get_leader(vote_view + vote.get_data().relay)
-                    != self.public_key
-                {
+                if self.membership.get_leader(vote_view + relay) != self.public_key {
                     // TODO ED This will occur because everyone is pulling down votes for now. Will be fixed in `https://github.com/EspressoSystems/HotShot/issues/1471`
                     debug!("View sync vote sent to wrong leader");
                     return;
@@ -311,14 +309,16 @@ impl<
                 };
                 let vote_collector = create_vote_accumulator(&info, vote.clone(), event).await;
                 if let Some(vote_task) = vote_collector {
-                    map.insert(vote_view, vote_task);
+                    relay_map.insert(relay, vote_task);
                 }
             }
 
             HotShotEvent::ViewSyncCommitVoteRecv(ref vote) => {
                 let mut map = self.commit_relay_map.write().await;
                 let vote_view = vote.get_view_number();
-                if let Some(relay_task) = map.remove(&vote_view) {
+                let relay = vote.get_data().relay;
+                let relay_map = map.entry(vote_view).or_insert(BTreeMap::new());
+                if let Some(relay_task) = relay_map.remove(&relay) {
                     debug!("Forwarding message");
                     let result = relay_task.handle_event(event.clone()).await;
 
@@ -327,16 +327,12 @@ impl<
                         return;
                     }
 
-                    map.insert(vote_view, result.1);
+                    relay_map.insert(relay, result.1);
                     return;
                 }
 
                 // We do not have a relay task already running, so start one
-                if self
-                    .membership
-                    .get_leader(vote_view + vote.get_data().relay)
-                    != self.public_key
-                {
+                if self.membership.get_leader(vote_view + relay) != self.public_key {
                     // TODO ED This will occur because everyone is pulling down votes for now. Will be fixed in `https://github.com/EspressoSystems/HotShot/issues/1471`
                     debug!("View sync vote sent to wrong leader");
                     return;
@@ -352,14 +348,16 @@ impl<
                 };
                 let vote_collector = create_vote_accumulator(&info, vote.clone(), event).await;
                 if let Some(vote_task) = vote_collector {
-                    map.insert(vote_view, vote_task);
+                    relay_map.insert(relay, vote_task);
                 }
             }
 
             HotShotEvent::ViewSyncFinalizeVoteRecv(ref vote) => {
                 let mut map = self.finalize_relay_map.write().await;
                 let vote_view = vote.get_view_number();
-                if let Some(relay_task) = map.remove(&vote_view) {
+                let relay = vote.get_data().relay;
+                let relay_map = map.entry(vote_view).or_insert(BTreeMap::new());
+                if let Some(relay_task) = relay_map.remove(&relay) {
                     debug!("Forwarding message");
                     let result = relay_task.handle_event(event.clone()).await;
 
@@ -368,16 +366,12 @@ impl<
                         return;
                     }
 
-                    map.insert(vote_view, result.1);
+                    relay_map.insert(relay, result.1);
                     return;
                 }
 
                 // We do not have a relay task already running, so start one
-                if self
-                    .membership
-                    .get_leader(vote_view + vote.get_data().relay)
-                    != self.public_key
-                {
+                if self.membership.get_leader(vote_view + relay) != self.public_key {
                     // TODO ED This will occur because everyone is pulling down votes for now. Will be fixed in `https://github.com/EspressoSystems/HotShot/issues/1471`
                     debug!("View sync vote sent to wrong leader");
                     return;
@@ -393,7 +387,7 @@ impl<
                 };
                 let vote_collector = create_vote_accumulator(&info, vote.clone(), event).await;
                 if let Some(vote_task) = vote_collector {
-                    map.insert(vote_view, vote_task);
+                    relay_map.insert(relay, vote_task);
                 }
             }
 

--- a/crates/task-impls/src/vote.rs
+++ b/crates/task-impls/src/vote.rs
@@ -201,7 +201,6 @@ where
     }
     let new_accumulator = VoteAccumulator {
         vote_outcomes: HashMap::new(),
-        sig_lists: HashMap::new(),
         signers: HashMap::new(),
         phantom: PhantomData,
     };

--- a/crates/task-impls/src/vote.rs
+++ b/crates/task-impls/src/vote.rs
@@ -2,7 +2,6 @@ use std::{collections::HashMap, fmt::Debug, marker::PhantomData, sync::Arc};
 
 use crate::events::HotShotEvent;
 use async_trait::async_trait;
-use bitvec::prelude::*;
 use either::Either::{self, Left, Right};
 use hotshot_task::{
     event_stream::{ChannelStream, EventStream},
@@ -202,8 +201,8 @@ where
     }
     let new_accumulator = VoteAccumulator {
         vote_outcomes: HashMap::new(),
-        sig_lists: Vec::new(),
-        signers: bitvec![0;info. membership.total_nodes()],
+        sig_lists: HashMap::new(),
+        signers: HashMap::new(),
         phantom: PhantomData,
     };
 

--- a/crates/types/src/vote.rs
+++ b/crates/types/src/vote.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use bincode::Options;
-use bitvec::vec::BitVec;
+use bitvec::{bitvec, vec::BitVec};
 use commit::Commitment;
 use either::Either;
 use ethereum_types::U256;
@@ -85,9 +85,12 @@ pub struct VoteAccumulator<
     /// Map of all signatures accumlated so far
     pub vote_outcomes: VoteMap2<Commitment<VOTE::Commitment>>,
     /// A list of valid signatures for certificate aggregation
-    pub sig_lists: Vec<<TYPES::SignatureKey as SignatureKey>::PureAssembledSignatureType>,
+    pub sig_lists: HashMap<
+        Commitment<VOTE::Commitment>,
+        Vec<<TYPES::SignatureKey as SignatureKey>::PureAssembledSignatureType>,
+    >,
     /// A bitvec to indicate which node is active and send out a valid signature for certificate aggregation, this automatically do uniqueness check
-    pub signers: BitVec,
+    pub signers: HashMap<Commitment<VOTE::Commitment>, BitVec>,
     /// Phantom data to specify the types this accumulator is for
     pub phantom: PhantomData<(TYPES, VOTE, CERT)>,
 }
@@ -138,13 +141,17 @@ impl<TYPES: NodeType, VOTE: Vote<TYPES>, CERT: Certificate<TYPES, Voteable = VOT
         if total_vote_map.contains_key(&encoded_key) {
             return Either::Left(self);
         }
-
-        if self.signers.get(vote_node_id).as_deref() == Some(&true) {
+        let signers = self
+            .signers
+            .entry(vote_commitment)
+            .or_insert(bitvec![0; membership.total_nodes()]);
+        let sig_list = self.sig_lists.entry(vote_commitment).or_default();
+        if signers.get(vote_node_id).as_deref() == Some(&true) {
             error!("Node id is already in signers list");
             return Either::Left(self);
         }
-        self.signers.set(vote_node_id, true);
-        self.sig_lists.push(original_signature);
+        signers.set(vote_node_id, true);
+        sig_list.push(original_signature);
 
         // TODO: Get the stake from the stake table entry.
         *total_stake_casted += stake_table_entry.get_stake();
@@ -163,8 +170,8 @@ impl<TYPES: NodeType, VOTE: Vote<TYPES>, CERT: Certificate<TYPES, Voteable = VOT
 
             let real_qc_sig = <TYPES::SignatureKey as SignatureKey>::assemble(
                 &real_qc_pp,
-                self.signers.as_bitslice(),
-                &self.sig_lists[..],
+                signers.as_bitslice(),
+                &sig_list[..],
             );
 
             let cert = CERT::create_signed_certificate(


### PR DESCRIPTION
### This PR: 

Keys the relay maps by relay number as well.  This makes it so that relays will accumulate votes separately for each time they are the relay.  

It also changes the vote accumulator to map vote commitment to the signers (sig_list and signers bitvec).  This mirrors how we map vote commitment to the vote outcomes and should make it impossible to form an invalid cert by accident.

### This PR does not: 

No garbage collection for old relay rounds (they will be clean up when the view moves on)

### Key places to review: 

In view_sync.rs make sure the new mapping makes sense.
In the vote accumulator, check the new mapping as well
