### PR TITLE
[Tech_Debt] - Remove varint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4008,7 +4008,6 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
- "unsigned-varint 0.8.0",
  "void",
 ]
 

--- a/crates/libp2p-networking/Cargo.toml
+++ b/crates/libp2p-networking/Cargo.toml
@@ -29,7 +29,6 @@ rand = { workspace = true }
 serde = { workspace = true }
 serde_json = "1.0.113"
 snafu = { workspace = true }
-unsigned-varint = "0.8"
 tide = { version = "0.16", optional = true, default-features = false, features = [
     "h1-server",
 ] }


### PR DESCRIPTION
### This PR: 
Removes varint. Varint was only pulled in so we could continue to support DirectMessageCodec, which is now removed.

### This PR does not: 
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->

### Key places to review: 
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
