### PR TITLE
refactor: remove unused rejected field from Leaf struct

### DIFF
--- a/crates/hotshot/src/traits/storage/memory_storage.rs
+++ b/crates/hotshot/src/traits/storage/memory_storage.rs
@@ -147,7 +147,6 @@ mod test {
             header,
             Some(payload),
             dummy_leaf_commit,
-            Vec::new(),
             <<TestTypes as NodeType>::SignatureKey as SignatureKey>::genesis_proposer_pk(),
         )
     }

--- a/crates/task-impls/src/consensus.rs
+++ b/crates/task-impls/src/consensus.rs
@@ -219,7 +219,6 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                     parent_commitment,
                     block_header: proposal.block_header.clone(),
                     block_payload: None,
-                    rejected: Vec::new(),
                     proposer_id: self.quorum_membership.get_leader(view),
                 };
                 let Ok(vote) = QuorumVote::<TYPES>::create_signed_vote(
@@ -305,7 +304,6 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                     parent_commitment,
                     block_header: proposal.block_header.clone(),
                     block_payload: None,
-                    rejected: Vec::new(),
                     proposer_id: self.quorum_membership.get_leader(view),
                 };
 
@@ -538,7 +536,6 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                         parent_commitment: justify_qc.get_data().leaf_commit,
                         block_header: proposal.data.block_header.clone(),
                         block_payload: None,
-                        rejected: Vec::new(),
                         proposer_id: sender,
                     };
                     let state =
@@ -609,7 +606,6 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                     parent_commitment,
                     block_header: proposal.data.block_header.clone(),
                     block_payload: None,
-                    rejected: Vec::new(),
                     proposer_id: sender.clone(),
                 };
                 let leaf_commitment = leaf.commit();
@@ -1230,7 +1226,6 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                 parent_commitment: parent_leaf.commit(),
                 block_header: block_header.clone(),
                 block_payload: None,
-                rejected: vec![],
                 proposer_id: self.api.public_key().clone(),
             };
 

--- a/crates/testing/src/task_helpers.rs
+++ b/crates/testing/src/task_helpers.rs
@@ -247,7 +247,6 @@ async fn build_quorum_proposal_and_signature(
         parent_commitment: parent_leaf.commit(),
         block_header: block_header.clone(),
         block_payload: None,
-        rejected: vec![],
         proposer_id: *api.public_key(),
     };
     let mut parent_state = <TestState as State>::from_header(&parent_leaf.block_header);
@@ -304,7 +303,6 @@ async fn build_quorum_proposal_and_signature(
             parent_commitment: parent_leaf.commit(),
             block_header: block_header.clone(),
             block_payload: None,
-            rejected: vec![],
             proposer_id: quorum_membership.get_leader(ViewNumber::new(cur_view)),
         };
         let signature_new_view =

--- a/crates/testing/tests/consensus_task.rs
+++ b/crates/testing/tests/consensus_task.rs
@@ -61,7 +61,6 @@ async fn build_vote(
         parent_commitment,
         block_header: proposal.block_header,
         block_payload: None,
-        rejected: Vec::new(),
         proposer_id: membership.get_leader(view),
     };
     let vote = QuorumVote::<TestTypes>::create_signed_vote(

--- a/crates/types/src/data.rs
+++ b/crates/types/src/data.rs
@@ -326,9 +326,6 @@ pub struct Leaf<TYPES: NodeType> {
     /// It may be empty for nodes not in the DA committee.
     pub block_payload: Option<TYPES::BlockPayload>,
 
-    /// Transactions that were marked for rejection while collecting the block.
-    pub rejected: Vec<<TYPES::BlockPayload as BlockPayload>::Transaction>,
-
     /// the proposer id of the leaf
     pub proposer_id: TYPES::SignatureKey,
 }
@@ -339,7 +336,6 @@ impl<TYPES: NodeType> PartialEq for Leaf<TYPES> {
             && self.justify_qc == other.justify_qc
             && self.parent_commitment == other.parent_commitment
             && self.block_header == other.block_header
-            && self.rejected == other.rejected
     }
 }
 
@@ -349,7 +345,6 @@ impl<TYPES: NodeType> Hash for Leaf<TYPES> {
         self.justify_qc.hash(state);
         self.parent_commitment.hash(state);
         self.block_header.hash(state);
-        self.rejected.hash(state);
     }
 }
 
@@ -376,7 +371,6 @@ impl<TYPES: NodeType> Leaf<TYPES> {
             parent_commitment: fake_commitment(),
             block_header: block_header.clone(),
             block_payload: Some(block_payload),
-            rejected: Vec::new(),
             proposer_id: <<TYPES as NodeType>::SignatureKey as SignatureKey>::genesis_proposer_pk(),
         }
     }
@@ -444,10 +438,6 @@ impl<TYPES: NodeType> Leaf<TYPES> {
         self.get_block_header().payload_commitment()
     }
 
-    /// Transactions rejected or invalidated by the application of this leaf.
-    pub fn get_rejected(&self) -> Vec<<TYPES::BlockPayload as BlockPayload>::Transaction> {
-        self.rejected.clone()
-    }
     /// Identity of the network participant who proposed this leaf.
     pub fn get_proposer_id(&self) -> TYPES::SignatureKey {
         self.proposer_id.clone()
@@ -460,7 +450,6 @@ impl<TYPES: NodeType> Leaf<TYPES> {
             parent_commitment: stored_view.parent,
             block_header: stored_view.block_header,
             block_payload: stored_view.block_payload,
-            rejected: stored_view.rejected,
             proposer_id: stored_view.proposer_id,
         }
     }
@@ -560,7 +549,6 @@ where
             justify_qc: leaf.get_justify_qc(),
             block_header: leaf.get_block_header().clone(),
             block_payload: leaf.get_block_payload(),
-            rejected: leaf.get_rejected(),
             proposer_id: leaf.get_proposer_id(),
         }
     }

--- a/crates/types/src/traits/storage.rs
+++ b/crates/types/src/traits/storage.rs
@@ -1,9 +1,7 @@
 //! Abstraction over on-disk storage of node state
 
 use super::node_implementation::NodeType;
-use crate::{
-    data::Leaf, simple_certificate::QuorumCertificate, traits::BlockPayload, vote::HasViewNumber,
-};
+use crate::{data::Leaf, simple_certificate::QuorumCertificate, vote::HasViewNumber};
 use async_trait::async_trait;
 use commit::Commitment;
 use derivative::Derivative;
@@ -130,8 +128,6 @@ pub struct StoredView<TYPES: NodeType> {
     ///
     /// It may be empty for nodes not in the DA committee.
     pub block_payload: Option<TYPES::BlockPayload>,
-    /// transactions rejected in this view
-    pub rejected: Vec<TYPES::Transaction>,
     /// the proposer id
     #[derivative(PartialEq = "ignore")]
     pub proposer_id: TYPES::SignatureKey,
@@ -150,7 +146,6 @@ where
         block_header: TYPES::BlockHeader,
         block_payload: Option<TYPES::BlockPayload>,
         parent_commitment: Commitment<Leaf<TYPES>>,
-        rejected: Vec<<TYPES::BlockPayload as BlockPayload>::Transaction>,
         proposer_id: TYPES::SignatureKey,
     ) -> Self {
         Self {
@@ -159,7 +154,6 @@ where
             justify_qc: qc,
             block_header,
             block_payload,
-            rejected,
             proposer_id,
         }
     }


### PR DESCRIPTION
Closes #2466

This is code clean up / refactor that removes an unused field from the leaf struct, there should be no functional differences.

### How to test this PR: 
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

CI tests should suffice

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
