### PR TITLE
[Stability] Move the poll delay to address test issues 

### DIFF
--- a/crates/hotshot/src/traits/networking/web_server_network.rs
+++ b/crates/hotshot/src/traits/networking/web_server_network.rs
@@ -252,6 +252,8 @@ impl<TYPES: NodeType> Inner<TYPES> {
         };
 
         while self.running.load(Ordering::Relaxed) {
+            async_sleep(additional_wait).await;
+
             let endpoint = match message_purpose {
                 MessagePurpose::Proposal => config::get_proposal_route(view_number),
                 MessagePurpose::LatestQuorumProposal => config::get_latest_quorum_proposal_route(),
@@ -437,7 +439,6 @@ impl<TYPES: NodeType> Inner<TYPES> {
                         async_sleep(self.wait_between_polls).await;
                     }
                 }
-                async_sleep(additional_wait).await;
             }
             let maybe_event = receiver.try_recv();
             match maybe_event {


### PR DESCRIPTION
Closes #2485 

### This PR: 
- Moves the wait from after the poll to before.

This asymmetrically applies a delay for only the `PollForLatest` functions, which allow the normal (per view) poll to progress _before_ the `Latest` one.

### This PR does not: 
Address any genesis block issues.

### Key places to review: 
**Is this a sufficient stopgap before the push CDN?**