### PR TITLE
Change test logging in CI

### DIFF
--- a/.github/workflows/build-and-test-self-hosted.yml
+++ b/.github/workflows/build-and-test-self-hosted.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Unit and integration tests for all crates in workspace
         run: |
-          just ${{ matrix.just_variants }} test
+          just ${{ matrix.just_variants }} test-ci
         timeout-minutes: 60
         env:
           RUST_BACKTRACE: full

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Unit and integration tests for all crates in workspace
         run: |
-          just ${{ matrix.just_variants }} test
+          just ${{ matrix.just_variants }} test-ci
         timeout-minutes: 60
         env:
           RUST_BACKTRACE: full

--- a/crates/testing/tests/upgrade_task.rs
+++ b/crates/testing/tests/upgrade_task.rs
@@ -119,7 +119,7 @@ async fn test_upgrade_task() {
         outputs: vec![
             exact(ViewChange(ViewNumber::new(5))),
             exact(QuorumProposalValidated(proposals[4].data.clone())),
-            leaf_decided(),
+            // leaf_decided(),
         ],
         asserts: vec![decided_upgrade_cert()],
     };

--- a/crates/testing/tests/upgrade_task.rs
+++ b/crates/testing/tests/upgrade_task.rs
@@ -119,7 +119,7 @@ async fn test_upgrade_task() {
         outputs: vec![
             exact(ViewChange(ViewNumber::new(5))),
             exact(QuorumProposalValidated(proposals[4].data.clone())),
-            // leaf_decided(),
+            leaf_decided(),
         ],
         asserts: vec![decided_upgrade_cert()],
     };

--- a/justfile
+++ b/justfile
@@ -45,6 +45,10 @@ test *ARGS:
   echo Testing {{ARGS}}
   cargo test --verbose --lib --bins --tests --benches --workspace --no-fail-fast {{ARGS}} -- --test-threads=1 --nocapture --skip crypto_test
 
+test-ci *ARGS:
+  echo Testing {{ARGS}}
+  RUST_LOG=hotshot=debug cargo test --verbose --lib --bins --tests --benches --workspace --no-fail-fast {{ARGS}} -- --test-threads=1 --skip crypto_test
+
 test_basic: test_success test_with_failures test_network_task test_consensus_task test_da_task test_vid_task test_view_sync_task
 
 test_catchup:


### PR DESCRIPTION
No linked issue.

### This PR: 
Sets `RUST_LOG=hotshot=debug` for CI tests, and removes `--nocapture`.

This should display logs only for failing tests, and enable debug logging for all hotshot crates.

### This PR does not: 
There should be no change to local testing. `just test` will function as before, and CI uses a new `just test-ci` instead.

### Key places to review:
For an example of what the log would look like, see: https://github.com/EspressoSystems/HotShot/actions/runs/8195751923/job/22414599861?pr=2724

Note: for integration tests like `test_catchup_web`, the logs will be _much_ bigger if they fail. But the hope is that this happens rarely, and when they do fail we have enough information to figure out why.