### PR TITLE
[VALIDATED_STATE] Add method to get undecided state

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -135,13 +135,13 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download executables AMD
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: binaries-amd64-${{ matrix.just_variants }}
           path: target/amd64/debug/examples
 
       - name: Download executables ARM
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: binaries-aarch64-${{ matrix.just_variants }}
           path: target/arm64/debug/examples

--- a/crates/hotshot/src/lib.rs
+++ b/crates/hotshot/src/lib.rs
@@ -345,7 +345,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> SystemContext<TYPES, I> {
             .map(|guard| guard.get_decided_leaf())
     }
 
-    /// Returns a copy of the last decided validated state.
+    /// Returns the last decided validated state.
     ///
     /// # Panics
     /// Panics if internal state for consensus is inconsistent
@@ -356,6 +356,17 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> SystemContext<TYPES, I> {
             .await
             .get_decided_state()
             .clone()
+    }
+
+    /// Get the validated state from a given `view`.
+    ///
+    /// Returns the requested state, if the [`SystemContext`] is tracking this view. Consensus
+    /// tracks views that have not yet been decided but could be in the future. This function may
+    /// return [`None`] if the requested view has already been decided (but see
+    /// [`get_decided_state`](Self::get_decided_state)) or if there is no path for the requested
+    /// view to ever be decided.
+    pub async fn get_state(&self, view: TYPES::Time) -> Option<Arc<TYPES::ValidatedState>> {
+        self.inner.consensus.read().await.get_state(view).cloned()
     }
 
     /// Initializes a new [`SystemContext`] and does the work of setting up all the background tasks

--- a/crates/hotshot/src/lib.rs
+++ b/crates/hotshot/src/lib.rs
@@ -191,7 +191,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> SystemContext<TYPES, I> {
 
         // insert genesis (or latest block) to state map
         let mut validated_state_map = BTreeMap::default();
-        let validated_state = TYPES::ValidatedState::genesis(&instance_state);
+        let validated_state = Arc::new(TYPES::ValidatedState::genesis(&instance_state));
         validated_state_map.insert(
             anchored_leaf.get_view_number(),
             View {
@@ -349,7 +349,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> SystemContext<TYPES, I> {
     ///
     /// # Panics
     /// Panics if internal state for consensus is inconsistent
-    pub async fn get_decided_state(&self) -> TYPES::ValidatedState {
+    pub async fn get_decided_state(&self) -> Arc<TYPES::ValidatedState> {
         self.inner
             .consensus
             .read()

--- a/crates/hotshot/src/types/handle.rs
+++ b/crates/hotshot/src/types/handle.rs
@@ -94,6 +94,17 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static> SystemContextHandl
         self.hotshot.get_decided_state().await
     }
 
+    /// Get the validated state from a given `view`.
+    ///
+    /// Returns the requested state, if the [`SystemContext`] is tracking this view. Consensus
+    /// tracks views that have not yet been decided but could be in the future. This function may
+    /// return [`None`] if the requested view has already been decided (but see
+    /// [`get_decided_state`](Self::get_decided_state)) or if there is no path for the requested
+    /// view to ever be decided.
+    pub async fn get_state(&self, view: TYPES::Time) -> Option<Arc<TYPES::ValidatedState>> {
+        self.hotshot.get_state(view).await
+    }
+
     /// Get the last decided leaf of the [`SystemContext`] instance.
     ///
     /// # Panics

--- a/crates/hotshot/src/types/handle.rs
+++ b/crates/hotshot/src/types/handle.rs
@@ -90,7 +90,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static> SystemContextHandl
     ///
     /// # Panics
     /// If the internal consensus is in an inconsistent state.
-    pub async fn get_decided_state(&self) -> TYPES::ValidatedState {
+    pub async fn get_decided_state(&self) -> Arc<TYPES::ValidatedState> {
         self.hotshot.get_decided_state().await
     }
 

--- a/crates/task-impls/src/consensus.rs
+++ b/crates/task-impls/src/consensus.rs
@@ -538,9 +538,9 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                         block_payload: None,
                         proposer_id: sender,
                     };
-                    let state = <TYPES::ValidatedState as ValidatedState>::from_header(
+                    let state = Arc::new(<TYPES::ValidatedState as ValidatedState>::from_header(
                         &proposal.data.block_header,
-                    );
+                    ));
 
                     consensus.validated_state_map.insert(
                         view,
@@ -600,6 +600,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                     error!("Block header doesn't extend the proposal",);
                     return;
                 };
+                let state = Arc::new(state);
                 let parent_commitment = parent.commit();
                 let leaf: Leaf<_> = Leaf {
                     view_number: view,

--- a/crates/testing/src/task_helpers.rs
+++ b/crates/testing/src/task_helpers.rs
@@ -42,7 +42,7 @@ use hotshot_types::vote::Certificate;
 use hotshot_types::vote::Vote;
 
 use serde::Serialize;
-use std::{fmt::Debug, hash::Hash};
+use std::{fmt::Debug, hash::Hash, sync::Arc};
 
 /// create the [`SystemContextHandle`] from a node id
 /// # Panics
@@ -238,10 +238,11 @@ async fn build_quorum_proposal_and_signature(
             .quorum_membership
             .total_nodes(),
     );
-    let mut parent_state =
-        <TestValidatedState as ValidatedState>::from_header(&parent_leaf.block_header);
+    let mut parent_state = Arc::new(<TestValidatedState as ValidatedState>::from_header(
+        &parent_leaf.block_header,
+    ));
     let block_header = TestBlockHeader::new(
-        &parent_state,
+        &*parent_state,
         &TestInstanceState {},
         &parent_leaf.block_header,
         payload_commitment,
@@ -269,9 +270,11 @@ async fn build_quorum_proposal_and_signature(
 
     // Only view 2 is tested, higher views are not tested
     for cur_view in 2..=view {
-        let state_new_view = parent_state
-            .validate_and_apply_header(&TestInstanceState {}, &block_header, &block_header)
-            .unwrap();
+        let state_new_view = Arc::new(
+            parent_state
+                .validate_and_apply_header(&TestInstanceState {}, &block_header, &block_header)
+                .unwrap(),
+        );
         // save states for the previous view to pass all the qc checks
         // In the long term, we want to get rid of this, do not manually update consensus state
         consensus.validated_state_map.insert(

--- a/crates/types/src/consensus.rs
+++ b/crates/types/src/consensus.rs
@@ -341,7 +341,7 @@ impl<TYPES: NodeType> Consensus<TYPES> {
 
     /// Gets the validated state with the given view number, if in the state map.
     #[must_use]
-    pub fn get_state(&self, view_number: TYPES::Time) -> Option<&TYPES::ValidatedState> {
+    pub fn get_state(&self, view_number: TYPES::Time) -> Option<&Arc<TYPES::ValidatedState>> {
         match self.validated_state_map.get(&view_number) {
             Some(view) => view.get_state(),
             None => None,
@@ -354,7 +354,7 @@ impl<TYPES: NodeType> Consensus<TYPES> {
     /// If the last decided view's state does not exist in the state map, which should never
     /// happen.
     #[must_use]
-    pub fn get_decided_state(&self) -> &TYPES::ValidatedState {
+    pub fn get_decided_state(&self) -> &Arc<TYPES::ValidatedState> {
         let decided_view_num = self.last_decided_view;
         self.get_state(decided_view_num)
             .expect("Decided state not found! Consensus internally inconsistent")

--- a/crates/types/src/traits/states.rs
+++ b/crates/types/src/traits/states.rs
@@ -22,7 +22,7 @@ pub trait InstanceState: Clone + Debug + Send + Sync {}
 /// produce a new state, with the modifications from the block applied
 /// ([`validate_and_apply_header`](`ValidatedState::validate_and_apply_header))
 pub trait ValidatedState:
-    Serialize + DeserializeOwned + Clone + Debug + Default + Hash + PartialEq + Eq + Send + Sync
+    Serialize + DeserializeOwned + Debug + Default + Hash + PartialEq + Eq + Send + Sync
 {
     /// The error type for this particular type of ledger state
     type Error: Error + Debug + Send + Sync;


### PR DESCRIPTION
### This PR: 
* Adds a method `SystemContextHandle::get_state` to look up a validated state by view number
* Changes the type of the validated state in the view map to `Arc<TYPES::ValidatedState>` to avoid unnecessary clones

### This PR does not: 
* Do anything else

### Key places to review: 
* Interface in `SystemContextHandle`
* View type changes in `hotshot_types::utils`
