### PR TITLE
[EASY] Don't limit Tokio to 2 Threads

### DIFF
--- a/crates/examples/combined/all.rs
+++ b/crates/examples/combined/all.rs
@@ -27,10 +27,7 @@ use crate::{
 #[path = "../infra/mod.rs"]
 pub mod infra;
 
-#[cfg_attr(
-    async_executor_impl = "tokio",
-    tokio::main(flavor = "multi_thread")
-)]
+#[cfg_attr(async_executor_impl = "tokio", tokio::main(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::main)]
 #[instrument]
 async fn main() {

--- a/crates/examples/combined/all.rs
+++ b/crates/examples/combined/all.rs
@@ -29,7 +29,7 @@ pub mod infra;
 
 #[cfg_attr(
     async_executor_impl = "tokio",
-    tokio::main(flavor = "multi_thread", worker_threads = 2)
+    tokio::main(flavor = "multi_thread")
 )]
 #[cfg_attr(async_executor_impl = "async-std", async_std::main)]
 #[instrument]

--- a/crates/examples/combined/multi-validator.rs
+++ b/crates/examples/combined/multi-validator.rs
@@ -19,7 +19,7 @@ pub mod infra;
 
 #[cfg_attr(
     async_executor_impl = "tokio",
-    tokio::main(flavor = "multi_thread", worker_threads = 2)
+    tokio::main(flavor = "multi_thread")
 )]
 #[cfg_attr(async_executor_impl = "async-std", async_std::main)]
 #[instrument]

--- a/crates/examples/combined/multi-validator.rs
+++ b/crates/examples/combined/multi-validator.rs
@@ -17,10 +17,7 @@ pub mod types;
 #[path = "../infra/mod.rs"]
 pub mod infra;
 
-#[cfg_attr(
-    async_executor_impl = "tokio",
-    tokio::main(flavor = "multi_thread")
-)]
+#[cfg_attr(async_executor_impl = "tokio", tokio::main(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::main)]
 #[instrument]
 async fn main() {

--- a/crates/examples/combined/orchestrator.rs
+++ b/crates/examples/combined/orchestrator.rs
@@ -15,10 +15,7 @@ use crate::types::{DANetwork, NodeImpl, QuorumNetwork};
 #[path = "../infra/mod.rs"]
 pub mod infra;
 
-#[cfg_attr(
-    async_executor_impl = "tokio",
-    tokio::main(flavor = "multi_thread")
-)]
+#[cfg_attr(async_executor_impl = "tokio", tokio::main(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::main)]
 #[instrument]
 async fn main() {

--- a/crates/examples/combined/orchestrator.rs
+++ b/crates/examples/combined/orchestrator.rs
@@ -17,7 +17,7 @@ pub mod infra;
 
 #[cfg_attr(
     async_executor_impl = "tokio",
-    tokio::main(flavor = "multi_thread", worker_threads = 2)
+    tokio::main(flavor = "multi_thread")
 )]
 #[cfg_attr(async_executor_impl = "async-std", async_std::main)]
 #[instrument]

--- a/crates/examples/combined/validator.rs
+++ b/crates/examples/combined/validator.rs
@@ -15,10 +15,7 @@ pub mod types;
 #[path = "../infra/mod.rs"]
 pub mod infra;
 
-#[cfg_attr(
-    async_executor_impl = "tokio",
-    tokio::main(flavor = "multi_thread")
-)]
+#[cfg_attr(async_executor_impl = "tokio", tokio::main(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::main)]
 #[instrument]
 async fn main() {

--- a/crates/examples/combined/validator.rs
+++ b/crates/examples/combined/validator.rs
@@ -17,7 +17,7 @@ pub mod infra;
 
 #[cfg_attr(
     async_executor_impl = "tokio",
-    tokio::main(flavor = "multi_thread", worker_threads = 2)
+    tokio::main(flavor = "multi_thread")
 )]
 #[cfg_attr(async_executor_impl = "async-std", async_std::main)]
 #[instrument]

--- a/crates/examples/libp2p/all.rs
+++ b/crates/examples/libp2p/all.rs
@@ -27,7 +27,7 @@ pub mod infra;
 
 #[cfg_attr(
     async_executor_impl = "tokio",
-    tokio::main(flavor = "multi_thread", worker_threads = 2)
+    tokio::main(flavor = "multi_thread")
 )]
 #[cfg_attr(async_executor_impl = "async-std", async_std::main)]
 #[instrument]

--- a/crates/examples/libp2p/all.rs
+++ b/crates/examples/libp2p/all.rs
@@ -25,10 +25,7 @@ use crate::{
 #[path = "../infra/mod.rs"]
 pub mod infra;
 
-#[cfg_attr(
-    async_executor_impl = "tokio",
-    tokio::main(flavor = "multi_thread")
-)]
+#[cfg_attr(async_executor_impl = "tokio", tokio::main(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::main)]
 #[instrument]
 async fn main() {

--- a/crates/examples/libp2p/multi-validator.rs
+++ b/crates/examples/libp2p/multi-validator.rs
@@ -19,7 +19,7 @@ pub mod infra;
 
 #[cfg_attr(
     async_executor_impl = "tokio",
-    tokio::main(flavor = "multi_thread", worker_threads = 2)
+    tokio::main(flavor = "multi_thread")
 )]
 #[cfg_attr(async_executor_impl = "async-std", async_std::main)]
 #[instrument]

--- a/crates/examples/libp2p/multi-validator.rs
+++ b/crates/examples/libp2p/multi-validator.rs
@@ -17,10 +17,7 @@ pub mod types;
 #[path = "../infra/mod.rs"]
 pub mod infra;
 
-#[cfg_attr(
-    async_executor_impl = "tokio",
-    tokio::main(flavor = "multi_thread")
-)]
+#[cfg_attr(async_executor_impl = "tokio", tokio::main(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::main)]
 #[instrument]
 async fn main() {

--- a/crates/examples/libp2p/orchestrator.rs
+++ b/crates/examples/libp2p/orchestrator.rs
@@ -16,10 +16,7 @@ use crate::types::{DANetwork, NodeImpl, QuorumNetwork};
 #[path = "../infra/mod.rs"]
 pub mod infra;
 
-#[cfg_attr(
-    async_executor_impl = "tokio",
-    tokio::main(flavor = "multi_thread")
-)]
+#[cfg_attr(async_executor_impl = "tokio", tokio::main(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::main)]
 #[instrument]
 async fn main() {

--- a/crates/examples/libp2p/orchestrator.rs
+++ b/crates/examples/libp2p/orchestrator.rs
@@ -18,7 +18,7 @@ pub mod infra;
 
 #[cfg_attr(
     async_executor_impl = "tokio",
-    tokio::main(flavor = "multi_thread", worker_threads = 2)
+    tokio::main(flavor = "multi_thread")
 )]
 #[cfg_attr(async_executor_impl = "async-std", async_std::main)]
 #[instrument]

--- a/crates/examples/libp2p/validator.rs
+++ b/crates/examples/libp2p/validator.rs
@@ -15,10 +15,7 @@ pub mod types;
 #[path = "../infra/mod.rs"]
 pub mod infra;
 
-#[cfg_attr(
-    async_executor_impl = "tokio",
-    tokio::main(flavor = "multi_thread")
-)]
+#[cfg_attr(async_executor_impl = "tokio", tokio::main(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::main)]
 #[instrument]
 async fn main() {

--- a/crates/examples/libp2p/validator.rs
+++ b/crates/examples/libp2p/validator.rs
@@ -17,7 +17,7 @@ pub mod infra;
 
 #[cfg_attr(
     async_executor_impl = "tokio",
-    tokio::main(flavor = "multi_thread", worker_threads = 2)
+    tokio::main(flavor = "multi_thread")
 )]
 #[cfg_attr(async_executor_impl = "async-std", async_std::main)]
 #[instrument]

--- a/crates/examples/webserver/multi-validator.rs
+++ b/crates/examples/webserver/multi-validator.rs
@@ -19,7 +19,7 @@ pub mod infra;
 
 #[cfg_attr(
     async_executor_impl = "tokio",
-    tokio::main(flavor = "multi_thread", worker_threads = 2)
+    tokio::main(flavor = "multi_thread")
 )]
 #[cfg_attr(async_executor_impl = "async-std", async_std::main)]
 #[instrument]

--- a/crates/examples/webserver/multi-validator.rs
+++ b/crates/examples/webserver/multi-validator.rs
@@ -17,10 +17,7 @@ pub mod types;
 #[path = "../infra/mod.rs"]
 pub mod infra;
 
-#[cfg_attr(
-    async_executor_impl = "tokio",
-    tokio::main(flavor = "multi_thread")
-)]
+#[cfg_attr(async_executor_impl = "tokio", tokio::main(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::main)]
 #[instrument]
 async fn main() {

--- a/crates/examples/webserver/orchestrator.rs
+++ b/crates/examples/webserver/orchestrator.rs
@@ -16,10 +16,7 @@ use crate::types::{DANetwork, NodeImpl, QuorumNetwork};
 #[path = "../infra/mod.rs"]
 pub mod infra;
 
-#[cfg_attr(
-    async_executor_impl = "tokio",
-    tokio::main(flavor = "multi_thread")
-)]
+#[cfg_attr(async_executor_impl = "tokio", tokio::main(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::main)]
 #[instrument]
 async fn main() {

--- a/crates/examples/webserver/orchestrator.rs
+++ b/crates/examples/webserver/orchestrator.rs
@@ -18,7 +18,7 @@ pub mod infra;
 
 #[cfg_attr(
     async_executor_impl = "tokio",
-    tokio::main(flavor = "multi_thread", worker_threads = 2)
+    tokio::main(flavor = "multi_thread")
 )]
 #[cfg_attr(async_executor_impl = "async-std", async_std::main)]
 #[instrument]

--- a/crates/examples/webserver/validator.rs
+++ b/crates/examples/webserver/validator.rs
@@ -15,10 +15,7 @@ pub mod types;
 #[path = "../infra/mod.rs"]
 pub mod infra;
 
-#[cfg_attr(
-    async_executor_impl = "tokio",
-    tokio::main(flavor = "multi_thread")
-)]
+#[cfg_attr(async_executor_impl = "tokio", tokio::main(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::main)]
 #[instrument]
 async fn main() {

--- a/crates/examples/webserver/validator.rs
+++ b/crates/examples/webserver/validator.rs
@@ -17,7 +17,7 @@ pub mod infra;
 
 #[cfg_attr(
     async_executor_impl = "tokio",
-    tokio::main(flavor = "multi_thread", worker_threads = 2)
+    tokio::main(flavor = "multi_thread")
 )]
 #[cfg_attr(async_executor_impl = "async-std", async_std::main)]
 #[instrument]

--- a/crates/hotshot/src/traits/networking/combined_network.rs
+++ b/crates/hotshot/src/traits/networking/combined_network.rs
@@ -488,7 +488,7 @@ mod test {
     /// cache eviction test
     #[cfg_attr(
         async_executor_impl = "tokio",
-        tokio::test(flavor = "multi_thread", worker_threads = 2)
+        tokio::test(flavor = "multi_thread")
     )]
     #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
     #[instrument]

--- a/crates/hotshot/src/traits/networking/combined_network.rs
+++ b/crates/hotshot/src/traits/networking/combined_network.rs
@@ -486,10 +486,7 @@ mod test {
     use tracing::instrument;
 
     /// cache eviction test
-    #[cfg_attr(
-        async_executor_impl = "tokio",
-        tokio::test(flavor = "multi_thread")
-    )]
+    #[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
     #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
     #[instrument]
     async fn test_cache_eviction() {

--- a/crates/libp2p-networking/tests/counter.rs
+++ b/crates/libp2p-networking/tests/counter.rs
@@ -472,10 +472,7 @@ async fn run_request_response_increment_all(
 }
 
 /// simple case of direct message
-#[cfg_attr(
-    async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread")
-)]
+#[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 #[instrument]
 async fn test_coverage_request_response_one_round() {
@@ -490,10 +487,7 @@ async fn test_coverage_request_response_one_round() {
 }
 
 /// stress test of direct messsage
-#[cfg_attr(
-    async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread")
-)]
+#[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 #[instrument]
 async fn test_coverage_request_response_many_rounds() {
@@ -508,10 +502,7 @@ async fn test_coverage_request_response_many_rounds() {
 }
 
 /// stress test of broadcast + direct message
-#[cfg_attr(
-    async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread")
-)]
+#[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 #[instrument]
 async fn test_coverage_intersperse_many_rounds() {
@@ -526,10 +517,7 @@ async fn test_coverage_intersperse_many_rounds() {
 }
 
 /// stress teset that we can broadcast a message out and get counter increments
-#[cfg_attr(
-    async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread")
-)]
+#[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 #[instrument]
 async fn test_coverage_gossip_many_rounds() {
@@ -544,10 +532,7 @@ async fn test_coverage_gossip_many_rounds() {
 }
 
 /// simple case of broadcast message
-#[cfg_attr(
-    async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread")
-)]
+#[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 #[instrument]
 async fn test_coverage_gossip_one_round() {
@@ -562,10 +547,7 @@ async fn test_coverage_gossip_one_round() {
 }
 
 /// simple case of direct message
-#[cfg_attr(
-    async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread")
-)]
+#[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 #[instrument]
 #[ignore]
@@ -581,10 +563,7 @@ async fn test_stress_request_response_one_round() {
 }
 
 /// stress test of direct messsage
-#[cfg_attr(
-    async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread")
-)]
+#[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 #[instrument]
 #[ignore]
@@ -600,10 +579,7 @@ async fn test_stress_request_response_many_rounds() {
 }
 
 /// stress test of broadcast + direct message
-#[cfg_attr(
-    async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread")
-)]
+#[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 #[instrument]
 #[ignore]
@@ -619,10 +595,7 @@ async fn test_stress_intersperse_many_rounds() {
 }
 
 /// stress teset that we can broadcast a message out and get counter increments
-#[cfg_attr(
-    async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread")
-)]
+#[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 #[instrument]
 #[ignore]
@@ -638,10 +611,7 @@ async fn test_stress_gossip_many_rounds() {
 }
 
 /// simple case of broadcast message
-#[cfg_attr(
-    async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread")
-)]
+#[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 #[instrument]
 #[ignore]
@@ -657,10 +627,7 @@ async fn test_stress_gossip_one_round() {
 }
 
 /// simple case of one dht publish event
-#[cfg_attr(
-    async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread")
-)]
+#[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 #[instrument]
 #[ignore]
@@ -676,10 +643,7 @@ async fn test_stress_dht_one_round() {
 }
 
 /// many dht publishing events
-#[cfg_attr(
-    async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread")
-)]
+#[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 #[instrument]
 #[ignore]
@@ -695,10 +659,7 @@ async fn test_stress_dht_many_rounds() {
 }
 
 /// simple case of one dht publish event
-#[cfg_attr(
-    async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread")
-)]
+#[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 #[instrument]
 async fn test_coverage_dht_one_round() {
@@ -713,10 +674,7 @@ async fn test_coverage_dht_one_round() {
 }
 
 /// many dht publishing events
-#[cfg_attr(
-    async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread")
-)]
+#[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 #[instrument]
 async fn test_coverage_dht_many_rounds() {

--- a/crates/libp2p-networking/tests/counter.rs
+++ b/crates/libp2p-networking/tests/counter.rs
@@ -474,7 +474,7 @@ async fn run_request_response_increment_all(
 /// simple case of direct message
 #[cfg_attr(
     async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread", worker_threads = 2)
+    tokio::test(flavor = "multi_thread")
 )]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 #[instrument]
@@ -492,7 +492,7 @@ async fn test_coverage_request_response_one_round() {
 /// stress test of direct messsage
 #[cfg_attr(
     async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread", worker_threads = 2)
+    tokio::test(flavor = "multi_thread")
 )]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 #[instrument]
@@ -510,7 +510,7 @@ async fn test_coverage_request_response_many_rounds() {
 /// stress test of broadcast + direct message
 #[cfg_attr(
     async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread", worker_threads = 2)
+    tokio::test(flavor = "multi_thread")
 )]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 #[instrument]
@@ -528,7 +528,7 @@ async fn test_coverage_intersperse_many_rounds() {
 /// stress teset that we can broadcast a message out and get counter increments
 #[cfg_attr(
     async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread", worker_threads = 2)
+    tokio::test(flavor = "multi_thread")
 )]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 #[instrument]
@@ -546,7 +546,7 @@ async fn test_coverage_gossip_many_rounds() {
 /// simple case of broadcast message
 #[cfg_attr(
     async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread", worker_threads = 2)
+    tokio::test(flavor = "multi_thread")
 )]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 #[instrument]
@@ -564,7 +564,7 @@ async fn test_coverage_gossip_one_round() {
 /// simple case of direct message
 #[cfg_attr(
     async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread", worker_threads = 2)
+    tokio::test(flavor = "multi_thread")
 )]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 #[instrument]
@@ -583,7 +583,7 @@ async fn test_stress_request_response_one_round() {
 /// stress test of direct messsage
 #[cfg_attr(
     async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread", worker_threads = 2)
+    tokio::test(flavor = "multi_thread")
 )]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 #[instrument]
@@ -602,7 +602,7 @@ async fn test_stress_request_response_many_rounds() {
 /// stress test of broadcast + direct message
 #[cfg_attr(
     async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread", worker_threads = 2)
+    tokio::test(flavor = "multi_thread")
 )]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 #[instrument]
@@ -621,7 +621,7 @@ async fn test_stress_intersperse_many_rounds() {
 /// stress teset that we can broadcast a message out and get counter increments
 #[cfg_attr(
     async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread", worker_threads = 2)
+    tokio::test(flavor = "multi_thread")
 )]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 #[instrument]
@@ -640,7 +640,7 @@ async fn test_stress_gossip_many_rounds() {
 /// simple case of broadcast message
 #[cfg_attr(
     async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread", worker_threads = 2)
+    tokio::test(flavor = "multi_thread")
 )]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 #[instrument]
@@ -659,7 +659,7 @@ async fn test_stress_gossip_one_round() {
 /// simple case of one dht publish event
 #[cfg_attr(
     async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread", worker_threads = 2)
+    tokio::test(flavor = "multi_thread")
 )]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 #[instrument]
@@ -678,7 +678,7 @@ async fn test_stress_dht_one_round() {
 /// many dht publishing events
 #[cfg_attr(
     async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread", worker_threads = 2)
+    tokio::test(flavor = "multi_thread")
 )]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 #[instrument]
@@ -697,7 +697,7 @@ async fn test_stress_dht_many_rounds() {
 /// simple case of one dht publish event
 #[cfg_attr(
     async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread", worker_threads = 2)
+    tokio::test(flavor = "multi_thread")
 )]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 #[instrument]
@@ -715,7 +715,7 @@ async fn test_coverage_dht_one_round() {
 /// many dht publishing events
 #[cfg_attr(
     async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread", worker_threads = 2)
+    tokio::test(flavor = "multi_thread")
 )]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 #[instrument]

--- a/crates/task/src/dependency.rs
+++ b/crates/task/src/dependency.rs
@@ -167,10 +167,7 @@ mod tests {
         }
     }
 
-    #[cfg_attr(
-        async_executor_impl = "tokio",
-        tokio::test(flavor = "multi_thread")
-    )]
+    #[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
     #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
     async fn it_works() {
         let (tx, rx) = broadcast(10);
@@ -186,10 +183,7 @@ mod tests {
         let result = and.completed().await;
         assert_eq!(result, Some(vec![5; 5]));
     }
-    #[cfg_attr(
-        async_executor_impl = "tokio",
-        tokio::test(flavor = "multi_thread")
-    )]
+    #[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
     #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
     async fn or_dep() {
         let (tx, rx) = broadcast(10);
@@ -204,10 +198,7 @@ mod tests {
         assert_eq!(result, Some(5));
     }
 
-    #[cfg_attr(
-        async_executor_impl = "tokio",
-        tokio::test(flavor = "multi_thread")
-    )]
+    #[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
     #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
     async fn and_or_dep() {
         let (tx, rx) = broadcast(10);
@@ -225,10 +216,7 @@ mod tests {
         assert_eq!(result, Some(vec![6, 5]));
     }
 
-    #[cfg_attr(
-        async_executor_impl = "tokio",
-        tokio::test(flavor = "multi_thread")
-    )]
+    #[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
     #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
     async fn or_and_dep() {
         let (tx, rx) = broadcast(10);
@@ -246,10 +234,7 @@ mod tests {
         assert_eq!(result, Some(vec![4, 5]));
     }
 
-    #[cfg_attr(
-        async_executor_impl = "tokio",
-        tokio::test(flavor = "multi_thread")
-    )]
+    #[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
     #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
     async fn many_and_dep() {
         let (tx, rx) = broadcast(10);

--- a/crates/task/src/dependency.rs
+++ b/crates/task/src/dependency.rs
@@ -169,7 +169,7 @@ mod tests {
 
     #[cfg_attr(
         async_executor_impl = "tokio",
-        tokio::test(flavor = "multi_thread", worker_threads = 2)
+        tokio::test(flavor = "multi_thread")
     )]
     #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
     async fn it_works() {
@@ -188,7 +188,7 @@ mod tests {
     }
     #[cfg_attr(
         async_executor_impl = "tokio",
-        tokio::test(flavor = "multi_thread", worker_threads = 2)
+        tokio::test(flavor = "multi_thread")
     )]
     #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
     async fn or_dep() {
@@ -206,7 +206,7 @@ mod tests {
 
     #[cfg_attr(
         async_executor_impl = "tokio",
-        tokio::test(flavor = "multi_thread", worker_threads = 2)
+        tokio::test(flavor = "multi_thread")
     )]
     #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
     async fn and_or_dep() {
@@ -227,7 +227,7 @@ mod tests {
 
     #[cfg_attr(
         async_executor_impl = "tokio",
-        tokio::test(flavor = "multi_thread", worker_threads = 2)
+        tokio::test(flavor = "multi_thread")
     )]
     #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
     async fn or_and_dep() {
@@ -248,7 +248,7 @@ mod tests {
 
     #[cfg_attr(
         async_executor_impl = "tokio",
-        tokio::test(flavor = "multi_thread", worker_threads = 2)
+        tokio::test(flavor = "multi_thread")
     )]
     #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
     async fn many_and_dep() {

--- a/crates/task/src/dependency_task.rs
+++ b/crates/task/src/dependency_task.rs
@@ -88,10 +88,7 @@ mod test {
         }
     }
 
-    #[cfg_attr(
-        async_executor_impl = "tokio",
-        tokio::test(flavor = "multi_thread")
-    )]
+    #[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
     #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
     // allow unused for tokio because it's a test
     #[allow(unused_must_use)]
@@ -107,10 +104,7 @@ mod test {
         join_handle.await;
     }
 
-    #[cfg_attr(
-        async_executor_impl = "tokio",
-        tokio::test(flavor = "multi_thread")
-    )]
+    #[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
     #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
     async fn many_works() {
         let (tx, rx) = broadcast(20);

--- a/crates/task/src/dependency_task.rs
+++ b/crates/task/src/dependency_task.rs
@@ -90,7 +90,7 @@ mod test {
 
     #[cfg_attr(
         async_executor_impl = "tokio",
-        tokio::test(flavor = "multi_thread", worker_threads = 2)
+        tokio::test(flavor = "multi_thread")
     )]
     #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
     // allow unused for tokio because it's a test
@@ -109,7 +109,7 @@ mod test {
 
     #[cfg_attr(
         async_executor_impl = "tokio",
-        tokio::test(flavor = "multi_thread", worker_threads = 2)
+        tokio::test(flavor = "multi_thread")
     )]
     #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
     async fn many_works() {

--- a/crates/task/src/task.rs
+++ b/crates/task/src/task.rs
@@ -381,10 +381,7 @@ mod tests {
             None
         }
     }
-    #[cfg_attr(
-        async_executor_impl = "tokio",
-        tokio::test(flavor = "multi_thread")
-    )]
+    #[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
     #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
     #[allow(unused_must_use)]
     async fn it_works() {

--- a/crates/task/src/task.rs
+++ b/crates/task/src/task.rs
@@ -383,7 +383,7 @@ mod tests {
     }
     #[cfg_attr(
         async_executor_impl = "tokio",
-        tokio::test(flavor = "multi_thread", worker_threads = 2)
+        tokio::test(flavor = "multi_thread")
     )]
     #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
     #[allow(unused_must_use)]

--- a/crates/testing-macros/src/lib.rs
+++ b/crates/testing-macros/src/lib.rs
@@ -112,7 +112,7 @@ impl TestData {
             #slow_attribute
             #[cfg_attr(
                 async_executor_impl = "tokio",
-                tokio::test(flavor = "multi_thread", worker_threads = 2)
+                tokio::test(flavor = "multi_thread")
             )]
             #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
             #[tracing::instrument]

--- a/crates/testing/tests/atomic_storage.rs
+++ b/crates/testing/tests/atomic_storage.rs
@@ -14,7 +14,7 @@ type AtomicStorage = hotshot::traits::implementations::AtomicStorage<DEntryState
 
 #[cfg_attr(
     async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread", worker_threads = 2)
+    tokio::test(flavor = "multi_thread")
 )]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 async fn test_happy_path_qcs() {
@@ -83,7 +83,7 @@ async fn test_happy_path_qcs() {
 
 #[cfg_attr(
     async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread", worker_threads = 2)
+    tokio::test(flavor = "multi_thread")
 )]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 async fn test_happy_path_leaves() {

--- a/crates/testing/tests/atomic_storage.rs
+++ b/crates/testing/tests/atomic_storage.rs
@@ -12,10 +12,7 @@ use rand::thread_rng;
 
 type AtomicStorage = hotshot::traits::implementations::AtomicStorage<DEntryState>;
 
-#[cfg_attr(
-    async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread")
-)]
+#[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 async fn test_happy_path_qcs() {
     // This folder will be destroyed when the last handle to it closes
@@ -81,10 +78,7 @@ async fn test_happy_path_qcs() {
     }
 }
 
-#[cfg_attr(
-    async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread")
-)]
+#[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 async fn test_happy_path_leaves() {
     // This folder will be destroyed when the last handle to it closes

--- a/crates/testing/tests/catchup.rs
+++ b/crates/testing/tests/catchup.rs
@@ -1,8 +1,5 @@
 #[cfg(test)]
-#[cfg_attr(
-    async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread")
-)]
+#[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 async fn test_catchup() {
     use std::time::Duration;
@@ -60,10 +57,7 @@ async fn test_catchup() {
 }
 
 #[cfg(test)]
-#[cfg_attr(
-    async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread")
-)]
+#[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 async fn test_catchup_web() {
     use std::time::Duration;
@@ -117,10 +111,7 @@ async fn test_catchup_web() {
 
 /// Test that one node catches up and has sucessful views after coming back
 #[cfg(test)]
-#[cfg_attr(
-    async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread")
-)]
+#[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 async fn test_catchup_one_node() {
     use std::time::Duration;
@@ -175,10 +166,7 @@ async fn test_catchup_one_node() {
 
 /// Same as `test_catchup` except we start the nodes after their leadership so they join during view sync
 #[cfg(test)]
-#[cfg_attr(
-    async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread")
-)]
+#[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 async fn test_catchup_in_view_sync() {
     use std::time::Duration;
@@ -240,10 +228,7 @@ async fn test_catchup_in_view_sync() {
 // Almost the same as `test_catchup`, but with catchup nodes reloaded from anchor leaf rather than
 // initialized from genesis.
 #[cfg(test)]
-#[cfg_attr(
-    async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread")
-)]
+#[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 async fn test_catchup_reload() {
     use std::time::Duration;

--- a/crates/testing/tests/catchup.rs
+++ b/crates/testing/tests/catchup.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 #[cfg_attr(
     async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread", worker_threads = 2)
+    tokio::test(flavor = "multi_thread")
 )]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 async fn test_catchup() {
@@ -62,7 +62,7 @@ async fn test_catchup() {
 #[cfg(test)]
 #[cfg_attr(
     async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread", worker_threads = 2)
+    tokio::test(flavor = "multi_thread")
 )]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 async fn test_catchup_web() {
@@ -119,7 +119,7 @@ async fn test_catchup_web() {
 #[cfg(test)]
 #[cfg_attr(
     async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread", worker_threads = 2)
+    tokio::test(flavor = "multi_thread")
 )]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 async fn test_catchup_one_node() {
@@ -177,7 +177,7 @@ async fn test_catchup_one_node() {
 #[cfg(test)]
 #[cfg_attr(
     async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread", worker_threads = 2)
+    tokio::test(flavor = "multi_thread")
 )]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 async fn test_catchup_in_view_sync() {
@@ -242,7 +242,7 @@ async fn test_catchup_in_view_sync() {
 #[cfg(test)]
 #[cfg_attr(
     async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread", worker_threads = 2)
+    tokio::test(flavor = "multi_thread")
 )]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 async fn test_catchup_reload() {

--- a/crates/testing/tests/combined_network.rs
+++ b/crates/testing/tests/combined_network.rs
@@ -14,10 +14,7 @@ use hotshot::traits::implementations::{calculate_hash_of, Cache};
 use hotshot_example_types::block_types::TestTransaction;
 
 #[cfg(test)]
-#[cfg_attr(
-    async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread")
-)]
+#[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 #[instrument]
 async fn test_hash_calculation() {
@@ -29,10 +26,7 @@ async fn test_hash_calculation() {
 }
 
 #[cfg(test)]
-#[cfg_attr(
-    async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread")
-)]
+#[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 #[instrument]
 async fn test_cache_integrity() {
@@ -57,10 +51,7 @@ async fn test_cache_integrity() {
 
 /// A run with both the webserver and libp2p functioning properly
 #[cfg(test)]
-#[cfg_attr(
-    async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread")
-)]
+#[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 #[instrument]
 async fn test_combined_network() {
@@ -95,10 +86,7 @@ async fn test_combined_network() {
 }
 
 // A run where the webserver crashes part-way through
-#[cfg_attr(
-    async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread")
-)]
+#[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 #[instrument]
 async fn test_combined_network_webserver_crash() {
@@ -147,10 +135,7 @@ async fn test_combined_network_webserver_crash() {
 
 // A run where the webserver crashes partway through
 // and then comes back up
-#[cfg_attr(
-    async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread")
-)]
+#[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 #[instrument]
 async fn test_combined_network_reup() {
@@ -203,10 +188,7 @@ async fn test_combined_network_reup() {
 }
 
 // A run where half of the nodes disconnect from the webserver
-#[cfg_attr(
-    async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread")
-)]
+#[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 #[instrument]
 async fn test_combined_network_half_dc() {
@@ -281,10 +263,7 @@ fn generate_random_node_changes(
 }
 
 // A fuzz test, where random network events take place on all nodes
-#[cfg_attr(
-    async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread")
-)]
+#[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 #[instrument]
 #[ignore]

--- a/crates/testing/tests/combined_network.rs
+++ b/crates/testing/tests/combined_network.rs
@@ -16,7 +16,7 @@ use hotshot_example_types::block_types::TestTransaction;
 #[cfg(test)]
 #[cfg_attr(
     async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread", worker_threads = 2)
+    tokio::test(flavor = "multi_thread")
 )]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 #[instrument]
@@ -31,7 +31,7 @@ async fn test_hash_calculation() {
 #[cfg(test)]
 #[cfg_attr(
     async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread", worker_threads = 2)
+    tokio::test(flavor = "multi_thread")
 )]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 #[instrument]
@@ -59,7 +59,7 @@ async fn test_cache_integrity() {
 #[cfg(test)]
 #[cfg_attr(
     async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread", worker_threads = 2)
+    tokio::test(flavor = "multi_thread")
 )]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 #[instrument]
@@ -97,7 +97,7 @@ async fn test_combined_network() {
 // A run where the webserver crashes part-way through
 #[cfg_attr(
     async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread", worker_threads = 2)
+    tokio::test(flavor = "multi_thread")
 )]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 #[instrument]
@@ -149,7 +149,7 @@ async fn test_combined_network_webserver_crash() {
 // and then comes back up
 #[cfg_attr(
     async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread", worker_threads = 2)
+    tokio::test(flavor = "multi_thread")
 )]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 #[instrument]
@@ -205,7 +205,7 @@ async fn test_combined_network_reup() {
 // A run where half of the nodes disconnect from the webserver
 #[cfg_attr(
     async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread", worker_threads = 2)
+    tokio::test(flavor = "multi_thread")
 )]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 #[instrument]
@@ -283,7 +283,7 @@ fn generate_random_node_changes(
 // A fuzz test, where random network events take place on all nodes
 #[cfg_attr(
     async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread", worker_threads = 2)
+    tokio::test(flavor = "multi_thread")
 )]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 #[instrument]

--- a/crates/testing/tests/consensus_task.rs
+++ b/crates/testing/tests/consensus_task.rs
@@ -13,7 +13,7 @@ use std::collections::HashMap;
 #[cfg(test)]
 #[cfg_attr(
     async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread", worker_threads = 2)
+    tokio::test(flavor = "multi_thread")
 )]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 async fn test_consensus_task() {
@@ -75,7 +75,7 @@ async fn test_consensus_task() {
 #[cfg(test)]
 #[cfg_attr(
     async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread", worker_threads = 2)
+    tokio::test(flavor = "multi_thread")
 )]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 async fn test_consensus_vote() {
@@ -127,7 +127,7 @@ async fn test_consensus_vote() {
 #[cfg(test)]
 #[cfg_attr(
     async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread", worker_threads = 2)
+    tokio::test(flavor = "multi_thread")
 )]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 // TODO: re-enable this when HotShot/the sequencer needs the shares for something

--- a/crates/testing/tests/consensus_task.rs
+++ b/crates/testing/tests/consensus_task.rs
@@ -11,10 +11,7 @@ use jf_primitives::vid::VidScheme;
 use std::collections::HashMap;
 
 #[cfg(test)]
-#[cfg_attr(
-    async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread")
-)]
+#[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 async fn test_consensus_task() {
     use hotshot::tasks::{inject_consensus_polls, task_state::CreateTaskState};
@@ -73,10 +70,7 @@ async fn test_consensus_task() {
 }
 
 #[cfg(test)]
-#[cfg_attr(
-    async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread")
-)]
+#[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 async fn test_consensus_vote() {
     use hotshot::tasks::{inject_consensus_polls, task_state::CreateTaskState};
@@ -125,10 +119,7 @@ async fn test_consensus_vote() {
 }
 
 #[cfg(test)]
-#[cfg_attr(
-    async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread")
-)]
+#[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 // TODO: re-enable this when HotShot/the sequencer needs the shares for something
 // issue: https://github.com/EspressoSystems/HotShot/issues/2236

--- a/crates/testing/tests/da_task.rs
+++ b/crates/testing/tests/da_task.rs
@@ -19,7 +19,7 @@ use std::{collections::HashMap, marker::PhantomData};
 
 #[cfg_attr(
     async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread", worker_threads = 2)
+    tokio::test(flavor = "multi_thread")
 )]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 async fn test_da_task() {

--- a/crates/testing/tests/da_task.rs
+++ b/crates/testing/tests/da_task.rs
@@ -17,10 +17,7 @@ use hotshot_types::{
 use sha2::{Digest, Sha256};
 use std::{collections::HashMap, marker::PhantomData};
 
-#[cfg_attr(
-    async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread")
-)]
+#[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 async fn test_da_task() {
     use hotshot_task_impls::harness::run_harness;

--- a/crates/testing/tests/libp2p.rs
+++ b/crates/testing/tests/libp2p.rs
@@ -10,10 +10,7 @@ use hotshot_testing::{
 use tracing::instrument;
 
 /// libp2p network test
-#[cfg_attr(
-    async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread")
-)]
+#[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 #[instrument]
 async fn libp2p_network() {
@@ -45,10 +42,7 @@ async fn libp2p_network() {
 }
 
 /// libp2p network test with failures
-#[cfg_attr(
-    async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread")
-)]
+#[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 #[instrument]
 async fn libp2p_network_failures_2() {
@@ -96,10 +90,7 @@ async fn libp2p_network_failures_2() {
 }
 
 /// stress test for libp2p
-#[cfg_attr(
-    async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread")
-)]
+#[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 #[instrument]
 #[ignore]

--- a/crates/testing/tests/libp2p.rs
+++ b/crates/testing/tests/libp2p.rs
@@ -12,7 +12,7 @@ use tracing::instrument;
 /// libp2p network test
 #[cfg_attr(
     async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread", worker_threads = 2)
+    tokio::test(flavor = "multi_thread")
 )]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 #[instrument]
@@ -47,7 +47,7 @@ async fn libp2p_network() {
 /// libp2p network test with failures
 #[cfg_attr(
     async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread", worker_threads = 2)
+    tokio::test(flavor = "multi_thread")
 )]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 #[instrument]
@@ -98,7 +98,7 @@ async fn libp2p_network_failures_2() {
 /// stress test for libp2p
 #[cfg_attr(
     async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread", worker_threads = 2)
+    tokio::test(flavor = "multi_thread")
 )]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 #[instrument]

--- a/crates/testing/tests/lossy.rs
+++ b/crates/testing/tests/lossy.rs
@@ -11,7 +11,7 @@
 // // tests base level of working synchronous network
 // #[cfg_attr(
 //     feature = "tokio-executor",
-//     tokio::test(flavor = "multi_thread", worker_threads = 2)
+//     tokio::test(flavor = "multi_thread")
 // )]
 // #[cfg_attr(feature = "async-std-executor", async_std::test)]
 // #[instrument]
@@ -36,7 +36,7 @@
 // // // tests network with forced packet delay
 // #[cfg_attr(
 //     feature = "tokio-executor",
-//     tokio::test(flavor = "multi_thread", worker_threads = 2)
+//     tokio::test(flavor = "multi_thread")
 // )]
 // #[cfg_attr(feature = "async-std-executor", async_std::test)]
 // #[instrument]
@@ -61,7 +61,7 @@
 // // tests network with small packet delay and dropped packets
 // #[cfg_attr(
 //     feature = "tokio-executor",
-//     tokio::test(flavor = "multi_thread", worker_threads = 2)
+//     tokio::test(flavor = "multi_thread")
 // )]
 // #[cfg_attr(feature = "async-std-executor", async_std::test)]
 // #[instrument]
@@ -89,7 +89,7 @@
 // /// tests network with asynchronous patch that eventually becomes synchronous
 // #[cfg_attr(
 //     feature = "tokio-executor",
-//     tokio::test(flavor = "multi_thread", worker_threads = 2)
+//     tokio::test(flavor = "multi_thread")
 // )]
 // #[cfg_attr(feature = "async-std-executor", async_std::test)]
 // #[instrument]

--- a/crates/testing/tests/memory_network.rs
+++ b/crates/testing/tests/memory_network.rs
@@ -119,10 +119,7 @@ fn gen_messages(num_messages: u64, seed: u64, pk: BLSPubKey) -> Vec<Message<Test
 }
 
 // Spawning a single MemoryNetwork should produce no errors
-#[cfg_attr(
-    async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread")
-)]
+#[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 #[instrument]
 async fn memory_network_spawn_single() {
@@ -133,10 +130,7 @@ async fn memory_network_spawn_single() {
 }
 
 // // Spawning a two MemoryNetworks and connecting them should produce no errors
-#[cfg_attr(
-    async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread")
-)]
+#[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 #[instrument]
 async fn memory_network_spawn_double() {
@@ -148,10 +142,7 @@ async fn memory_network_spawn_double() {
 }
 
 // Check to make sure direct queue works
-#[cfg_attr(
-    async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread")
-)]
+#[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 #[instrument]
 async fn memory_network_direct_queue() {
@@ -216,10 +207,7 @@ async fn memory_network_direct_queue() {
 }
 
 // Check to make sure direct queue works
-#[cfg_attr(
-    async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread")
-)]
+#[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 #[instrument]
 async fn memory_network_broadcast_queue() {
@@ -285,10 +273,7 @@ async fn memory_network_broadcast_queue() {
     }
 }
 
-#[cfg_attr(
-    async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread")
-)]
+#[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 #[instrument]
 #[allow(deprecated)]

--- a/crates/testing/tests/memory_network.rs
+++ b/crates/testing/tests/memory_network.rs
@@ -121,7 +121,7 @@ fn gen_messages(num_messages: u64, seed: u64, pk: BLSPubKey) -> Vec<Message<Test
 // Spawning a single MemoryNetwork should produce no errors
 #[cfg_attr(
     async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread", worker_threads = 2)
+    tokio::test(flavor = "multi_thread")
 )]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 #[instrument]
@@ -135,7 +135,7 @@ async fn memory_network_spawn_single() {
 // // Spawning a two MemoryNetworks and connecting them should produce no errors
 #[cfg_attr(
     async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread", worker_threads = 2)
+    tokio::test(flavor = "multi_thread")
 )]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 #[instrument]
@@ -150,7 +150,7 @@ async fn memory_network_spawn_double() {
 // Check to make sure direct queue works
 #[cfg_attr(
     async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread", worker_threads = 2)
+    tokio::test(flavor = "multi_thread")
 )]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 #[instrument]
@@ -218,7 +218,7 @@ async fn memory_network_direct_queue() {
 // Check to make sure direct queue works
 #[cfg_attr(
     async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread", worker_threads = 2)
+    tokio::test(flavor = "multi_thread")
 )]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 #[instrument]
@@ -287,7 +287,7 @@ async fn memory_network_broadcast_queue() {
 
 #[cfg_attr(
     async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread", worker_threads = 2)
+    tokio::test(flavor = "multi_thread")
 )]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 #[instrument]

--- a/crates/testing/tests/network_task.rs
+++ b/crates/testing/tests/network_task.rs
@@ -11,10 +11,7 @@ use sha2::{Digest, Sha256};
 use std::{collections::HashMap, marker::PhantomData};
 
 #[cfg(test)]
-#[cfg_attr(
-    async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread")
-)]
+#[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 #[ignore]
 #[allow(clippy::too_many_lines)]

--- a/crates/testing/tests/network_task.rs
+++ b/crates/testing/tests/network_task.rs
@@ -13,7 +13,7 @@ use std::{collections::HashMap, marker::PhantomData};
 #[cfg(test)]
 #[cfg_attr(
     async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread", worker_threads = 2)
+    tokio::test(flavor = "multi_thread")
 )]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 #[ignore]

--- a/crates/testing/tests/storage.rs
+++ b/crates/testing/tests/storage.rs
@@ -39,7 +39,7 @@ fn random_stored_view(view_number: <TestTypes as NodeType>::Time) -> StoredView<
 #[cfg(test)]
 #[cfg_attr(
     async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread", worker_threads = 2)
+    tokio::test(flavor = "multi_thread")
 )]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 #[instrument]

--- a/crates/testing/tests/storage.rs
+++ b/crates/testing/tests/storage.rs
@@ -37,10 +37,7 @@ fn random_stored_view(view_number: <TestTypes as NodeType>::Time) -> StoredView<
 }
 
 #[cfg(test)]
-#[cfg_attr(
-    async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread")
-)]
+#[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 #[instrument]
 async fn memory_storage() {

--- a/crates/testing/tests/timeout.rs
+++ b/crates/testing/tests/timeout.rs
@@ -1,8 +1,5 @@
 #[cfg(test)]
-#[cfg_attr(
-    async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread")
-)]
+#[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 // TODO Add memory network tests after this issue is finished:
 // https://github.com/EspressoSystems/HotShot/issues/1790
@@ -64,10 +61,7 @@ async fn test_timeout_web() {
 }
 
 #[cfg(test)]
-#[cfg_attr(
-    async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread")
-)]
+#[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 #[ignore]
 async fn test_timeout_libp2p() {

--- a/crates/testing/tests/timeout.rs
+++ b/crates/testing/tests/timeout.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 #[cfg_attr(
     async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread", worker_threads = 2)
+    tokio::test(flavor = "multi_thread")
 )]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 // TODO Add memory network tests after this issue is finished:
@@ -66,7 +66,7 @@ async fn test_timeout_web() {
 #[cfg(test)]
 #[cfg_attr(
     async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread", worker_threads = 2)
+    tokio::test(flavor = "multi_thread")
 )]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 #[ignore]

--- a/crates/testing/tests/unreliable_network.rs
+++ b/crates/testing/tests/unreliable_network.rs
@@ -14,10 +14,7 @@ use hotshot_testing::{
 };
 use tracing::instrument;
 
-#[cfg_attr(
-    async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread")
-)]
+#[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 #[instrument]
 async fn libp2p_network_sync() {
@@ -48,10 +45,7 @@ async fn libp2p_network_sync() {
 }
 
 #[cfg(test)]
-#[cfg_attr(
-    async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread")
-)]
+#[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 async fn test_memory_network_sync() {
     use hotshot_example_types::node_types::{MemoryImpl, TestTypes};
@@ -83,10 +77,7 @@ async fn test_memory_network_sync() {
         .await;
 }
 
-#[cfg_attr(
-    async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread")
-)]
+#[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 #[ignore]
 #[instrument]
@@ -126,10 +117,7 @@ async fn libp2p_network_async() {
 }
 
 #[cfg(test)]
-#[cfg_attr(
-    async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread")
-)]
+#[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[ignore]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 async fn test_memory_network_async() {
@@ -176,10 +164,7 @@ async fn test_memory_network_async() {
 }
 
 #[cfg(test)]
-#[cfg_attr(
-    async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread")
-)]
+#[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 async fn test_memory_network_partially_sync() {
     use hotshot_example_types::node_types::{MemoryImpl, TestTypes};
@@ -230,10 +215,7 @@ async fn test_memory_network_partially_sync() {
         .await;
 }
 
-#[cfg_attr(
-    async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread")
-)]
+#[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 #[instrument]
 async fn libp2p_network_partially_sync() {
@@ -274,10 +256,7 @@ async fn libp2p_network_partially_sync() {
 }
 
 #[cfg(test)]
-#[cfg_attr(
-    async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread")
-)]
+#[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[ignore]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 async fn test_memory_network_chaos() {
@@ -314,10 +293,7 @@ async fn test_memory_network_chaos() {
         .await;
 }
 
-#[cfg_attr(
-    async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread")
-)]
+#[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 #[ignore]
 #[instrument]

--- a/crates/testing/tests/unreliable_network.rs
+++ b/crates/testing/tests/unreliable_network.rs
@@ -16,7 +16,7 @@ use tracing::instrument;
 
 #[cfg_attr(
     async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread", worker_threads = 2)
+    tokio::test(flavor = "multi_thread")
 )]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 #[instrument]
@@ -50,7 +50,7 @@ async fn libp2p_network_sync() {
 #[cfg(test)]
 #[cfg_attr(
     async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread", worker_threads = 2)
+    tokio::test(flavor = "multi_thread")
 )]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 async fn test_memory_network_sync() {
@@ -85,7 +85,7 @@ async fn test_memory_network_sync() {
 
 #[cfg_attr(
     async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread", worker_threads = 2)
+    tokio::test(flavor = "multi_thread")
 )]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 #[ignore]
@@ -128,7 +128,7 @@ async fn libp2p_network_async() {
 #[cfg(test)]
 #[cfg_attr(
     async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread", worker_threads = 2)
+    tokio::test(flavor = "multi_thread")
 )]
 #[ignore]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
@@ -178,7 +178,7 @@ async fn test_memory_network_async() {
 #[cfg(test)]
 #[cfg_attr(
     async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread", worker_threads = 2)
+    tokio::test(flavor = "multi_thread")
 )]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 async fn test_memory_network_partially_sync() {
@@ -232,7 +232,7 @@ async fn test_memory_network_partially_sync() {
 
 #[cfg_attr(
     async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread", worker_threads = 2)
+    tokio::test(flavor = "multi_thread")
 )]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 #[instrument]
@@ -276,7 +276,7 @@ async fn libp2p_network_partially_sync() {
 #[cfg(test)]
 #[cfg_attr(
     async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread", worker_threads = 2)
+    tokio::test(flavor = "multi_thread")
 )]
 #[ignore]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
@@ -316,7 +316,7 @@ async fn test_memory_network_chaos() {
 
 #[cfg_attr(
     async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread", worker_threads = 2)
+    tokio::test(flavor = "multi_thread")
 )]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 #[ignore]

--- a/crates/testing/tests/upgrade_task.rs
+++ b/crates/testing/tests/upgrade_task.rs
@@ -10,7 +10,7 @@ use hotshot_types::{
 
 #[cfg_attr(
     async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread", worker_threads = 2)
+    tokio::test(flavor = "multi_thread")
 )]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 async fn test_upgrade_task() {

--- a/crates/testing/tests/upgrade_task.rs
+++ b/crates/testing/tests/upgrade_task.rs
@@ -8,10 +8,7 @@ use hotshot_types::{
     data::ViewNumber, simple_vote::UpgradeProposalData, traits::node_implementation::ConsensusTime,
 };
 
-#[cfg_attr(
-    async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread")
-)]
+#[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 async fn test_upgrade_task() {
     use hotshot_testing::script::{run_test_script, TestScriptStage};

--- a/crates/testing/tests/vid_task.rs
+++ b/crates/testing/tests/vid_task.rs
@@ -11,10 +11,7 @@ use jf_primitives::vid::VidScheme;
 use std::collections::HashMap;
 use std::marker::PhantomData;
 
-#[cfg_attr(
-    async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread")
-)]
+#[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 async fn test_vid_task() {
     use hotshot_task_impls::harness::run_harness;

--- a/crates/testing/tests/vid_task.rs
+++ b/crates/testing/tests/vid_task.rs
@@ -13,7 +13,7 @@ use std::marker::PhantomData;
 
 #[cfg_attr(
     async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread", worker_threads = 2)
+    tokio::test(flavor = "multi_thread")
 )]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 async fn test_vid_task() {

--- a/crates/testing/tests/view_sync_task.rs
+++ b/crates/testing/tests/view_sync_task.rs
@@ -6,10 +6,7 @@ use hotshot_types::{data::ViewNumber, traits::node_implementation::ConsensusTime
 use std::collections::HashMap;
 
 #[cfg(test)]
-#[cfg_attr(
-    async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread")
-)]
+#[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 async fn test_view_sync_task() {
     use hotshot_task_impls::harness::run_harness;

--- a/crates/testing/tests/view_sync_task.rs
+++ b/crates/testing/tests/view_sync_task.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 #[cfg(test)]
 #[cfg_attr(
     async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread", worker_threads = 2)
+    tokio::test(flavor = "multi_thread")
 )]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 async fn test_view_sync_task() {

--- a/crates/testing/tests/web_server.rs
+++ b/crates/testing/tests/web_server.rs
@@ -10,10 +10,7 @@ use hotshot_testing::{
 use tracing::instrument;
 
 /// Web server network test
-#[cfg_attr(
-    async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread")
-)]
+#[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 #[instrument]
 async fn web_server_network() {

--- a/crates/testing/tests/web_server.rs
+++ b/crates/testing/tests/web_server.rs
@@ -12,7 +12,7 @@ use tracing::instrument;
 /// Web server network test
 #[cfg_attr(
     async_executor_impl = "tokio",
-    tokio::test(flavor = "multi_thread", worker_threads = 2)
+    tokio::test(flavor = "multi_thread")
 )]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 #[instrument]


### PR DESCRIPTION
For some reason we have configured with 2 worker threads almost everywhere.  This doesn't really make any sense to me.  I thought it was just in tests to force some more race conditions but I saw it for most of the example executables as well.  By default tokio will use as many worker threads as cpu cores, this seems like a more sensible default.
