### PR TITLE
[Stability] Always poll for latest DA proposal

### DIFF
--- a/crates/hotshot/examples/infra/mod.rs
+++ b/crates/hotshot/examples/infra/mod.rs
@@ -473,8 +473,7 @@ pub trait RunDA<
                         EventType::NextLeaderViewTimeout { view_number } => {
                             warn!("Timed out as the next leader in view {:?}", view_number);
                         }
-                        EventType::ViewFinished { view_number: _ } => {}
-                        _ => {},
+                        _ => {}
                     }
                 }
             }

--- a/crates/hotshot/examples/infra/mod.rs
+++ b/crates/hotshot/examples/infra/mod.rs
@@ -474,7 +474,7 @@ pub trait RunDA<
                             warn!("Timed out as the next leader in view {:?}", view_number);
                         }
                         EventType::ViewFinished { view_number: _ } => {}
-                        _ => unimplemented!(),
+                        _ => {},
                     }
                 }
             }

--- a/crates/hotshot/src/tasks/mod.rs
+++ b/crates/hotshot/src/tasks/mod.rs
@@ -258,8 +258,24 @@ pub async fn add_consensus_task<TYPES: NodeType, I: NodeImplementation<TYPES>>(
     // Poll (forever) for the latest quorum proposal
     consensus_state
         .quorum_network
-        .inject_consensus_info(ConsensusIntentEvent::PollForLatestQuorumProposal)
+        .inject_consensus_info(ConsensusIntentEvent::PollForLatestProposal)
         .await;
+
+    // See if we're in the DA committee
+    // This will not work for epochs (because dynamic subscription
+    // With the Push CDN, we are _always_ polling for latest anyway.
+    let is_da = consensus_state
+        .committee_membership
+        .get_committee(<TYPES as NodeType>::Time::new(0))
+        .contains(&consensus_state.public_key);
+
+    // If we are, poll for latest DA proposal.
+    if is_da {
+        consensus_state
+            .committee_network
+            .inject_consensus_info(ConsensusIntentEvent::PollForLatestProposal)
+            .await;
+    }
 
     // Poll (forever) for the latest view sync certificate
     consensus_state

--- a/crates/hotshot/src/traits/networking/web_server_network.rs
+++ b/crates/hotshot/src/traits/networking/web_server_network.rs
@@ -278,7 +278,7 @@ impl<TYPES: NodeType> Inner<TYPES> {
         view_number: u64,
         message_purpose: MessagePurpose,
         vote_index: &mut u64,
-        seen_quorum_proposals: &mut LruCache<u64, ()>,
+        seen_proposals: &mut LruCache<u64, ()>,
         seen_view_sync_certificates: &mut LruCache<u64, ()>,
     ) -> bool {
         let broadcast_poll_queue = &self.broadcast_poll_queue_0_1;
@@ -302,7 +302,7 @@ impl<TYPES: NodeType> Inner<TYPES> {
                     let proposal = deserialized_message.clone();
                     let hash = hash(&proposal);
                     // Only allow unseen proposals to be pushed to the queue
-                    if seen_quorum_proposals.put(hash, ()).is_none() {
+                    if seen_proposals.put(hash, ()).is_none() {
                         broadcast_poll_queue.write().await.push(proposal);
                     }
 
@@ -397,7 +397,7 @@ impl<TYPES: NodeType> Inner<TYPES> {
     ) -> Result<(), NetworkError> {
         let mut vote_index = 0;
         let mut tx_index = 0;
-        let mut seen_quorum_proposals = LruCache::new(NonZeroUsize::new(100).unwrap());
+        let mut seen_proposals = LruCache::new(NonZeroUsize::new(100).unwrap());
         let mut seen_view_sync_certificates = LruCache::new(NonZeroUsize::new(100).unwrap());
 
         if message_purpose == MessagePurpose::Data {
@@ -519,7 +519,7 @@ impl<TYPES: NodeType> Inner<TYPES> {
                                                 view_number,
                                                 message_purpose,
                                                 &mut vote_index,
-                                                &mut seen_quorum_proposals,
+                                                &mut seen_proposals,
                                                 &mut seen_view_sync_certificates,
                                             )
                                             .await;

--- a/crates/types/src/message.rs
+++ b/crates/types/src/message.rs
@@ -63,10 +63,10 @@ pub struct Messages<TYPES: NodeType>(pub Vec<Message<TYPES>>);
 /// A message type agnostic description of a message's purpose
 #[derive(PartialEq, Copy, Clone)]
 pub enum MessagePurpose {
-    /// Message with a quorum proposal.
+    /// Message with a [quorum/DA] proposal.
     Proposal,
-    /// Message with most recent quorum proposal the server has
-    LatestQuorumProposal,
+    /// Message with most recent [quorum/DA] proposal the server has
+    LatestProposal,
     /// Message with most recent view sync certificate the server has
     LatestViewSyncCertificate,
     /// Message with a quorum vote.

--- a/crates/types/src/traits/network.rs
+++ b/crates/types/src/traits/network.rs
@@ -147,8 +147,8 @@ pub enum ConsensusIntentEvent<K: SignatureKey> {
     PollForProposal(u64),
     /// Poll for VID disperse data for a particular view
     PollForVIDDisperse(u64),
-    /// Poll for the most recent quorum proposal the webserver has
-    PollForLatestQuorumProposal,
+    /// Poll for the most recent [quorum/da] proposal the webserver has
+    PollForLatestProposal,
     /// Poll for the most recent view sync proposal the webserver has
     PollForLatestViewSyncCertificate,
     /// Poll for a DAC for a particular view
@@ -203,7 +203,7 @@ impl<K: SignatureKey> ConsensusIntentEvent<K> {
             | ConsensusIntentEvent::PollForTransactions(view_number)
             | ConsensusIntentEvent::CancelPollForTransactions(view_number)
             | ConsensusIntentEvent::PollFutureLeader(view_number, _) => *view_number,
-            ConsensusIntentEvent::PollForLatestQuorumProposal
+            ConsensusIntentEvent::PollForLatestProposal
             | ConsensusIntentEvent::PollForLatestViewSyncCertificate => 1,
         }
     }

--- a/crates/web_server/api.toml
+++ b/crates/web_server/api.toml
@@ -20,7 +20,7 @@ Return the VID disperse data for a given view number
 """
 
 # GET the latest quorum proposal
-[route.get_latest_quorum_proposal]
+[route.get_latest_proposal]
 PATH = ["proposal/latest"]
 DOC = """
 Return the proposal for the most recent view the server has

--- a/crates/web_server/src/config.rs
+++ b/crates/web_server/src/config.rs
@@ -26,7 +26,7 @@ pub fn post_proposal_route(view_number: u64) -> String {
 
 /// get latest qc
 #[must_use]
-pub fn get_latest_quorum_proposal_route() -> String {
+pub fn get_latest_proposal_route() -> String {
     "api/proposal/latest".to_string()
 }
 

--- a/crates/web_server/src/lib.rs
+++ b/crates/web_server/src/lib.rs
@@ -43,7 +43,7 @@ struct WebServerState<KEY> {
     /// view number -> (secret, da_certificates)
     da_certificates: HashMap<u64, (String, Vec<u8>)>,
     /// view for the most recent proposal to help nodes catchup
-    latest_quorum_proposal: u64,
+    latest_proposal: u64,
     /// view for the most recent view sync proposal
     latest_view_sync_certificate: u64,
     /// view for the oldest DA certificate
@@ -101,7 +101,7 @@ impl<KEY: SignatureKey + 'static> WebServerState<KEY> {
             votes: HashMap::new(),
             num_txns: 0,
             oldest_vote: 0,
-            latest_quorum_proposal: 0,
+            latest_proposal: 0,
             latest_view_sync_certificate: 0,
             oldest_certificate: 0,
             shutdown: None,
@@ -153,7 +153,7 @@ pub trait WebServerDataSource<KEY> {
     /// Get latest quanrum proposal
     /// # Errors
     /// Error if unable to serve.
-    fn get_latest_quorum_proposal(&self) -> Result<Option<Vec<Vec<u8>>>, Error>;
+    fn get_latest_proposal(&self) -> Result<Option<Vec<Vec<u8>>>, Error>;
     /// Get latest view sync proposal
     /// # Errors
     /// Error if unable to serve.
@@ -306,8 +306,8 @@ impl<KEY: SignatureKey> WebServerDataSource<KEY> for WebServerState<KEY> {
         }
     }
 
-    fn get_latest_quorum_proposal(&self) -> Result<Option<Vec<Vec<u8>>>, Error> {
-        self.get_proposal(self.latest_quorum_proposal)
+    fn get_latest_proposal(&self) -> Result<Option<Vec<Vec<u8>>>, Error> {
+        self.get_proposal(self.latest_proposal)
     }
 
     fn get_latest_view_sync_certificate(&self) -> Result<Option<Vec<Vec<u8>>>, Error> {
@@ -556,8 +556,8 @@ impl<KEY: SignatureKey> WebServerDataSource<KEY> for WebServerState<KEY> {
     fn post_proposal(&mut self, view_number: u64, mut proposal: Vec<u8>) -> Result<(), Error> {
         info!("Received proposal for view {}", view_number);
 
-        if view_number > self.latest_quorum_proposal {
-            self.latest_quorum_proposal = view_number;
+        if view_number > self.latest_proposal {
+            self.latest_proposal = view_number;
         }
 
         // Only keep proposal history for MAX_VIEWS number of view
@@ -781,8 +781,8 @@ where
         }
         .boxed()
     })?
-    .get("get_latest_quorum_proposal", |_req, state| {
-        async move { state.get_latest_quorum_proposal() }.boxed()
+    .get("get_latest_proposal", |_req, state| {
+        async move { state.get_latest_proposal() }.boxed()
     })?
     .get("get_latest_view_sync_certificate", |_req, state| {
         async move { state.get_latest_view_sync_certificate() }.boxed()


### PR DESCRIPTION
Closes #2503 

### This PR: 
<!-- Describe what this PR adds to HotSHot -->
<!-- E.g. -->
<!-- * Implements feature 1 -->
<!-- * Implements feature 2 -->
<!-- * Fixes bug 3 -->
- Adds polling for the latest DA proposal (if we're a member of the committee)
- Changes terminology for proposals (quorum/DA) to be more consistent
- Fixes examples to work with new events (instead of throwing `unimplemented`)

### This PR does not: 
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->
Implement _dynamic_ polling for latest whether or not we're in the DA committee for the **next** view.

### Key places to review: 
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->
`tasks/mod.rs`

### PR tests:
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->
- Network is able to run on only `poll_for_latest` ✅ , albeit with some timeouts.
- Tested that polls are only happening for DA committee members
- Verified that task pruning still works (we don't leak memory)
- Cancellation still works
- Examples run

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
