### PR TITLE
Make `BlockHeader::new()` and `validate_and_apply_header()` async

### DIFF
--- a/crates/example-types/src/block_types.rs
+++ b/crates/example-types/src/block_types.rs
@@ -184,7 +184,7 @@ impl BlockHeader for TestBlockHeader {
     type Payload = TestBlockPayload;
     type State = TestValidatedState;
 
-    fn new(
+    async fn new(
         _parent_state: &Self::State,
         _instance_state: &<Self::State as ValidatedState>::Instance,
         parent_header: &Self,

--- a/crates/example-types/src/state_types.rs
+++ b/crates/example-types/src/state_types.rs
@@ -64,7 +64,7 @@ impl ValidatedState for TestValidatedState {
 
     type Time = ViewNumber;
 
-    fn validate_and_apply_header(
+    async fn validate_and_apply_header(
         &self,
         _instance: &Self::Instance,
         _parent_header: &Self::BlockHeader,

--- a/crates/task-impls/src/consensus.rs
+++ b/crates/task-impls/src/consensus.rs
@@ -616,11 +616,14 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
 
                     return;
                 };
-                let Ok(state) = parent_state.validate_and_apply_header(
-                    &consensus.instance_state,
-                    &parent_leaf.block_header.clone(),
-                    &proposal.data.block_header.clone(),
-                ) else {
+                let Ok(state) = parent_state
+                    .validate_and_apply_header(
+                        &consensus.instance_state,
+                        &parent_leaf.block_header.clone(),
+                        &proposal.data.block_header.clone(),
+                    )
+                    .await
+                else {
                     error!("Block header doesn't extend the proposal",);
                     return;
                 };
@@ -1298,7 +1301,8 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                 &parent_header,
                 commit_and_metadata.commitment,
                 commit_and_metadata.metadata.clone(),
-            );
+            )
+            .await;
             let leaf = Leaf {
                 view_number: view,
                 justify_qc: consensus.high_qc.clone(),

--- a/crates/testing/src/task_helpers.rs
+++ b/crates/testing/src/task_helpers.rs
@@ -242,7 +242,8 @@ async fn build_quorum_proposal_and_signature(
         &parent_leaf.block_header,
         payload_commitment,
         (),
-    );
+    )
+    .await;
     // current leaf that can be re-assigned everytime when entering a new view
     let mut leaf = Leaf {
         view_number: ViewNumber::new(1),
@@ -269,6 +270,7 @@ async fn build_quorum_proposal_and_signature(
         let state_new_view = Arc::new(
             parent_state
                 .validate_and_apply_header(&TestInstanceState {}, &block_header, &block_header)
+                .await
                 .unwrap(),
         );
         // save states for the previous view to pass all the qc checks

--- a/crates/types/src/traits/block_contents.rs
+++ b/crates/types/src/traits/block_contents.rs
@@ -15,6 +15,7 @@ use serde::{de::DeserializeOwned, Serialize};
 use std::{
     error::Error,
     fmt::{Debug, Display},
+    future::Future,
     hash::Hash,
 };
 
@@ -130,7 +131,7 @@ pub trait BlockHeader:
         parent_header: &Self,
         payload_commitment: VidCommitment,
         metadata: <Self::Payload as BlockPayload>::Metadata,
-    ) -> Self;
+    ) -> impl Future<Output = Self> + Send;
 
     /// Build the genesis header, payload, and metadata.
     fn genesis(

--- a/crates/types/src/traits/states.rs
+++ b/crates/types/src/traits/states.rs
@@ -7,7 +7,7 @@
 use super::block_contents::{BlockHeader, TestableBlock};
 use crate::traits::{node_implementation::ConsensusTime, BlockPayload};
 use serde::{de::DeserializeOwned, Serialize};
-use std::{error::Error, fmt::Debug, hash::Hash};
+use std::{error::Error, fmt::Debug, future::Future, hash::Hash};
 
 /// Instance-level state, which allows us to fetch missing validated state.
 pub trait InstanceState: Clone + Debug + Send + Sync {}
@@ -50,7 +50,7 @@ pub trait ValidatedState:
         instance: &Self::Instance,
         parent_header: &Self::BlockHeader,
         proposed_header: &Self::BlockHeader,
-    ) -> Result<Self, Self::Error>;
+    ) -> impl Future<Output = Result<Self, Self::Error>> + Send;
 
     /// Construct the state with the given block header.
     ///


### PR DESCRIPTION
Closes #2620 

### This PR: 

Makes 2 trait functions async for the Sequencer:
`BlockHeader::new` and `ValidatedState::validate_and_apply_header`

### This PR does not: 

No functional changes

### Key places to review: 

Changes to the 2 traits
