### PR TITLE
Speed Up DHT Retrieval

### DIFF
--- a/crates/hotshot/src/tasks/mod.rs
+++ b/crates/hotshot/src/tasks/mod.rs
@@ -381,7 +381,7 @@ pub async fn add_vid_task<TYPES: NodeType, I: NodeImplementation<TYPES>>(
 ///
 /// # Panics
 ///
-/// Uses .unwrap(), though this should never panic.
+/// Uses .`unwrap()`, though this should never panic.
 pub async fn add_upgrade_task<TYPES: NodeType, I: NodeImplementation<TYPES>>(
     task_runner: TaskRunner,
     event_stream: ChannelStream<HotShotEvent<TYPES>>,

--- a/crates/hotshot/src/traits/networking/web_server_network.rs
+++ b/crates/hotshot/src/traits/networking/web_server_network.rs
@@ -324,7 +324,7 @@ impl<TYPES: NodeType> Inner<TYPES> {
 
                     return false;
                 }
-                MessagePurpose::DAC => {
+                MessagePurpose::DAC | MessagePurpose::ViewSyncVote => {
                     debug!(
                         "Received DAC from web server for view {} {}",
                         view_number, self.is_da
@@ -349,13 +349,6 @@ impl<TYPES: NodeType> Inner<TYPES> {
 
                     // Only pushing the first proposal since we will soon only be allowing 1 proposal per view
                     return true;
-                }
-                MessagePurpose::ViewSyncVote => {
-                    let vote = deserialized_message.clone();
-                    *vote_index += 1;
-                    direct_poll_queue.write().await.push(vote);
-
-                    return false;
                 }
                 MessagePurpose::ViewSyncCertificate => {
                     // TODO ED Special case this for view sync

--- a/crates/hotshot/src/traits/networking/web_server_network.rs
+++ b/crates/hotshot/src/traits/networking/web_server_network.rs
@@ -317,14 +317,14 @@ impl<TYPES: NodeType> Inner<TYPES> {
                     }
                     return false;
                 }
-                MessagePurpose::Vote => {
+                MessagePurpose::Vote | MessagePurpose::ViewSyncVote => {
                     let vote = deserialized_message.clone();
                     *vote_index += 1;
                     direct_poll_queue.write().await.push(vote);
 
                     return false;
                 }
-                MessagePurpose::DAC | MessagePurpose::ViewSyncVote => {
+                MessagePurpose::DAC => {
                     debug!(
                         "Received DAC from web server for view {} {}",
                         view_number, self.is_da

--- a/crates/libp2p-networking/src/network/behaviours/dht/cache.rs
+++ b/crates/libp2p-networking/src/network/behaviours/dht/cache.rs
@@ -65,6 +65,8 @@ impl Default for Cache {
 }
 
 /// key value cache
+
+#[derive(Clone)]
 pub struct Cache {
     /// the cache's config
     config: Config,

--- a/crates/libp2p-networking/src/network/behaviours/dht/mod.rs
+++ b/crates/libp2p-networking/src/network/behaviours/dht/mod.rs
@@ -8,7 +8,7 @@ use std::{
 /// a local caching layer for the DHT key value pairs
 mod cache;
 
-use async_compatibility_layer::art::{async_block_on, async_spawn};
+use async_compatibility_layer::art::async_block_on;
 use futures::channel::oneshot::Sender;
 use libp2p::kad::Behaviour as KademliaBehaviour;
 use libp2p::kad::Event as KademliaEvent;
@@ -331,6 +331,7 @@ impl DHTBehaviour {
                 {
                     // insert into cache
                     // TODO we should find a better place to set the cache
+                    // https://github.com/EspressoSystems/HotShot/issues/2554
                     async_spawn(self.cache.insert(key, r.clone()));
 
                     // return value

--- a/crates/libp2p-networking/src/network/behaviours/dht/mod.rs
+++ b/crates/libp2p-networking/src/network/behaviours/dht/mod.rs
@@ -8,7 +8,7 @@ use std::{
 /// a local caching layer for the DHT key value pairs
 mod cache;
 
-use async_compatibility_layer::art::async_block_on;
+use async_compatibility_layer::art::{async_block_on, async_spawn};
 use futures::channel::oneshot::Sender;
 use libp2p::kad::Behaviour as KademliaBehaviour;
 use libp2p::kad::Event as KademliaEvent;
@@ -332,7 +332,9 @@ impl DHTBehaviour {
                     // insert into cache
                     // TODO we should find a better place to set the cache
                     // https://github.com/EspressoSystems/HotShot/issues/2554
-                    async_block_on(self.cache.insert(key, r.clone()));
+                    let cache = self.cache.clone();
+                    let val = r.clone();
+                    async_spawn(async move { cache.insert(key, val).await });
 
                     // return value
                     if notify.send(r).is_err() {

--- a/crates/libp2p-networking/src/network/behaviours/dht/mod.rs
+++ b/crates/libp2p-networking/src/network/behaviours/dht/mod.rs
@@ -269,7 +269,7 @@ impl DHTBehaviour {
     }
 
     /// update state based on recv-ed get query
-    fn handle_get_query(&mut self, record_results: GetRecordResult, id: QueryId, mut last: bool) {
+    fn handle_get_query(&mut self, record_results: GetRecordResult, id: QueryId) {
         let num = if let Some(query) = self.in_progress_get_record_queries.get_mut(&id) {
             match record_results {
                 Ok(results) => match results {
@@ -289,7 +289,7 @@ impl DHTBehaviour {
                     GetRecordOk::FinishedWithNoAdditionalRecord {
                         cache_candidates: _,
                     } => {
-                        last = true;
+                        tracing::debug!("GetRecord Finished with No Additional Record");
                         0
                     }
                 },
@@ -446,10 +446,9 @@ impl DHTBehaviour {
             KademliaEvent::OutboundQueryProgressed {
                 result: QueryResult::GetRecord(record_results),
                 id,
-                step: ProgressStep { last, .. },
                 ..
             } => {
-                self.handle_get_query(record_results, id, last);
+                self.handle_get_query(record_results, id);
             }
             KademliaEvent::OutboundQueryProgressed {
                 result:

--- a/crates/libp2p-networking/src/network/behaviours/dht/mod.rs
+++ b/crates/libp2p-networking/src/network/behaviours/dht/mod.rs
@@ -8,7 +8,7 @@ use std::{
 /// a local caching layer for the DHT key value pairs
 mod cache;
 
-use async_compatibility_layer::art::async_block_on;
+use async_compatibility_layer::art::{async_block_on, async_spawn};
 use futures::channel::oneshot::Sender;
 use libp2p::kad::Behaviour as KademliaBehaviour;
 use libp2p::kad::Event as KademliaEvent;
@@ -330,8 +330,8 @@ impl DHTBehaviour {
                     .find(|(_, v)| *v >= NUM_REPLICATED_TO_TRUST)
                 {
                     // insert into cache
-                    // TODO we should not block here, this is called in poll.
-                    async_block_on(self.cache.insert(key, r.clone()));
+                    // TODO we should find a better place to set the cache
+                    async_spawn(self.cache.insert(key, r.clone()));
 
                     // return value
                     if notify.send(r).is_err() {

--- a/crates/libp2p-networking/src/network/behaviours/dht/mod.rs
+++ b/crates/libp2p-networking/src/network/behaviours/dht/mod.rs
@@ -332,7 +332,7 @@ impl DHTBehaviour {
                     // insert into cache
                     // TODO we should find a better place to set the cache
                     // https://github.com/EspressoSystems/HotShot/issues/2554
-                    async_spawn(self.cache.insert(key, r.clone()));
+                    async_block_on(self.cache.insert(key, r.clone()));
 
                     // return value
                     if notify.send(r).is_err() {

--- a/crates/orchestrator/api.toml
+++ b/crates/orchestrator/api.toml
@@ -3,15 +3,6 @@ NAME = "orchestrator"
 DESCRIPTION = "Orchestrator for HotShot"
 FORMAT_VERSION = "0.1.0"
 
-# POST node's identity
-[route.postidentity]
-PATH = ["identity/:identity"]
-METHOD = "POST"
-":identity" = "Literal"
-DOC = """
-POST a node's identity (IP address) to the orchestrator.  Returns the node's node_index
-"""
-
 # POST retrieve the network configuration
 [route.post_getconfig]
 PATH = ["config/:node_index"]

--- a/crates/orchestrator/src/lib.rs
+++ b/crates/orchestrator/src/lib.rs
@@ -7,14 +7,10 @@ pub mod config;
 
 use async_lock::RwLock;
 use hotshot_types::traits::{election::ElectionConfig, signature_key::SignatureKey};
-use std::{
-    io,
-    io::ErrorKind,
-    net::{IpAddr, SocketAddr},
-};
+use std::{io, io::ErrorKind};
 use tide_disco::{Api, App};
 
-use surf_disco::{error::ClientError, Url};
+use surf_disco::Url;
 use tide_disco::{
     api::ApiError,
     error::ServerError,
@@ -46,8 +42,6 @@ pub fn libp2p_generate_indexed_identity(seed: [u8; 32], index: u64) -> Keypair {
 /// The state of the orchestrator
 #[derive(Default, Clone)]
 struct OrchestratorState<KEY: SignatureKey, ELECTION: ElectionConfig> {
-    /// Tracks the latest node index we have generated a configuration for
-    latest_index: u16,
     /// The network configuration
     config: NetworkConfig<KEY, ELECTION>,
     /// Whether nodes should start their HotShot instances
@@ -55,8 +49,6 @@ struct OrchestratorState<KEY: SignatureKey, ELECTION: ElectionConfig> {
     start: bool,
     /// The total nodes that have posted they are ready to start
     pub nodes_connected: u64,
-    /// connection to the web server
-    client: Option<surf_disco::Client<ClientError>>,
 }
 
 impl<KEY: SignatureKey + 'static, ELECTION: ElectionConfig + 'static>
@@ -64,27 +56,16 @@ impl<KEY: SignatureKey + 'static, ELECTION: ElectionConfig + 'static>
 {
     /// create a new [`OrchestratorState`]
     pub fn new(network_config: NetworkConfig<KEY, ELECTION>) -> Self {
-        let mut web_client = None;
-        if network_config.web_server_config.is_some() {
-            let base_url = "http://0.0.0.0/9000".to_string().parse().unwrap();
-            web_client = Some(surf_disco::Client::<ClientError>::new(base_url));
-        }
         OrchestratorState {
-            latest_index: 0,
             config: network_config,
             start: false,
             nodes_connected: 0,
-            client: web_client,
         }
     }
 }
 
 /// An api exposed by the orchestrator
 pub trait OrchestratorApi<KEY: SignatureKey, ELECTION: ElectionConfig> {
-    /// post endpoint for identity
-    /// # Errors
-    /// if unable to serve
-    fn post_identity(&mut self, identity: IpAddr) -> Result<u16, ServerError>;
     /// post endpoint for each node's config
     /// # Errors
     /// if unable to serve
@@ -111,56 +92,6 @@ where
     KEY: serde::Serialize + Clone + SignatureKey,
     ELECTION: serde::Serialize + Clone + Send + ElectionConfig,
 {
-    fn post_identity(&mut self, identity: IpAddr) -> Result<u16, ServerError> {
-        let node_index = self.latest_index;
-        self.latest_index += 1;
-
-        // TODO https://github.com/EspressoSystems/HotShot/issues/850
-        if usize::from(node_index) >= self.config.config.total_nodes.get() {
-            return Err(ServerError {
-                status: tide_disco::StatusCode::BadRequest,
-                message: "Network has reached capacity".to_string(),
-            });
-        }
-
-        //add new node's key to stake table
-        if self.config.web_server_config.clone().is_some() {
-            let new_key = &self.config.config.my_own_validator_config.public_key;
-            let client_clone = self.client.clone().unwrap();
-            async move {
-                client_clone
-                    .post::<()>("api/staketable")
-                    .body_binary(&new_key)
-                    .unwrap()
-                    .send()
-                    .await
-            }
-            .boxed();
-        }
-
-        if self.config.libp2p_config.clone().is_some() {
-            let libp2p_config_clone = self.config.libp2p_config.clone().unwrap();
-            // Designate node as bootstrap node and store its identity information
-            if libp2p_config_clone.bootstrap_nodes.len() < libp2p_config_clone.num_bootstrap_nodes {
-                let port_index = if libp2p_config_clone.index_ports {
-                    node_index
-                } else {
-                    0
-                };
-                let socketaddr =
-                    SocketAddr::new(identity, libp2p_config_clone.base_port + port_index);
-                let keypair = libp2p_generate_indexed_identity(self.config.seed, node_index.into());
-                self.config
-                    .libp2p_config
-                    .as_mut()
-                    .unwrap()
-                    .bootstrap_nodes
-                    .push((socketaddr, keypair.to_protobuf_encoding().unwrap()));
-            }
-        }
-        Ok(node_index)
-    }
-
     // Assumes nodes will set their own index that they received from the
     // 'identity' endpoint
     fn post_getconfig(
@@ -229,20 +160,7 @@ where
     )))
     .expect("API file is not valid toml");
     let mut api = Api::<State, ServerError>::new(api_toml)?;
-    api.post("postidentity", |req, state| {
-        async move {
-            let identity = req.string_param("identity")?.parse::<IpAddr>();
-            if identity.is_err() {
-                return Err(ServerError {
-                    status: tide_disco::StatusCode::BadRequest,
-                    message: "Identity is not a properly formed IP address".to_string(),
-                });
-            }
-            state.post_identity(identity.unwrap())
-        }
-        .boxed()
-    })?
-    .post("post_getconfig", |req, state| {
+    api.post("post_getconfig", |req, state| {
         async move {
             let node_index = req.integer_param("node_index")?;
             state.post_getconfig(node_index)

--- a/crates/task-impls/src/transactions.rs
+++ b/crates/task-impls/src/transactions.rs
@@ -270,10 +270,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
     }
 
     #[instrument(skip_all, fields(id = self.id, view = *self.cur_view), name = "Transaction Handling Task", level = "error")]
-    async fn wait_for_transactions(
-        &self,
-        _parent_leaf: Leaf<TYPES>,
-    ) -> Option<Vec<TYPES::Transaction>> {
+    async fn wait_for_transactions(&self, _: Leaf<TYPES>) -> Option<Vec<TYPES::Transaction>> {
         let task_start_time = Instant::now();
 
         // TODO (Keyao) Investigate the use of transaction hash

--- a/crates/task-impls/src/upgrade.rs
+++ b/crates/task-impls/src/upgrade.rs
@@ -88,10 +88,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                 let should_vote = self.should_vote;
                 // If the proposal does not match our upgrade target, we immediately exit.
                 if !should_vote(proposal.data.upgrade_proposal.clone()) {
-                    warn!(
-                        "Received unexpected upgrade proposal:\n{:?}",
-                        proposal.data
-                    );
+                    warn!("Received unexpected upgrade proposal:\n{:?}", proposal.data);
                     return None;
                 }
 

--- a/crates/testing/tests/libp2p.rs
+++ b/crates/testing/tests/libp2p.rs
@@ -61,11 +61,11 @@ async fn libp2p_network_failures_2() {
         },
         completion_task_description: CompletionTaskDescription::TimeBasedCompletionTaskBuilder(
             TimeBasedCompletionTaskDescription {
-                duration: Duration::new(240, 0),
+                duration: Duration::from_secs(60),
             },
         ),
         timing_data: TimingData {
-            next_view_timeout: 25000,
+            next_view_timeout: 2500,
             propose_max_round_time: Duration::from_millis(100),
             ..Default::default()
         },

--- a/crates/testing/tests/libp2p.rs
+++ b/crates/testing/tests/libp2p.rs
@@ -61,11 +61,11 @@ async fn libp2p_network_failures_2() {
         },
         completion_task_description: CompletionTaskDescription::TimeBasedCompletionTaskBuilder(
             TimeBasedCompletionTaskDescription {
-                duration: Duration::from_secs(60),
+                duration: Duration::from_secs(240),
             },
         ),
         timing_data: TimingData {
-            next_view_timeout: 2500,
+            next_view_timeout: 4000,
             propose_max_round_time: Duration::from_millis(100),
             ..Default::default()
         },

--- a/crates/types/src/message.rs
+++ b/crates/types/src/message.rs
@@ -353,7 +353,9 @@ impl<TYPES: NodeType> SequencingMessage<TYPES> {
                     GeneralConsensusMessage::ViewSyncFinalizeCertificate(message) => {
                         message.get_view_number()
                     }
-                    GeneralConsensusMessage::UpgradeProposal(message) => message.data.get_view_number(),
+                    GeneralConsensusMessage::UpgradeProposal(message) => {
+                        message.data.get_view_number()
+                    }
                     GeneralConsensusMessage::UpgradeVote(message) => message.get_view_number(),
                 }
             }


### PR DESCRIPTION
Closes #2551 


### This PR: 

Fixes an issue in the DHT.  Basically the semantics of how queries worked were changed in libp2p specifically to allow for faster DHT lookups.  Previously the GetRecords query would only report when it was finished.  It was finished when it got some records from all the peers it expected.  Now it returns all the records it gets incrementally.  Meaning if a few nodes respond quickly we will get those records quickly in an `OutboundQueryProgressed` event.  The issue we had is that were were waiting for the query to be marked as completed before returning the records to the HotShot.  This PR makes it so that we return as we get the minimum number of replicas agreeing on the record.

What I think was happening was that when a node went down we were expecting it to have the record sometimes and therefore would wait a long time to try to get it from them until the implementation gave up and told use the query was completed.

### This PR does not: 

Address some other issues I spotted in the DHT code.  Namely: #2554  and #2535 

### Key places to review: 

Changes to DHT, the rest is just lint and decreasing timeout

