### PR TITLE
[CHORE] Update Jellyfish

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1127,11 +1127,13 @@ dependencies = [
 
 [[package]]
 name = "blst"
-version = "0.3.10"
-source = "git+https://github.com/EspressoSystems/blst.git?branch=no-std#faefc7fcb21864aaf4f6f443636ce8924108fcbd"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c94087b935a822949d3291a9989ad2b2051ea141eda0fd4e478a75f6aa3e604b"
 dependencies = [
  "cc",
  "glob",
+ "threadpool",
  "zeroize",
 ]
 
@@ -3503,7 +3505,7 @@ checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 [[package]]
 name = "jf-plonk"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/EspressoSystems/jellyfish#d9c1b634a96256b9adf92f549fb87e0167adfae4"
+source = "git+https://github.com/EspressoSystems/jellyfish?tag=0.4.0#bffc0198a89c195e42f394a4acf2eebf1db8ad5b"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -3532,7 +3534,7 @@ dependencies = [
 [[package]]
 name = "jf-primitives"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/EspressoSystems/jellyfish#d9c1b634a96256b9adf92f549fb87e0167adfae4"
+source = "git+https://github.com/EspressoSystems/jellyfish?tag=0.4.0#bffc0198a89c195e42f394a4acf2eebf1db8ad5b"
 dependencies = [
  "anyhow",
  "ark-bls12-377",
@@ -3577,7 +3579,7 @@ dependencies = [
 [[package]]
 name = "jf-relation"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/EspressoSystems/jellyfish#d9c1b634a96256b9adf92f549fb87e0167adfae4"
+source = "git+https://github.com/EspressoSystems/jellyfish?tag=0.4.0#bffc0198a89c195e42f394a4acf2eebf1db8ad5b"
 dependencies = [
  "ark-bls12-377",
  "ark-bls12-381",
@@ -3603,7 +3605,7 @@ dependencies = [
 [[package]]
 name = "jf-utils"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/EspressoSystems/jellyfish#d9c1b634a96256b9adf92f549fb87e0167adfae4"
+source = "git+https://github.com/EspressoSystems/jellyfish?tag=0.4.0#bffc0198a89c195e42f394a4acf2eebf1db8ad5b"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -6727,6 +6729,15 @@ checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
 dependencies = [
  "cfg-if",
  "once_cell",
+]
+
+[[package]]
+name = "threadpool"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
+dependencies = [
+ "num_cpus",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,10 +61,10 @@ futures = "0.3.30"
 # https://github.com/EspressoSystems/HotShot/issues/1850
 generic-array = { version = "0.14.7", features = ["serde"] }
 
-jf-primitives = { git = "https://github.com/EspressoSystems/jellyfish" }
-jf-plonk = { git = "https://github.com/EspressoSystems/jellyfish" }
-jf-relation = { git = "https://github.com/EspressoSystems/jellyfish" }
-jf-utils = { git = "https://github.com/espressosystems/jellyfish" }
+jf-primitives = { git = "https://github.com/EspressoSystems/jellyfish", tag = "0.4.0" }
+jf-plonk = { git = "https://github.com/EspressoSystems/jellyfish", tag = "0.4.0" }
+jf-relation = { git = "https://github.com/EspressoSystems/jellyfish", tag = "0.4.0" }
+jf-utils = { git = "https://github.com/espressosystems/jellyfish", tag = "0.4.0" }
 libp2p-identity = "0.2"
 libp2p-networking = { path = "./crates/libp2p-networking", version = "0.1.0", default-features = false }
 libp2p-swarm-derive = { version = "0.34.1" }

--- a/crates/task-impls/src/vid.rs
+++ b/crates/task-impls/src/vid.rs
@@ -82,7 +82,9 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
 
                 // calculate vid shares
                 let vid_disperse = spawn_blocking(move || {
-                    let vid = VidScheme::new(chunk_size, num_quorum_committee, &srs).unwrap();
+                    let multiplicity = 1;
+                    let vid = VidScheme::new(chunk_size, num_quorum_committee, multiplicity, &srs)
+                        .unwrap();
                     vid.disperse(encoded_transactions.clone()).unwrap()
                 })
                 .await;

--- a/crates/testing/src/task_helpers.rs
+++ b/crates/testing/src/task_helpers.rs
@@ -371,6 +371,6 @@ pub fn vid_init<TYPES: NodeType>(
 
     // TODO <https://github.com/EspressoSystems/HotShot/issues/1686>
     let srs = hotshot_types::data::test_srs(num_committee);
-
-    VidScheme::new(chunk_size, num_committee, srs).unwrap()
+    let multiplicity = 1;
+    VidScheme::new(chunk_size, num_committee, multiplicity, srs).unwrap()
 }

--- a/crates/types/src/traits/block_contents.rs
+++ b/crates/types/src/traits/block_contents.rs
@@ -104,8 +104,8 @@ pub fn vid_commitment(
 
     // TODO <https://github.com/EspressoSystems/HotShot/issues/1686>
     let srs = test_srs(num_storage_nodes);
-
-    let vid = VidScheme::new(num_chunks, num_storage_nodes, srs).unwrap();
+    let multiplicity = 1;
+    let vid = VidScheme::new(num_chunks, num_storage_nodes, multiplicity, srs).unwrap();
     vid.commit_only(encoded_transactions).unwrap()
 }
 


### PR DESCRIPTION
* Pin to version (0.4.0)
* Update VID construction
* Brings in persistent merkle tree for use in sequencer