### PR TITLE
[BUILDER] Add builder_commitment to BlockPayload

### DIFF
--- a/crates/testing/src/block_types.rs
+++ b/crates/testing/src/block_types.rs
@@ -163,7 +163,7 @@ impl BlockPayload for TestBlockPayload {
 
     fn builder_commitment(&self, _metadata: &Self::Metadata) -> BuilderCommitment {
         let mut digest = sha2::Sha256::new();
-        for txn in self.transactions.iter() {
+        for txn in &self.transactions {
             digest.update(&txn.0);
         }
         BuilderCommitment::from_raw_digest(digest.finalize())

--- a/crates/testing/src/block_types.rs
+++ b/crates/testing/src/block_types.rs
@@ -10,6 +10,7 @@ use hotshot_types::{
         block_contents::{vid_commitment, BlockHeader, TestableBlock, Transaction},
         BlockPayload, ValidatedState,
     },
+    utils::BuilderCommitment,
 };
 use serde::{Deserialize, Serialize};
 use sha3::{Digest, Keccak256};
@@ -158,6 +159,14 @@ impl BlockPayload for TestBlockPayload {
             .iter()
             .map(commit::Committable::commit)
             .collect()
+    }
+
+    fn builder_commitment(&self, _metadata: &Self::Metadata) -> BuilderCommitment {
+        let mut digest = sha2::Sha256::new();
+        for txn in self.transactions.iter() {
+            digest.update(&txn.0);
+        }
+        BuilderCommitment::from_raw_digest(digest.finalize())
     }
 }
 

--- a/crates/types/src/traits/block_contents.rs
+++ b/crates/types/src/traits/block_contents.rs
@@ -6,6 +6,7 @@
 use crate::{
     data::{test_srs, VidCommitment, VidScheme, VidSchemeTrait},
     traits::ValidatedState,
+    utils::BuilderCommitment,
 };
 use commit::{Commitment, Committable};
 use serde::{de::DeserializeOwned, Serialize};
@@ -77,6 +78,9 @@ pub trait BlockPayload:
         &self,
         metadata: &Self::Metadata,
     ) -> Vec<Commitment<Self::Transaction>>;
+
+    /// Generate commitment that builders use to sign block options.
+    fn builder_commitment(&self, metadata: &Self::Metadata) -> BuilderCommitment;
 }
 
 /// extra functions required on block to be usable by hotshot-testing

--- a/crates/types/src/utils.rs
+++ b/crates/types/src/utils.rs
@@ -107,6 +107,7 @@ pub enum Terminator<T> {
     Inclusive(T),
 }
 
+/// Type alias for byte array of SHA256 digest length
 type Sha256Digest = [u8; <sha2::Sha256 as OutputSizeUser>::OutputSize::USIZE];
 
 #[tagged("BUILDER_COMMITMENT")]


### PR DESCRIPTION
Closes #2517 

### This PR: 
- adds `builder_commitment` method to `BlockPayload`
- adds `BuilderCommitment` type, which is a thin wrapper around Sha256
- implements new method for `TestBlockPayload`

### This PR does not


### Key places to review: 

All changed files, probably

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
