### PR TITLE
Remove unused TaskError structs

### DIFF
--- a/crates/task-impls/src/consensus.rs
+++ b/crates/task-impls/src/consensus.rs
@@ -39,7 +39,6 @@ use tracing::warn;
 
 use crate::vote::HandleVoteEvent;
 use chrono::Utc;
-use snafu::Snafu;
 use std::{
     collections::{BTreeMap, HashSet},
     marker::PhantomData,
@@ -48,10 +47,6 @@ use std::{
 #[cfg(async_executor_impl = "tokio")]
 use tokio::task::JoinHandle;
 use tracing::{debug, error, info, instrument};
-
-/// Error returned by the consensus task
-#[derive(Snafu, Debug)]
-pub struct ConsensusTaskError {}
 
 /// Alias for the block payload commitment and the associated metadata.
 pub struct CommitmentAndMetadata<PAYLOAD: BlockPayload> {

--- a/crates/task-impls/src/da.rs
+++ b/crates/task-impls/src/da.rs
@@ -28,16 +28,11 @@ use hotshot_types::{
 use sha2::{Digest, Sha256};
 
 use crate::vote::HandleVoteEvent;
-use snafu::Snafu;
 use std::{marker::PhantomData, sync::Arc};
 use tracing::{debug, error, instrument, warn};
 
 /// Alias for Optional type for Vote Collectors
 type VoteCollectorOption<TYPES, VOTE, CERT> = Option<VoteCollectionTaskState<TYPES, VOTE, CERT>>;
-
-#[derive(Snafu, Debug)]
-/// Error type for consensus tasks
-pub struct ConsensusTaskError {}
 
 /// Tracks state of a DA task
 pub struct DATaskState<

--- a/crates/task-impls/src/transactions.rs
+++ b/crates/task-impls/src/transactions.rs
@@ -25,7 +25,6 @@ use hotshot_types::{
     },
 };
 use hotshot_utils::bincode::bincode_opts;
-use snafu::Snafu;
 use std::{
     collections::{HashMap, HashSet},
     sync::Arc,
@@ -35,10 +34,6 @@ use tracing::{debug, error, instrument, warn};
 
 /// A type alias for `HashMap<Commitment<T>, T>`
 type CommitmentMap<T> = HashMap<Commitment<T>, T>;
-
-#[derive(Snafu, Debug)]
-/// Error type for consensus tasks
-pub struct ConsensusTaskError {}
 
 /// Tracks state of a Transaction task
 pub struct TransactionTaskState<

--- a/crates/task-impls/src/upgrade.rs
+++ b/crates/task-impls/src/upgrade.rs
@@ -21,16 +21,11 @@ use hotshot_types::{
 };
 
 use crate::vote::HandleVoteEvent;
-use snafu::Snafu;
 use std::sync::Arc;
 use tracing::{debug, error, instrument, warn};
 
 /// Alias for Optional type for Vote Collectors
 type VoteCollectorOption<TYPES, VOTE, CERT> = Option<VoteCollectionTaskState<TYPES, VOTE, CERT>>;
-
-#[derive(Snafu, Debug)]
-/// Error type for consensus tasks
-pub struct ConsensusTaskError {}
 
 /// Tracks state of a DA task
 pub struct UpgradeTaskState<

--- a/crates/task-impls/src/vid.rs
+++ b/crates/task-impls/src/vid.rs
@@ -25,14 +25,9 @@ use hotshot_types::{
 #[cfg(async_executor_impl = "tokio")]
 use tokio::task::spawn_blocking;
 
-use snafu::Snafu;
 use std::marker::PhantomData;
 use std::sync::Arc;
 use tracing::{debug, error, instrument, warn};
-
-#[derive(Snafu, Debug)]
-/// Error type for consensus tasks
-pub struct ConsensusTaskError {}
 
 /// Tracks state of a VID task
 pub struct VIDTaskState<

--- a/crates/task-impls/src/view_sync.rs
+++ b/crates/task-impls/src/view_sync.rs
@@ -35,7 +35,6 @@ use hotshot_types::{
         node_implementation::{ConsensusTime, NodeImplementation, NodeType},
     },
 };
-use snafu::Snafu;
 use std::{collections::BTreeMap, collections::HashMap, fmt::Debug, sync::Arc, time::Duration};
 #[cfg(async_executor_impl = "tokio")]
 use tokio::task::JoinHandle;
@@ -52,10 +51,6 @@ pub enum ViewSyncPhase {
     /// Finalize phase
     Finalize,
 }
-
-#[derive(Snafu, Debug)]
-/// Stub of a view sync error
-pub struct ViewSyncTaskError {}
 
 /// Type alias for a map from View Number to Relay to Vote Task
 type RelayMap<TYPES, VOTE, CERT> =

--- a/crates/task-impls/src/vote.rs
+++ b/crates/task-impls/src/vote.rs
@@ -21,12 +21,7 @@ use hotshot_types::{
     traits::{election::Membership, node_implementation::NodeType},
     vote::{Certificate, HasViewNumber, Vote, VoteAccumulator},
 };
-use snafu::Snafu;
 use tracing::{debug, error};
-
-#[derive(Snafu, Debug)]
-/// Stub of a vote error
-pub struct VoteTaskError {}
 
 /// Task state for collecting votes of one type and emiting a certificate
 pub struct VoteCollectionTaskState<


### PR DESCRIPTION
No linked issue.

### This PR: 
@shenkeyao pointed out that `ConsensusTaskError` in `upgrade.rs` was misnamed, and could probably be deleted anyway. This seems to be the case for the other tasks too.

The `***TaskError` structs are now removed, since they appear to be completely unused.

### This PR does not: 

### Key places to review: 
The task files in `task-impls`.
