### PR TITLE
refactor: move NUM_REPLICATED_TO_TRUST to mod

### DIFF
--- a/crates/libp2p-networking/src/network/behaviours/dht/mod.rs
+++ b/crates/libp2p-networking/src/network/behaviours/dht/mod.rs
@@ -26,9 +26,8 @@ use tracing::{error, info, warn};
 
 /// the number of nodes required to get an answer from
 /// in order to trust that the answer is correct when retrieving from the DHT
-/// TODO why are there two of these?
-/// <https://github.com/EspressoSystems/HotShot/issues/2434>
 pub(crate) const NUM_REPLICATED_TO_TRUST: usize = 2;
+
 /// the maximum number of nodes to query in the DHT at any one time
 const MAX_DHT_QUERY_SIZE: usize = 5;
 

--- a/crates/libp2p-networking/src/network/def.rs
+++ b/crates/libp2p-networking/src/network/def.rs
@@ -22,12 +22,6 @@ use super::{
 
 use libp2p_swarm_derive::NetworkBehaviour;
 
-/// the number of nodes required to get an answer from
-/// in order to trust that the answer is correct when retrieving from the DHT
-/// TODO why are there two of these?
-/// <https://github.com/EspressoSystems/HotShot/issues/2434>
-pub(crate) const NUM_REPLICATED_TO_TRUST: usize = 2;
-
 /// Overarching network behaviour performing:
 /// - network topology discovoery
 /// - direct messaging

--- a/crates/libp2p-networking/src/network/node.rs
+++ b/crates/libp2p-networking/src/network/node.rs
@@ -19,15 +19,12 @@ use super::{
     NetworkNodeType,
 };
 
-use crate::network::{
-    behaviours::{
-        dht::{DHTBehaviour, DHTEvent, DHTProgress, KadPutQuery},
-        direct_message::{DMBehaviour, DMEvent},
-        direct_message_codec::{DirectMessageProtocol, MAX_MSG_SIZE_DM},
-        exponential_backoff::ExponentialBackoff,
-        gossip::GossipEvent,
-    },
-    def::NUM_REPLICATED_TO_TRUST,
+use crate::network::behaviours::{
+    dht::{DHTBehaviour, DHTEvent, DHTProgress, KadPutQuery, NUM_REPLICATED_TO_TRUST},
+    direct_message::{DMBehaviour, DMEvent},
+    direct_message_codec::{DirectMessageProtocol, MAX_MSG_SIZE_DM},
+    exponential_backoff::ExponentialBackoff,
+    gossip::GossipEvent,
 };
 use async_compatibility_layer::{
     art::async_spawn,


### PR DESCRIPTION
Seems like this was an oversight when https://github.com/EspressoSystems/HotShot/pull/302 was merged.

Perhaps the most effective way to avoid a recurrence is to move all constants to a file within the folder structure of a crate as it seems non-trivial to accomplish using [clippy](https://github.com/rust-lang/rust-clippy)

Closes #2434


