### PR TITLE
[Tech Debt] - fix nix flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -205,6 +205,7 @@
             inherit CARGO_TARGET_DIR;
             buildInputs = [
               (pkgs.cargo-semver-checks.overrideAttrs (final: prev: {doCheck = false;}))
+              fenixStable
             ] ++ buildDeps;
           };
 


### PR DESCRIPTION
### This PR: 
Disables checks so we can get the semver binary on darwin (these aren't necessary to get the working binary), and moves the semver to a separate shell so we don't have to build it each time

### This PR does not: 
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->

### Key places to review: 
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
