### PR TITLE
Fix cargo fmt check on CI

### DIFF
--- a/crates/hotshot/src/traits/networking/combined_network.rs
+++ b/crates/hotshot/src/traits/networking/combined_network.rs
@@ -317,9 +317,7 @@ impl<TYPES: NodeType> ConnectedNetwork<Message<TYPES>, TYPES::SignatureKey>
         self.secondary().direct_message(message, recipient).await
     }
 
-    fn recv_msgs<'a, 'b>(
-        &'a self,
-    ) -> BoxSyncFuture<'b, Result<Vec<Message<TYPES>>, NetworkError>>
+    fn recv_msgs<'a, 'b>(&'a self) -> BoxSyncFuture<'b, Result<Vec<Message<TYPES>>, NetworkError>>
     where
         'a: 'b,
         Self: 'b,

--- a/crates/hotshot/src/traits/networking/libp2p_network.rs
+++ b/crates/hotshot/src/traits/networking/libp2p_network.rs
@@ -558,10 +558,7 @@ impl<M: NetworkMsg, K: SignatureKey + 'static> Libp2pNetwork<M, K> {
 
     /// task to propagate messages to handlers
     /// terminates on shut down of network
-    fn handle_event_generator(
-        &self,
-        sender: UnboundedSender<M>,
-    ) {
+    fn handle_event_generator(&self, sender: UnboundedSender<M>) {
         let handle = self.clone();
         let is_bootstrapped = self.inner.is_bootstrapped.clone();
         async_spawn(async move {
@@ -574,9 +571,7 @@ impl<M: NetworkMsg, K: SignatureKey + 'static> Libp2pNetwork<M, K> {
                         let message_version = read_version(raw);
                         match message_version {
                             Some(VERSION_0_1) => {
-                                let _ = handle
-                                    .handle_recvd_events_0_1(message, &sender)
-                                    .await;
+                                let _ = handle.handle_recvd_events_0_1(message, &sender).await;
                             }
                             Some(version) => {
                                 warn!(
@@ -819,9 +814,7 @@ impl<M: NetworkMsg, K: SignatureKey + 'static> ConnectedNetwork<M, K> for Libp2p
     }
 
     #[instrument(name = "Libp2pNetwork::recv_msgs", skip_all)]
-    fn recv_msgs<'a, 'b>(
-        &'a self,
-    ) -> BoxSyncFuture<'b, Result<Vec<M>, NetworkError>>
+    fn recv_msgs<'a, 'b>(&'a self) -> BoxSyncFuture<'b, Result<Vec<M>, NetworkError>>
     where
         'a: 'b,
         Self: 'b,
@@ -836,10 +829,7 @@ impl<M: NetworkMsg, K: SignatureKey + 'static> ConnectedNetwork<M, K> for Libp2p
                     .drain_at_least_one()
                     .await
                     .map_err(|_x| NetworkError::ShutDown)?;
-                self.inner
-                    .metrics
-                    .incoming_message_count
-                    .add(result.len());
+                self.inner.metrics.incoming_message_count.add(result.len());
                 Ok(result)
             }
         };

--- a/crates/hotshot/src/traits/networking/memory_network.rs
+++ b/crates/hotshot/src/traits/networking/memory_network.rs
@@ -6,13 +6,13 @@
 use super::{FailedToSerializeSnafu, NetworkError, NetworkReliability, NetworkingMetricsValue};
 use async_compatibility_layer::{
     art::async_spawn,
-    channel::{bounded, Receiver, SendError, Sender, BoundedStream},
+    channel::{bounded, BoundedStream, Receiver, SendError, Sender},
 };
 use async_lock::{Mutex, RwLock};
 use async_trait::async_trait;
 use bincode::Options;
 use dashmap::DashMap;
-use futures::{StreamExt};
+use futures::StreamExt;
 use hotshot_types::{
     boxed_sync,
     message::Message,
@@ -352,9 +352,7 @@ impl<M: NetworkMsg, K: SignatureKey + 'static> ConnectedNetwork<M, K> for Memory
     }
 
     #[instrument(name = "MemoryNetwork::recv_msgs", skip_all)]
-    fn recv_msgs<'a, 'b>(
-        &'a self,
-    ) -> BoxSyncFuture<'b, Result<Vec<M>, NetworkError>>
+    fn recv_msgs<'a, 'b>(&'a self) -> BoxSyncFuture<'b, Result<Vec<M>, NetworkError>>
     where
         'a: 'b,
         Self: 'b,
@@ -371,10 +369,7 @@ impl<M: NetworkMsg, K: SignatureKey + 'static> ConnectedNetwork<M, K> for Memory
             self.inner
                 .in_flight_message_count
                 .fetch_sub(ret.len(), Ordering::Relaxed);
-            self.inner
-                .metrics
-                .incoming_message_count
-                .add(ret.len());
+            self.inner.metrics.incoming_message_count.add(ret.len());
             Ok(ret)
         };
         boxed_sync(closure)

--- a/crates/hotshot/src/traits/networking/web_server_network.rs
+++ b/crates/hotshot/src/traits/networking/web_server_network.rs
@@ -229,10 +229,7 @@ impl<TYPES: NodeType> Inner<TYPES> {
             let deserialized_message = RecvMsg {
                 message: Some(deserialized_message_inner),
             };
-            poll_queue
-                .write()
-                .await
-                .push(deserialized_message.clone());
+            poll_queue.write().await.push(deserialized_message.clone());
         } else {
             async_sleep(self.wait_between_polls).await;
         }
@@ -290,7 +287,9 @@ impl<TYPES: NodeType> Inner<TYPES> {
                     }
                     return false;
                 }
-                MessagePurpose::Vote | MessagePurpose::ViewSyncVote | MessagePurpose::ViewSyncCertificate => {
+                MessagePurpose::Vote
+                | MessagePurpose::ViewSyncVote
+                | MessagePurpose::ViewSyncCertificate => {
                     let vote = deserialized_message.clone();
                     *vote_index += 1;
                     poll_queue.write().await.push(vote);
@@ -302,10 +301,7 @@ impl<TYPES: NodeType> Inner<TYPES> {
                         "Received DAC from web server for view {} {}",
                         view_number, self.is_da
                     );
-                    poll_queue
-                        .write()
-                        .await
-                        .push(deserialized_message.clone());
+                    poll_queue.write().await.push(deserialized_message.clone());
 
                     // Only pushing the first proposal since we will soon only be allowing 1 proposal per view
                     // return if we found a DAC, since there will only be 1 per view
@@ -331,10 +327,7 @@ impl<TYPES: NodeType> Inner<TYPES> {
                 }
 
                 MessagePurpose::Upgrade => {
-                    poll_queue
-                        .write()
-                        .await
-                        .push(deserialized_message.clone());
+                    poll_queue.write().await.push(deserialized_message.clone());
 
                     return true;
                 }
@@ -851,9 +844,7 @@ impl<TYPES: NodeType + 'static> ConnectedNetwork<Message<TYPES>, TYPES::Signatur
     ///
     /// Will unwrap the underlying `NetworkMessage`
     /// blocking
-    fn recv_msgs<'a, 'b>(
-        &'a self,
-    ) -> BoxSyncFuture<'b, Result<Vec<Message<TYPES>>, NetworkError>>
+    fn recv_msgs<'a, 'b>(&'a self) -> BoxSyncFuture<'b, Result<Vec<Message<TYPES>>, NetworkError>>
     where
         'a: 'b,
         Self: 'b,

--- a/crates/testing/tests/memory_network.rs
+++ b/crates/testing/tests/memory_network.rs
@@ -17,8 +17,8 @@ use hotshot_example_types::{
 };
 use hotshot_types::message::Message;
 use hotshot_types::signature_key::BLSPubKey;
-use hotshot_types::traits::network::TestableNetworkingImplementation;
 use hotshot_types::traits::network::ConnectedNetwork;
+use hotshot_types::traits::network::TestableNetworkingImplementation;
 use hotshot_types::traits::node_implementation::{ConsensusTime, NodeType};
 use hotshot_types::{
     data::ViewNumber,

--- a/crates/types/src/traits/network.rs
+++ b/crates/types/src/traits/network.rs
@@ -281,9 +281,7 @@ pub trait ConnectedNetwork<M: NetworkMsg, K: SignatureKey + 'static>:
     ///
     /// Will unwrap the underlying `NetworkMessage`
     /// blocking
-    fn recv_msgs<'a, 'b>(
-        &'a self,
-    ) -> BoxSyncFuture<'b, Result<Vec<M>, NetworkError>>
+    fn recv_msgs<'a, 'b>(&'a self) -> BoxSyncFuture<'b, Result<Vec<M>, NetworkError>>
     where
         'a: 'b,
         Self: 'b;

--- a/justfile
+++ b/justfile
@@ -114,12 +114,14 @@ check:
   echo Checking
   cargo check --workspace --bins --tests --examples
 
-lint: fmt
+lint: 
   echo linting
+  cargo fmt --check
   cargo clippy --workspace --examples --bins --tests -- -D warnings
 
-lint_release: fmt
+lint_release: 
   echo linting
+  cargo fmt --check
   cargo clippy --package hotshot --no-default-features --features="docs, doc-images" -- -D warnings
 
 fmt:


### PR DESCRIPTION
No linked issue.

### This PR: 
Causes `just lint` to error if `cargo fmt` would have made any changes. CI should now fail if files have not been formatted.

### This PR does not: 

### Key places to review: 
