### PR TITLE
[TECH DEBT] Clean up header genesis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3505,7 +3505,7 @@ checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 [[package]]
 name = "jf-plonk"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/EspressoSystems/jellyfish?tag=0.4.0#bffc0198a89c195e42f394a4acf2eebf1db8ad5b"
+source = "git+https://github.com/EspressoSystems/jellyfish?tag=0.4.0#214227e0608c231cb55234809727723c2a6740c2"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -3534,7 +3534,7 @@ dependencies = [
 [[package]]
 name = "jf-primitives"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/EspressoSystems/jellyfish?tag=0.4.0#bffc0198a89c195e42f394a4acf2eebf1db8ad5b"
+source = "git+https://github.com/EspressoSystems/jellyfish?tag=0.4.0#214227e0608c231cb55234809727723c2a6740c2"
 dependencies = [
  "anyhow",
  "ark-bls12-377",
@@ -3579,7 +3579,7 @@ dependencies = [
 [[package]]
 name = "jf-relation"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/EspressoSystems/jellyfish?tag=0.4.0#bffc0198a89c195e42f394a4acf2eebf1db8ad5b"
+source = "git+https://github.com/EspressoSystems/jellyfish?tag=0.4.0#214227e0608c231cb55234809727723c2a6740c2"
 dependencies = [
  "ark-bls12-377",
  "ark-bls12-381",
@@ -3605,7 +3605,7 @@ dependencies = [
 [[package]]
 name = "jf-utils"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/EspressoSystems/jellyfish?tag=0.4.0#bffc0198a89c195e42f394a4acf2eebf1db8ad5b"
+source = "git+https://github.com/EspressoSystems/jellyfish?tag=0.4.0#214227e0608c231cb55234809727723c2a6740c2"
 dependencies = [
  "ark-ec",
  "ark-ff",

--- a/crates/example-types/src/block_types.rs
+++ b/crates/example-types/src/block_types.rs
@@ -5,9 +5,9 @@ use std::{
 
 use commit::{Commitment, Committable, RawCommitmentBuilder};
 use hotshot_types::{
-    data::{BlockError, VidCommitment, VidScheme, VidSchemeTrait},
+    data::{BlockError, VidCommitment},
     traits::{
-        block_contents::{vid_commitment, BlockHeader, TestableBlock, Transaction},
+        block_contents::{BlockHeader, TestableBlock, Transaction},
         BlockPayload, ValidatedState,
     },
     utils::BuilderCommitment,
@@ -170,16 +170,6 @@ impl BlockPayload for TestBlockPayload {
     }
 }
 
-/// Computes the (empty) genesis VID commitment
-/// The number of storage nodes does not do anything, unless in the future we add fake transactions
-/// to the genesis payload.
-///
-/// In that case, the payloads may mismatch and cause problems.
-#[must_use]
-pub fn genesis_vid_commitment() -> <VidScheme as VidSchemeTrait>::Commit {
-    vid_commitment(&vec![], 8)
-}
-
 /// A [`BlockHeader`] that commits to [`TestBlockPayload`].
 #[derive(PartialEq, Eq, Hash, Clone, Debug, Deserialize, Serialize)]
 pub struct TestBlockHeader {
@@ -208,20 +198,13 @@ impl BlockHeader for TestBlockHeader {
 
     fn genesis(
         _instance_state: &<Self::State as ValidatedState>::Instance,
-    ) -> (
-        Self,
-        Self::Payload,
-        <Self::Payload as BlockPayload>::Metadata,
-    ) {
-        let (payload, metadata) = <Self::Payload as BlockPayload>::genesis();
-        (
-            Self {
-                block_number: 0,
-                payload_commitment: genesis_vid_commitment(),
-            },
-            payload,
-            metadata,
-        )
+        payload_commitment: VidCommitment,
+        _metadata: <Self::Payload as BlockPayload>::Metadata,
+    ) -> Self {
+        Self {
+            block_number: 0,
+            payload_commitment,
+        }
     }
 
     fn block_number(&self) -> u64 {

--- a/crates/example-types/src/state_types.rs
+++ b/crates/example-types/src/state_types.rs
@@ -17,7 +17,7 @@ use crate::block_types::{TestBlockHeader, TestBlockPayload};
 pub use crate::node_types::TestTypes;
 
 /// Instance-level state implementation for testing purposes.
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct TestInstanceState {}
 
 impl InstanceState for TestInstanceState {}
@@ -84,6 +84,10 @@ impl ValidatedState for TestValidatedState {
     }
 
     fn on_commit(&self) {}
+
+    fn genesis(_instance: &Self::Instance) -> Self {
+        Self::default()
+    }
 }
 
 impl TestableState for TestValidatedState {

--- a/crates/hotshot/src/traits/networking/combined_network.rs
+++ b/crates/hotshot/src/traits/networking/combined_network.rs
@@ -317,9 +317,7 @@ impl<TYPES: NodeType> ConnectedNetwork<Message<TYPES>, TYPES::SignatureKey>
         self.secondary().direct_message(message, recipient).await
     }
 
-    fn recv_msgs<'a, 'b>(
-        &'a self,
-    ) -> BoxSyncFuture<'b, Result<Vec<Message<TYPES>>, NetworkError>>
+    fn recv_msgs<'a, 'b>(&'a self) -> BoxSyncFuture<'b, Result<Vec<Message<TYPES>>, NetworkError>>
     where
         'a: 'b,
         Self: 'b,

--- a/crates/hotshot/src/traits/networking/libp2p_network.rs
+++ b/crates/hotshot/src/traits/networking/libp2p_network.rs
@@ -558,10 +558,7 @@ impl<M: NetworkMsg, K: SignatureKey + 'static> Libp2pNetwork<M, K> {
 
     /// task to propagate messages to handlers
     /// terminates on shut down of network
-    fn handle_event_generator(
-        &self,
-        sender: UnboundedSender<M>,
-    ) {
+    fn handle_event_generator(&self, sender: UnboundedSender<M>) {
         let handle = self.clone();
         let is_bootstrapped = self.inner.is_bootstrapped.clone();
         async_spawn(async move {
@@ -574,9 +571,7 @@ impl<M: NetworkMsg, K: SignatureKey + 'static> Libp2pNetwork<M, K> {
                         let message_version = read_version(raw);
                         match message_version {
                             Some(VERSION_0_1) => {
-                                let _ = handle
-                                    .handle_recvd_events_0_1(message, &sender)
-                                    .await;
+                                let _ = handle.handle_recvd_events_0_1(message, &sender).await;
                             }
                             Some(version) => {
                                 warn!(
@@ -819,9 +814,7 @@ impl<M: NetworkMsg, K: SignatureKey + 'static> ConnectedNetwork<M, K> for Libp2p
     }
 
     #[instrument(name = "Libp2pNetwork::recv_msgs", skip_all)]
-    fn recv_msgs<'a, 'b>(
-        &'a self,
-    ) -> BoxSyncFuture<'b, Result<Vec<M>, NetworkError>>
+    fn recv_msgs<'a, 'b>(&'a self) -> BoxSyncFuture<'b, Result<Vec<M>, NetworkError>>
     where
         'a: 'b,
         Self: 'b,
@@ -836,10 +829,7 @@ impl<M: NetworkMsg, K: SignatureKey + 'static> ConnectedNetwork<M, K> for Libp2p
                     .drain_at_least_one()
                     .await
                     .map_err(|_x| NetworkError::ShutDown)?;
-                self.inner
-                    .metrics
-                    .incoming_message_count
-                    .add(result.len());
+                self.inner.metrics.incoming_message_count.add(result.len());
                 Ok(result)
             }
         };

--- a/crates/hotshot/src/traits/networking/memory_network.rs
+++ b/crates/hotshot/src/traits/networking/memory_network.rs
@@ -6,13 +6,13 @@
 use super::{FailedToSerializeSnafu, NetworkError, NetworkReliability, NetworkingMetricsValue};
 use async_compatibility_layer::{
     art::async_spawn,
-    channel::{bounded, Receiver, SendError, Sender, BoundedStream},
+    channel::{bounded, BoundedStream, Receiver, SendError, Sender},
 };
 use async_lock::{Mutex, RwLock};
 use async_trait::async_trait;
 use bincode::Options;
 use dashmap::DashMap;
-use futures::{StreamExt};
+use futures::StreamExt;
 use hotshot_types::{
     boxed_sync,
     message::Message,
@@ -352,9 +352,7 @@ impl<M: NetworkMsg, K: SignatureKey + 'static> ConnectedNetwork<M, K> for Memory
     }
 
     #[instrument(name = "MemoryNetwork::recv_msgs", skip_all)]
-    fn recv_msgs<'a, 'b>(
-        &'a self,
-    ) -> BoxSyncFuture<'b, Result<Vec<M>, NetworkError>>
+    fn recv_msgs<'a, 'b>(&'a self) -> BoxSyncFuture<'b, Result<Vec<M>, NetworkError>>
     where
         'a: 'b,
         Self: 'b,
@@ -371,10 +369,7 @@ impl<M: NetworkMsg, K: SignatureKey + 'static> ConnectedNetwork<M, K> for Memory
             self.inner
                 .in_flight_message_count
                 .fetch_sub(ret.len(), Ordering::Relaxed);
-            self.inner
-                .metrics
-                .incoming_message_count
-                .add(ret.len());
+            self.inner.metrics.incoming_message_count.add(ret.len());
             Ok(ret)
         };
         boxed_sync(closure)

--- a/crates/hotshot/src/traits/networking/web_server_network.rs
+++ b/crates/hotshot/src/traits/networking/web_server_network.rs
@@ -229,10 +229,7 @@ impl<TYPES: NodeType> Inner<TYPES> {
             let deserialized_message = RecvMsg {
                 message: Some(deserialized_message_inner),
             };
-            poll_queue
-                .write()
-                .await
-                .push(deserialized_message.clone());
+            poll_queue.write().await.push(deserialized_message.clone());
         } else {
             async_sleep(self.wait_between_polls).await;
         }
@@ -290,7 +287,9 @@ impl<TYPES: NodeType> Inner<TYPES> {
                     }
                     return false;
                 }
-                MessagePurpose::Vote | MessagePurpose::ViewSyncVote | MessagePurpose::ViewSyncCertificate => {
+                MessagePurpose::Vote
+                | MessagePurpose::ViewSyncVote
+                | MessagePurpose::ViewSyncCertificate => {
                     let vote = deserialized_message.clone();
                     *vote_index += 1;
                     poll_queue.write().await.push(vote);
@@ -302,10 +301,7 @@ impl<TYPES: NodeType> Inner<TYPES> {
                         "Received DAC from web server for view {} {}",
                         view_number, self.is_da
                     );
-                    poll_queue
-                        .write()
-                        .await
-                        .push(deserialized_message.clone());
+                    poll_queue.write().await.push(deserialized_message.clone());
 
                     // Only pushing the first proposal since we will soon only be allowing 1 proposal per view
                     // return if we found a DAC, since there will only be 1 per view
@@ -331,10 +327,7 @@ impl<TYPES: NodeType> Inner<TYPES> {
                 }
 
                 MessagePurpose::Upgrade => {
-                    poll_queue
-                        .write()
-                        .await
-                        .push(deserialized_message.clone());
+                    poll_queue.write().await.push(deserialized_message.clone());
 
                     return true;
                 }
@@ -851,9 +844,7 @@ impl<TYPES: NodeType + 'static> ConnectedNetwork<Message<TYPES>, TYPES::Signatur
     ///
     /// Will unwrap the underlying `NetworkMessage`
     /// blocking
-    fn recv_msgs<'a, 'b>(
-        &'a self,
-    ) -> BoxSyncFuture<'b, Result<Vec<Message<TYPES>>, NetworkError>>
+    fn recv_msgs<'a, 'b>(&'a self) -> BoxSyncFuture<'b, Result<Vec<Message<TYPES>>, NetworkError>>
     where
         'a: 'b,
         Self: 'b,

--- a/crates/testing/tests/memory_network.rs
+++ b/crates/testing/tests/memory_network.rs
@@ -17,8 +17,8 @@ use hotshot_example_types::{
 };
 use hotshot_types::message::Message;
 use hotshot_types::signature_key::BLSPubKey;
-use hotshot_types::traits::network::TestableNetworkingImplementation;
 use hotshot_types::traits::network::ConnectedNetwork;
+use hotshot_types::traits::network::TestableNetworkingImplementation;
 use hotshot_types::traits::node_implementation::{ConsensusTime, NodeType};
 use hotshot_types::{
     data::ViewNumber,

--- a/crates/types/src/data.rs
+++ b/crates/types/src/data.rs
@@ -7,7 +7,9 @@ use crate::{
     simple_certificate::{QuorumCertificate, TimeoutCertificate, UpgradeCertificate},
     simple_vote::UpgradeProposalData,
     traits::{
-        block_contents::{vid_commitment, BlockHeader, TestableBlock},
+        block_contents::{
+            vid_commitment, BlockHeader, TestableBlock, GENESIS_VID_NUM_STORAGE_NODES,
+        },
         election::Membership,
         node_implementation::{ConsensusTime, NodeType},
         signature_key::SignatureKey,
@@ -330,15 +332,27 @@ impl<TYPES: NodeType> Display for Leaf<TYPES> {
 
 impl<TYPES: NodeType> Leaf<TYPES> {
     /// Create a new leaf from its components.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the genesis payload (`TYPES::BlockPayload::genesis()`) is malformed (unable to be
+    /// interpreted as bytes).
     #[must_use]
     pub fn genesis(instance_state: &TYPES::InstanceState) -> Self {
-        let (block_header, block_payload, _) = TYPES::BlockHeader::genesis(instance_state);
+        let (payload, metadata) = TYPES::BlockPayload::genesis();
+        let payload_bytes = payload
+            .encode()
+            .expect("unable to encode genesis payload")
+            .collect();
+        let payload_commitment = vid_commitment(&payload_bytes, GENESIS_VID_NUM_STORAGE_NODES);
+        let block_header =
+            TYPES::BlockHeader::genesis(instance_state, payload_commitment, metadata);
         Self {
             view_number: TYPES::Time::genesis(),
             justify_qc: QuorumCertificate::<TYPES>::genesis(),
             parent_commitment: fake_commitment(),
             block_header: block_header.clone(),
-            block_payload: Some(block_payload),
+            block_payload: Some(payload),
             proposer_id: <<TYPES as NodeType>::SignatureKey as SignatureKey>::genesis_proposer_pk(),
         }
     }

--- a/crates/types/src/traits/block_contents.rs
+++ b/crates/types/src/traits/block_contents.rs
@@ -109,6 +109,12 @@ pub fn vid_commitment(
     vid.commit_only(encoded_transactions).unwrap()
 }
 
+/// The number of storage nodes to use when computing the genesis VID commitment.
+///
+/// The number of storage nodes for the genesis VID commitment is arbitrary, since we don't actually
+/// do dispersal for the genesis block. For simplicity and performance, we use 1.
+pub const GENESIS_VID_NUM_STORAGE_NODES: usize = 1;
+
 /// Header of a block, which commits to a [`BlockPayload`].
 pub trait BlockHeader:
     Serialize + Clone + Debug + Hash + PartialEq + Eq + Send + Sync + DeserializeOwned + Committable
@@ -132,11 +138,9 @@ pub trait BlockHeader:
     /// Build the genesis header, payload, and metadata.
     fn genesis(
         instance_state: &<Self::State as ValidatedState>::Instance,
-    ) -> (
-        Self,
-        Self::Payload,
-        <Self::Payload as BlockPayload>::Metadata,
-    );
+        payload_commitment: VidCommitment,
+        metadata: <Self::Payload as BlockPayload>::Metadata,
+    ) -> Self;
 
     /// Get the block number.
     fn block_number(&self) -> u64;

--- a/crates/types/src/traits/network.rs
+++ b/crates/types/src/traits/network.rs
@@ -281,9 +281,7 @@ pub trait ConnectedNetwork<M: NetworkMsg, K: SignatureKey + 'static>:
     ///
     /// Will unwrap the underlying `NetworkMessage`
     /// blocking
-    fn recv_msgs<'a, 'b>(
-        &'a self,
-    ) -> BoxSyncFuture<'b, Result<Vec<M>, NetworkError>>
+    fn recv_msgs<'a, 'b>(&'a self) -> BoxSyncFuture<'b, Result<Vec<M>, NetworkError>>
     where
         'a: 'b,
         Self: 'b;

--- a/crates/types/src/traits/states.rs
+++ b/crates/types/src/traits/states.rs
@@ -59,9 +59,7 @@ pub trait ValidatedState:
 
     /// Construct a genesis validated state.
     #[must_use]
-    fn genesis(instance: &Self::Instance) -> Self {
-        Self::from_header(&Self::BlockHeader::genesis(instance).0)
-    }
+    fn genesis(instance: &Self::Instance) -> Self;
 
     /// Gets called to notify the persistence backend that this state has been committed
     fn on_commit(&self);


### PR DESCRIPTION
Previously, `Header::genesis` was required to also return a payload and metadata. This is redundant, because we also have `Payload::genesis`. In addition, `Header::genesis` was expected to compute a genesis VID commitment, since a VID commitment is required to construct a header. This breaks abstraction, since in all other cases only HotShot computes VID stuff, never the application. It is also error prone: I am adding a feature to the query service to handle the genesis VID case, where we don't receive VID data from HotShot. This feature requires that the genesis VID is computed uniformly regardless of the application. Currently, we use 8 storage nodes for this commitment in the HotShot example types (quite arbitrarily) and 1 in the sequencer types. This change standardizes the computation of the genesis VID commitment.
