### PR TITLE
[Hotfix] Combined network to use proper key

### DIFF
--- a/crates/examples/infra/mod.rs
+++ b/crates/examples/infra/mod.rs
@@ -851,26 +851,22 @@ where
     async fn initialize_networking(
         config: NetworkConfig<TYPES::SignatureKey, TYPES::ElectionConfigType>,
     ) -> CombinedDARun<TYPES> {
-        // generate our own key
-        let (pub_key, _privkey) =
-            <<TYPES as NodeType>::SignatureKey as SignatureKey>::generated_from_seed_indexed(
-                config.seed,
-                config.node_index,
-            );
+        // Get our own key
+        let pub_key = config.config.my_own_validator_config.public_key.clone();
 
-        // create and wait for libp2p network
+        // Create and wait for libp2p network
         let libp2p_underlying_quorum_network =
             libp2p_network_from_config::<TYPES>(config.clone(), pub_key.clone()).await;
 
         libp2p_underlying_quorum_network.wait_for_ready().await;
 
-        // extract values from config (for webserver DA network)
+        // Extract values from config (for webserver DA network)
         let WebServerConfig {
             url,
             wait_between_polls,
         }: WebServerConfig = config.clone().da_web_server_config.unwrap();
 
-        // create and wait for underlying webserver network
+        // Create and wait for underlying webserver network
         let web_quorum_network =
             webserver_network_from_config::<TYPES>(config.clone(), pub_key.clone());
 
@@ -878,8 +874,7 @@ where
 
         web_quorum_network.wait_for_ready().await;
 
-        // combine the two communication channel
-
+        // Combine the two communication channels
         let da_channel = CombinedNetworks::new(Arc::new(UnderlyingCombinedNetworks(
             web_da_network.clone(),
             libp2p_underlying_quorum_network.clone(),


### PR DESCRIPTION
### This PR: 
<!-- Describe what this PR adds to HotShot -->
<!-- E.g. -->
<!-- * Implements feature 1 -->
<!-- * Implements feature 2 -->
<!-- * Fixes bug 3 -->
Fixes a bug wherein we still use the `generated_from_seed_indexed` when initializing a combined network. This was causing issues where messages went to the wrong place.

