### PR TITLE
Fix publishing Rust docs

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Create documentation
         if: ${{ github.ref == 'refs/heads/main' }}
         run: |
-          cp -R target/doc public
+          cp -R target/async-std/doc public
           echo '<meta http-equiv="refresh" content="0; url=hotshot">' > public/index.html
 
       - name: Deploy


### PR DESCRIPTION
No linked issue.

### This PR: 
Fixes an oversight in #2675 which made documentation fail to generate.

### This PR does not: 

### Key places to review: 
