### PR TITLE
Cache async-std and tokio builds separately

### DIFF
--- a/.github/workflows/build-and-test-self-hosted.yml
+++ b/.github/workflows/build-and-test-self-hosted.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         just_variants:
-          - async_std
+          - async-std
           #- tokio
     runs-on: [self-hosted]
     steps:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -51,13 +51,6 @@ jobs:
       - name: Build HotShot in release mode
         run: just ${{ matrix.just_variants }} build_release
 
-      - name: Unit and integration tests for all crates in workspace
-        run: |
-          just ${{ matrix.just_variants }} test
-        timeout-minutes: 60
-        env:
-          RUST_BACKTRACE: full
-
       - name: Upload Binaries
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -190,6 +190,8 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.orchestrator-libp2p.outputs.tags }}
           labels: ${{ steps.orchestrator-libp2p.outputs.labels }}
+          build-args: |
+            ASYNC_EXECUTOR=${{ matrix.just_variants }}
 
       - name: Build and push validator-libp2p docker
         uses: docker/build-push-action@v5
@@ -200,6 +202,8 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.validator-libp2p.outputs.tags }}
           labels: ${{ steps.validator-libp2p.outputs.labels }}
+          build-args: |
+            ASYNC_EXECUTOR=${{ matrix.just_variants }}
 
       - name: Build and push webserver docker
         uses: docker/build-push-action@v5
@@ -210,6 +214,8 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.webserver.outputs.tags }}
           labels: ${{ steps.webserver.outputs.labels }}
+          build-args: |
+            ASYNC_EXECUTOR=${{ matrix.just_variants }}
 
       - name: Build and push orchestrator-webserver docker
         uses: docker/build-push-action@v5
@@ -220,6 +226,8 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.orchestrator-webserver.outputs.tags }}
           labels: ${{ steps.orchestrator-webserver.outputs.labels }}
+          build-args: |
+            ASYNC_EXECUTOR=${{ matrix.just_variants }}
 
       - name: Build and push validator-webserver docker
         uses: docker/build-push-action@v5
@@ -230,6 +238,8 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.validator-webserver.outputs.tags }}
           labels: ${{ steps.validator-webserver.outputs.labels }}
+          build-args: |
+            ASYNC_EXECUTOR=${{ matrix.just_variants }}
 
   test-crypto:
     strategy:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         just_variants:
-          - async_std
+          - async-std
           - tokio
     runs-on: ubuntu-latest
     steps:
@@ -63,21 +63,21 @@ jobs:
         with:
           name: binaries-amd64-${{ matrix.just_variants }}
           path: |
-            target/debug/examples/counter
-            target/debug/examples/multi-validator-libp2p
-            target/debug/examples/orchestrator-libp2p
-            target/debug/examples/validator-libp2p
-            target/debug/examples/multi-validator-webserver
-            target/debug/examples/multi-webserver
-            target/debug/examples/webserver
-            target/debug/examples/orchestrator-webserver
-            target/debug/examples/validator-webserver
+            target/${{ matrix.just_variants }}/debug/examples/counter
+            target/${{ matrix.just_variants }}/debug/examples/multi-validator-libp2p
+            target/${{ matrix.just_variants }}/debug/examples/orchestrator-libp2p
+            target/${{ matrix.just_variants }}/debug/examples/validator-libp2p
+            target/${{ matrix.just_variants }}/debug/examples/multi-validator-webserver
+            target/${{ matrix.just_variants }}/debug/examples/multi-webserver
+            target/${{ matrix.just_variants }}/debug/examples/webserver
+            target/${{ matrix.just_variants }}/debug/examples/orchestrator-webserver
+            target/${{ matrix.just_variants }}/debug/examples/validator-webserver
 
   build-arm:
     strategy:
       matrix:
         just_variants:
-          - async_std
+          - async-std
           - tokio
     runs-on: [self-hosted, arm64]
     steps:
@@ -101,21 +101,21 @@ jobs:
         with:
           name: binaries-aarch64-${{ matrix.just_variants }}
           path: |
-            target/debug/examples/counter
-            target/debug/examples/multi-validator-libp2p
-            target/debug/examples/orchestrator-libp2p
-            target/debug/examples/validator-libp2p
-            target/debug/examples/multi-validator-webserver
-            target/debug/examples/multi-webserver
-            target/debug/examples/webserver
-            target/debug/examples/orchestrator-webserver
-            target/debug/examples/validator-webserver
+            target/${{ matrix.just_variants }}/debug/examples/counter
+            target/${{ matrix.just_variants }}/debug/examples/multi-validator-libp2p
+            target/${{ matrix.just_variants }}/debug/examples/orchestrator-libp2p
+            target/${{ matrix.just_variants }}/debug/examples/validator-libp2p
+            target/${{ matrix.just_variants }}/debug/examples/multi-validator-webserver
+            target/${{ matrix.just_variants }}/debug/examples/multi-webserver
+            target/${{ matrix.just_variants }}/debug/examples/webserver
+            target/${{ matrix.just_variants }}/debug/examples/orchestrator-webserver
+            target/${{ matrix.just_variants }}/debug/examples/validator-webserver
 
   build-dockers:
     strategy:
       matrix:
         just_variants:
-          - async_std
+          - async-std
           - tokio
     runs-on: ubuntu-latest
     needs: [build-and-test, build-arm]
@@ -138,13 +138,13 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: binaries-amd64-${{ matrix.just_variants }}
-          path: target/amd64/debug/examples
+          path: target/${{ matrix.just_variants }}/amd64/debug/examples
 
       - name: Download executables ARM
         uses: actions/download-artifact@v4
         with:
           name: binaries-aarch64-${{ matrix.just_variants }}
-          path: target/arm64/debug/examples
+          path: target/${{ matrix.just_variants }}/arm64/debug/examples
 
       - name: Generate orchestrator-libp2p docker metadata
         uses: docker/metadata-action@v5
@@ -235,7 +235,7 @@ jobs:
     strategy:
       matrix:
         just_variants:
-          - async_std
+          - async-std
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -51,6 +51,13 @@ jobs:
       - name: Build HotShot in release mode
         run: just ${{ matrix.just_variants }} build_release
 
+      - name: Unit and integration tests for all crates in workspace
+        run: |
+          just ${{ matrix.just_variants }} test
+        timeout-minutes: 60
+        env:
+          RUST_BACKTRACE: full
+
       - name: Upload Binaries
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build_nix.yml
+++ b/.github/workflows/build_nix.yml
@@ -45,4 +45,4 @@ jobs:
       # sanity check that repository builds with nix
       - name: Build
         run: |
-          nix develop -c just async_std build
+          nix develop -c just async-std build

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -37,11 +37,11 @@ jobs:
 
       - name: Test Docs
         run: |
-          just async_std doc_test
+          just async-std doc_test
 
       - name: Build Docs
         run: |
-          just async_std doc
+          just async-std doc
 
       - name: Create documentation
         if: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/lint-self-hosted.yml
+++ b/.github/workflows/lint-self-hosted.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         just_variants:
-          - async_std
+          - async-std
           #- tokio
     runs-on: [self-hosted]
     steps:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         just_variants:
-          - async_std
+          - async-std
           - tokio
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/semver-check.yml
+++ b/.github/workflows/semver-check.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         async_runtimes:
-          - async_std
+          - async-std
           - tokio
     steps:
       - uses: actions/checkout@v4

--- a/docker/orchestrator-libp2p.Dockerfile
+++ b/docker/orchestrator-libp2p.Dockerfile
@@ -5,8 +5,9 @@ RUN apt-get update \
     &&  rm -rf /var/lib/apt/lists/*
 
 ARG TARGETARCH
+ARG ASYNC_EXECUTOR
 
-COPY ./target/$TARGETARCH/debug/examples/orchestrator-libp2p /usr/local/bin/orchestrator-libp2p
+COPY ./target/${TARGETARCH}/${ASYNC_EXECUTOR}/debug/examples/orchestrator-libp2p /usr/local/bin/orchestrator-libp2p
 
 # logging
 ENV RUST_LOG="warn"

--- a/docker/orchestrator-libp2p.Dockerfile
+++ b/docker/orchestrator-libp2p.Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update \
 ARG TARGETARCH
 ARG ASYNC_EXECUTOR
 
-COPY ./target/${TARGETARCH}/${ASYNC_EXECUTOR}/debug/examples/orchestrator-libp2p /usr/local/bin/orchestrator-libp2p
+COPY ./target/${ASYNC_EXECUTOR}/${TARGETARCH}/debug/examples/orchestrator-libp2p /usr/local/bin/orchestrator-libp2p
 
 # logging
 ENV RUST_LOG="warn"

--- a/docker/orchestrator-webserver.Dockerfile
+++ b/docker/orchestrator-webserver.Dockerfile
@@ -5,8 +5,9 @@ RUN apt-get update \
     &&  rm -rf /var/lib/apt/lists/*
 
 ARG TARGETARCH
+ARG ASYNC_EXECUTOR
 
-COPY ./target/$TARGETARCH/debug/examples/orchestrator-webserver /usr/local/bin/orchestrator-webserver
+COPY ./target/${TARGETARCH}/${ASYNC_EXECUTOR}/debug/examples/orchestrator-webserver /usr/local/bin/orchestrator-webserver
 
 # logging
 ENV RUST_LOG="warn"

--- a/docker/orchestrator-webserver.Dockerfile
+++ b/docker/orchestrator-webserver.Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update \
 ARG TARGETARCH
 ARG ASYNC_EXECUTOR
 
-COPY ./target/${TARGETARCH}/${ASYNC_EXECUTOR}/debug/examples/orchestrator-webserver /usr/local/bin/orchestrator-webserver
+COPY ./target/${ASYNC_EXECUTOR}/${TARGETARCH}/debug/examples/orchestrator-webserver /usr/local/bin/orchestrator-webserver
 
 # logging
 ENV RUST_LOG="warn"

--- a/docker/validator-libp2p.Dockerfile
+++ b/docker/validator-libp2p.Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update \
 ARG TARGETARCH
 ARG ASYNC_EXECUTOR
 
-COPY ./target/${TARGETARCH}/${ASYNC_EXECUTOR}/debug/examples/validator-libp2p /usr/local/bin/validator-libp2p
+COPY ./target/${ASYNC_EXECUTOR}/${TARGETARCH}/debug/examples/validator-libp2p /usr/local/bin/validator-libp2p
 
 # logging
 ENV RUST_LOG="warn"

--- a/docker/validator-libp2p.Dockerfile
+++ b/docker/validator-libp2p.Dockerfile
@@ -5,8 +5,9 @@ RUN apt-get update \
     &&  rm -rf /var/lib/apt/lists/*
 
 ARG TARGETARCH
+ARG ASYNC_EXECUTOR
 
-COPY ./target/$TARGETARCH/debug/examples/validator-libp2p /usr/local/bin/validator-libp2p
+COPY ./target/${TARGETARCH}/${ASYNC_EXECUTOR}/debug/examples/validator-libp2p /usr/local/bin/validator-libp2p
 
 # logging
 ENV RUST_LOG="warn"

--- a/docker/validator-webserver.Dockerfile
+++ b/docker/validator-webserver.Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update \
 ARG TARGETARCH
 ARG ASYNC_EXECUTOR
 
-COPY ./target/${TARGETARCH}/${ASYNC_EXECUTOR}/debug/examples/validator-webserver /usr/local/bin/validator-webserver
+COPY ./target/${ASYNC_EXECUTOR}/${TARGETARCH}/debug/examples/validator-webserver /usr/local/bin/validator-webserver
 
 # logging
 ENV RUST_LOG="warn"

--- a/docker/validator-webserver.Dockerfile
+++ b/docker/validator-webserver.Dockerfile
@@ -5,8 +5,9 @@ RUN apt-get update \
     &&  rm -rf /var/lib/apt/lists/*
 
 ARG TARGETARCH
+ARG ASYNC_EXECUTOR
 
-COPY ./target/$TARGETARCH/debug/examples/validator-webserver /usr/local/bin/validator-webserver
+COPY ./target/${TARGETARCH}/${ASYNC_EXECUTOR}/debug/examples/validator-webserver /usr/local/bin/validator-webserver
 
 # logging
 ENV RUST_LOG="warn"

--- a/docker/webserver.Dockerfile
+++ b/docker/webserver.Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update \
 ARG TARGETARCH
 ARG ASYNC_EXECUTOR
 
-COPY ./target/${TARGETARCH}/${ASYNC_EXECUTOR}/debug/examples/webserver /usr/local/bin/webserver
+COPY ./target/${ASYNC_EXECUTOR}/${TARGETARCH}/debug/examples/webserver /usr/local/bin/webserver
 
 # logging
 ENV RUST_LOG="warn"

--- a/docker/webserver.Dockerfile
+++ b/docker/webserver.Dockerfile
@@ -5,8 +5,9 @@ RUN apt-get update \
     &&  rm -rf /var/lib/apt/lists/*
 
 ARG TARGETARCH
+ARG ASYNC_EXECUTOR
 
-COPY ./target/$TARGETARCH/debug/examples/webserver /usr/local/bin/webserver
+COPY ./target/${TARGETARCH}/${ASYNC_EXECUTOR}/debug/examples/webserver /usr/local/bin/webserver
 
 # logging
 ENV RUST_LOG="warn"

--- a/justfile
+++ b/justfile
@@ -28,6 +28,10 @@ async := "async-std"
   echo setting executor to async-std
   export RUST_MIN_STACK=4194304 RUSTDOCFLAGS='-D warnings --cfg async_executor_impl="async-std" --cfg async_channel_impl="async-std" {{original_rustdocflags}}' RUSTFLAGS='--cfg async_executor_impl="async-std" --cfg async_channel_impl="async-std" {{original_rustflags}}' CARGO_TARGET_DIR='{{original_target_dir}}/async-std' && just {{target}} {{ARGS}}
 
+@async-std target *ARGS:
+  echo setting executor to async-std
+  export RUST_MIN_STACK=4194304 RUSTDOCFLAGS='-D warnings --cfg async_executor_impl="async-std" --cfg async_channel_impl="async-std" {{original_rustdocflags}}' RUSTFLAGS='--cfg async_executor_impl="async-std" --cfg async_channel_impl="async-std" {{original_rustflags}}' CARGO_TARGET_DIR='{{original_target_dir}}/async-std' && just {{target}} {{ARGS}}
+
 build:
   cargo build --workspace --examples --bins --tests --lib --benches
 

--- a/justfile
+++ b/justfile
@@ -4,6 +4,7 @@ set export
 
 original_rustflags := env_var_or_default('RUSTFLAGS', '--cfg hotshot_example')
 original_rustdocflags := env_var_or_default('RUSTDOCFLAGS', '--cfg hotshot_example')
+original_target_dir := env_var_or_default('CARGO_TARGET_DIR', 'target')
 
 run_ci: lint build test
 
@@ -12,19 +13,20 @@ async := "async-std"
 # Run arbitrary cargo commands, with e.g.
 #     just async=async-std cargo check
 # or
-#     just async=tokio cargo test -p unit_tests
+#     just async=tokio cargo test --tests test_consensus_task
+# Defaults to async-std.
 
 @cargo *ARGS:
   echo setting async executor to {{async}}
-  export RUSTDOCFLAGS='-D warnings --cfg async_executor_impl="{{async}}" --cfg async_channel_impl="{{async}}" {{original_rustdocflags}}' RUSTFLAGS='--cfg async_executor_impl="{{async}}" --cfg async_channel_impl="{{async}}" {{original_rustflags}}' && cargo {{ARGS}}
+  export RUSTDOCFLAGS='-D warnings --cfg async_executor_impl="{{async}}" --cfg async_channel_impl="{{async}}" {{original_rustdocflags}}' RUSTFLAGS='--cfg async_executor_impl="{{async}}" --cfg async_channel_impl="{{async}}" {{original_rustflags}}' CARGO_TARGET_DIR='{{original_target_dir}}/{{async}}' && cargo {{ARGS}}
 
 @tokio target *ARGS:
   echo setting executor to tokio
-  export RUSTDOCFLAGS='-D warnings --cfg async_executor_impl="tokio" --cfg async_channel_impl="tokio" {{original_rustdocflags}}' RUSTFLAGS='--cfg async_executor_impl="tokio" --cfg async_channel_impl="tokio" {{original_rustflags}}' && just {{target}} {{ARGS}}
+  export RUSTDOCFLAGS='-D warnings --cfg async_executor_impl="tokio" --cfg async_channel_impl="tokio" {{original_rustdocflags}}' RUSTFLAGS='--cfg async_executor_impl="tokio" --cfg async_channel_impl="tokio" {{original_rustflags}}' CARGO_TARGET_DIR='{{original_target_dir}}/tokio' && just {{target}} {{ARGS}}
 
 @async_std target *ARGS:
   echo setting executor to async-std
-  export RUST_MIN_STACK=4194304 RUSTDOCFLAGS='-D warnings --cfg async_executor_impl="async-std" --cfg async_channel_impl="async-std" {{original_rustdocflags}}' RUSTFLAGS='--cfg async_executor_impl="async-std" --cfg async_channel_impl="async-std" {{original_rustflags}}' && just {{target}} {{ARGS}}
+  export RUST_MIN_STACK=4194304 RUSTDOCFLAGS='-D warnings --cfg async_executor_impl="async-std" --cfg async_channel_impl="async-std" {{original_rustdocflags}}' RUSTFLAGS='--cfg async_executor_impl="async-std" --cfg async_channel_impl="async-std" {{original_rustflags}}' CARGO_TARGET_DIR='{{original_target_dir}}/async-std' && just {{target}} {{ARGS}}
 
 build:
   cargo build --workspace --examples --bins --tests --lib --benches


### PR DESCRIPTION
No linked issue.

### This PR: 
Makes `just *` commands use different directories for `async-std` and `tokio`. `cargo` should now cache these separately, avoiding wiping the cache when switching async executors.

### This PR does not: 

### Key places to review: 
