### PR TITLE
Add a task to handle an upgrade vote

### DIFF
--- a/crates/hotshot/src/lib.rs
+++ b/crates/hotshot/src/lib.rs
@@ -15,7 +15,7 @@ pub mod tasks;
 use crate::{
     tasks::{
         add_consensus_task, add_da_task, add_network_event_task, add_network_message_task,
-        add_transaction_task, add_view_sync_task,
+        add_transaction_task, add_upgrade_task, add_view_sync_task,
     },
     traits::{NodeImplementation, Storage},
     types::{Event, SystemContextHandle},
@@ -408,7 +408,6 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> SystemContext<TYPES, I> {
 
         Ok((handle, internal_event_stream))
     }
-
     /// return the timeout for a view for `self`
     #[must_use]
     pub fn get_next_view_timeout(&self) -> u64 {
@@ -510,6 +509,8 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> SystemContext<TYPES, I> {
             add_transaction_task(task_runner, internal_event_stream.clone(), handle.clone()).await;
         let task_runner =
             add_view_sync_task(task_runner, internal_event_stream.clone(), handle.clone()).await;
+        let task_runner =
+            add_upgrade_task(task_runner, internal_event_stream.clone(), handle.clone()).await;
         async_spawn(async move {
             let _ = task_runner.launch().await;
             info!("Task runner exited!");

--- a/crates/hotshot/src/tasks/mod.rs
+++ b/crates/hotshot/src/tasks/mod.rs
@@ -395,7 +395,6 @@ pub async fn add_upgrade_task<TYPES: NodeType, I: NodeImplementation<TYPES>>(
         api: c_api.clone(),
         registry: registry.clone(),
         cur_view: TYPES::Time::new(0),
-        consensus: handle.hotshot.get_consensus(),
         quorum_membership: c_api.inner.memberships.quorum_membership.clone().into(),
         quorum_network: c_api.inner.networks.quorum_network.clone().into(),
         should_vote: |_upgrade_proposal| false,

--- a/crates/hotshot/src/tasks/mod.rs
+++ b/crates/hotshot/src/tasks/mod.rs
@@ -22,6 +22,7 @@ use hotshot_task_impls::{
         NetworkMessageTaskTypes, NetworkTaskKind,
     },
     transactions::{TransactionTaskState, TransactionsTaskTypes},
+    upgrade::{UpgradeTaskState, UpgradeTaskTypes},
     vid::{VIDTaskState, VIDTaskTypes},
     view_sync::{ViewSyncTaskState, ViewSyncTaskStateTypes},
 };
@@ -374,6 +375,64 @@ pub async fn add_vid_task<TYPES: NodeType, I: NodeImplementation<TYPES>>(
     let vid_task_id = vid_task_builder.get_task_id().unwrap();
     let vid_task = VIDTaskTypes::build(vid_task_builder).launch();
     task_runner.add_task(vid_task_id, vid_name.to_string(), vid_task)
+}
+
+/// add the Upgrade task.
+///
+/// # Panics
+///
+/// Uses .unwrap(), though this should never panic.
+pub async fn add_upgrade_task<TYPES: NodeType, I: NodeImplementation<TYPES>>(
+    task_runner: TaskRunner,
+    event_stream: ChannelStream<HotShotEvent<TYPES>>,
+    handle: SystemContextHandle<TYPES, I>,
+) -> TaskRunner {
+    let c_api: HotShotConsensusApi<TYPES, I> = HotShotConsensusApi {
+        inner: handle.hotshot.inner.clone(),
+    };
+    let registry = task_runner.registry.clone();
+    let upgrade_state = UpgradeTaskState {
+        api: c_api.clone(),
+        registry: registry.clone(),
+        cur_view: TYPES::Time::new(0),
+        consensus: handle.hotshot.get_consensus(),
+        quorum_membership: c_api.inner.memberships.quorum_membership.clone().into(),
+        quorum_network: c_api.inner.networks.quorum_network.clone().into(),
+        should_vote: |_upgrade_proposal| false,
+        vote_collector: None.into(),
+        event_stream: event_stream.clone(),
+        public_key: c_api.public_key().clone(),
+        private_key: c_api.private_key().clone(),
+        id: handle.hotshot.inner.id,
+    };
+    let upgrade_event_handler = HandleEvent(Arc::new(
+        move |event, mut state: UpgradeTaskState<TYPES, I, HotShotConsensusApi<TYPES, I>>| {
+            async move {
+                let completion_status = state.handle_event(event).await;
+                (completion_status, state)
+            }
+            .boxed()
+        },
+    ));
+    let upgrade_name = "Upgrade Task";
+    let upgrade_event_filter = FilterEvent(Arc::new(
+        UpgradeTaskState::<TYPES, I, HotShotConsensusApi<TYPES, I>>::filter,
+    ));
+
+    let upgrade_task_builder = TaskBuilder::<
+        UpgradeTaskTypes<TYPES, I, HotShotConsensusApi<TYPES, I>>,
+    >::new(upgrade_name.to_string())
+    .register_event_stream(event_stream.clone(), upgrade_event_filter)
+    .await
+    .register_registry(&mut registry.clone())
+    .await
+    .register_state(upgrade_state)
+    .register_event_handler(upgrade_event_handler);
+    // impossible for unwrap to fail
+    // we *just* registered
+    let upgrade_task_id = upgrade_task_builder.get_task_id().unwrap();
+    let upgrade_task = UpgradeTaskTypes::build(upgrade_task_builder).launch();
+    task_runner.add_task(upgrade_task_id, upgrade_name.to_string(), upgrade_task)
 }
 
 /// add the Data Availability task

--- a/crates/task-impls/src/events.rs
+++ b/crates/task-impls/src/events.rs
@@ -112,7 +112,7 @@ pub enum HotShotEvent<TYPES: NodeType> {
     /// Like [`HotShotEvent::DAProposalRecv`].
     VidDisperseRecv(Proposal<TYPES, VidDisperse<TYPES>>, TYPES::SignatureKey),
     /// Upgrade proposal has been received from the network
-    UpgradeProposalRecv(UpgradeProposal<TYPES>),
+    UpgradeProposalRecv(Proposal<TYPES, UpgradeProposal<TYPES>>, TYPES::SignatureKey),
     /// Upgrade proposal has been sent to the network
     UpgradeProposalSend(UpgradeProposal<TYPES>),
     /// Upgrade vote has been received from the network

--- a/crates/task-impls/src/events.rs
+++ b/crates/task-impls/src/events.rs
@@ -119,8 +119,6 @@ pub enum HotShotEvent<TYPES: NodeType> {
     UpgradeVoteRecv(UpgradeVote<TYPES>),
     /// Upgrade vote has been sent to the network
     UpgradeVoteSend(UpgradeVote<TYPES>),
-    /// Upgrade certificate has been received from the network
-    UpgradeCertificateRecv(UpgradeCertificate<TYPES>),
     /// Upgrade certificate has been sent to the network
-    UpgradeCertificateSend(UpgradeCertificate<TYPES>),
+    UpgradeCertificateFormed(UpgradeCertificate<TYPES>),
 }

--- a/crates/task-impls/src/lib.rs
+++ b/crates/task-impls/src/lib.rs
@@ -28,5 +28,8 @@ pub mod vid;
 /// Generic task for collecting votes
 pub mod vote;
 
+/// Task for handling upgrades
+pub mod upgrade;
+
 /// Helper functions used by any task
 mod helpers;

--- a/crates/task-impls/src/network.rs
+++ b/crates/task-impls/src/network.rs
@@ -90,7 +90,7 @@ impl<TYPES: NodeType> NetworkMessageTaskState<TYPES> {
                                 HotShotEvent::UpgradeCertificateRecv(message)
                             }
                             GeneralConsensusMessage::UpgradeProposal(message) => {
-                                HotShotEvent::UpgradeProposalRecv(message)
+                                HotShotEvent::UpgradeProposalRecv(message, sender)
                             }
                             GeneralConsensusMessage::UpgradeVote(message) => {
                                 HotShotEvent::UpgradeVoteRecv(message)

--- a/crates/task-impls/src/network.rs
+++ b/crates/task-impls/src/network.rs
@@ -86,9 +86,6 @@ impl<TYPES: NodeType> NetworkMessageTaskState<TYPES> {
                             GeneralConsensusMessage::TimeoutVote(message) => {
                                 HotShotEvent::TimeoutVoteRecv(message)
                             }
-                            GeneralConsensusMessage::UpgradeCertificate(message) => {
-                                HotShotEvent::UpgradeCertificateRecv(message)
-                            }
                             GeneralConsensusMessage::UpgradeProposal(message) => {
                                 HotShotEvent::UpgradeProposalRecv(message, sender)
                             }

--- a/crates/task-impls/src/upgrade.rs
+++ b/crates/task-impls/src/upgrade.rs
@@ -11,7 +11,6 @@ use hotshot_task::{
     task_impls::HSTWithEvent,
 };
 use hotshot_types::{
-    consensus::Consensus,
     event::{Event, EventType},
     simple_certificate::UpgradeCertificate,
     simple_vote::{UpgradeProposalData, UpgradeVote},
@@ -49,9 +48,6 @@ pub struct UpgradeTaskState<
 
     /// View number this view is executing in.
     pub cur_view: TYPES::Time,
-
-    /// Reference to consensus. Leader will require a read lock on this.
-    pub consensus: Arc<RwLock<Consensus<TYPES>>>,
 
     /// Membership for Quorum Certs/votes
     pub quorum_membership: Arc<TYPES::Membership>,
@@ -91,7 +87,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
             HotShotEvent::UpgradeProposalRecv(proposal, sender) => {
                 let should_vote = self.should_vote;
                 // If the proposal does not match our upgrade target, we immediately exit.
-                if should_vote(proposal.data.upgrade_proposal.clone()) {
+                if !should_vote(proposal.data.upgrade_proposal.clone()) {
                     warn!(
                         "Received unexpected upgrade proposal:\n{:?}",
                         proposal.data

--- a/crates/task-impls/src/upgrade.rs
+++ b/crates/task-impls/src/upgrade.rs
@@ -1,0 +1,255 @@
+use crate::{
+    events::HotShotEvent,
+    vote::{create_vote_accumulator, AccumulatorInfo, VoteCollectionTaskState},
+};
+use async_lock::RwLock;
+
+use hotshot_task::{
+    event_stream::{ChannelStream, EventStream},
+    global_registry::GlobalRegistry,
+    task::{HotShotTaskCompleted, TS},
+    task_impls::HSTWithEvent,
+};
+use hotshot_types::{
+    consensus::Consensus,
+    event::{Event, EventType},
+    simple_certificate::UpgradeCertificate,
+    simple_vote::{UpgradeProposalData, UpgradeVote},
+    traits::{
+        consensus_api::ConsensusApi,
+        election::Membership,
+        node_implementation::{ConsensusTime, NodeImplementation, NodeType},
+        signature_key::SignatureKey,
+    },
+    vote::HasViewNumber,
+};
+
+use crate::vote::HandleVoteEvent;
+use snafu::Snafu;
+use std::sync::Arc;
+use tracing::{debug, error, instrument, warn};
+
+/// Alias for Optional type for Vote Collectors
+type VoteCollectorOption<TYPES, VOTE, CERT> = Option<VoteCollectionTaskState<TYPES, VOTE, CERT>>;
+
+#[derive(Snafu, Debug)]
+/// Error type for consensus tasks
+pub struct ConsensusTaskError {}
+
+/// Tracks state of a DA task
+pub struct UpgradeTaskState<
+    TYPES: NodeType,
+    I: NodeImplementation<TYPES>,
+    A: ConsensusApi<TYPES, I> + 'static,
+> {
+    /// The state's api
+    pub api: A,
+    /// Global registry task for the state
+    pub registry: GlobalRegistry,
+
+    /// View number this view is executing in.
+    pub cur_view: TYPES::Time,
+
+    /// Reference to consensus. Leader will require a read lock on this.
+    pub consensus: Arc<RwLock<Consensus<TYPES>>>,
+
+    /// Membership for Quorum Certs/votes
+    pub quorum_membership: Arc<TYPES::Membership>,
+    /// Network for all nodes
+    pub quorum_network: Arc<I::QuorumNetwork>,
+
+    /// Whether we should vote affirmatively on a given upgrade proposal (true) or not (false)
+    pub should_vote: fn(UpgradeProposalData<TYPES>) -> bool,
+
+    /// The current vote collection task, if there is one.
+    pub vote_collector:
+        RwLock<VoteCollectorOption<TYPES, UpgradeVote<TYPES>, UpgradeCertificate<TYPES>>>,
+
+    /// Global events stream to publish events
+    pub event_stream: ChannelStream<HotShotEvent<TYPES>>,
+
+    /// This Nodes public key
+    pub public_key: TYPES::SignatureKey,
+
+    /// This Nodes private key
+    pub private_key: <TYPES::SignatureKey as SignatureKey>::PrivateKey,
+
+    /// This state's ID
+    pub id: u64,
+}
+
+impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 'static>
+    UpgradeTaskState<TYPES, I, A>
+{
+    /// main task event handler
+    #[instrument(skip_all, fields(id = self.id, view = *self.cur_view), name = "Upgrade Task", level = "error")]
+    pub async fn handle_event(
+        &mut self,
+        event: HotShotEvent<TYPES>,
+    ) -> Option<HotShotTaskCompleted> {
+        match event {
+            HotShotEvent::UpgradeProposalRecv(proposal, sender) => {
+                let should_vote = self.should_vote;
+                // If the proposal does not match our upgrade target, we immediately exit.
+                if should_vote(proposal.data.upgrade_proposal.clone()) {
+                    warn!(
+                        "Received unexpected upgrade proposal:\n{:?}",
+                        proposal.data
+                    );
+                    return None;
+                }
+
+                // If we have an upgrade target, we validate that the proposal is relevant for the current view.
+
+                debug!(
+                    "Upgrade proposal received for view: {:?}",
+                    proposal.data.get_view_number()
+                );
+                // NOTE: Assuming that the next view leader is the one who sends an upgrade proposal for this view
+                let view = proposal.data.get_view_number();
+
+                // Allow an upgrade proposal that is one view older, in case we have voted on a quorum
+                // proposal and updated the view.
+                // `self.cur_view` should be at least 1 since there is a view change before getting
+                // the `UpgradeProposalRecv` event. Otherewise, the view number subtraction below will
+                // cause an overflow error.
+                // TODO Come back to this - we probably don't need this, but we should also never receive a UpgradeCertificate where this fails, investigate block ready so it doesn't make one for the genesis block
+
+                if self.cur_view != TYPES::Time::genesis() && view < self.cur_view - 1 {
+                    warn!("Discarding old upgrade proposal; the proposal is for view {:?}, but the current view is {:?}.",
+                      view,
+                      self.cur_view
+                    );
+                    return None;
+                }
+
+                // We then validate that the proposal was issued by the leader for the view.
+                let view_leader_key = self.quorum_membership.get_leader(view);
+                if view_leader_key != sender {
+                    error!("Upgrade proposal doesn't have expected leader key for view {} \n Upgrade proposal is: {:?}", *view, proposal.data.clone());
+                    return None;
+                }
+
+                // At this point, we've checked that:
+                //   * the proposal was expected,
+                //   * the proposal is valid, and
+                //   * the proposal is recent,
+                // so we notify the application layer
+                self.api
+                    .send_event(Event {
+                        view_number: self.cur_view,
+                        event: EventType::UpgradeProposal {
+                            proposal: proposal.clone(),
+                            sender: sender.clone(),
+                        },
+                    })
+                    .await;
+
+                // If everything is fine up to here, we generate and send a vote on the proposal.
+                let Ok(vote) = UpgradeVote::create_signed_vote(
+                    proposal.data.upgrade_proposal,
+                    view,
+                    &self.public_key,
+                    &self.private_key,
+                ) else {
+                    error!("Failed to sign UpgradeVote!");
+                    return None;
+                };
+                debug!("Sending upgrade vote {:?}", vote.get_view_number());
+                self.event_stream
+                    .publish(HotShotEvent::UpgradeVoteSend(vote))
+                    .await;
+            }
+            HotShotEvent::UpgradeVoteRecv(ref vote) => {
+                debug!("Upgrade vote recv, Main Task {:?}", vote.get_view_number());
+                // Check if we are the leader.
+                let view = vote.get_view_number();
+                if self.quorum_membership.get_leader(view) != self.public_key {
+                    error!(
+                        "We are not the leader for view {} are we leader for next view? {}",
+                        *view,
+                        self.quorum_membership.get_leader(view + 1) == self.public_key
+                    );
+                    return None;
+                }
+                let mut collector = self.vote_collector.write().await;
+
+                let maybe_task = collector.take();
+
+                if maybe_task.is_none()
+                    || vote.get_view_number() > maybe_task.as_ref().unwrap().view
+                {
+                    debug!("Starting vote handle for view {:?}", vote.get_view_number());
+                    let info = AccumulatorInfo {
+                        public_key: self.public_key.clone(),
+                        membership: self.quorum_membership.clone(),
+                        view: vote.get_view_number(),
+                        event_stream: self.event_stream.clone(),
+                        id: self.id,
+                        registry: self.registry.clone(),
+                    };
+                    *collector = create_vote_accumulator::<
+                        TYPES,
+                        UpgradeVote<TYPES>,
+                        UpgradeCertificate<TYPES>,
+                    >(&info, vote.clone(), event)
+                    .await;
+                } else {
+                    let result = maybe_task.unwrap().handle_event(event.clone()).await;
+
+                    if result.0 == Some(HotShotTaskCompleted::ShutDown) {
+                        // The protocol has finished
+                        return None;
+                    }
+                    *collector = Some(result.1);
+                }
+            }
+            HotShotEvent::ViewChange(view) => {
+                if *self.cur_view >= *view {
+                    return None;
+                }
+
+                if *view - *self.cur_view > 1 {
+                    warn!("View changed by more than 1 going to view {:?}", view);
+                }
+                self.cur_view = view;
+
+                return None;
+            }
+            HotShotEvent::Shutdown => {
+                error!("Shutting down because of shutdown signal!");
+                return Some(HotShotTaskCompleted::ShutDown);
+            }
+            _ => {
+                error!("unexpected event {:?}", event);
+            }
+        }
+        None
+    }
+
+    /// Filter the upgrade event.
+    pub fn filter(event: &HotShotEvent<TYPES>) -> bool {
+        matches!(
+            event,
+            HotShotEvent::UpgradeProposalRecv(_, _)
+                | HotShotEvent::UpgradeVoteRecv(_)
+                | HotShotEvent::Shutdown
+                | HotShotEvent::Timeout(_)
+                | HotShotEvent::ViewChange(_)
+        )
+    }
+}
+
+/// task state implementation for DA Task
+impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 'static> TS
+    for UpgradeTaskState<TYPES, I, A>
+{
+}
+
+/// Type alias for DA Task Types
+pub type UpgradeTaskTypes<TYPES, I, A> = HSTWithEvent<
+    ConsensusTaskError,
+    HotShotEvent<TYPES>,
+    ChannelStream<HotShotEvent<TYPES>>,
+    UpgradeTaskState<TYPES, I, A>,
+>;

--- a/crates/task-impls/src/vote.rs
+++ b/crates/task-impls/src/vote.rs
@@ -276,7 +276,7 @@ impl<TYPES: NodeType> AggregatableVote<TYPES, UpgradeVote<TYPES>, UpgradeCertifi
         certificate: UpgradeCertificate<TYPES>,
         _key: &TYPES::SignatureKey,
     ) -> HotShotEvent<TYPES> {
-        HotShotEvent::UpgradeCertificateSend(certificate)
+        HotShotEvent::UpgradeCertificateFormed(certificate)
     }
 }
 

--- a/crates/types/src/event.rs
+++ b/crates/types/src/event.rs
@@ -1,7 +1,7 @@
 //! Events that a `HotShot` instance can emit
 
 use crate::{
-    data::{DAProposal, Leaf, QuorumProposal},
+    data::{DAProposal, Leaf, QuorumProposal, UpgradeProposal},
     error::HotShotError,
     message::Proposal,
     simple_certificate::QuorumCertificate,
@@ -84,6 +84,14 @@ pub enum EventType<TYPES: NodeType> {
     QuorumProposal {
         /// Contents of the proposal
         proposal: Proposal<TYPES, QuorumProposal<TYPES>>,
+        /// Public key of the leader submitting the proposal
+        sender: TYPES::SignatureKey,
+    },
+    /// Upgrade proposal was received from the network
+    /// or submitted to the network by us
+    UpgradeProposal {
+        /// Contents of the proposal
+        proposal: Proposal<TYPES, UpgradeProposal<TYPES>>,
         /// Public key of the leader submitting the proposal
         sender: TYPES::SignatureKey,
     },

--- a/crates/types/src/message.rs
+++ b/crates/types/src/message.rs
@@ -5,7 +5,7 @@
 
 use crate::data::{QuorumProposal, UpgradeProposal};
 use crate::simple_certificate::{
-    DACertificate, UpgradeCertificate, ViewSyncCommitCertificate2, ViewSyncFinalizeCertificate2,
+    DACertificate, ViewSyncCommitCertificate2, ViewSyncFinalizeCertificate2,
     ViewSyncPreCommitCertificate2,
 };
 use crate::simple_vote::{
@@ -173,7 +173,6 @@ impl<TYPES: NodeType> ProcessedGeneralConsensusMessage<TYPES> {
             GeneralConsensusMessage::ViewSyncPreCommitCertificate(_) => unimplemented!(),
             GeneralConsensusMessage::ViewSyncCommitCertificate(_) => unimplemented!(),
             GeneralConsensusMessage::ViewSyncFinalizeCertificate(_) => unimplemented!(),
-            GeneralConsensusMessage::UpgradeCertificate(_) => unimplemented!(),
             GeneralConsensusMessage::UpgradeProposal(_) => unimplemented!(),
             GeneralConsensusMessage::UpgradeVote(_) => unimplemented!(),
         }
@@ -287,9 +286,6 @@ pub enum GeneralConsensusMessage<TYPES: NodeType> {
     /// Message with a Timeout vote
     TimeoutVote(TimeoutVote<TYPES>),
 
-    /// Message with an upgrade certificate
-    UpgradeCertificate(UpgradeCertificate<TYPES>),
-
     /// Message with an upgrade proposal
     UpgradeProposal(Proposal<TYPES, UpgradeProposal<TYPES>>),
 
@@ -357,9 +353,6 @@ impl<TYPES: NodeType> SequencingMessage<TYPES> {
                     GeneralConsensusMessage::ViewSyncFinalizeCertificate(message) => {
                         message.get_view_number()
                     }
-                    GeneralConsensusMessage::UpgradeCertificate(message) => {
-                        message.get_view_number()
-                    }
                     GeneralConsensusMessage::UpgradeProposal(message) => message.data.get_view_number(),
                     GeneralConsensusMessage::UpgradeVote(message) => message.get_view_number(),
                 }
@@ -403,8 +396,7 @@ impl<TYPES: NodeType> SequencingMessage<TYPES> {
                     MessagePurpose::ViewSyncCertificate
                 }
 
-                GeneralConsensusMessage::UpgradeCertificate(_)
-                | GeneralConsensusMessage::UpgradeProposal(_)
+                GeneralConsensusMessage::UpgradeProposal(_)
                 | GeneralConsensusMessage::UpgradeVote(_) => MessagePurpose::Upgrade,
             },
             Right(committee_message) => match committee_message {

--- a/crates/types/src/message.rs
+++ b/crates/types/src/message.rs
@@ -291,7 +291,7 @@ pub enum GeneralConsensusMessage<TYPES: NodeType> {
     UpgradeCertificate(UpgradeCertificate<TYPES>),
 
     /// Message with an upgrade proposal
-    UpgradeProposal(UpgradeProposal<TYPES>),
+    UpgradeProposal(Proposal<TYPES, UpgradeProposal<TYPES>>),
 
     /// Message with an upgrade vote
     UpgradeVote(UpgradeVote<TYPES>),
@@ -360,7 +360,7 @@ impl<TYPES: NodeType> SequencingMessage<TYPES> {
                     GeneralConsensusMessage::UpgradeCertificate(message) => {
                         message.get_view_number()
                     }
-                    GeneralConsensusMessage::UpgradeProposal(message) => message.get_view_number(),
+                    GeneralConsensusMessage::UpgradeProposal(message) => message.data.get_view_number(),
                     GeneralConsensusMessage::UpgradeVote(message) => message.get_view_number(),
                 }
             }


### PR DESCRIPTION
Closes #2454

### This PR: 
Adds a hotshot task to handle the upgrade process. The task allows nodes to vote on upgrades matching a target, and leaders to collect votes to form an upgrade certificate.

### This PR does not: 
Implement a mechanism to initiate an upgrade.

### Key places to review: 
Logic in `task-impls/src/upgrade.rs`.
