### PR TITLE
Voting for all Possible Orderings Regression Test

### DIFF
--- a/crates/testing/src/lib.rs
+++ b/crates/testing/src/lib.rs
@@ -42,6 +42,9 @@ pub mod script;
 /// view generator for tests
 pub mod view_generator;
 
+/// helper functions for test scripts
+pub mod test_helpers;
+
 /// global event at the test level
 #[derive(Clone, Debug)]
 pub enum GlobalTestEvent {

--- a/crates/testing/src/predicates.rs
+++ b/crates/testing/src/predicates.rs
@@ -1,7 +1,7 @@
 use hotshot_task_impls::{
     consensus::ConsensusTaskState, events::HotShotEvent, events::HotShotEvent::*,
 };
-use hotshot_types::traits::node_implementation::NodeType;
+use hotshot_types::{data::ViewNumber, traits::node_implementation::NodeType};
 
 use hotshot::types::SystemContextHandle;
 

--- a/crates/testing/src/predicates.rs
+++ b/crates/testing/src/predicates.rs
@@ -1,7 +1,7 @@
 use hotshot_task_impls::{
     consensus::ConsensusTaskState, events::HotShotEvent, events::HotShotEvent::*,
 };
-use hotshot_types::{data::ViewNumber, traits::node_implementation::NodeType};
+use hotshot_types::traits::node_implementation::NodeType;
 
 use hotshot::types::SystemContextHandle;
 

--- a/crates/testing/src/test_helpers.rs
+++ b/crates/testing/src/test_helpers.rs
@@ -1,4 +1,10 @@
-pub fn permute<T>(inputs: Vec<T>, order: Vec<usize>) -> Vec<T>
+/// This function permutes the provided input vector `inputs`, given some order provided within the
+/// `order` vector.
+///
+/// # Examples
+/// let output = permute_input_with_index_order(vec![1, 2, 3], vec![2, 1, 0]);
+/// // Output is [3, 2, 1] now
+pub fn permute_input_with_index_order<T>(inputs: Vec<T>, order: Vec<usize>) -> Vec<T>
 where
     T: Clone,
 {

--- a/crates/testing/src/test_helpers.rs
+++ b/crates/testing/src/test_helpers.rs
@@ -1,0 +1,10 @@
+pub fn permute<T>(inputs: Vec<T>, order: Vec<usize>) -> Vec<T>
+where
+    T: Clone,
+{
+    let mut ordered_inputs = Vec::with_capacity(inputs.len());
+    for &index in &order {
+        ordered_inputs.push(inputs[index].clone());
+    }
+    ordered_inputs
+}

--- a/crates/testing/tests/consensus_task.rs
+++ b/crates/testing/tests/consensus_task.rs
@@ -3,23 +3,13 @@ use hotshot::types::SystemContextHandle;
 use hotshot_example_types::node_types::{MemoryImpl, TestTypes};
 use hotshot_task_impls::events::HotShotEvent;
 use hotshot_testing::task_helpers::{build_quorum_proposal, build_vote, key_pair_for_id};
+use hotshot_testing::test_helpers::permute_input_with_index_order;
 use hotshot_types::traits::{consensus_api::ConsensusApi, election::Membership};
 use hotshot_types::{
     data::ViewNumber, message::GeneralConsensusMessage, traits::node_implementation::ConsensusTime,
 };
 use jf_primitives::vid::VidScheme;
 use std::collections::HashMap;
-
-fn permute<T>(inputs: Vec<T>, order: Vec<usize>) -> Vec<T>
-where
-    T: Clone,
-{
-    let mut ordered_inputs = Vec::with_capacity(inputs.len());
-    for &index in &order {
-        ordered_inputs.push(inputs[index].clone());
-    }
-    ordered_inputs
-}
 
 #[cfg(test)]
 #[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
@@ -210,7 +200,7 @@ async fn test_vote_with_specific_order(input_permutation: Vec<usize>, force_pani
         DACRecv(dacs[1].clone()),
         QuorumProposalRecv(proposals[1].clone(), leaders[1]),
     ];
-    let view_2_inputs = permute(inputs, input_permutation);
+    let view_2_inputs = permute_input_with_index_order(inputs, input_permutation);
 
     let mut view_2_outputs = vec![
         exact(ViewChange(ViewNumber::new(2))),

--- a/crates/testing/tests/consensus_task.rs
+++ b/crates/testing/tests/consensus_task.rs
@@ -155,47 +155,97 @@ async fn test_consensus_vote() {
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 async fn test_consensus_task_old() {
     use hotshot::tasks::{inject_consensus_polls, task_state::CreateTaskState};
-    use hotshot_task_impls::{consensus::ConsensusTaskState, harness::run_harness};
-    use hotshot_testing::task_helpers::build_system_handle;
+    use hotshot_task_impls::{
+        consensus::ConsensusTaskState, events::HotShotEvent::*, harness::run_harness,
+    };
+    use hotshot_testing::{
+        predicates::{exact, is_at_view_number},
+        script::{run_test_script, TestScriptStage},
+        task_helpers::build_system_handle,
+        view_generator::TestViewGenerator,
+    };
     use hotshot_types::simple_certificate::QuorumCertificate;
 
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
 
-    let handle = build_system_handle(1).await.0;
+    let handle = build_system_handle(2).await.0;
+    let quorum_membership = handle.hotshot.memberships.quorum_membership.clone();
     // We assign node's key pair rather than read from config file since it's a test
-    let (private_key, public_key) = key_pair_for_id(1);
+    let (private_key, public_key) = key_pair_for_id(2);
 
-    let mut input = Vec::new();
-    let mut output = HashMap::new();
+    // let mut input = Vec::new();
+    // let mut output = HashMap::new();
 
     // Trigger a proposal to send by creating a new QC.  Then recieve that proposal and update view based on the valid QC in the proposal
     let qc = QuorumCertificate::<TestTypes>::genesis();
-    let proposal = build_quorum_proposal(&handle, &private_key, 1).await;
+    let mut generator = TestViewGenerator::generate(quorum_membership.clone());
 
-    input.push(HotShotEvent::QCFormed(either::Left(qc.clone())));
-    input.push(HotShotEvent::QuorumProposalRecv(
-        proposal.clone(),
-        public_key,
-    ));
-
-    input.push(HotShotEvent::Shutdown);
-
-    output.insert(
-        HotShotEvent::QuorumProposalSend(proposal.clone(), public_key),
-        1,
-    );
-    output.insert(
-        HotShotEvent::QuorumProposalValidated(proposal.data.clone()),
-        1,
-    );
-
-    output.insert(HotShotEvent::ViewChange(ViewNumber::new(1)), 1);
-
-    if let GeneralConsensusMessage::Vote(vote) = build_vote(&handle, proposal.data).await {
-        output.insert(HotShotEvent::QuorumVoteSend(vote.clone()), 1);
-        input.push(HotShotEvent::QuorumVoteRecv(vote.clone()));
+    let mut proposals = Vec::new();
+    let mut leaders = Vec::new();
+    let mut votes = Vec::new();
+    for view in (&mut generator).take(2) {
+        proposals.push(view.quorum_proposal.clone());
+        leaders.push(view.leader_public_key);
+        votes.push(view.create_vote(&handle));
     }
+
+    // Run view 1 (the genesis stage).
+    let view_1 = TestScriptStage {
+        inputs: vec![QuorumProposalRecv(proposals[0].clone(), leaders[0])],
+        outputs: vec![
+            exact(ViewChange(ViewNumber::new(1))),
+            exact(QuorumProposalValidated(proposals[0].data.clone())),
+            exact(QuorumVoteSend(votes[0].clone())),
+        ],
+        asserts: vec![is_at_view_number(1)],
+    };
+
+    let cert = proposals[1].data.justify_qc.clone();
+
+    // Run view 2 and propose.
+    let view_2 = TestScriptStage {
+        inputs: vec![
+            QCFormed(either::Left(cert)),
+            QuorumProposalRecv(proposals[1].clone(), leaders[1]),
+        ],
+        outputs: vec![
+            exact(ViewChange(ViewNumber::new(2))),
+            exact(QuorumProposalValidated(proposals[1].data.clone())),
+            exact(QuorumProposalSend(proposals[1].clone(), leaders[1])),
+        ],
+        asserts: vec![is_at_view_number(2)],
+    };
+
+    // input.push(HotShotEvent::QCFormed(either::Left(qc.clone())));
+    // input.push(HotShotEvent::QuorumProposalRecv(
+    //     proposal.clone(),
+    //     public_key,
+    // ));
+
+    // input.push(HotShotEvent::Shutdown);
+
+    // output.insert(
+    //     HotShotEvent::QuorumProposalSend(proposal.clone(), public_key),
+    //     1,
+    // );
+    // output.insert(
+    //     HotShotEvent::QuorumProposalValidated(proposal.data.clone()),
+    //     1,
+    // );
+
+    // output.insert(HotShotEvent::ViewChange(ViewNumber::new(1)), 1);
+
+    // if let GeneralConsensusMessage::Vote(vote) =
+    //     build_vote(&handle, proposals[0].data.clone()).await
+    // {
+    //     view_1
+    //         .outputs
+    //         .push(exact(HotShotEvent::QuorumVoteSend(vote.clone())));
+    //     view_1
+    //         .inputs
+    //         .push(HotShotEvent::QuorumVoteRecv(vote.clone()));
+    // }
 
     let consensus_state = ConsensusTaskState::<
         TestTypes,
@@ -206,7 +256,8 @@ async fn test_consensus_task_old() {
 
     inject_consensus_polls(&consensus_state).await;
 
-    run_harness(input, output, consensus_state, false).await;
+    // run_harness(input, output, consensus_state, false).await;
+    run_test_script(vec![view_1, view_2], consensus_state).await;
 }
 
 #[cfg(test)]

--- a/crates/testing/tests/consensus_task.rs
+++ b/crates/testing/tests/consensus_task.rs
@@ -210,7 +210,7 @@ async fn test_vote_with_specific_order(input_permutation: Vec<usize>, force_pani
         view_2_outputs.push(exact(QuorumVoteSend(votes[1].clone())));
     }
 
-    // Now, for view 2, receive a DAC before the quorum proposal.
+    // Use the permuted inputs for view 2 depending on the provided index ordering.
     let view_2 = TestScriptStage {
         inputs: view_2_inputs,
         outputs: view_2_outputs,

--- a/crates/testing/tests/consensus_task.rs
+++ b/crates/testing/tests/consensus_task.rs
@@ -146,6 +146,119 @@ async fn test_consensus_vote() {
     run_test_script(vec![view_1], consensus_state).await;
 }
 
+async fn test_vote_with_specific_order(dac_first: bool, force_panic: bool) {
+    use hotshot::tasks::{inject_consensus_polls, task_state::CreateTaskState};
+    use hotshot_task_impls::{consensus::ConsensusTaskState, events::HotShotEvent::*};
+    use hotshot_testing::{
+        predicates::{exact, is_at_view_number},
+        script::{run_test_script, TestScriptStage},
+        task_helpers::build_system_handle,
+        view_generator::TestViewGenerator,
+    };
+
+    async_compatibility_layer::logging::setup_logging();
+    async_compatibility_layer::logging::setup_backtrace();
+
+    let handle = build_system_handle(2).await.0;
+    let quorum_membership = handle.hotshot.memberships.quorum_membership.clone();
+
+    let mut generator = TestViewGenerator::generate(quorum_membership.clone());
+
+    let mut proposals = Vec::new();
+    let mut leaders = Vec::new();
+    let mut votes = Vec::new();
+    let mut dacs = Vec::new();
+    let mut vids = Vec::new();
+    for view in (&mut generator).take(2) {
+        proposals.push(view.quorum_proposal.clone());
+        leaders.push(view.leader_public_key);
+        votes.push(view.create_vote(&handle));
+        dacs.push(view.da_certificate.clone());
+        vids.push(view.vid_proposal.clone());
+    }
+
+    // Get out of the genesis view first
+    let view_1 = TestScriptStage {
+        inputs: vec![QuorumProposalRecv(proposals[0].clone(), leaders[0])],
+        outputs: vec![
+            exact(ViewChange(ViewNumber::new(1))),
+            exact(QuorumProposalValidated(proposals[0].data.clone())),
+            exact(QuorumVoteSend(votes[0].clone())),
+        ],
+        asserts: vec![is_at_view_number(1)],
+    };
+
+    let mut view_2_inputs = vec![
+        // We need a VID share for view 2 otherwise we cannot vote at view 2 (as node 2).
+        VidDisperseRecv(vids[1].0.clone(), vids[1].1),
+        DACRecv(dacs[1].clone()),
+        QuorumProposalRecv(proposals[1].clone(), leaders[1]),
+    ];
+    if !dac_first {
+        view_2_inputs.swap(1, 2);
+    }
+
+    let mut view_2_outputs = vec![
+        exact(ViewChange(ViewNumber::new(2))),
+        exact(QuorumProposalValidated(proposals[1].data.clone())),
+    ];
+    if !force_panic {
+        view_2_outputs.push(exact(QuorumVoteSend(votes[1].clone())));
+    }
+
+    // Now, for view 2, receive a DAC before the quorum proposal.
+    let view_2 = TestScriptStage {
+        inputs: view_2_inputs,
+        outputs: view_2_outputs,
+        asserts: vec![is_at_view_number(2)],
+    };
+
+    let consensus_state = ConsensusTaskState::<
+        TestTypes,
+        MemoryImpl,
+        SystemContextHandle<TestTypes, MemoryImpl>,
+    >::create_from(&handle)
+    .await;
+
+    inject_consensus_polls(&consensus_state).await;
+    run_test_script(vec![view_1, view_2], consensus_state).await;
+}
+
+#[cfg(test)]
+#[cfg_attr(
+    async_executor_impl = "tokio",
+    tokio::test(flavor = "multi_thread", worker_threads = 2)
+)]
+#[cfg_attr(async_executor_impl = "async-std", async_std::test)]
+async fn test_consensus_vote_with_permuted_dac() {
+    // Both of these tests verify that a vote is indeed sent no matter when it receives a DACRecv
+    // event. In particular, we want to verify that receiving events in an unexpected (but still
+    // valid) order allows the system to proceed as it normally would.
+    // Test the vote send where a `DACRecv` event comes first.
+    test_vote_with_specific_order(true /* dac_first */, false /* force_panic */).await;
+
+    // Test the vote send where a `DACRecv` event comes second.
+    test_vote_with_specific_order(false /* dac_first */, false /* force_panic */).await;
+}
+
+#[cfg(test)]
+#[cfg_attr(
+    async_executor_impl = "tokio",
+    tokio::test(flavor = "multi_thread", worker_threads = 2)
+)]
+#[cfg_attr(async_executor_impl = "async-std", async_std::test)]
+#[should_panic]
+async fn test_consensus_vote_with_permuted_dac_should_panic() {
+    // Both of these tests verify that a vote is indeed sent no matter when it receives a DACRecv
+    // event. In particular, we want to verify that receiving events in an unexpected (but still
+    // valid) order allows the system to proceed as it normally would.
+    // Test the vote send where a `DACRecv` event comes first.
+    test_vote_with_specific_order(true /* dac_first */, true /* force_panic */).await;
+
+    // Test the vote send where a `DACRecv` event comes second.
+    test_vote_with_specific_order(false /* dac_first */, true /* force_panic */).await;
+}
+
 /// TODO (jparr721): Nuke these old tests. Tracking: https://github.com/EspressoSystems/HotShot/issues/2727
 #[cfg(test)]
 #[cfg_attr(

--- a/crates/testing/tests/consensus_task.rs
+++ b/crates/testing/tests/consensus_task.rs
@@ -155,30 +155,27 @@ async fn test_consensus_vote() {
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 async fn test_consensus_task_old() {
     use hotshot::tasks::{inject_consensus_polls, task_state::CreateTaskState};
-    use hotshot_task_impls::{
-        consensus::ConsensusTaskState, events::HotShotEvent::*, harness::run_harness,
-    };
+    use hotshot_task_impls::{consensus::ConsensusTaskState, events::HotShotEvent::*};
     use hotshot_testing::{
-        predicates::{exact, is_at_view_number},
+        predicates::{exact, is_at_view_number, quorum_proposal_send},
         script::{run_test_script, TestScriptStage},
-        task_helpers::build_system_handle,
+        task_helpers::{build_system_handle, vid_scheme_from_view_number},
         view_generator::TestViewGenerator,
     };
-    use hotshot_types::simple_certificate::QuorumCertificate;
 
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
 
     let handle = build_system_handle(2).await.0;
     let quorum_membership = handle.hotshot.memberships.quorum_membership.clone();
-    // We assign node's key pair rather than read from config file since it's a test
-    let (private_key, public_key) = key_pair_for_id(2);
 
-    // let mut input = Vec::new();
-    // let mut output = HashMap::new();
+    // Make some empty encoded transactions, we just care about having a commitment handy for the
+    // later calls. We need the VID commitment to be able to propose later.
+    let vid = vid_scheme_from_view_number::<TestTypes>(&quorum_membership, ViewNumber::new(2));
+    let encoded_transactions = Vec::new();
+    let vid_disperse = vid.disperse(&encoded_transactions).unwrap();
+    let payload_commitment = vid_disperse.commit;
 
-    // Trigger a proposal to send by creating a new QC.  Then recieve that proposal and update view based on the valid QC in the proposal
-    let qc = QuorumCertificate::<TestTypes>::genesis();
     let mut generator = TestViewGenerator::generate(quorum_membership.clone());
 
     let mut proposals = Vec::new();
@@ -206,46 +203,18 @@ async fn test_consensus_task_old() {
     // Run view 2 and propose.
     let view_2 = TestScriptStage {
         inputs: vec![
-            QCFormed(either::Left(cert)),
             QuorumProposalRecv(proposals[1].clone(), leaders[1]),
+            QCFormed(either::Left(cert)),
+            // We must have a payload commitment and metadata to propose.
+            SendPayloadCommitmentAndMetadata(payload_commitment, (), ViewNumber::new(2)),
         ],
         outputs: vec![
             exact(ViewChange(ViewNumber::new(2))),
             exact(QuorumProposalValidated(proposals[1].data.clone())),
-            exact(QuorumProposalSend(proposals[1].clone(), leaders[1])),
+            quorum_proposal_send(),
         ],
         asserts: vec![is_at_view_number(2)],
     };
-
-    // input.push(HotShotEvent::QCFormed(either::Left(qc.clone())));
-    // input.push(HotShotEvent::QuorumProposalRecv(
-    //     proposal.clone(),
-    //     public_key,
-    // ));
-
-    // input.push(HotShotEvent::Shutdown);
-
-    // output.insert(
-    //     HotShotEvent::QuorumProposalSend(proposal.clone(), public_key),
-    //     1,
-    // );
-    // output.insert(
-    //     HotShotEvent::QuorumProposalValidated(proposal.data.clone()),
-    //     1,
-    // );
-
-    // output.insert(HotShotEvent::ViewChange(ViewNumber::new(1)), 1);
-
-    // if let GeneralConsensusMessage::Vote(vote) =
-    //     build_vote(&handle, proposals[0].data.clone()).await
-    // {
-    //     view_1
-    //         .outputs
-    //         .push(exact(HotShotEvent::QuorumVoteSend(vote.clone())));
-    //     view_1
-    //         .inputs
-    //         .push(HotShotEvent::QuorumVoteRecv(vote.clone()));
-    // }
 
     let consensus_state = ConsensusTaskState::<
         TestTypes,
@@ -256,7 +225,6 @@ async fn test_consensus_task_old() {
 
     inject_consensus_polls(&consensus_state).await;
 
-    // run_harness(input, output, consensus_state, false).await;
     run_test_script(vec![view_1, view_2], consensus_state).await;
 }
 

--- a/crates/testing/tests/consensus_task.rs
+++ b/crates/testing/tests/consensus_task.rs
@@ -240,30 +240,32 @@ async fn test_consensus_vote_old() {
     async_compatibility_layer::logging::setup_backtrace();
 
     let handle = build_system_handle(2).await.0;
-    // We assign node's key pair rather than read from config file since it's a test
-    let (private_key, public_key) = key_pair_for_id(1);
+    let quorum_membership = handle.hotshot.memberships.quorum_membership.clone();
 
-    let mut input = Vec::new();
-    let mut output = HashMap::new();
+    let mut generator = TestViewGenerator::generate(quorum_membership.clone());
 
-    let proposal = build_quorum_proposal(&handle, &private_key, 1).await;
-
-    // Send a proposal, vote on said proposal, update view based on proposal QC, receive vote as next leader
-    input.push(HotShotEvent::QuorumProposalRecv(
-        proposal.clone(),
-        public_key,
-    ));
-
-    let proposal = proposal.data;
-    output.insert(HotShotEvent::QuorumProposalValidated(proposal.clone()), 1);
-    if let GeneralConsensusMessage::Vote(vote) = build_vote(&handle, proposal).await {
-        output.insert(HotShotEvent::QuorumVoteSend(vote.clone()), 1);
-        input.push(HotShotEvent::QuorumVoteRecv(vote.clone()));
+    let mut proposals = Vec::new();
+    let mut leaders = Vec::new();
+    let mut votes = Vec::new();
+    for view in (&mut generator).take(2) {
+        proposals.push(view.quorum_proposal.clone());
+        leaders.push(view.leader_public_key);
+        votes.push(view.create_vote(&handle));
     }
 
-    output.insert(HotShotEvent::ViewChange(ViewNumber::new(1)), 1);
-
-    input.push(HotShotEvent::Shutdown);
+    // Send a proposal, vote on said proposal, update view based on proposal QC, receive vote as next leader
+    let view_1 = TestScriptStage {
+        inputs: vec![
+            QuorumProposalRecv(proposals[0].clone(), leaders[0]),
+            QuorumVoteRecv(votes[0].clone()),
+        ],
+        outputs: vec![
+            exact(ViewChange(ViewNumber::new(1))),
+            exact(QuorumProposalValidated(proposals[0].data.clone())),
+            exact(QuorumVoteSend(votes[0].clone())),
+        ],
+        asserts: vec![],
+    };
 
     let consensus_state = ConsensusTaskState::<
         TestTypes,
@@ -273,8 +275,7 @@ async fn test_consensus_vote_old() {
     .await;
 
     inject_consensus_polls(&consensus_state).await;
-
-    run_harness(input, output, consensus_state, false).await;
+    run_test_script(vec![view_1], consensus_state).await;
 }
 
 #[cfg(test)]

--- a/crates/testing/tests/consensus_task.rs
+++ b/crates/testing/tests/consensus_task.rs
@@ -200,7 +200,7 @@ async fn test_vote_with_specific_order(input_permutation: Vec<usize>) {
     ];
     let view_2_inputs = permute_input_with_index_order(inputs, input_permutation);
 
-    let mut view_2_outputs = vec![
+    let view_2_outputs = vec![
         exact(ViewChange(ViewNumber::new(2))),
         exact(QuorumProposalValidated(proposals[1].data.clone())),
         exact(QuorumVoteSend(votes[1].clone())),

--- a/crates/testing/tests/proposal_ordering.rs
+++ b/crates/testing/tests/proposal_ordering.rs
@@ -101,18 +101,7 @@ async fn test_ordering_with_specific_order(input_permutation: Vec<usize>) {
         asserts: vec![is_at_view_number(2)],
     };
 
-    // Attempt to initiate a proposal when a different view is up.
-    let fail_view = TestScriptStage {
-        inputs: vec![SendPayloadCommitmentAndMetadata(
-            payload_commitment,
-            (),
-            ViewNumber::new(3),
-        )],
-        outputs: vec![/* There should be nothing emitted here */],
-        asserts: vec![],
-    };
-
-    let script = vec![view_0, view_1, view_2, fail_view];
+    let script = vec![view_0, view_1];
 
     let consensus_state = ConsensusTaskState::<
         TestTypes,

--- a/crates/testing/tests/proposal_ordering.rs
+++ b/crates/testing/tests/proposal_ordering.rs
@@ -6,7 +6,10 @@ use hotshot_testing::{
     task_helpers::vid_scheme_from_view_number,
     view_generator::TestViewGenerator,
 };
-use hotshot_types::{data::ViewNumber, traits::node_implementation::ConsensusTime};
+use hotshot_types::{
+    data::ViewNumber,
+    traits::{consensus_api::ConsensusApi, node_implementation::ConsensusTime},
+};
 use jf_primitives::vid::VidScheme;
 
 fn permute<T>(inputs: Vec<T>, order: Vec<usize>) -> Vec<T>
@@ -33,6 +36,8 @@ async fn test_ordering_with_specific_order(input_permutation: Vec<usize>) {
     let node_id = 2;
     let handle = build_system_handle(node_id).await.0;
     let quorum_membership = handle.hotshot.memberships.quorum_membership.clone();
+    let public_key = handle.get_public_key();
+    let private_key = handle.private_key();
 
     let vid =
         vid_scheme_from_view_number::<TestTypes>(&quorum_membership, ViewNumber::new(node_id));
@@ -107,13 +112,13 @@ async fn test_ordering_with_specific_order(input_permutation: Vec<usize>) {
         inputs: vec![SendPayloadCommitmentAndMetadata(
             payload_commitment,
             (),
-            ViewNumber::new(2),
+            ViewNumber::new(3),
         )],
         outputs: vec![/* There should be nothing emitted here */],
         asserts: vec![],
     };
 
-    let script = vec![view_0, view_1, fail_view];
+    let script = vec![view_0, view_1, view_2, fail_view];
 
     let consensus_state = ConsensusTaskState::<
         TestTypes,

--- a/crates/testing/tests/proposal_ordering.rs
+++ b/crates/testing/tests/proposal_ordering.rs
@@ -102,7 +102,18 @@ async fn test_ordering_with_specific_order(input_permutation: Vec<usize>) {
         asserts: vec![is_at_view_number(2)],
     };
 
-    let script = vec![view_0, view_1];
+    // Attempt to initiate a proposal when a different view is up.
+    let fail_view = TestScriptStage {
+        inputs: vec![SendPayloadCommitmentAndMetadata(
+            payload_commitment,
+            (),
+            ViewNumber::new(2),
+        )],
+        outputs: vec![/* There should be nothing emitted here */],
+        asserts: vec![],
+    };
+
+    let script = vec![view_0, view_1, fail_view];
 
     let consensus_state = ConsensusTaskState::<
         TestTypes,

--- a/crates/testing/tests/proposal_ordering.rs
+++ b/crates/testing/tests/proposal_ordering.rs
@@ -25,6 +25,7 @@ where
 async fn test_ordering_with_specific_order(input_permutation: Vec<usize>) {
     use hotshot_testing::script::{run_test_script, TestScriptStage};
     use hotshot_testing::task_helpers::build_system_handle;
+    use hotshot_types::simple_certificate::QuorumCertificate;
 
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();

--- a/crates/testing/tests/proposal_ordering.rs
+++ b/crates/testing/tests/proposal_ordering.rs
@@ -6,10 +6,7 @@ use hotshot_testing::{
     task_helpers::vid_scheme_from_view_number,
     view_generator::TestViewGenerator,
 };
-use hotshot_types::{
-    data::ViewNumber,
-    traits::{consensus_api::ConsensusApi, node_implementation::ConsensusTime},
-};
+use hotshot_types::{data::ViewNumber, traits::node_implementation::ConsensusTime};
 use jf_primitives::vid::VidScheme;
 
 fn permute<T>(inputs: Vec<T>, order: Vec<usize>) -> Vec<T>
@@ -28,7 +25,6 @@ where
 async fn test_ordering_with_specific_order(input_permutation: Vec<usize>) {
     use hotshot_testing::script::{run_test_script, TestScriptStage};
     use hotshot_testing::task_helpers::build_system_handle;
-    use hotshot_types::simple_certificate::QuorumCertificate;
 
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
@@ -36,8 +32,6 @@ async fn test_ordering_with_specific_order(input_permutation: Vec<usize>) {
     let node_id = 2;
     let handle = build_system_handle(node_id).await.0;
     let quorum_membership = handle.hotshot.memberships.quorum_membership.clone();
-    let public_key = handle.get_public_key();
-    let private_key = handle.private_key();
 
     let vid =
         vid_scheme_from_view_number::<TestTypes>(&quorum_membership, ViewNumber::new(node_id));

--- a/crates/testing/tests/proposal_ordering.rs
+++ b/crates/testing/tests/proposal_ordering.rs
@@ -101,7 +101,7 @@ async fn test_ordering_with_specific_order(input_permutation: Vec<usize>) {
         asserts: vec![is_at_view_number(2)],
     };
 
-    let script = vec![view_0, view_1];
+    let script = vec![view_1, view_2];
 
     let consensus_state = ConsensusTaskState::<
         TestTypes,

--- a/crates/testing/tests/proposal_ordering.rs
+++ b/crates/testing/tests/proposal_ordering.rs
@@ -4,21 +4,11 @@ use hotshot_task_impls::{consensus::ConsensusTaskState, events::HotShotEvent::*}
 use hotshot_testing::{
     predicates::{exact, is_at_view_number, quorum_proposal_send},
     task_helpers::vid_scheme_from_view_number,
+    test_helpers::permute,
     view_generator::TestViewGenerator,
 };
 use hotshot_types::{data::ViewNumber, traits::node_implementation::ConsensusTime};
 use jf_primitives::vid::VidScheme;
-
-fn permute<T>(inputs: Vec<T>, order: Vec<usize>) -> Vec<T>
-where
-    T: Clone,
-{
-    let mut ordered_inputs = Vec::with_capacity(inputs.len());
-    for &index in &order {
-        ordered_inputs.push(inputs[index].clone());
-    }
-    ordered_inputs
-}
 
 /// Runs a basic test where a qualified proposal occurs (i.e. not initiated by the genesis view or node 1).
 /// This proposal should happen no matter how the `input_permutation` is specified.

--- a/crates/testing/tests/proposal_ordering.rs
+++ b/crates/testing/tests/proposal_ordering.rs
@@ -102,13 +102,7 @@ async fn test_ordering_with_specific_order(input_permutation: Vec<usize>) {
         asserts: vec![is_at_view_number(2)],
     };
 
-    let view_3 = TestScriptStage {
-        inputs: vec![QuorumProposalRecv(proposals[1].clone(), leaders[1])],
-        outputs: vec![exact(ViewChange(ViewNumber::new(2)))],
-        asserts: vec![],
-    };
-
-    let script = vec![view_1, view_2, view_3];
+    let script = vec![view_0, view_1];
 
     let consensus_state = ConsensusTaskState::<
         TestTypes,

--- a/crates/testing/tests/proposal_ordering.rs
+++ b/crates/testing/tests/proposal_ordering.rs
@@ -4,7 +4,7 @@ use hotshot_task_impls::{consensus::ConsensusTaskState, events::HotShotEvent::*}
 use hotshot_testing::{
     predicates::{exact, is_at_view_number, quorum_proposal_send},
     task_helpers::vid_scheme_from_view_number,
-    test_helpers::permute,
+    test_helpers::permute_input_with_index_order,
     view_generator::TestViewGenerator,
 };
 use hotshot_types::{data::ViewNumber, traits::node_implementation::ConsensusTime};
@@ -81,7 +81,7 @@ async fn test_ordering_with_specific_order(input_permutation: Vec<usize>) {
         ]
     };
 
-    let view_2_inputs = permute(inputs, input_permutation);
+    let view_2_inputs = permute_input_with_index_order(inputs, input_permutation);
 
     // This stage transitions from view 1 to view 2.
     let view_2 = TestScriptStage {

--- a/crates/testing/tests/proposal_ordering.rs
+++ b/crates/testing/tests/proposal_ordering.rs
@@ -102,7 +102,13 @@ async fn test_ordering_with_specific_order(input_permutation: Vec<usize>) {
         asserts: vec![is_at_view_number(2)],
     };
 
-    let script = vec![view_1, view_2];
+    let view_3 = TestScriptStage {
+        inputs: vec![QuorumProposalRecv(proposals[1].clone(), leaders[1])],
+        outputs: vec![exact(ViewChange(ViewNumber::new(2)))],
+        asserts: vec![],
+    };
+
+    let script = vec![view_1, view_2, view_3];
 
     let consensus_state = ConsensusTaskState::<
         TestTypes,


### PR DESCRIPTION
Depends on: https://github.com/EspressoSystems/HotShot/pull/2697 and https://github.com/EspressoSystems/HotShot/pull/2716.
Closes #2306 
<!-- See here for keywords in Github -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

### This PR: 
>We've seen multiple bugs with not sending a vote after receiving events in an order we don't expect. First we saw this when a replica got a DAC after the proposal. Another example could be receiving a VID before/after the proposal.

This PR creates two unit tests where we vote for a (non-genesis) proposal, receiving a DAC:
1. After Quorum proposal and 
2. Before the Quorum proposal

### This PR does not: 
This PR does not address the underlying logic issues that my have precipitated this issue, it only adds a test to alert if it happens again.

### Key places to review: 
All test code, in particular, to verify that this does actually test the described case.

### How to test this PR:
cargo test -p hotshot-testing --test consensus_task

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
