### PR TITLE
Add Event for Validated Quorum Proposal

### DIFF
--- a/crates/task-impls/src/consensus.rs
+++ b/crates/task-impls/src/consensus.rs
@@ -698,6 +698,12 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                         },
                     })
                     .await;
+                // Notify other tasks
+                broadcast_event(
+                    HotShotEvent::QuorumProposalValidated(proposal.data.clone()),
+                    &event_stream,
+                )
+                .await;
 
                 let mut new_anchor_view = consensus.last_decided_view;
                 let mut new_locked_view = consensus.locked_view;

--- a/crates/task-impls/src/events.rs
+++ b/crates/task-impls/src/events.rs
@@ -43,6 +43,8 @@ pub enum HotShotEvent<TYPES: NodeType> {
     QuorumProposalSend(Proposal<TYPES, QuorumProposal<TYPES>>, TYPES::SignatureKey),
     /// Send a quorum vote to the next leader; emitted by a replica in the consensus task after seeing a valid quorum proposal
     QuorumVoteSend(QuorumVote<TYPES>),
+    /// A proposal was validated. This means it comes from the correct leader and has a correct QC.
+    QuorumProposalValidated(QuorumProposal<TYPES>),
     /// Send a DA proposal to the DA committee; emitted by the DA leader (which is the same node as the leader of view v + 1) in the DA task
     DAProposalSend(Proposal<TYPES, DAProposal<TYPES>>, TYPES::SignatureKey),
     /// Send a DA vote to the DA leader; emitted by DA committee members in the DA task after seeing a valid DA proposal

--- a/crates/testing/tests/consensus_task.rs
+++ b/crates/testing/tests/consensus_task.rs
@@ -41,6 +41,7 @@ async fn test_consensus_task() {
         proposal.clone(),
         public_key,
     ));
+    input.push(HotShotEvent::QuorumProposalValidated(proposal.data.clone()));
 
     input.push(HotShotEvent::Shutdown);
 
@@ -96,6 +97,7 @@ async fn test_consensus_vote() {
         proposal.clone(),
         public_key,
     ));
+    input.push(HotShotEvent::QuorumProposalValidated(proposal.data.clone()));
 
     let proposal = proposal.data;
     if let GeneralConsensusMessage::Vote(vote) = build_vote(&handle, proposal).await {

--- a/crates/testing/tests/consensus_task.rs
+++ b/crates/testing/tests/consensus_task.rs
@@ -48,7 +48,10 @@ async fn test_consensus_task() {
         HotShotEvent::QuorumProposalSend(proposal.clone(), public_key),
         1,
     );
-    output.insert(HotShotEvent::QuorumProposalValidated(proposal.data.clone()), 1);
+    output.insert(
+        HotShotEvent::QuorumProposalValidated(proposal.data.clone()),
+        1,
+    );
 
     output.insert(HotShotEvent::ViewChange(ViewNumber::new(1)), 1);
 

--- a/crates/testing/tests/consensus_task.rs
+++ b/crates/testing/tests/consensus_task.rs
@@ -41,7 +41,6 @@ async fn test_consensus_task() {
         proposal.clone(),
         public_key,
     ));
-    input.push(HotShotEvent::QuorumProposalValidated(proposal.data.clone()));
 
     input.push(HotShotEvent::Shutdown);
 
@@ -49,6 +48,7 @@ async fn test_consensus_task() {
         HotShotEvent::QuorumProposalSend(proposal.clone(), public_key),
         1,
     );
+    output.insert(HotShotEvent::QuorumProposalValidated(proposal.data.clone()), 1);
 
     output.insert(HotShotEvent::ViewChange(ViewNumber::new(1)), 1);
 
@@ -97,9 +97,9 @@ async fn test_consensus_vote() {
         proposal.clone(),
         public_key,
     ));
-    input.push(HotShotEvent::QuorumProposalValidated(proposal.data.clone()));
 
     let proposal = proposal.data;
+    output.insert(HotShotEvent::QuorumProposalValidated(proposal.clone()), 1);
     if let GeneralConsensusMessage::Vote(vote) = build_vote(&handle, proposal).await {
         output.insert(HotShotEvent::QuorumVoteSend(vote.clone()), 1);
         input.push(HotShotEvent::QuorumVoteRecv(vote.clone()));

--- a/crates/testing/tests/upgrade_task.rs
+++ b/crates/testing/tests/upgrade_task.rs
@@ -64,6 +64,7 @@ async fn test_upgrade_task() {
         inputs: vec![QuorumProposalRecv(proposals[0].clone(), leaders[0])],
         outputs: vec![
             exact(ViewChange(ViewNumber::new(1))),
+            exact(QuorumProposalValidated(proposals[0].data.clone())),
             exact(QuorumVoteSend(votes[0].clone())),
         ],
         asserts: vec![],
@@ -77,6 +78,7 @@ async fn test_upgrade_task() {
         ],
         outputs: vec![
             exact(ViewChange(ViewNumber::new(2))),
+            exact(QuorumProposalValidated(proposals[1].data.clone())),
             exact(QuorumVoteSend(votes[1].clone())),
         ],
         asserts: vec![no_decided_upgrade_cert()],
@@ -90,6 +92,7 @@ async fn test_upgrade_task() {
         ],
         outputs: vec![
             exact(ViewChange(ViewNumber::new(3))),
+            exact(QuorumProposalValidated(proposals[2].data.clone())),
             leaf_decided(),
             exact(QuorumVoteSend(votes[2].clone())),
         ],
@@ -104,6 +107,7 @@ async fn test_upgrade_task() {
         ],
         outputs: vec![
             exact(ViewChange(ViewNumber::new(4))),
+            exact(QuorumProposalValidated(proposals[3].data.clone())),
             leaf_decided(),
             exact(QuorumVoteSend(votes[3].clone())),
         ],
@@ -112,7 +116,11 @@ async fn test_upgrade_task() {
 
     let view_5 = TestScriptStage {
         inputs: vec![QuorumProposalRecv(proposals[4].clone(), leaders[4])],
-        outputs: vec![exact(ViewChange(ViewNumber::new(5))), leaf_decided()],
+        outputs: vec![
+            exact(ViewChange(ViewNumber::new(5))),
+            exact(QuorumProposalValidated(proposals[4].data.clone())),
+            leaf_decided(),
+        ],
         asserts: vec![decided_upgrade_cert()],
     };
 


### PR DESCRIPTION


### This PR: 

Adding a new event before I do: #2648.  I want to use this event to drive the request task.  We'll wait some time after getting the `QuorumProposalValidated` event and then try to request VID if we don't get it sooner.

I'm making the assumption that if we couldn't vote on the proposal we don't deem it valid.  A proposal that doesn't have a parent in our state map would fit this criteria, but it could otherwise be valid.  This fits my purpose because we only need would request the data to be able to vote.  This assumption might not be correct if others use this event.

I also think this event will be useful for the task cleanup work.

### This PR does not: 

We don't yet use the event. 

### Key places to review: 

New event, and the place it's emitted.  

