### PR TITLE
Send timeout vote to trigger next proposal

### DIFF
--- a/crates/task-impls/src/view_sync.rs
+++ b/crates/task-impls/src/view_sync.rs
@@ -11,7 +11,7 @@ use hotshot_types::{
     simple_certificate::{
         ViewSyncCommitCertificate2, ViewSyncFinalizeCertificate2, ViewSyncPreCommitCertificate2,
     },
-    simple_vote::ViewSyncFinalizeData,
+    simple_vote::{TimeoutData, TimeoutVote, ViewSyncFinalizeData},
     traits::signature_key::SignatureKey,
 };
 use hotshot_types::{
@@ -702,6 +702,23 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
             }
 
             HotShotEvent::ViewSyncFinalizeCertificate2Recv(certificate) => {
+                // HACK sending a timeout vote to the next leader so we they
+                // can actually propose.  We don't give the leader the actual view sync cert
+                // so they have nothing to propose from.  Proper fix is to handle the
+                // view sync cert in the consensus task as another cert to propose from
+                let Ok(vote) = TimeoutVote::create_signed_vote(
+                    TimeoutData {
+                        view: self.next_view - 1,
+                    },
+                    self.next_view - 1,
+                    &self.public_key,
+                    &self.private_key,
+                ) else {
+                    error!("Failed to sign TimeoutData!");
+                    return None;
+                };
+
+                broadcast_event(HotShotEvent::TimeoutVoteSend(vote), &event_stream).await;
                 // Ignore certificate if it is for an older round
                 if certificate.get_view_number() < self.next_view {
                     warn!("We're already in a higher round");


### PR DESCRIPTION
Closes #2212 

### This PR: 

There is a bug right now where we do not propose based on a view sync certificate.  A proposal must either have a justify qc which is equal to the prior view, or a timeout certificate for the correct view.   There is a race condition which comes up if there is a good leader after 2 bad ones.  If view sync completes very fast it's possible that some nodes don't even timeout the second bad view because they get evidence to move ahead before their timer expires!  In practice this is extremely unlikely to happen because network latency makes view sync take long enough that each node would timeout on their own.  In tests there is effectively no latency and each node is competing with each other for time to execute so they get slightly out of sync but are able to process events vary fast.  The precise sequence I observed was:

- 12 nodes total, 2 of them completely offline, the two offline are consecutive leaders
- Everyone times out because they can't send to the first bad leader.  
- 5-8 nodes are slightly ahead of the remaining 2-5 online nodes.
- The 5-8 nodes ahead timeout a little before the rest.
- The 5-8 nodes timeout and send their votes to the next leader (This is not enough for a quorum)
- The ahead nodes enter view sync and quickly form precommit
- At this point the remaining nodes (still waiting to for their timer to expire) send votes to form a commit
- Everyone sees this commit and moves to the next view which has a good leader.
- The lagging nodes cancel their timeout task for the previous view, thus never sending a timeout cert
- The honest leader of the view everyone just entered can't form a valid proposal because they don't have a QC or TC from the last view.

It's worth noting that the lagging here only needs to be a just long enough to complete two rounds of viewsync
Also this shows up much more often on tokio, most likely because the executor doesn't share time as evenly between all the nodes, allowing them to get further adrift from each other.

Finally if we hit this case in production it would not be a big deal, one honest leader wouldn't propose, the next leader would get a TC and everything would be normal again.

### This PR does not: 

This really isn't a proper fix, but to do that we'd need to send the `ViewSyncFinalizedCertRecv` event to consensus and allow it to be attached to a proposal, then we'd have to add a check during proposal verification for this cert as well.

I opted for the hackier fix because the task refactoring is about to start, so it would just be overwritten anyway.

### Key places to review: 

everything changed, if CI fails then something else is wrong.
