### PR TITLE
[HOTFIX] Poll forever for latest data

### DIFF
--- a/crates/hotshot/src/tasks/mod.rs
+++ b/crates/hotshot/src/tasks/mod.rs
@@ -256,10 +256,18 @@ pub async fn add_consensus_task<TYPES: NodeType, I: NodeImplementation<TYPES>>(
         quorum_membership: c_api.inner.memberships.quorum_membership.clone().into(),
         committee_membership: c_api.inner.memberships.da_membership.clone().into(),
     };
+    // Poll (forever) for the latest quorum proposal
     consensus_state
         .quorum_network
         .inject_consensus_info(ConsensusIntentEvent::PollForLatestQuorumProposal)
         .await;
+
+    // Poll (forever) for the latest view sync certificate
+    consensus_state
+        .quorum_network
+        .inject_consensus_info(ConsensusIntentEvent::PollForLatestViewSyncCertificate)
+        .await;
+
     let filter = FilterEvent(Arc::new(consensus_event_filter));
     let consensus_name = "Consensus Task";
     let consensus_event_handler = HandleEvent(Arc::new(

--- a/crates/hotshot/src/traits/networking/web_server_network.rs
+++ b/crates/hotshot/src/traits/networking/web_server_network.rs
@@ -226,7 +226,7 @@ struct Inner<TYPES: NodeType> {
     /// Task polling for latest quorum propsal
     latest_quorum_proposal_task: Arc<RwLock<Option<TaskChannel<TYPES::SignatureKey>>>>,
     /// Task polling for latest view sync proposal
-    latest_view_sync_proposal_task: Arc<RwLock<Option<TaskChannel<TYPES::SignatureKey>>>>,
+    latest_view_sync_certificate_task: Arc<RwLock<Option<TaskChannel<TYPES::SignatureKey>>>>,
 }
 
 impl<TYPES: NodeType> Inner<TYPES> {
@@ -251,14 +251,14 @@ impl<TYPES: NodeType> Inner<TYPES> {
             let endpoint = match message_purpose {
                 MessagePurpose::Proposal => config::get_proposal_route(view_number),
                 MessagePurpose::LatestQuorumProposal => config::get_latest_quorum_proposal_route(),
-                MessagePurpose::LatestViewSyncProposal => {
-                    config::get_latest_view_sync_proposal_route()
+                MessagePurpose::LatestViewSyncCertificate => {
+                    config::get_latest_view_sync_certificate_route()
                 }
                 MessagePurpose::Vote => config::get_vote_route(view_number, vote_index),
                 MessagePurpose::Data => config::get_transactions_route(tx_index),
                 MessagePurpose::Internal => unimplemented!(),
-                MessagePurpose::ViewSyncProposal => {
-                    config::get_view_sync_proposal_route(view_number, vote_index)
+                MessagePurpose::ViewSyncCertificate => {
+                    config::get_view_sync_certificate_route(view_number, vote_index)
                 }
                 MessagePurpose::ViewSyncVote => {
                     config::get_view_sync_vote_route(view_number, vote_index)
@@ -325,7 +325,7 @@ impl<TYPES: NodeType> Inner<TYPES> {
 
                                 return Ok(());
                             }
-                            MessagePurpose::LatestViewSyncProposal => {
+                            MessagePurpose::LatestViewSyncCertificate => {
                                 let mut broadcast_poll_queue =
                                     self.broadcast_poll_queue.write().await;
 
@@ -399,7 +399,7 @@ impl<TYPES: NodeType> Inner<TYPES> {
                                     direct_poll_queue.push(vote.clone());
                                 }
                             }
-                            MessagePurpose::ViewSyncProposal => {
+                            MessagePurpose::ViewSyncCertificate => {
                                 // error!(
                                 //     "Received {} view sync certs from web server for view {} is da {}",
                                 //     deserialized_messages.len(),
@@ -470,7 +470,7 @@ impl<TYPES: NodeType> Inner<TYPES> {
                             }
                         }
 
-                        ConsensusIntentEvent::CancelPollForLatestViewSyncProposal => {
+                        ConsensusIntentEvent::CancelPollForLatestViewSyncCertificate => {
                             return Ok(());
                         }
 
@@ -622,7 +622,7 @@ impl<TYPES: NodeType + 'static> WebServerNetwork<TYPES> {
             view_sync_vote_task_map: Arc::default(),
             txn_task_map: Arc::default(),
             latest_quorum_proposal_task: Arc::default(),
-            latest_view_sync_proposal_task: Arc::default(),
+            latest_view_sync_certificate_task: Arc::default(),
         });
 
         inner.connected.store(true, Ordering::Relaxed);
@@ -646,12 +646,12 @@ impl<TYPES: NodeType + 'static> WebServerNetwork<TYPES> {
             MessagePurpose::Data => config::post_transactions_route(),
             MessagePurpose::Internal
             | MessagePurpose::LatestQuorumProposal
-            | MessagePurpose::LatestViewSyncProposal => {
+            | MessagePurpose::LatestViewSyncCertificate => {
                 return Err(WebServerNetworkError::EndpointError)
             }
-            MessagePurpose::ViewSyncProposal => {
-                // error!("Posting view sync proposal route is: {}", config::post_view_sync_proposal_route(*view_number));
-                config::post_view_sync_proposal_route(*view_number)
+            MessagePurpose::ViewSyncCertificate => {
+                // error!("Posting view sync proposal route is: {}", config::post_view_sync_certificate_route(*view_number));
+                config::post_view_sync_certificate_route(*view_number)
             }
             MessagePurpose::ViewSyncVote => config::post_view_sync_vote_route(*view_number),
             MessagePurpose::DAC => config::post_da_certificate_route(*view_number),
@@ -987,13 +987,13 @@ impl<TYPES: NodeType + 'static> ConnectedNetwork<Message<TYPES>, TYPES::Signatur
                     });
                 }
             }
-            ConsensusIntentEvent::PollForLatestViewSyncProposal => {
-                let mut latest_view_sync_proposal_task =
-                    self.inner.latest_view_sync_proposal_task.write().await;
-                if latest_view_sync_proposal_task.is_none() {
+            ConsensusIntentEvent::PollForLatestViewSyncCertificate => {
+                let mut latest_view_sync_certificate_task =
+                    self.inner.latest_view_sync_certificate_task.write().await;
+                if latest_view_sync_certificate_task.is_none() {
                     // create new task
                     let (sender, receiver) = unbounded();
-                    *latest_view_sync_proposal_task = Some(sender);
+                    *latest_view_sync_certificate_task = Some(sender);
 
                     async_spawn({
                         let inner_clone = self.inner.clone();
@@ -1001,7 +1001,7 @@ impl<TYPES: NodeType + 'static> ConnectedNetwork<Message<TYPES>, TYPES::Signatur
                             if let Err(e) = inner_clone
                                 .poll_web_server(
                                     receiver,
-                                    MessagePurpose::LatestViewSyncProposal,
+                                    MessagePurpose::LatestViewSyncCertificate,
                                     1,
                                 )
                                 .await
@@ -1011,9 +1011,9 @@ impl<TYPES: NodeType + 'static> ConnectedNetwork<Message<TYPES>, TYPES::Signatur
                                 e
                             );
                             }
-                            let mut latest_view_sync_proposal_task =
-                                inner_clone.latest_view_sync_proposal_task.write().await;
-                            *latest_view_sync_proposal_task = None;
+                            let mut latest_view_sync_certificate_task =
+                                inner_clone.latest_view_sync_certificate_task.write().await;
+                            *latest_view_sync_certificate_task = None;
                         }
                     });
                 }
@@ -1091,13 +1091,13 @@ impl<TYPES: NodeType + 'static> ConnectedNetwork<Message<TYPES>, TYPES::Signatur
                 }
             }
 
-            ConsensusIntentEvent::CancelPollForLatestViewSyncProposal => {
-                let mut latest_view_sync_proposal_task =
-                    self.inner.latest_view_sync_proposal_task.write().await;
+            ConsensusIntentEvent::CancelPollForLatestViewSyncCertificate => {
+                let mut latest_view_sync_certificate_task =
+                    self.inner.latest_view_sync_certificate_task.write().await;
 
-                if let Some(thing) = latest_view_sync_proposal_task.take() {
+                if let Some(thing) = latest_view_sync_certificate_task.take() {
                     let _res = thing
-                        .send(ConsensusIntentEvent::CancelPollForLatestViewSyncProposal)
+                        .send(ConsensusIntentEvent::CancelPollForLatestViewSyncCertificate)
                         .await;
                 }
             }
@@ -1114,7 +1114,7 @@ impl<TYPES: NodeType + 'static> ConnectedNetwork<Message<TYPES>, TYPES::Signatur
                             if let Err(e) = inner_clone
                                 .poll_web_server(
                                     receiver,
-                                    MessagePurpose::ViewSyncProposal,
+                                    MessagePurpose::ViewSyncCertificate,
                                     view_number,
                                 )
                                 .await

--- a/crates/hotshot/src/traits/networking/web_server_network.rs
+++ b/crates/hotshot/src/traits/networking/web_server_network.rs
@@ -470,10 +470,6 @@ impl<TYPES: NodeType> Inner<TYPES> {
                             }
                         }
 
-                        ConsensusIntentEvent::CancelPollForLatestViewSyncCertificate => {
-                            return Ok(());
-                        }
-
                         _ => {
                             unimplemented!()
                         }
@@ -1087,17 +1083,6 @@ impl<TYPES: NodeType + 'static> ConnectedNetwork<Message<TYPES>, TYPES::Signatur
                     // If task already exited we expect an error
                     let _res = sender
                         .send(ConsensusIntentEvent::CancelPollForVotes(view_number))
-                        .await;
-                }
-            }
-
-            ConsensusIntentEvent::CancelPollForLatestViewSyncCertificate => {
-                let mut latest_view_sync_certificate_task =
-                    self.inner.latest_view_sync_certificate_task.write().await;
-
-                if let Some(thing) = latest_view_sync_certificate_task.take() {
-                    let _res = thing
-                        .send(ConsensusIntentEvent::CancelPollForLatestViewSyncCertificate)
                         .await;
                 }
             }

--- a/crates/hotshot/src/traits/networking/web_server_network.rs
+++ b/crates/hotshot/src/traits/networking/web_server_network.rs
@@ -223,10 +223,12 @@ struct Inner<TYPES: NodeType> {
     view_sync_vote_task_map: Arc<RwLock<TaskMap<TYPES::SignatureKey>>>,
     /// Task map for transactions
     txn_task_map: Arc<RwLock<TaskMap<TYPES::SignatureKey>>>,
+    #[allow(clippy::type_complexity)]
     /// A handle for cancelling the task polling for latest quorum propsal
     cancel_latest_quorum_proposal_task: Arc<
         RwLock<Option<UnboundedSender<ConsensusIntentEvent<<TYPES as NodeType>::SignatureKey>>>>,
     >,
+    #[allow(clippy::type_complexity)]
     /// A handle for cancelling the task polling for the latest view sync certificate
     cancel_latest_view_sync_certificate_task: Arc<
         RwLock<Option<UnboundedSender<ConsensusIntentEvent<<TYPES as NodeType>::SignatureKey>>>>,

--- a/crates/hotshot/src/traits/networking/web_server_network.rs
+++ b/crates/hotshot/src/traits/networking/web_server_network.rs
@@ -306,11 +306,7 @@ impl<TYPES: NodeType> Inner<TYPES> {
                             MessagePurpose::Proposal => {
                                 // Only pushing the first proposal since we will soon only be allowing 1 proposal per view
                                 let proposal = deserialized_messages[0].clone();
-                                let hash = hash(&proposal);
-                                // Only allow unseen proposals to be pushed to the queue
-                                if seen_quorum_proposals.put(hash, ()).is_none() {
-                                    self.broadcast_poll_queue.write().await.push(proposal);
-                                }
+                                self.broadcast_poll_queue.write().await.push(proposal);
 
                                 return Ok(());
                                 // Wait for the view to change before polling for proposals again

--- a/crates/task-impls/src/consensus.rs
+++ b/crates/task-impls/src/consensus.rs
@@ -369,7 +369,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
 
     async fn update_view(&mut self, new_view: TYPES::Time) -> bool {
         if *self.cur_view < *new_view {
-            debug!(
+            error!(
                 "Updating view from {} to {} in consensus task",
                 *self.cur_view, *new_view
             );

--- a/crates/task-impls/src/consensus.rs
+++ b/crates/task-impls/src/consensus.rs
@@ -369,7 +369,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
 
     async fn update_view(&mut self, new_view: TYPES::Time) -> bool {
         if *self.cur_view < *new_view {
-            error!(
+            debug!(
                 "Updating view from {} to {} in consensus task",
                 *self.cur_view, *new_view
             );

--- a/crates/task-impls/src/view_sync.rs
+++ b/crates/task-impls/src/view_sync.rs
@@ -471,11 +471,6 @@ impl<
                         ))
                         .await;
 
-                    // Poll for future view sync certificates
-                    self.network
-                        .inject_consensus_info(ConsensusIntentEvent::PollForLatestViewSyncCertificate)
-                        .await;
-
                     // Spawn replica task
                     let next_view = *view_number + 1;
                     // Subscribe to the view after we are leader since we know we won't propose in the next view if we are leader.
@@ -492,12 +487,6 @@ impl<
                             subscribe_view,
                         ))
                         .await;
-                    // Also subscribe to the latest view for the same reason. The GC will remove the above poll
-                    // in the case that one doesn't resolve but this one does.
-                    self.network
-                        .inject_consensus_info(ConsensusIntentEvent::PollForLatestQuorumProposal)
-                        .await;
-
                     self.network
                         .inject_consensus_info(ConsensusIntentEvent::PollForDAC(subscribe_view))
                         .await;
@@ -802,10 +791,6 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                     if let Some(timeout_task) = self.timeout_task.take() {
                         cancel_task(timeout_task).await;
                     }
-                    // Keep trying to get a more recent proposal to catch up to
-                    self.network
-                        .inject_consensus_info(ConsensusIntentEvent::PollForLatestQuorumProposal)
-                        .await;
                     self.relay += 1;
                     match last_seen_certificate {
                         ViewSyncPhase::None | ViewSyncPhase::PreCommit | ViewSyncPhase::Commit => {

--- a/crates/task-impls/src/view_sync.rs
+++ b/crates/task-impls/src/view_sync.rs
@@ -412,12 +412,6 @@ impl<
                     // Garbage collect old tasks
                     // We could put this into a separate async task, but that would require making several fields on ViewSyncTaskState thread-safe and harm readability.  In the common case this will have zero tasks to clean up.
                     // cancel poll for votes
-                    self.network
-                        .inject_consensus_info(
-                            ConsensusIntentEvent::CancelPollForLatestViewSyncCertificate,
-                        )
-                        .await;
-
                     // run GC
                     for i in *self.last_garbage_collected_view..*self.current_view {
                         self.replica_task_map
@@ -742,13 +736,6 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                     .inject_consensus_info(ConsensusIntentEvent::CancelPollForViewSyncCertificate(
                         *certificate.view_number,
                     ))
-                    .await;
-
-                // Cancel poll for future view sync certificates
-                self.network
-                    .inject_consensus_info(
-                        ConsensusIntentEvent::CancelPollForLatestViewSyncCertificate,
-                    )
                     .await;
 
                 if certificate.get_data().relay > self.relay {

--- a/crates/task-impls/src/view_sync.rs
+++ b/crates/task-impls/src/view_sync.rs
@@ -414,7 +414,7 @@ impl<
                     // cancel poll for votes
                     self.network
                         .inject_consensus_info(
-                            ConsensusIntentEvent::CancelPollForLatestViewSyncProposal,
+                            ConsensusIntentEvent::CancelPollForLatestViewSyncCertificate,
                         )
                         .await;
 
@@ -479,7 +479,7 @@ impl<
 
                     // Poll for future view sync certificates
                     self.network
-                        .inject_consensus_info(ConsensusIntentEvent::PollForLatestViewSyncProposal)
+                        .inject_consensus_info(ConsensusIntentEvent::PollForLatestViewSyncCertificate)
                         .await;
 
                     // Spawn replica task
@@ -747,7 +747,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                 // Cancel poll for future view sync certificates
                 self.network
                     .inject_consensus_info(
-                        ConsensusIntentEvent::CancelPollForLatestViewSyncProposal,
+                        ConsensusIntentEvent::CancelPollForLatestViewSyncCertificate,
                     )
                     .await;
 

--- a/crates/types/src/message.rs
+++ b/crates/types/src/message.rs
@@ -67,14 +67,14 @@ pub enum MessagePurpose {
     Proposal,
     /// Message with most recent quorum proposal the server has
     LatestQuorumProposal,
-    /// Message with most recent view sync proposal the server has
-    LatestViewSyncProposal,
+    /// Message with most recent view sync certificate the server has
+    LatestViewSyncCertificate,
     /// Message with a quorum vote.
     Vote,
     /// Message with a view sync vote.
     ViewSyncVote,
-    /// Message with a view sync proposal.
-    ViewSyncProposal,
+    /// Message with a view sync certificate.
+    ViewSyncCertificate,
     /// Message with a DAC.
     DAC,
     /// Message for internal use
@@ -427,7 +427,7 @@ impl<TYPES: NodeType> SequencingMessage<TYPES> {
                 GeneralConsensusMessage::ViewSyncPreCommitCertificate(_)
                 | GeneralConsensusMessage::ViewSyncCommitCertificate(_)
                 | GeneralConsensusMessage::ViewSyncFinalizeCertificate(_) => {
-                    MessagePurpose::ViewSyncProposal
+                    MessagePurpose::ViewSyncCertificate
                 }
 
                 GeneralConsensusMessage::UpgradeCertificate(_)

--- a/crates/types/src/traits/network.rs
+++ b/crates/types/src/traits/network.rs
@@ -175,8 +175,6 @@ pub enum ConsensusIntentEvent<K: SignatureKey> {
     CancelPollForVIDDisperse(u64),
     /// Cancel polling for transactions
     CancelPollForTransactions(u64),
-    /// Cancel polling for most recent view sync proposal
-    CancelPollForLatestViewSyncCertificate,
 }
 
 impl<K: SignatureKey> ConsensusIntentEvent<K> {
@@ -200,8 +198,7 @@ impl<K: SignatureKey> ConsensusIntentEvent<K> {
             | ConsensusIntentEvent::CancelPollForTransactions(view_number)
             | ConsensusIntentEvent::PollFutureLeader(view_number, _) => *view_number,
             ConsensusIntentEvent::PollForLatestQuorumProposal
-            | ConsensusIntentEvent::PollForLatestViewSyncCertificate
-            | ConsensusIntentEvent::CancelPollForLatestViewSyncCertificate => 1,
+            | ConsensusIntentEvent::PollForLatestViewSyncCertificate => 1,
         }
     }
 }

--- a/crates/types/src/traits/network.rs
+++ b/crates/types/src/traits/network.rs
@@ -150,7 +150,7 @@ pub enum ConsensusIntentEvent<K: SignatureKey> {
     /// Poll for the most recent quorum proposal the webserver has
     PollForLatestQuorumProposal,
     /// Poll for the most recent view sync proposal the webserver has
-    PollForLatestViewSyncProposal,
+    PollForLatestViewSyncCertificate,
     /// Poll for a DAC for a particular view
     PollForDAC(u64),
     /// Poll for view sync votes starting at a particular view
@@ -176,7 +176,7 @@ pub enum ConsensusIntentEvent<K: SignatureKey> {
     /// Cancel polling for transactions
     CancelPollForTransactions(u64),
     /// Cancel polling for most recent view sync proposal
-    CancelPollForLatestViewSyncProposal,
+    CancelPollForLatestViewSyncCertificate,
 }
 
 impl<K: SignatureKey> ConsensusIntentEvent<K> {
@@ -200,8 +200,8 @@ impl<K: SignatureKey> ConsensusIntentEvent<K> {
             | ConsensusIntentEvent::CancelPollForTransactions(view_number)
             | ConsensusIntentEvent::PollFutureLeader(view_number, _) => *view_number,
             ConsensusIntentEvent::PollForLatestQuorumProposal
-            | ConsensusIntentEvent::PollForLatestViewSyncProposal
-            | ConsensusIntentEvent::CancelPollForLatestViewSyncProposal => 1,
+            | ConsensusIntentEvent::PollForLatestViewSyncCertificate
+            | ConsensusIntentEvent::CancelPollForLatestViewSyncCertificate => 1,
         }
     }
 }

--- a/crates/types/src/traits/network.rs
+++ b/crates/types/src/traits/network.rs
@@ -167,6 +167,10 @@ pub enum ConsensusIntentEvent<K: SignatureKey> {
     CancelPollForViewSyncVotes(u64),
     /// Cancel polling for proposals.
     CancelPollForProposal(u64),
+    /// Cancel polling for the latest proposal.
+    CancelPollForLatestProposal(u64),
+    /// Cancel polling for the latest view sync certificate
+    CancelPollForLatestViewSyncCertificate(u64),
     /// Cancal polling for DAC.
     CancelPollForDAC(u64),
     /// Cancel polling for view sync certificate.
@@ -189,6 +193,8 @@ impl<K: SignatureKey> ConsensusIntentEvent<K> {
             | ConsensusIntentEvent::CancelPollForViewSyncVotes(view_number)
             | ConsensusIntentEvent::CancelPollForVotes(view_number)
             | ConsensusIntentEvent::CancelPollForProposal(view_number)
+            | ConsensusIntentEvent::CancelPollForLatestProposal(view_number)
+            | ConsensusIntentEvent::CancelPollForLatestViewSyncCertificate(view_number)
             | ConsensusIntentEvent::PollForVIDDisperse(view_number)
             | ConsensusIntentEvent::CancelPollForVIDDisperse(view_number)
             | ConsensusIntentEvent::CancelPollForDAC(view_number)

--- a/crates/web_server/api.toml
+++ b/crates/web_server/api.toml
@@ -27,8 +27,8 @@ Return the proposal for the most recent view the server has
 """
 
 # GET the latest quorum proposal
-[route.get_latest_view_sync_proposal]
-PATH = ["view_sync_proposal/latest"]
+[route.get_latest_view_sync_certificate]
+PATH = ["view_sync_certificate/latest"]
 DOC = """
 Return the proposal for the most recent view the server has
 """
@@ -155,8 +155,8 @@ GET a view sync vote
 """
 
 # POST a view sync proposal, where the view number is passed as an argument
-[route.postviewsyncproposal]
-PATH = ["view_sync_proposal/:view_number"]
+[route.postviewsynccertificate]
+PATH = ["view_sync_certificate/:view_number"]
 ":view_number" = "Integer"
 METHOD = "POST"
 DOC = """
@@ -164,8 +164,8 @@ Send a view sync vote
 """
 
 # GET a view sync certificate, where the view number is passed as an argument
-[route.getviewsyncproposal]
-PATH = ["view_sync_proposal/:view_number/:index"]
+[route.getviewsynccertificate]
+PATH = ["view_sync_certificate/:view_number/:index"]
 ":view_number" = "Integer"
 ":index" = "Integer"
 METHOD = "GET"

--- a/crates/web_server/src/config.rs
+++ b/crates/web_server/src/config.rs
@@ -32,8 +32,8 @@ pub fn get_latest_quorum_proposal_route() -> String {
 
 /// get latest view sync proposal
 #[must_use]
-pub fn get_latest_view_sync_proposal_route() -> String {
-    "api/view_sync_proposal/latest".to_string()
+pub fn get_latest_view_sync_certificate_route() -> String {
+    "api/view_sync_certificate/latest".to_string()
 }
 
 /// get latest certificate
@@ -128,14 +128,14 @@ pub fn post_staketable_route() -> String {
 
 /// post view sync proposal
 #[must_use]
-pub fn post_view_sync_proposal_route(view_number: u64) -> String {
-    format!("api/view_sync_proposal/{view_number}")
+pub fn post_view_sync_certificate_route(view_number: u64) -> String {
+    format!("api/view_sync_certificate/{view_number}")
 }
 
 /// get view sync proposal
 #[must_use]
-pub fn get_view_sync_proposal_route(view_number: u64, index: u64) -> String {
-    format!("api/view_sync_proposal/{view_number}/{index}")
+pub fn get_view_sync_certificate_route(view_number: u64, index: u64) -> String {
+    format!("api/view_sync_certificate/{view_number}/{index}")
 }
 
 /// post view sync vote

--- a/crates/web_server/src/lib.rs
+++ b/crates/web_server/src/lib.rs
@@ -33,9 +33,9 @@ struct WebServerState<KEY> {
     /// view number -> (secret, proposal)
     proposals: HashMap<u64, (String, Vec<u8>)>,
     /// for view sync: view number -> (relay, certificate)
-    view_sync_proposals: HashMap<u64, Vec<(u64, Vec<u8>)>>,
+    view_sync_certificates: HashMap<u64, Vec<(u64, Vec<u8>)>>,
     /// view number -> relay
-    view_sync_proposal_index: HashMap<u64, u64>,
+    view_sync_certificate_index: HashMap<u64, u64>,
     /// view number -> (secret, da_certificates)
     da_certificates: HashMap<u64, (String, Vec<u8>)>,
     /// view for oldest proposals in memory
@@ -43,11 +43,11 @@ struct WebServerState<KEY> {
     /// view for the most recent proposal to help nodes catchup
     latest_quorum_proposal: u64,
     /// view for the most recent view sync proposal
-    latest_view_sync_proposal: u64,
+    latest_view_sync_certificate: u64,
     /// view for the oldest DA certificate
     oldest_certificate: u64,
     /// view for the oldest view sync certificate
-    oldest_view_sync_proposal: u64,
+    oldest_view_sync_certificate: u64,
     /// view number -> Vec(index, vote)
     votes: HashMap<u64, Vec<(u64, Vec<u8>)>>,
     /// view sync: view number -> Vec(relay, vote)
@@ -103,7 +103,7 @@ impl<KEY: SignatureKey + 'static> WebServerState<KEY> {
             oldest_vote: 0,
             oldest_proposal: 0,
             latest_quorum_proposal: 0,
-            latest_view_sync_proposal: 0,
+            latest_view_sync_certificate: 0,
             oldest_certificate: 0,
             shutdown: None,
             stake_table: Vec::new(),
@@ -111,7 +111,7 @@ impl<KEY: SignatureKey + 'static> WebServerState<KEY> {
             transactions: HashMap::new(),
             txn_lookup: HashMap::new(),
             _prng: StdRng::from_entropy(),
-            view_sync_proposals: HashMap::new(),
+            view_sync_certificates: HashMap::new(),
             view_sync_votes: HashMap::new(),
             view_sync_vote_index: HashMap::new(),
 
@@ -128,8 +128,8 @@ impl<KEY: SignatureKey + 'static> WebServerState<KEY> {
             vid_vote_index: HashMap::new(),
 
             oldest_view_sync_vote: 0,
-            oldest_view_sync_proposal: 0,
-            view_sync_proposal_index: HashMap::new(),
+            oldest_view_sync_certificate: 0,
+            view_sync_certificate_index: HashMap::new(),
         }
     }
     /// Provide a shutdown signal to the server
@@ -159,11 +159,11 @@ pub trait WebServerDataSource<KEY> {
     /// Get latest view sync proposal
     /// # Errors
     /// Error if unable to serve.
-    fn get_latest_view_sync_proposal(&self) -> Result<Option<Vec<Vec<u8>>>, Error>;
+    fn get_latest_view_sync_certificate(&self) -> Result<Option<Vec<Vec<u8>>>, Error>;
     /// Get view sync proposal
     /// # Errors
     /// Error if unable to serve.
-    fn get_view_sync_proposal(
+    fn get_view_sync_certificate(
         &self,
         view_number: u64,
         index: u64,
@@ -207,7 +207,7 @@ pub trait WebServerDataSource<KEY> {
     /// Post view sync proposal
     /// # Errors
     /// Error if unable to serve.
-    fn post_view_sync_proposal(&mut self, view_number: u64, proposal: Vec<u8>)
+    fn post_view_sync_certificate(&mut self, view_number: u64, proposal: Vec<u8>)
         -> Result<(), Error>;
 
     /// Post data avaiability certificate
@@ -309,19 +309,19 @@ impl<KEY: SignatureKey> WebServerDataSource<KEY> for WebServerState<KEY> {
         self.get_proposal(self.latest_quorum_proposal)
     }
 
-    fn get_latest_view_sync_proposal(&self) -> Result<Option<Vec<Vec<u8>>>, Error> {
-        self.get_view_sync_proposal(self.latest_view_sync_proposal, 0)
+    fn get_latest_view_sync_certificate(&self) -> Result<Option<Vec<Vec<u8>>>, Error> {
+        self.get_view_sync_certificate(self.latest_view_sync_certificate, 0)
     }
 
-    fn get_view_sync_proposal(
+    fn get_view_sync_certificate(
         &self,
         view_number: u64,
         index: u64,
     ) -> Result<Option<Vec<Vec<u8>>>, Error> {
-        let proposals = self.view_sync_proposals.get(&view_number);
+        let proposals = self.view_sync_certificates.get(&view_number);
         let mut ret_proposals = vec![];
         if let Some(cert) = proposals {
-            for i in index..*self.view_sync_proposal_index.get(&view_number).unwrap() {
+            for i in index..*self.view_sync_certificate_index.get(&view_number).unwrap() {
                 ret_proposals.push(cert[usize::try_from(i).unwrap()].1.clone());
             }
         }
@@ -593,35 +593,35 @@ impl<KEY: SignatureKey> WebServerDataSource<KEY> for WebServerState<KEY> {
         Ok(())
     }
 
-    fn post_view_sync_proposal(
+    fn post_view_sync_certificate(
         &mut self,
         view_number: u64,
         proposal: Vec<u8>,
     ) -> Result<(), Error> {
-        if view_number > self.latest_view_sync_proposal {
-            self.latest_view_sync_proposal = view_number;
+        if view_number > self.latest_view_sync_certificate {
+            self.latest_view_sync_certificate = view_number;
         }
 
         // Only keep proposal history for MAX_VIEWS number of view
-        if self.view_sync_proposals.len() >= MAX_VIEWS {
-            self.view_sync_proposals
-                .remove(&self.oldest_view_sync_proposal);
+        if self.view_sync_certificates.len() >= MAX_VIEWS {
+            self.view_sync_certificates
+                .remove(&self.oldest_view_sync_certificate);
             while !self
-                .view_sync_proposals
-                .contains_key(&self.oldest_view_sync_proposal)
+                .view_sync_certificates
+                .contains_key(&self.oldest_view_sync_certificate)
             {
-                self.oldest_view_sync_proposal += 1;
+                self.oldest_view_sync_certificate += 1;
             }
         }
         let next_index = self
-            .view_sync_proposal_index
+            .view_sync_certificate_index
             .entry(view_number)
             .or_insert(0);
-        self.view_sync_proposals
+        self.view_sync_certificates
             .entry(view_number)
             .and_modify(|current_props| current_props.push((*next_index, proposal.clone())))
             .or_insert_with(|| vec![(*next_index, proposal)]);
-        self.view_sync_proposal_index
+        self.view_sync_certificate_index
             .entry(view_number)
             .and_modify(|index| *index += 1);
         Ok(())
@@ -796,14 +796,14 @@ where
     .get("get_latest_quorum_proposal", |_req, state| {
         async move { state.get_latest_quorum_proposal() }.boxed()
     })?
-    .get("get_latest_view_sync_proposal", |_req, state| {
-        async move { state.get_latest_view_sync_proposal() }.boxed()
+    .get("get_latest_view_sync_certificate", |_req, state| {
+        async move { state.get_latest_view_sync_certificate() }.boxed()
     })?
-    .get("getviewsyncproposal", |req, state| {
+    .get("getviewsynccertificate", |req, state| {
         async move {
             let view_number: u64 = req.integer_param("view_number")?;
             let index: u64 = req.integer_param("index")?;
-            state.get_view_sync_proposal(view_number, index)
+            state.get_view_sync_certificate(view_number, index)
         }
         .boxed()
     })?
@@ -871,11 +871,11 @@ where
         }
         .boxed()
     })?
-    .post("postviewsyncproposal", |req, state| {
+    .post("postviewsynccertificate", |req, state| {
         async move {
             let view_number: u64 = req.integer_param("view_number")?;
             let proposal = req.body_bytes();
-            state.post_view_sync_proposal(view_number, proposal)
+            state.post_view_sync_certificate(view_number, proposal)
         }
         .boxed()
     })?

--- a/crates/web_server/src/lib.rs
+++ b/crates/web_server/src/lib.rs
@@ -204,11 +204,14 @@ pub trait WebServerDataSource<KEY> {
     /// # Errors
     /// Error if unable to serve.
     fn post_proposal(&mut self, view_number: u64, proposal: Vec<u8>) -> Result<(), Error>;
-    /// Post view sync proposal
+    /// Post view sync certificate
     /// # Errors
     /// Error if unable to serve.
-    fn post_view_sync_certificate(&mut self, view_number: u64, proposal: Vec<u8>)
-        -> Result<(), Error>;
+    fn post_view_sync_certificate(
+        &mut self,
+        view_number: u64,
+        certificate: Vec<u8>,
+    ) -> Result<(), Error>;
 
     /// Post data avaiability certificate
     /// # Errors

--- a/crates/web_server/src/lib.rs
+++ b/crates/web_server/src/lib.rs
@@ -11,7 +11,11 @@ use futures::FutureExt;
 
 use hotshot_types::traits::signature_key::SignatureKey;
 use rand::{distributions::Alphanumeric, rngs::StdRng, thread_rng, Rng, SeedableRng};
-use std::{collections::HashMap, io, path::PathBuf};
+use std::{
+    collections::{BTreeMap, HashMap},
+    io,
+    path::PathBuf,
+};
 use tide_disco::{
     api::ApiError,
     error::ServerError,
@@ -31,23 +35,19 @@ type Error = ServerError;
 // TODO should the view numbers be generic over time?
 struct WebServerState<KEY> {
     /// view number -> (secret, proposal)
-    proposals: HashMap<u64, (String, Vec<u8>)>,
+    proposals: BTreeMap<u64, (String, Vec<u8>)>,
     /// for view sync: view number -> (relay, certificate)
-    view_sync_certificates: HashMap<u64, Vec<(u64, Vec<u8>)>>,
+    view_sync_certificates: BTreeMap<u64, Vec<(u64, Vec<u8>)>>,
     /// view number -> relay
     view_sync_certificate_index: HashMap<u64, u64>,
     /// view number -> (secret, da_certificates)
     da_certificates: HashMap<u64, (String, Vec<u8>)>,
-    /// view for oldest proposals in memory
-    oldest_proposal: u64,
     /// view for the most recent proposal to help nodes catchup
     latest_quorum_proposal: u64,
     /// view for the most recent view sync proposal
     latest_view_sync_certificate: u64,
     /// view for the oldest DA certificate
     oldest_certificate: u64,
-    /// view for the oldest view sync certificate
-    oldest_view_sync_certificate: u64,
     /// view number -> Vec(index, vote)
     votes: HashMap<u64, Vec<(u64, Vec<u8>)>>,
     /// view sync: view number -> Vec(relay, vote)
@@ -96,12 +96,11 @@ impl<KEY: SignatureKey + 'static> WebServerState<KEY> {
     /// Create new web server state
     fn new() -> Self {
         Self {
-            proposals: HashMap::new(),
+            proposals: BTreeMap::new(),
             da_certificates: HashMap::new(),
             votes: HashMap::new(),
             num_txns: 0,
             oldest_vote: 0,
-            oldest_proposal: 0,
             latest_quorum_proposal: 0,
             latest_view_sync_certificate: 0,
             oldest_certificate: 0,
@@ -111,7 +110,7 @@ impl<KEY: SignatureKey + 'static> WebServerState<KEY> {
             transactions: HashMap::new(),
             txn_lookup: HashMap::new(),
             _prng: StdRng::from_entropy(),
-            view_sync_certificates: HashMap::new(),
+            view_sync_certificates: BTreeMap::new(),
             view_sync_votes: HashMap::new(),
             view_sync_vote_index: HashMap::new(),
 
@@ -128,7 +127,6 @@ impl<KEY: SignatureKey + 'static> WebServerState<KEY> {
             vid_vote_index: HashMap::new(),
 
             oldest_view_sync_vote: 0,
-            oldest_view_sync_certificate: 0,
             view_sync_certificate_index: HashMap::new(),
         }
     }
@@ -564,10 +562,7 @@ impl<KEY: SignatureKey> WebServerDataSource<KEY> for WebServerState<KEY> {
 
         // Only keep proposal history for MAX_VIEWS number of view
         if self.proposals.len() >= MAX_VIEWS {
-            self.proposals.remove(&self.oldest_proposal);
-            while !self.proposals.contains_key(&self.oldest_proposal) {
-                self.oldest_proposal += 1;
-            }
+            self.proposals.pop_first();
         }
         self.proposals
             .entry(view_number)
@@ -607,14 +602,7 @@ impl<KEY: SignatureKey> WebServerDataSource<KEY> for WebServerState<KEY> {
 
         // Only keep proposal history for MAX_VIEWS number of view
         if self.view_sync_certificates.len() >= MAX_VIEWS {
-            self.view_sync_certificates
-                .remove(&self.oldest_view_sync_certificate);
-            while !self
-                .view_sync_certificates
-                .contains_key(&self.oldest_view_sync_certificate)
-            {
-                self.oldest_view_sync_certificate += 1;
-            }
+            self.view_sync_certificates.pop_first();
         }
         let next_index = self
             .view_sync_certificate_index
@@ -733,10 +721,7 @@ impl<KEY: SignatureKey> WebServerDataSource<KEY> for WebServerState<KEY> {
 
         // Only keep proposal history for MAX_VIEWS number of views
         if self.proposals.len() >= MAX_VIEWS {
-            self.proposals.remove(&self.oldest_proposal);
-            while !self.proposals.contains_key(&self.oldest_proposal) {
-                self.oldest_proposal += 1;
-            }
+            self.proposals.pop_first();
         }
         self.proposals
             .entry(view_number)


### PR DESCRIPTION
### This PR: 
<!-- Describe what this PR adds to HotSHot -->
<!-- E.g. -->
<!-- * Implements feature 1 -->
<!-- * Implements feature 2 -->
<!-- * Fixes bug 3 -->

- Changes terminology from view sync proposal -> view sync cert everywhere to be more consistent

For view sync certificates and quorum proposals:
- Refactors so that we always poll for the latest data
- Starts each "poll for latest" task at the beginning of consensus
- Adds an additional wait to specific polls

### This PR does not: 
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->
Fix the relay number check.

### Key places to review: 
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->
`web_server_network.rs`
