### PR TITLE
[DEAD CODE] Remove More Unused Code

### DIFF
--- a/crates/hotshot/examples/combined/types.rs
+++ b/crates/hotshot/examples/combined/types.rs
@@ -1,7 +1,7 @@
 use crate::infra::CombinedDARun;
 use hotshot::traits::implementations::{CombinedCommChannel, MemoryStorage};
 use hotshot_testing::state_types::TestTypes;
-use hotshot_types::traits::node_implementation::{ChannelMaps, NodeImplementation, NodeType};
+use hotshot_types::traits::node_implementation::NodeImplementation;
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
 
@@ -22,12 +22,6 @@ impl NodeImplementation<TestTypes> for NodeImpl {
     type Storage = MemoryStorage<TestTypes>;
     type QuorumNetwork = QuorumNetwork;
     type CommitteeNetwork = DANetwork;
-
-    fn new_channel_maps(
-        start_view: <TestTypes as NodeType>::Time,
-    ) -> (ChannelMaps<TestTypes>, Option<ChannelMaps<TestTypes>>) {
-        (ChannelMaps::new(start_view), None)
-    }
 }
 /// convenience type alias
 pub type ThisRun = CombinedDARun<TestTypes>;

--- a/crates/hotshot/examples/libp2p/types.rs
+++ b/crates/hotshot/examples/libp2p/types.rs
@@ -1,7 +1,7 @@
 use crate::infra::Libp2pDARun;
 use hotshot::traits::implementations::{Libp2pCommChannel, MemoryStorage};
 use hotshot_testing::state_types::TestTypes;
-use hotshot_types::traits::node_implementation::{ChannelMaps, NodeImplementation, NodeType};
+use hotshot_types::traits::node_implementation::NodeImplementation;
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
 
@@ -22,12 +22,6 @@ impl NodeImplementation<TestTypes> for NodeImpl {
     type Storage = MemoryStorage<TestTypes>;
     type QuorumNetwork = QuorumNetwork;
     type CommitteeNetwork = DANetwork;
-
-    fn new_channel_maps(
-        start_view: <TestTypes as NodeType>::Time,
-    ) -> (ChannelMaps<TestTypes>, Option<ChannelMaps<TestTypes>>) {
-        (ChannelMaps::new(start_view), None)
-    }
 }
 /// convenience type alias
 pub type ThisRun = Libp2pDARun<TestTypes>;

--- a/crates/hotshot/examples/webserver/types.rs
+++ b/crates/hotshot/examples/webserver/types.rs
@@ -1,7 +1,7 @@
 use crate::infra::WebServerDARun;
 use hotshot::traits::implementations::{MemoryStorage, WebCommChannel};
 use hotshot_testing::state_types::TestTypes;
-use hotshot_types::traits::node_implementation::{ChannelMaps, NodeImplementation, NodeType};
+use hotshot_types::traits::node_implementation::NodeImplementation;
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
 
@@ -22,12 +22,6 @@ impl NodeImplementation<TestTypes> for NodeImpl {
     type Storage = MemoryStorage<TestTypes>;
     type CommitteeNetwork = DANetwork;
     type QuorumNetwork = QuorumNetwork;
-
-    fn new_channel_maps(
-        start_view: <TestTypes as NodeType>::Time,
-    ) -> (ChannelMaps<TestTypes>, Option<ChannelMaps<TestTypes>>) {
-        (ChannelMaps::new(start_view), None)
-    }
 }
 /// convenience type alias
 pub type ThisRun = WebServerDARun<TestTypes>;

--- a/crates/hotshot/src/types/handle.rs
+++ b/crates/hotshot/src/types/handle.rs
@@ -255,40 +255,4 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static> SystemContextHandl
             .send_direct_message(MessageKind::from_consensus_message(msg), recipient)
             .await;
     }
-
-    /// Get length of the replica's receiver channel
-    #[cfg(feature = "hotshot-testing")]
-    pub async fn get_replica_receiver_channel_len(
-        &self,
-        view_number: TYPES::Time,
-    ) -> Option<usize> {
-        use async_compatibility_layer::channel::UnboundedReceiver;
-
-        let channel_map = self.hotshot.inner.channel_maps.0.vote_channel.read().await;
-        let chan = channel_map.channel_map.get(&view_number)?;
-        let receiver = chan.receiver_chan.lock().await;
-        UnboundedReceiver::len(&*receiver)
-    }
-
-    /// Get length of the next leaders's receiver channel
-    #[cfg(feature = "hotshot-testing")]
-    pub async fn get_next_leader_receiver_channel_len(
-        &self,
-        view_number: TYPES::Time,
-    ) -> Option<usize> {
-        use async_compatibility_layer::channel::UnboundedReceiver;
-
-        let channel_map = self
-            .hotshot
-            .inner
-            .channel_maps
-            .0
-            .proposal_channel
-            .read()
-            .await;
-        let chan = channel_map.channel_map.get(&view_number)?;
-
-        let receiver = chan.receiver_chan.lock().await;
-        UnboundedReceiver::len(&*receiver)
-    }
 }

--- a/crates/task-impls/src/network.rs
+++ b/crates/task-impls/src/network.rs
@@ -95,10 +95,6 @@ impl<TYPES: NodeType> NetworkMessageTaskState<TYPES> {
                             GeneralConsensusMessage::UpgradeVote(message) => {
                                 HotShotEvent::UpgradeVoteRecv(message)
                             }
-                            GeneralConsensusMessage::InternalTrigger(_) => {
-                                error!("Got unexpected message type in network task!");
-                                return;
-                            }
                         },
                         Either::Right(committee_message) => match committee_message {
                             CommitteeConsensusMessage::DAProposal(proposal) => {

--- a/crates/testing/src/node_types.rs
+++ b/crates/testing/src/node_types.rs
@@ -13,9 +13,7 @@ use hotshot::traits::{
     NodeImplementation,
 };
 use hotshot_types::{
-    data::ViewNumber,
-    signature_key::BLSPubKey,
-    traits::node_implementation::{ChannelMaps, NodeType},
+    data::ViewNumber, signature_key::BLSPubKey, traits::node_implementation::NodeType,
 };
 use serde::{Deserialize, Serialize};
 
@@ -100,58 +98,22 @@ impl NodeImplementation<TestTypes> for Libp2pImpl {
     type Storage = MemoryStorage<TestTypes>;
     type QuorumNetwork = StaticLibp2pQuorumComm;
     type CommitteeNetwork = StaticLibp2pDAComm;
-
-    fn new_channel_maps(
-        start_view: <TestTypes as NodeType>::Time,
-    ) -> (ChannelMaps<TestTypes>, Option<ChannelMaps<TestTypes>>) {
-        (
-            ChannelMaps::new(start_view),
-            Some(ChannelMaps::new(start_view)),
-        )
-    }
 }
 
 impl NodeImplementation<TestTypes> for MemoryImpl {
     type Storage = MemoryStorage<TestTypes>;
     type QuorumNetwork = StaticMemoryQuorumComm;
     type CommitteeNetwork = StaticMemoryDAComm;
-
-    fn new_channel_maps(
-        start_view: <TestTypes as NodeType>::Time,
-    ) -> (ChannelMaps<TestTypes>, Option<ChannelMaps<TestTypes>>) {
-        (
-            ChannelMaps::new(start_view),
-            Some(ChannelMaps::new(start_view)),
-        )
-    }
 }
 
 impl NodeImplementation<TestTypes> for WebImpl {
     type Storage = MemoryStorage<TestTypes>;
     type QuorumNetwork = StaticWebQuorumComm;
     type CommitteeNetwork = StaticWebDAComm;
-
-    fn new_channel_maps(
-        start_view: <TestTypes as NodeType>::Time,
-    ) -> (ChannelMaps<TestTypes>, Option<ChannelMaps<TestTypes>>) {
-        (
-            ChannelMaps::new(start_view),
-            Some(ChannelMaps::new(start_view)),
-        )
-    }
 }
 
 impl NodeImplementation<TestTypes> for CombinedImpl {
     type Storage = MemoryStorage<TestTypes>;
     type QuorumNetwork = StaticCombinedQuorumComm;
     type CommitteeNetwork = StaticCombinedDAComm;
-
-    fn new_channel_maps(
-        start_view: <TestTypes as NodeType>::Time,
-    ) -> (ChannelMaps<TestTypes>, Option<ChannelMaps<TestTypes>>) {
-        (
-            ChannelMaps::new(start_view),
-            Some(ChannelMaps::new(start_view)),
-        )
-    }
 }

--- a/crates/testing/tests/memory_network.rs
+++ b/crates/testing/tests/memory_network.rs
@@ -19,7 +19,7 @@ use hotshot_types::message::Message;
 use hotshot_types::signature_key::BLSPubKey;
 use hotshot_types::traits::network::TestableNetworkingImplementation;
 use hotshot_types::traits::network::{ConnectedNetwork, TransmitType};
-use hotshot_types::traits::node_implementation::{ChannelMaps, ConsensusTime, NodeType};
+use hotshot_types::traits::node_implementation::{ConsensusTime, NodeType};
 use hotshot_types::{
     data::ViewNumber,
     message::{DataMessage, MessageKind},
@@ -70,12 +70,6 @@ impl NodeImplementation<Test> for TestImpl {
     type Storage = MemoryStorage<Test>;
     type QuorumNetwork = QuorumNetwork;
     type CommitteeNetwork = DANetwork;
-
-    fn new_channel_maps(
-        start_view: <Test as NodeType>::Time,
-    ) -> (ChannelMaps<Test>, Option<ChannelMaps<Test>>) {
-        (ChannelMaps::new(start_view), None)
-    }
 }
 
 /// fake Eq

--- a/crates/types/src/consensus.rs
+++ b/crates/types/src/consensus.rs
@@ -1,9 +1,6 @@
 //! Provides the core consensus types
 
-pub use crate::{
-    traits::node_implementation::ViewQueue,
-    utils::{View, ViewInner},
-};
+pub use crate::utils::{View, ViewInner};
 use displaydoc::Display;
 
 use crate::{

--- a/crates/types/src/data.rs
+++ b/crates/types/src/data.rs
@@ -243,41 +243,6 @@ impl<TYPES: NodeType> HasViewNumber<TYPES> for UpgradeProposal<TYPES> {
     }
 }
 
-/// A state change encoded in a leaf.
-///
-/// [`DeltasType`] represents a [block](NodeType::BlockPayload), but it may not contain the block in
-/// full. It is guaranteed to contain, at least, a cryptographic commitment to the block, and it
-/// provides an interface for resolving the commitment to a full block if the full block is
-/// available.
-pub trait DeltasType<PAYLOAD: BlockPayload>:
-    Clone + Debug + for<'a> Deserialize<'a> + PartialEq + Eq + std::hash::Hash + Send + Serialize + Sync
-{
-    /// Errors reported by this type.
-    type Error: std::error::Error;
-
-    /// Get a cryptographic commitment to the block represented by this delta.
-    fn payload_commitment(&self) -> VidCommitment;
-
-    /// Get the full block if it is available, otherwise return this object unchanged.
-    ///
-    /// # Errors
-    ///
-    /// Returns the original [`DeltasType`], unchanged, in an [`Err`] variant in the case where the
-    /// full block is not currently available.
-    fn try_resolve(self) -> Result<PAYLOAD, Self>;
-
-    /// Fill this [`DeltasType`] by providing a complete block.
-    ///
-    /// After this function succeeds, [`try_resolve`](Self::try_resolve) is guaranteed to return
-    /// `Ok(block)`.
-    ///
-    /// # Errors
-    ///
-    /// Fails if `block` does not match `self.payload_commitment()`, or if the block is not able to be
-    /// stored for some implementation-defined reason.
-    fn fill(&mut self, block: PAYLOAD) -> Result<(), Self::Error>;
-}
-
 /// The error type for block and its transactions.
 #[derive(Snafu, Debug)]
 pub enum BlockError {

--- a/crates/types/src/message.rs
+++ b/crates/types/src/message.rs
@@ -132,15 +132,6 @@ impl<TYPES: NodeType> ViewMessage<TYPES> for MessageKind<TYPES> {
     }
 }
 
-/// Internal triggers sent by consensus messages.
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash)]
-#[serde(bound(deserialize = ""))]
-pub enum InternalTrigger<TYPES: NodeType> {
-    // May add other triggers if necessary.
-    /// Internal timeout at the specified view number.
-    Timeout(TYPES::Time),
-}
-
 /// A processed consensus message for both validating and sequencing consensus.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 #[serde(bound(deserialize = ""))]
@@ -149,9 +140,6 @@ pub enum ProcessedGeneralConsensusMessage<TYPES: NodeType> {
     Proposal(Proposal<TYPES, QuorumProposal<TYPES>>, TYPES::SignatureKey),
     /// Message with a quorum vote.
     Vote(QuorumVote<TYPES>, TYPES::SignatureKey),
-    /// Internal ONLY message indicating a view interrupt.
-    #[serde(skip)]
-    InternalTrigger(InternalTrigger<TYPES>),
 }
 
 impl<TYPES: NodeType> From<ProcessedGeneralConsensusMessage<TYPES>>
@@ -163,9 +151,6 @@ impl<TYPES: NodeType> From<ProcessedGeneralConsensusMessage<TYPES>>
                 GeneralConsensusMessage::Proposal(p)
             }
             ProcessedGeneralConsensusMessage::Vote(v, _) => GeneralConsensusMessage::Vote(v),
-            ProcessedGeneralConsensusMessage::InternalTrigger(a) => {
-                GeneralConsensusMessage::InternalTrigger(a)
-            }
         }
     }
 }
@@ -180,9 +165,6 @@ impl<TYPES: NodeType> ProcessedGeneralConsensusMessage<TYPES> {
                 ProcessedGeneralConsensusMessage::Proposal(p, sender)
             }
             GeneralConsensusMessage::Vote(v) => ProcessedGeneralConsensusMessage::Vote(v, sender),
-            GeneralConsensusMessage::InternalTrigger(a) => {
-                ProcessedGeneralConsensusMessage::InternalTrigger(a)
-            }
             // ED NOTE These are deprecated
             GeneralConsensusMessage::TimeoutVote(_) => unimplemented!(),
             GeneralConsensusMessage::ViewSyncPreCommitVote(_) => unimplemented!(),
@@ -313,10 +295,6 @@ pub enum GeneralConsensusMessage<TYPES: NodeType> {
 
     /// Message with an upgrade vote
     UpgradeVote(UpgradeVote<TYPES>),
-
-    /// Internal ONLY message indicating a view interrupt.
-    #[serde(skip)]
-    InternalTrigger(InternalTrigger<TYPES>),
 }
 
 #[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Hash, Eq)]
@@ -360,10 +338,6 @@ impl<TYPES: NodeType> SequencingMessage<TYPES> {
                         p.data.get_view_number()
                     }
                     GeneralConsensusMessage::Vote(vote_message) => vote_message.get_view_number(),
-                    GeneralConsensusMessage::InternalTrigger(trigger) => match trigger {
-                        InternalTrigger::Timeout(time) => *time,
-                    },
-
                     GeneralConsensusMessage::TimeoutVote(message) => message.get_view_number(),
                     GeneralConsensusMessage::ViewSyncPreCommitVote(message) => {
                         message.get_view_number()
@@ -419,7 +393,6 @@ impl<TYPES: NodeType> SequencingMessage<TYPES> {
                 GeneralConsensusMessage::Vote(_) | GeneralConsensusMessage::TimeoutVote(_) => {
                     MessagePurpose::Vote
                 }
-                GeneralConsensusMessage::InternalTrigger(_) => MessagePurpose::Internal,
                 GeneralConsensusMessage::ViewSyncPreCommitVote(_)
                 | GeneralConsensusMessage::ViewSyncCommitVote(_)
                 | GeneralConsensusMessage::ViewSyncFinalizeVote(_) => MessagePurpose::ViewSyncVote,


### PR DESCRIPTION
### This PR: 
Removes the following things from the code

- `ChannelMaps` - an old type that was used back in the round based (not event driven) code
- `ViewQueue` - same as previous
- `SendToTask` - same as previous
- Functions associated with those 3 types - they aren't used internally and if used externally they would not do anything
- ` maybe_do_genesis_init()` - we do genesis init a different way in `SystemContext::new`
- Api functions that send network messages - while this code seems like it's valid we don't use them internally and it seems like a bad thing to expose to the layers above.  If we need a specific interface which allows the application layer access to the network we should build one that doesn't just directly expose broadcast send.
- `DeltasType` - This is the newest code on the list.  It was created to handle when we had both sequencing and validating and leafs would either have a block or block commitment.  This trait could still be valid for resolving DA blocks/commitments but we don't use it, and the interface is directly on the block.  If anyone still thinks we'll need this I'm happy to keep it. 

### This PR does not: 

Should make no functional change, this code was not used and mostly not functional.

### Key places to review: 

Check each item in the list above and flag if you think we should keep any of it

