### PR TITLE
Add timestamp to `TestBlockHeader`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2820,6 +2820,7 @@ dependencies = [
  "sha2 0.10.8",
  "sha3",
  "snafu",
+ "time 0.3.34",
  "tokio",
  "tracing",
 ]

--- a/crates/example-types/Cargo.toml
+++ b/crates/example-types/Cargo.toml
@@ -29,6 +29,7 @@ snafu = { workspace = true }
 tracing = { workspace = true }
 serde = { workspace = true }
 sha2 = { workspace = true }
+time = { workspace = true }
 async-lock = { workspace = true }
 bitvec = { workspace = true }
 ethereum-types = { workspace = true }

--- a/crates/example-types/src/block_types.rs
+++ b/crates/example-types/src/block_types.rs
@@ -17,6 +17,7 @@ use hotshot_types::{
 };
 use serde::{Deserialize, Serialize};
 use sha3::{Digest, Keccak256};
+use time::OffsetDateTime;
 
 /// The transaction in a [`TestBlockPayload`].
 #[derive(Default, PartialEq, Eq, Hash, Serialize, Deserialize, Clone, Debug)]
@@ -178,9 +179,13 @@ pub struct TestBlockHeader {
     pub block_number: u64,
     /// VID commitment to the payload.
     pub payload_commitment: VidCommitment,
+    /// Timestamp when this header was created.
+    pub timestamp: u64,
 }
 
-impl<TYPES: NodeType<BlockPayload = TestBlockPayload>> BlockHeader<TYPES> for TestBlockHeader {
+impl<TYPES: NodeType<BlockHeader = Self, BlockPayload = TestBlockPayload>> BlockHeader<TYPES>
+    for TestBlockHeader
+{
     async fn new(
         _parent_state: &TYPES::ValidatedState,
         _instance_state: &<TYPES::ValidatedState as ValidatedState<TYPES>>::Instance,
@@ -188,9 +193,18 @@ impl<TYPES: NodeType<BlockPayload = TestBlockPayload>> BlockHeader<TYPES> for Te
         payload_commitment: VidCommitment,
         _metadata: <TYPES::BlockPayload as BlockPayload>::Metadata,
     ) -> Self {
+        let parent = &parent_leaf.block_header;
+
+        let mut timestamp = OffsetDateTime::now_utc().unix_timestamp() as u64;
+        if timestamp < parent.timestamp {
+            // Prevent decreasing timestamps.
+            timestamp = parent.timestamp;
+        }
+
         Self {
-            block_number: parent_leaf.block_header.block_number() + 1,
+            block_number: parent.block_number + 1,
             payload_commitment,
+            timestamp,
         }
     }
 
@@ -202,6 +216,7 @@ impl<TYPES: NodeType<BlockPayload = TestBlockPayload>> BlockHeader<TYPES> for Te
         Self {
             block_number: 0,
             payload_commitment,
+            timestamp: 0,
         }
     }
 

--- a/crates/testing/src/view_generator.rs
+++ b/crates/testing/src/view_generator.rs
@@ -72,6 +72,7 @@ impl TestView {
 
         let block_header = TestBlockHeader {
             block_number: 1,
+            timestamp: 1,
             payload_commitment,
         };
 
@@ -188,6 +189,7 @@ impl TestView {
 
         let block_header = TestBlockHeader {
             block_number: *next_view,
+            timestamp: *next_view,
             payload_commitment,
         };
 


### PR DESCRIPTION
This is extremely useful for downstream testing. For example, many tests in the query service rely on a timestamp. Without this change, we would have to implement our own test types or implement something very unrealistic (like always getting the current time every time we get the timestamp for the same header).

This is also pretty realistic, as any real application will probably timestamp its blocks, and it demonstrates getting inputs in `Header::new` from the outside world (ie the hardware clock) in addition to just the inputs which are passed in, which is good for example purposes.
