### PR TITLE
remove testing gating for get_leader

### DIFF
--- a/crates/hotshot/src/types/handle.rs
+++ b/crates/hotshot/src/types/handle.rs
@@ -7,7 +7,6 @@ use async_lock::RwLock;
 use futures::Stream;
 
 use hotshot_task_impls::events::HotShotEvent;
-#[cfg(feature = "hotshot-testing")]
 use hotshot_types::traits::election::Membership;
 
 use hotshot_task::task::TaskRegistry;

--- a/crates/hotshot/src/types/handle.rs
+++ b/crates/hotshot/src/types/handle.rs
@@ -153,11 +153,8 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static> SystemContextHandl
         self.hotshot.get_next_view_timeout()
     }
 
-    // Below is for testing only:
-
     /// Wrapper for `HotShotConsensusApi`'s `get_leader` function
     #[allow(clippy::unused_async)] // async for API compatibility reasons
-    #[cfg(feature = "hotshot-testing")]
     pub async fn get_leader(&self, view_number: TYPES::Time) -> TYPES::SignatureKey {
         self.hotshot
             .memberships
@@ -165,6 +162,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static> SystemContextHandl
             .get_leader(view_number)
     }
 
+    // Below is for testing only:
     /// Wrapper to get this node's public key
     #[cfg(feature = "hotshot-testing")]
     pub fn get_public_key(&self) -> TYPES::SignatureKey {


### PR DESCRIPTION
Closes #<ISSUE_NUMBER>


### This PR: 
Just removes the `testing` gate over `get_leader`. Builder needs it beyond testing.

### This PR does not: 

### Key places to review: 
`hotshot::src::types::handle.rs`

<!-- ### How to test this PR:  -->


<!-- Complete the following items before creating this PR
