### PR TITLE
[FALLBACK] Send DA broadcast Properly

### DIFF
--- a/crates/hotshot/src/traits/networking/combined_network.rs
+++ b/crates/hotshot/src/traits/networking/combined_network.rs
@@ -285,10 +285,17 @@ impl<TYPES: NodeType> ConnectedNetwork<Message<TYPES>, TYPES::SignatureKey>
         message: Message<TYPES>,
         recipients: BTreeSet<TYPES::SignatureKey>,
     ) -> Result<(), NetworkError> {
-        if self.primary().broadcast_message(message.clone(), recipients.clone()).await.is_err() {
+        if self
+            .primary()
+            .broadcast_message(message.clone(), recipients.clone())
+            .await
+            .is_err()
+        {
             warn!("Failed broadcasting DA on primary");
         }
-        self.secondary().da_broadcast_message(message, recipients).await
+        self.secondary()
+            .da_broadcast_message(message, recipients)
+            .await
     }
 
     async fn direct_message(

--- a/crates/hotshot/src/traits/networking/combined_network.rs
+++ b/crates/hotshot/src/traits/networking/combined_network.rs
@@ -287,7 +287,7 @@ impl<TYPES: NodeType> ConnectedNetwork<Message<TYPES>, TYPES::SignatureKey>
     ) -> Result<(), NetworkError> {
         if self
             .primary()
-            .broadcast_message(message.clone(), recipients.clone())
+            .da_broadcast_message(message.clone(), recipients.clone())
             .await
             .is_err()
         {

--- a/crates/hotshot/src/traits/networking/combined_network.rs
+++ b/crates/hotshot/src/traits/networking/combined_network.rs
@@ -285,7 +285,10 @@ impl<TYPES: NodeType> ConnectedNetwork<Message<TYPES>, TYPES::SignatureKey>
         message: Message<TYPES>,
         recipients: BTreeSet<TYPES::SignatureKey>,
     ) -> Result<(), NetworkError> {
-        self.broadcast_message(message, recipients).await
+        if self.primary().broadcast_message(message.clone(), recipients.clone()).await.is_err() {
+            warn!("Failed broadcasting DA on primary");
+        }
+        self.secondary().da_broadcast_message(message, recipients).await
     }
 
     async fn direct_message(


### PR DESCRIPTION
Just happened to notice this while working on the networking.  The DA broadcast should fallback to the correct method.  This changes the behavior to from gossiping DA as a backup to using the new direct messaging DA proposal on the libp2p backup
