### PR TITLE
[BUILDER] Add `Committable` bound to `BlockPayload`

### DIFF
--- a/crates/testing/src/block_types.rs
+++ b/crates/testing/src/block_types.rs
@@ -99,6 +99,30 @@ impl TestableBlock for TestBlockPayload {
     }
 }
 
+/// <div class="warning">
+///
+/// **DO NOT** use [`BlockPayload`]'s implementation of [`Committable`] for DA commitment!
+///
+/// [`Committable`] bound here is needed by builders to sign advertised blocks and is not used
+/// outside of PBS context. For VID commitment used in DA see [`vid_commitment`] instead.
+///
+/// </div>
+impl Committable for TestBlockPayload {
+    fn commit(&self) -> Commitment<Self> {
+        let builder = commit::RawCommitmentBuilder::new("Block Payload Comm");
+        let mut hasher = Keccak256::new();
+        for txn in &self.transactions {
+            hasher.update(&txn.0);
+        }
+        let generic_array = hasher.finalize();
+        builder.generic_byte_array(&generic_array).finalize()
+    }
+
+    fn tag() -> String {
+        "TEST_BLOCK_PAYLOAD".to_string()
+    }
+}
+
 impl BlockPayload for TestBlockPayload {
     type Error = BlockError;
     type Transaction = TestTransaction;

--- a/crates/types/src/traits/block_contents.rs
+++ b/crates/types/src/traits/block_contents.rs
@@ -24,14 +24,41 @@ pub trait Transaction:
 
 /// Abstraction over the full contents of a block
 ///
+/// <div class="warning">
+///
+/// **DO NOT** use [`BlockPayload`]'s implementation of [`Committable`] for DA commitment!
+///
+/// [`Committable`] bound here is needed by builders to sign advertised blocks and is not used
+/// outside of PBS context. For VID commitment used in DA see [`vid_commitment`] instead.
+///
+/// </div>
+///
+/// <div class="warning">
+///
+/// Please include the previous warning above `impl` block for [`Committable`] when implementing it for
+/// your block payload types.
+///
+/// </div>
+///
 /// This trait encapsulates the behaviors that the transactions of a block must have in order to be
 /// used by consensus
 ///   * Must have a predefined error type ([`BlockPayload::Error`])
 ///   * Must have a transaction type that can be compared for equality, serialized and serialized,
 ///     sent between threads, and can have a hash produced of it
 ///   * Must be hashable
+///
 pub trait BlockPayload:
-    Serialize + Clone + Debug + Display + Hash + PartialEq + Eq + Send + Sync + DeserializeOwned
+    Serialize
+    + Clone
+    + Debug
+    + Display
+    + Hash
+    + PartialEq
+    + Eq
+    + Send
+    + Sync
+    + DeserializeOwned
+    + Committable
 {
     /// The error type for this type of block
     type Error: Error + Debug + Send + Sync;


### PR DESCRIPTION
Closes #2501

### This PR: 
- Adds `Committable` bound to `BlockPayload`
- Documents its inteded usage
- Implements `Committable` for `TestBlockPayload`

### This PR does not: 
do anything else 

### Key places to review: 
`Committable` implementation for `TestBlockPayload` in `crates/testing/src/block_types.rs`
Documentation for `BlockPayload` trait in `crates/types/src/traits/block_contents.rs`

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
