### PR TITLE
[Metrics] Add last_decided_time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1233,8 +1233,10 @@ checksum = "41daef31d7a747c5c847246f36de49ced6f7403b4cdabc807a97b5cc184cda7a"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-targets 0.52.0",
 ]
 
@@ -2929,6 +2931,7 @@ dependencies = [
  "async-trait",
  "bincode",
  "bitvec",
+ "chrono",
  "commit",
  "either",
  "futures",

--- a/crates/task-impls/Cargo.toml
+++ b/crates/task-impls/Cargo.toml
@@ -23,6 +23,7 @@ bitvec = { workspace = true }
 sha2 = { workspace = true }
 hotshot-task = { path = "../task" }
 async-broadcast = { workspace = true }
+chrono = "0.4"
 
 [target.'cfg(all(async_executor_impl = "tokio"))'.dependencies]
 tokio = { workspace = true }

--- a/crates/task-impls/src/consensus.rs
+++ b/crates/task-impls/src/consensus.rs
@@ -37,6 +37,7 @@ use hotshot_types::{
 use tracing::warn;
 
 use crate::vote::HandleVoteEvent;
+use chrono::Utc;
 use snafu::Snafu;
 use std::{
     collections::{BTreeMap, HashSet},
@@ -46,7 +47,6 @@ use std::{
 #[cfg(async_executor_impl = "tokio")]
 use tokio::task::JoinHandle;
 use tracing::{debug, error, info, instrument};
-use chrono::Utc;
 
 /// Error returned by the consensus task
 #[derive(Snafu, Debug)]
@@ -807,7 +807,10 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                         .await;
                     self.vid_shares = self.vid_shares.split_off(&new_anchor_view);
                     consensus.last_decided_view = new_anchor_view;
-                    consensus.metrics.last_decided_time.set(Utc::now().timestamp().try_into().unwrap());
+                    consensus
+                        .metrics
+                        .last_decided_time
+                        .set(Utc::now().timestamp().try_into().unwrap());
                     consensus.metrics.invalid_qc.set(0);
                     consensus
                         .metrics

--- a/crates/task-impls/src/consensus.rs
+++ b/crates/task-impls/src/consensus.rs
@@ -46,6 +46,7 @@ use std::{
 #[cfg(async_executor_impl = "tokio")]
 use tokio::task::JoinHandle;
 use tracing::{debug, error, info, instrument};
+use chrono::Utc;
 
 /// Error returned by the consensus task
 #[derive(Snafu, Debug)]
@@ -806,6 +807,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                         .await;
                     self.vid_shares = self.vid_shares.split_off(&new_anchor_view);
                     consensus.last_decided_view = new_anchor_view;
+                    consensus.metrics.last_decided_time.set(Utc::now().timestamp().try_into().unwrap());
                     consensus.metrics.invalid_qc.set(0);
                     consensus
                         .metrics

--- a/crates/types/src/consensus.rs
+++ b/crates/types/src/consensus.rs
@@ -72,6 +72,8 @@ pub struct ConsensusMetricsValue {
     pub last_synced_block_height: Box<dyn Gauge>,
     /// The number of last decided view
     pub last_decided_view: Box<dyn Gauge>,
+    /// Number of timestamp for the last decided time
+    pub last_decided_time: Box<dyn Gauge>,
     /// The current view
     pub current_view: Box<dyn Gauge>,
     /// Number of views that are in-flight since the last decided view
@@ -210,6 +212,7 @@ impl ConsensusMetricsValue {
             last_synced_block_height: metrics
                 .create_gauge(String::from("last_synced_block_height"), None),
             last_decided_view: metrics.create_gauge(String::from("last_decided_view"), None),
+            last_decided_time: metrics.create_gauge(String::from("last_decided_time"), None),
             current_view: metrics.create_gauge(String::from("current_view"), None),
             number_of_views_since_last_decide: metrics
                 .create_gauge(String::from("number_of_views_since_last_decide"), None),


### PR DESCRIPTION
<!-- See here for keywords in Github -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

### This PR: 
Adds a metric `last_decided_time`. This would let us implement the query "time since last decide" using prometheus data only, which means we could have this endpoint even for nodes that aren't running the full query service.
<!-- Describe what this PR adds to HotSHot -->
<!-- E.g. -->
<!-- * Implements feature 1 -->
<!-- * Implements feature 2 -->
<!-- * Fixes bug 3 -->

<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->

### Key places to review: 
All changes.
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
