### PR TITLE
[Cleanup] Remove BoxedSync `RecvMsgs`

### DIFF
--- a/crates/hotshot/src/traits/networking/combined_network.rs
+++ b/crates/hotshot/src/traits/networking/combined_network.rs
@@ -332,6 +332,8 @@ impl<TYPES: NodeType> ConnectedNetwork<Message<TYPES>, TYPES::SignatureKey>
     /// # Errors
     /// Does not error
     async fn recv_msgs(&self) -> Result<Vec<Message<TYPES>>, NetworkError> {
+        // recv on both networks because nodes may be accessible only on either. discard duplicates
+        // TODO: improve this algorithm: https://github.com/EspressoSystems/HotShot/issues/2089
         let mut primary_msgs = self.primary().recv_msgs().await?;
         let mut secondary_msgs = self.secondary().recv_msgs().await?;
 

--- a/crates/hotshot/src/traits/networking/combined_network.rs
+++ b/crates/hotshot/src/traits/networking/combined_network.rs
@@ -327,40 +327,34 @@ impl<TYPES: NodeType> ConnectedNetwork<Message<TYPES>, TYPES::SignatureKey>
         self.secondary().direct_message(message, recipient).await
     }
 
-    fn recv_msgs<'a, 'b>(&'a self) -> BoxSyncFuture<'b, Result<Vec<Message<TYPES>>, NetworkError>>
-    where
-        'a: 'b,
-        Self: 'b,
-    {
-        // recv on both networks because nodes may be accessible only on either. discard duplicates
-        // TODO: improve this algorithm: https://github.com/EspressoSystems/HotShot/issues/2089
-        let closure = async move {
-            let mut primary_msgs = self.primary().recv_msgs().await?;
-            let mut secondary_msgs = self.secondary().recv_msgs().await?;
+    /// Receive one or many messages from the underlying network.
+    ///
+    /// # Errors
+    /// Does not error
+    async fn recv_msgs(&self) -> Result<Vec<Message<TYPES>>, NetworkError> {
+        let mut primary_msgs = self.primary().recv_msgs().await?;
+        let mut secondary_msgs = self.secondary().recv_msgs().await?;
 
-            primary_msgs.append(secondary_msgs.as_mut());
+        primary_msgs.append(secondary_msgs.as_mut());
 
-            let mut filtered_msgs = Vec::with_capacity(primary_msgs.len());
-            for msg in primary_msgs {
-                // see if we've already seen this message
-                if !self
-                    .message_cache
-                    .read()
+        let mut filtered_msgs = Vec::with_capacity(primary_msgs.len());
+        for msg in primary_msgs {
+            // see if we've already seen this message
+            if !self
+                .message_cache
+                .read()
+                .await
+                .contains(calculate_hash_of(&msg))
+            {
+                filtered_msgs.push(msg.clone());
+                self.message_cache
+                    .write()
                     .await
-                    .contains(calculate_hash_of(&msg))
-                {
-                    filtered_msgs.push(msg.clone());
-                    self.message_cache
-                        .write()
-                        .await
-                        .insert(calculate_hash_of(&msg));
-                }
+                    .insert(calculate_hash_of(&msg));
             }
+        }
 
-            Ok(filtered_msgs)
-        };
-
-        boxed_sync(closure)
+        Ok(filtered_msgs)
     }
 
     async fn queue_node_lookup(

--- a/crates/hotshot/src/traits/networking/libp2p_network.rs
+++ b/crates/hotshot/src/traits/networking/libp2p_network.rs
@@ -844,23 +844,21 @@ impl<M: NetworkMsg, K: SignatureKey + 'static> ConnectedNetwork<M, K> for Libp2p
         }
     }
 
+    /// Receive one or many messages from the underlying network.
+    ///
+    /// # Errors
+    /// If there is a network-related failure.
     #[instrument(name = "Libp2pNetwork::recv_msgs", skip_all)]
-    fn recv_msgs<'a, 'b>(&'a self) -> BoxSyncFuture<'b, Result<Vec<M>, NetworkError>>
-    where
-        'a: 'b,
-        Self: 'b,
-    {
-        let closure = async move {
-            let result = self
-                .inner
-                .receiver
-                .drain_at_least_one()
-                .await
-                .map_err(|_x| NetworkError::ShutDown)?;
-            self.inner.metrics.incoming_message_count.add(result.len());
-            Ok(result)
-        };
-        boxed_sync(closure)
+    async fn recv_msgs(&self) -> Result<Vec<M>, NetworkError> {
+        let result = self
+            .inner
+            .receiver
+            .drain_at_least_one()
+            .await
+            .map_err(|_x| NetworkError::ShutDown)?;
+        self.inner.metrics.incoming_message_count.add(result.len());
+
+        Ok(result)
     }
 
     #[instrument(name = "Libp2pNetwork::queue_node_lookup", skip_all)]

--- a/crates/hotshot/src/traits/networking/web_server_network.rs
+++ b/crates/hotshot/src/traits/networking/web_server_network.rs
@@ -840,25 +840,18 @@ impl<TYPES: NodeType + 'static> ConnectedNetwork<Message<TYPES>, TYPES::Signatur
         }
     }
 
-    /// Moves out the entire queue of received messages
+    /// Receive one or many messages from the underlying network.
     ///
-    /// Will unwrap the underlying `NetworkMessage`
-    /// blocking
-    fn recv_msgs<'a, 'b>(&'a self) -> BoxSyncFuture<'b, Result<Vec<Message<TYPES>>, NetworkError>>
-    where
-        'a: 'b,
-        Self: 'b,
-    {
-        let closure = async move {
-            let mut queue = self.inner.poll_queue_0_1.write().await;
-            Ok(queue
-                .drain(..)
-                .collect::<Vec<_>>()
-                .iter()
-                .map(|x| x.get_message().unwrap())
-                .collect())
-        };
-        boxed_sync(closure)
+    /// # Errors
+    /// Does not error
+    async fn recv_msgs(&self) -> Result<Vec<Message<TYPES>>, NetworkError> {
+        let mut queue = self.inner.poll_queue_0_1.write().await;
+        Ok(queue
+            .drain(..)
+            .collect::<Vec<_>>()
+            .iter()
+            .map(|x| x.get_message().expect("failed to clone message"))
+            .collect())
     }
 
     #[allow(clippy::too_many_lines)]

--- a/crates/types/src/traits/network.rs
+++ b/crates/types/src/traits/network.rs
@@ -277,14 +277,11 @@ pub trait ConnectedNetwork<M: NetworkMsg, K: SignatureKey + 'static>:
     /// blocking
     async fn direct_message(&self, message: M, recipient: K) -> Result<(), NetworkError>;
 
-    /// Moves out the entire queue of received messages of 'transmit_type`
+    /// Receive one or many messages from the underlying network.
     ///
-    /// Will unwrap the underlying `NetworkMessage`
-    /// blocking
-    fn recv_msgs<'a, 'b>(&'a self) -> BoxSyncFuture<'b, Result<Vec<M>, NetworkError>>
-    where
-        'a: 'b,
-        Self: 'b;
+    /// # Errors
+    /// If there is a network-related failure.
+    async fn recv_msgs(&self) -> Result<Vec<M>, NetworkError>;
 
     /// queues lookup of a node
     async fn queue_node_lookup(


### PR DESCRIPTION
### This PR: 
<!-- Describe what this PR adds to HotSHot -->
<!-- E.g. -->
<!-- * Implements feature 1 -->
<!-- * Implements feature 2 -->
<!-- * Fixes bug 3 -->
Changes `recv_msgs` in the network trait from using `BoxedSync` to being an async function returning the value directly. Since we never use it in sync code, this is okay. This is just one of the changes made in the Push CDN branch, but put into a smaller PR to make more sense.

### This PR does not: 
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->
Change any message receiving logic

### Key places to review: 
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->
`network.rs`

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
