### PR TITLE
[Auto Benchmarks] Post benchmark stats to orchestrator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1596,6 +1596,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "csv"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac574ff4d437a7b5ad237ef331c17ccca63c46479e5b5453eb8e10bb99a759fe"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efa2b3d7902f4b634a20cae3c9c4e6209dc4779feb6863329607560143efa70"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "ctr"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2878,6 +2899,7 @@ dependencies = [
  "async-std",
  "blake3",
  "clap",
+ "csv",
  "futures",
  "hotshot-types",
  "hotshot-utils",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2880,6 +2880,7 @@ dependencies = [
  "clap",
  "futures",
  "hotshot-types",
+ "hotshot-utils",
  "libp2p",
  "serde",
  "serde-inline-default",

--- a/crates/examples/infra/mod.rs
+++ b/crates/examples/infra/mod.rs
@@ -471,6 +471,7 @@ pub trait RunDA<
     }
 
     /// Starts HotShot consensus, returns when consensus has finished
+    #[allow(clippy::too_many_lines)]
     async fn run_hotshot(
         &self,
         context: SystemContextHandle<TYPES, NODE>,
@@ -608,7 +609,8 @@ pub trait RunDA<
         error!("[{node_index}]: {rounds} rounds completed in {total_time_elapsed:?} - Total transactions sent: {total_transactions_sent} - Total transactions committed: {total_transactions_committed} - Total commitments: {num_successful_commits}");
         if total_transactions_committed != 0 {
             // extra 8 bytes for timestamp
-            let throughput_bytes_per_sec = total_transactions_committed * (transaction_size_in_bytes + 8)
+            let throughput_bytes_per_sec = total_transactions_committed
+                * (transaction_size_in_bytes + 8)
                 / total_time_elapsed.as_secs();
             BenchResults {
                 avg_latency_in_sec: total_latency / num_latency,

--- a/crates/examples/infra/mod.rs
+++ b/crates/examples/infra/mod.rs
@@ -471,8 +471,6 @@ pub trait RunDA<
     }
 
     /// Starts HotShot consensus, returns when consensus has finished
-    // Sishan TODO: remove this clippy after posting stats to orchestrator
-    #[allow(clippy::too_many_lines)]
     async fn run_hotshot(
         &self,
         context: SystemContextHandle<TYPES, NODE>,
@@ -610,14 +608,14 @@ pub trait RunDA<
         error!("[{node_index}]: {rounds} rounds completed in {total_time_elapsed:?} - Total transactions sent: {total_transactions_sent} - Total transactions committed: {total_transactions_committed} - Total commitments: {num_successful_commits}");
         if total_transactions_committed != 0 {
             // extra 8 bytes for timestamp
-            let throughput = total_transactions_committed * (transaction_size_in_bytes + 8)
+            let throughput_bytes_per_sec = total_transactions_committed * (transaction_size_in_bytes + 8)
                 / total_time_elapsed.as_secs();
-            error!("[{node_index}]: Avg latency: {:?} sec, Minimum latency: {minimum_latency} sec, Maximum latency: {maximum_latency} sec, Throughput: {throughput} bytes/sec", total_latency / num_latency);
             BenchResults {
                 avg_latency_in_sec: total_latency / num_latency,
+                num_latency,
                 minimum_latency_in_sec: minimum_latency,
                 maximum_latency_in_sec: maximum_latency,
-                throughput_bytes_per_sec: throughput,
+                throughput_bytes_per_sec,
                 total_transactions_committed,
                 transaction_size_in_bytes: transaction_size_in_bytes + 8, // extra 8 bytes for timestamp
                 total_time_elapsed_in_sec: total_time_elapsed.as_secs(),
@@ -625,7 +623,6 @@ pub trait RunDA<
                 failed_num_views,
             }
         } else {
-            error!("[{node_index}]: No transactions committed");
             // all values with zero
             BenchResults::default()
         }

--- a/crates/examples/infra/mod.rs
+++ b/crates/examples/infra/mod.rs
@@ -95,7 +95,7 @@ pub fn read_orchestrator_init_config<TYPES: NodeType>(
                 .short('c')
                 .long("config_file")
                 .value_name("FILE")
-                .help("Sets a custom config file")
+                .help("Sets a custom config file with default values, some might be changed if they are set manually in the command line")
                 .required(true),
         )
         .arg(
@@ -143,7 +143,7 @@ pub fn read_orchestrator_init_config<TYPES: NodeType>(
                 .short('m')
                 .long("commit_sha")
                 .value_name("SHA")
-                .help("Sets the commit sha")
+                .help("Sets the commit sha to output in the results")
                 .required(false),
         )
         .get_matches();
@@ -177,6 +177,9 @@ pub fn read_orchestrator_init_config<TYPES: NodeType>(
     }
     if let Some(rounds_string) = matches.get_one::<String>("rounds") {
         config.rounds = rounds_string.parse::<usize>().unwrap();
+    }
+    if let Some(commit_sha_string) = matches.get_one::<String>("commit_sha") {
+        config.commit_sha = commit_sha_string.to_string();
     }
     config
 }

--- a/crates/examples/infra/mod.rs
+++ b/crates/examples/infra/mod.rs
@@ -138,6 +138,14 @@ pub fn read_orchestrator_init_config<TYPES: NodeType>(
                 .help("Sets the number of rounds to run")
                 .required(false),
         )
+        .arg(
+            Arg::new("commit_sha")
+                .short('m')
+                .long("commit_sha")
+                .value_name("SHA")
+                .help("Sets the commit sha")
+                .required(false),
+        )
         .get_matches();
     let mut args = ConfigArgs {
         config_file: "./crates/orchestrator/run-config.toml".to_string(),

--- a/crates/examples/infra/mod.rs
+++ b/crates/examples/infra/mod.rs
@@ -172,7 +172,7 @@ pub fn read_orchestrator_init_config<TYPES: NodeType>(
     {
         config.transactions_per_round = transactions_per_round_string.parse::<usize>().unwrap();
     }
-    if let Some(transaction_size_string) = matches.get_one::<String>("transaction_size_in_bytes") {
+    if let Some(transaction_size_string) = matches.get_one::<String>("transaction_size") {
         config.transaction_size = transaction_size_string.parse::<usize>().unwrap();
     }
     if let Some(rounds_string) = matches.get_one::<String>("rounds") {

--- a/crates/orchestrator/Cargo.toml
+++ b/crates/orchestrator/Cargo.toml
@@ -20,6 +20,7 @@ serde_json = { workspace = true }
 toml = { workspace = true }
 thiserror = "1.0.50"
 serde-inline-default = "0.1.1"
+csv = "1.3.0"
 
 [target.'cfg(all(async_executor_impl = "tokio"))'.dependencies]
 tokio = { workspace = true }

--- a/crates/orchestrator/Cargo.toml
+++ b/crates/orchestrator/Cargo.toml
@@ -11,6 +11,7 @@ futures = { workspace = true }
 libp2p = { workspace = true }
 blake3 = { workspace = true }
 hotshot-types = { version = "0.1.0", path = "../types", default-features = false }
+hotshot-utils = { path = "../utils" }
 tide-disco = { workspace = true }
 surf-disco = { workspace = true }
 tracing = { workspace = true }

--- a/crates/orchestrator/api.toml
+++ b/crates/orchestrator/api.toml
@@ -74,7 +74,6 @@ Get whether the node should start the run, returns a boolean
 # POST the run results
 [route.postresults]
 PATH = ["results"]
-":run_results" = "TaggedBase64"
 METHOD = "POST"
 DOC = """
 Post run results.

--- a/crates/orchestrator/src/client.rs
+++ b/crates/orchestrator/src/client.rs
@@ -79,7 +79,7 @@ pub struct BenchResultsDownloadConfig {
     /// Number of transactions submitted per round
     pub transactions_per_round: usize,
     /// The size of each transaction in bytes
-    pub transaction_size: usize,
+    pub transaction_size: u64,
     /// The number of rounds
     pub rounds: usize,
     /// The type of leader election used

--- a/crates/orchestrator/src/client.rs
+++ b/crates/orchestrator/src/client.rs
@@ -66,6 +66,44 @@ impl BenchResults {
     }
 }
 
+/// Struct describing a benchmark result needed for download, also include the config
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Default, PartialEq)]
+pub struct BenchResultsDownloadConfig {
+    // Config starting here
+    /// The commit this benchmark was run on
+    pub commit_sha: String,
+    /// Total number of nodes
+    pub total_nodes: usize,
+    /// The size of the da committee
+    pub da_committee_size: usize,
+    /// Number of transactions submitted per round
+    pub transactions_per_round: usize,
+    /// The size of each transaction in bytes
+    pub transaction_size: usize,
+    /// The number of rounds
+    pub rounds: usize,
+    /// The type of leader election used
+    pub leader_election_type: String,
+
+    // Results starting here
+    /// The average latency of the transactions
+    pub avg_latency_in_sec: i64,
+    /// The minimum latency of the transactions
+    pub minimum_latency_in_sec: i64,
+    /// The maximum latency of the transactions
+    pub maximum_latency_in_sec: i64,
+    /// The throughput of the consensus protocol = number of transactions committed per second * transaction size in bytes
+    pub throughput_bytes_per_sec: u64,
+    /// The number of transactions committed during benchmarking
+    pub total_transactions_committed: u64,
+    /// The total time elapsed for benchmarking
+    pub total_time_elapsed_in_sec: u64,
+    /// The total number of views during benchmarking
+    pub total_num_views: usize,
+    /// The number of failed views during benchmarking
+    pub failed_num_views: usize,
+}
+
 // VALIDATOR
 
 #[derive(Parser, Debug, Clone)]

--- a/crates/orchestrator/src/client.rs
+++ b/crates/orchestrator/src/client.rs
@@ -19,6 +19,30 @@ pub struct OrchestratorClient {
     pub identity: String,
 }
 
+// Sishan TODO: add function printout() to this struct
+/// Struct describing a benchmark result
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Default, PartialEq)]
+pub struct BenchResults {
+    /// The average latency of the transactions
+    pub avg_latency_in_sec: i64,
+    /// The minimum latency of the transactions
+    pub minimum_latency_in_sec: i64,
+    /// The maximum latency of the transactions
+    pub maximum_latency_in_sec: i64,
+    /// The throughput of the consensus protocol = number of transactions committed per second * transaction size in bytes
+    pub throughput_bytes_per_sec: u64,
+    /// The number of transactions committed during benchmarking
+    pub total_transactions_committed: u64,
+    /// The size of each transaction in bytes
+    pub transaction_size_in_bytes: u64,
+    /// The total time elapsed for benchmarking
+    pub total_time_elapsed_in_sec: u64,
+    /// The total number of views during benchmarking
+    pub total_num_views: usize,
+    /// The number of failed views during benchmarking
+    pub failed_num_views: usize,
+}
+
 // VALIDATOR
 
 #[derive(Parser, Debug, Clone)]
@@ -218,6 +242,19 @@ impl OrchestratorClient {
         };
         self.wait_for_fn_from_orchestrator(wait_for_all_nodes_ready_f)
             .await
+    }
+
+    /// Sends the benchmark metrics to the orchestrator
+    /// # Panics
+    /// Panics if unable to post
+    pub async fn post_bench_results(&self, bench_results: BenchResults) {
+        let _send_metrics_f: Result<(), ClientError> = self
+            .client
+            .post("api/results")
+            .body_json(&bench_results)
+            .unwrap()
+            .send()
+            .await;
     }
 
     /// Generic function that waits for the orchestrator to return a non-error

--- a/crates/orchestrator/src/client.rs
+++ b/crates/orchestrator/src/client.rs
@@ -19,12 +19,13 @@ pub struct OrchestratorClient {
     pub identity: String,
 }
 
-// Sishan TODO: add function printout() to this struct
 /// Struct describing a benchmark result
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Default, PartialEq)]
 pub struct BenchResults {
     /// The average latency of the transactions
     pub avg_latency_in_sec: i64,
+    /// The number of transactions that were latency measured
+    pub num_latency: i64,
     /// The minimum latency of the transactions
     pub minimum_latency_in_sec: i64,
     /// The maximum latency of the transactions
@@ -41,6 +42,23 @@ pub struct BenchResults {
     pub total_num_views: usize,
     /// The number of failed views during benchmarking
     pub failed_num_views: usize,
+}
+
+impl BenchResults {
+    /// printout the results of one example run
+    pub fn printout(&self) {
+        println!("=====================");
+        println!("Benchmark results:");
+        println!("Average latency: {} seconds, Minimum latency: {} seconds, Maximum latency: {} seconds", self.avg_latency_in_sec, self.minimum_latency_in_sec, self.maximum_latency_in_sec);
+        println!(
+            "Throughput: {} bytes/sec",
+            self.throughput_bytes_per_sec
+        );
+        println!("Total transactions committed: {}", self.total_transactions_committed);
+        println!("Total number of views: {}, Failed number of views: {}", self.total_num_views, self.failed_num_views);
+        println!("=====================");
+    }
+    
 }
 
 // VALIDATOR

--- a/crates/orchestrator/src/client.rs
+++ b/crates/orchestrator/src/client.rs
@@ -49,16 +49,21 @@ impl BenchResults {
     pub fn printout(&self) {
         println!("=====================");
         println!("Benchmark results:");
-        println!("Average latency: {} seconds, Minimum latency: {} seconds, Maximum latency: {} seconds", self.avg_latency_in_sec, self.minimum_latency_in_sec, self.maximum_latency_in_sec);
         println!(
-            "Throughput: {} bytes/sec",
-            self.throughput_bytes_per_sec
+            "Average latency: {} seconds, Minimum latency: {} seconds, Maximum latency: {} seconds",
+            self.avg_latency_in_sec, self.minimum_latency_in_sec, self.maximum_latency_in_sec
         );
-        println!("Total transactions committed: {}", self.total_transactions_committed);
-        println!("Total number of views: {}, Failed number of views: {}", self.total_num_views, self.failed_num_views);
+        println!("Throughput: {} bytes/sec", self.throughput_bytes_per_sec);
+        println!(
+            "Total transactions committed: {}",
+            self.total_transactions_committed
+        );
+        println!(
+            "Total number of views: {}, Failed number of views: {}",
+            self.total_num_views, self.failed_num_views
+        );
         println!("=====================");
     }
-    
 }
 
 // VALIDATOR

--- a/crates/orchestrator/src/config.rs
+++ b/crates/orchestrator/src/config.rs
@@ -153,6 +153,8 @@ pub struct NetworkConfig<KEY: SignatureKey, ELECTIONCONFIG: ElectionConfig> {
     pub web_server_config: Option<WebServerConfig>,
     /// the data availability web server config
     pub da_web_server_config: Option<WebServerConfig>,
+    /// the commit this run is based on
+    pub commit_sha: String,
 }
 
 /// the source of the network config
@@ -392,6 +394,7 @@ impl<K: SignatureKey, E: ElectionConfig> Default for NetworkConfig<K, E> {
             num_bootrap: 5,
             propose_min_round_time: Duration::from_secs(0),
             propose_max_round_time: Duration::from_secs(10),
+            commit_sha: String::new(),
         }
     }
 }
@@ -472,6 +475,7 @@ impl<K: SignatureKey, E: ElectionConfig> From<NetworkConfigFile<K>> for NetworkC
             start_delay_seconds: val.start_delay_seconds,
             web_server_config: val.web_server_config,
             da_web_server_config: val.da_web_server_config,
+            commit_sha: String::new(),
         }
     }
 }

--- a/crates/orchestrator/src/lib.rs
+++ b/crates/orchestrator/src/lib.rs
@@ -293,16 +293,34 @@ where
             } else {
                 // Deal with the bench results from different nodes
                 let cur_metrics = self.bench_results.clone();
-                self.bench_results.avg_latency_in_sec = (metrics.avg_latency_in_sec * metrics.num_latency + cur_metrics.avg_latency_in_sec * cur_metrics.num_latency) / (metrics.num_latency + cur_metrics.num_latency);
+                self.bench_results.avg_latency_in_sec = (metrics.avg_latency_in_sec
+                    * metrics.num_latency
+                    + cur_metrics.avg_latency_in_sec * cur_metrics.num_latency)
+                    / (metrics.num_latency + cur_metrics.num_latency);
                 self.bench_results.num_latency += metrics.num_latency;
-                self.bench_results.minimum_latency_in_sec = metrics.minimum_latency_in_sec.min(cur_metrics.minimum_latency_in_sec);
-                self.bench_results.maximum_latency_in_sec = metrics.maximum_latency_in_sec.max(cur_metrics.maximum_latency_in_sec);
-                self.bench_results.throughput_bytes_per_sec = metrics.throughput_bytes_per_sec.max(cur_metrics.throughput_bytes_per_sec);
-                self.bench_results.total_transactions_committed = metrics.total_transactions_committed.max(cur_metrics.total_transactions_committed);
-                assert_eq!(metrics.transaction_size_in_bytes, cur_metrics.transaction_size_in_bytes);
-                self.bench_results.total_time_elapsed_in_sec = metrics.total_time_elapsed_in_sec.max(cur_metrics.total_time_elapsed_in_sec);
-                self.bench_results.total_num_views = metrics.total_num_views.min(cur_metrics.total_num_views);
-                self.bench_results.failed_num_views = metrics.failed_num_views.max(cur_metrics.failed_num_views);
+                self.bench_results.minimum_latency_in_sec = metrics
+                    .minimum_latency_in_sec
+                    .min(cur_metrics.minimum_latency_in_sec);
+                self.bench_results.maximum_latency_in_sec = metrics
+                    .maximum_latency_in_sec
+                    .max(cur_metrics.maximum_latency_in_sec);
+                self.bench_results.throughput_bytes_per_sec = metrics
+                    .throughput_bytes_per_sec
+                    .max(cur_metrics.throughput_bytes_per_sec);
+                self.bench_results.total_transactions_committed = metrics
+                    .total_transactions_committed
+                    .max(cur_metrics.total_transactions_committed);
+                assert_eq!(
+                    metrics.transaction_size_in_bytes,
+                    cur_metrics.transaction_size_in_bytes
+                );
+                self.bench_results.total_time_elapsed_in_sec = metrics
+                    .total_time_elapsed_in_sec
+                    .max(cur_metrics.total_time_elapsed_in_sec);
+                self.bench_results.total_num_views =
+                    metrics.total_num_views.min(cur_metrics.total_num_views);
+                self.bench_results.failed_num_views =
+                    metrics.failed_num_views.max(cur_metrics.failed_num_views);
             }
         }
         self.nodes_post_results += 1;

--- a/crates/orchestrator/src/lib.rs
+++ b/crates/orchestrator/src/lib.rs
@@ -100,7 +100,7 @@ impl<KEY: SignatureKey + 'static, ELECTION: ElectionConfig + 'static>
             total_nodes: self.config.config.total_nodes.into(),
             da_committee_size: self.config.config.da_committee_size,
             transactions_per_round: self.config.transactions_per_round,
-            transaction_size: self.config.transaction_size,
+            transaction_size: self.bench_results.transaction_size_in_bytes,
             rounds: self.config.rounds,
             leader_election_type: self.config.election_config_type_name.clone(),
             avg_latency_in_sec: self.bench_results.avg_latency_in_sec,

--- a/scripts/benchmarks_results/results.csv
+++ b/scripts/benchmarks_results/results.csv
@@ -1,2 +1,2 @@
 commit_sha,total_nodes,da_committee_size,transactions_per_round,transaction_size,rounds,leader_election_type,avg_latency_in_sec,minimum_latency_in_sec,maximum_latency_in_sec,throughput_bytes_per_sec,total_transactions_committed,total_time_elapsed_in_sec,total_num_views,failed_num_views
-,10,5,10,1749,10,hotshot::traits::election::static_committee::StaticElectionConfig,2,1,4,9266,21,4,10,0
+,20,5,10,1040,10,hotshot::traits::election::static_committee::StaticElectionConfig,2,1,5,8320,32,5,10,0

--- a/scripts/benchmarks_results/results.csv
+++ b/scripts/benchmarks_results/results.csv
@@ -1,0 +1,2 @@
+commit_sha,total_nodes,da_committee_size,transactions_per_round,transaction_size,rounds,leader_election_type,avg_latency_in_sec,minimum_latency_in_sec,maximum_latency_in_sec,throughput_bytes_per_sec,total_transactions_committed,total_time_elapsed_in_sec,total_num_views,failed_num_views
+,10,5,10,1749,10,hotshot::traits::election::static_committee::StaticElectionConfig,2,1,4,9266,21,4,10,0


### PR DESCRIPTION
Closes #2346 .
<!-- See here for keywords in Github -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

### This PR: 
- adds a metrics endpoint to the orchestrator.
- adds a post at the end of the examples for the stats.
- formats output into a csv file `scripts/benchmarks_results/results.csv`.
- adds an end point for run commit, it will `GITHUB_SHA` later.
<!-- Describe what this PR adds to HotSHot -->
<!-- E.g. -->
<!-- * Implements feature 1 -->
<!-- * Implements feature 2 -->
<!-- * Fixes bug 3 -->

### This PR does not: 
- consider any VID-related factor yet.
- start CI integration yet, as this will be the next step.
- consider saving past benchmark results yet, as this will be solved after integration.
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->

### Key places to review: 
All changes.
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->

### How to test this PR:
`just async_std example all-webserver -- --config_file ./crates/orchestrator/run-config.toml --commit_sha [ANY STRING]` and check out `scripts/benchmarks_results/results.csv`.
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
