### PR TITLE
[Libp2p] Add topic to committees

### DIFF
--- a/crates/examples/infra/mod.rs
+++ b/crates/examples/infra/mod.rs
@@ -27,7 +27,7 @@ use hotshot_orchestrator::{
     config::{NetworkConfig, NetworkConfigFile, WebServerConfig},
 };
 use hotshot_types::message::Message;
-use hotshot_types::traits::network::ConnectedNetwork;
+use hotshot_types::traits::network::{ConnectedNetwork, Topic};
 use hotshot_types::PeerConfig;
 use hotshot_types::ValidatorConfig;
 use hotshot_types::{
@@ -405,9 +405,7 @@ async fn libp2p_network_from_config<TYPES: NodeType>(
         config.node_index as usize,
         // NOTE: this introduces an invariant that the keys are assigned using this indexed
         // function
-        all_keys,
         None,
-        da_keys.clone(),
         da_keys.contains(&pub_key),
     )
     .await
@@ -458,11 +456,15 @@ pub trait RunDA<
 
         // Since we do not currently pass the election config type in the NetworkConfig, this will always be the default election config
         let quorum_election_config = config.config.election_config.clone().unwrap_or_else(|| {
-            TYPES::Membership::default_election_config(config.config.total_nodes.get() as u64)
+            TYPES::Membership::default_election_config(
+                config.config.total_nodes.get() as u64,
+                Topic::Global,
+            )
         });
 
         let committee_election_config = TYPES::Membership::default_election_config(
             config.config.da_committee_size.try_into().unwrap(),
+            Topic::DA,
         );
         let networks_bundle = Networks {
             quorum_network: quorum_network.clone().into(),

--- a/crates/hotshot/src/traits/election/static_committee.rs
+++ b/crates/hotshot/src/traits/election/static_committee.rs
@@ -1,5 +1,6 @@
 // use ark_bls12_381::Parameters as Param381;
 use hotshot_types::signature_key::BLSPubKey;
+use hotshot_types::traits::network::Topic;
 use hotshot_types::traits::{
     election::{ElectionConfig, Membership},
     node_implementation::NodeType,
@@ -22,6 +23,9 @@ pub struct GeneralStaticCommittee<T, PUBKEY: SignatureKey> {
     nodes_with_stake: Vec<PUBKEY::StakeTableEntry>,
     /// The nodes on the static committee and their stake
     committee_nodes_with_stake: Vec<PUBKEY::StakeTableEntry>,
+    /// The topic pertaining to the particular committee. This helps
+    /// us attribute a membership to a particular subscription.
+    topic: Topic,
     /// Node type phantom
     _type_phantom: PhantomData<T>,
 }
@@ -32,10 +36,15 @@ pub type StaticCommittee<T> = GeneralStaticCommittee<T, BLSPubKey>;
 impl<T, PUBKEY: SignatureKey> GeneralStaticCommittee<T, PUBKEY> {
     /// Creates a new dummy elector
     #[must_use]
-    pub fn new(_nodes: &[PUBKEY], nodes_with_stake: Vec<PUBKEY::StakeTableEntry>) -> Self {
+    pub fn new(
+        _nodes: &[PUBKEY],
+        nodes_with_stake: Vec<PUBKEY::StakeTableEntry>,
+        topic: Topic,
+    ) -> Self {
         Self {
             nodes_with_stake: nodes_with_stake.clone(),
             committee_nodes_with_stake: nodes_with_stake,
+            topic,
             _type_phantom: PhantomData,
         }
     }
@@ -46,6 +55,9 @@ impl<T, PUBKEY: SignatureKey> GeneralStaticCommittee<T, PUBKEY> {
 pub struct StaticElectionConfig {
     /// Number of nodes on the committee
     num_nodes: u64,
+    /// The topic pertaining to the particular committee. This helps
+    /// us attribute a membership to a particular subscription.
+    topic: Topic,
 }
 
 impl ElectionConfig for StaticElectionConfig {}
@@ -95,8 +107,8 @@ where
         }
     }
 
-    fn default_election_config(num_nodes: u64) -> TYPES::ElectionConfigType {
-        StaticElectionConfig { num_nodes }
+    fn default_election_config(num_nodes: u64, topic: Topic) -> TYPES::ElectionConfigType {
+        StaticElectionConfig { num_nodes, topic }
     }
 
     fn create_election(
@@ -113,6 +125,7 @@ where
         Self {
             nodes_with_stake,
             committee_nodes_with_stake,
+            topic: config.topic,
             _type_phantom: PhantomData,
         }
     }
@@ -145,5 +158,11 @@ where
                 )
             })
             .collect()
+    }
+
+    /// Get the committee's dedicated topic. Used in subscriptions for the
+    /// Push CDN as well as Libp2p.
+    fn get_committee_topic(&self) -> Topic {
+        self.topic.clone()
     }
 }

--- a/crates/hotshot/src/traits/networking/libp2p_network.rs
+++ b/crates/hotshot/src/traits/networking/libp2p_network.rs
@@ -51,14 +51,14 @@ use libp2p_networking::{
 use serde::Serialize;
 use snafu::ResultExt;
 #[cfg(feature = "hotshot-testing")]
-use std::{collections::HashSet, num::NonZeroUsize, str::FromStr};
+use std::{num::NonZeroUsize, str::FromStr};
 
 use futures::{
     future::{join_all, Either},
     FutureExt,
 };
 use std::{
-    collections::BTreeSet,
+    collections::{BTreeSet, HashSet},
     fmt::Debug,
     sync::{
         atomic::{AtomicBool, AtomicU64, Ordering},

--- a/crates/testing/src/task_helpers.rs
+++ b/crates/testing/src/task_helpers.rs
@@ -22,12 +22,7 @@ use hotshot_types::{
     simple_certificate::{DACertificate, QuorumCertificate},
     simple_vote::{DAData, DAVote, SimpleVote},
     traits::{
-        block_contents::{vid_commitment, BlockHeader, TestableBlock},
-        consensus_api::ConsensusApi,
-        election::Membership,
-        node_implementation::{ConsensusTime, NodeType},
-        states::ValidatedState,
-        BlockPayload,
+        block_contents::{vid_commitment, BlockHeader, TestableBlock}, consensus_api::ConsensusApi, election::Membership, network::Topic, node_implementation::{ConsensusTime, NodeType}, states::ValidatedState, BlockPayload
     },
     vid::{vid_scheme, VidCommitment, VidSchemeType},
     vote::HasViewNumber,
@@ -71,19 +66,19 @@ pub async fn build_system_handle(
     let known_nodes_with_stake = config.known_nodes_with_stake.clone();
     let private_key = config.my_own_validator_config.private_key.clone();
     let public_key = config.my_own_validator_config.public_key;
-    let quorum_election_config =
-        config.election_config.clone().unwrap_or_else(|| {
-            <TestTypes as NodeType>::Membership::default_election_config(
-                config.total_nodes.get() as u64
-            )
-        });
+    let quorum_election_config = config.election_config.clone().unwrap_or_else(|| {
+        <TestTypes as NodeType>::Membership::default_election_config(
+            config.total_nodes.get() as u64,
+            Topic::Global,
+        )
+    });
 
-    let committee_election_config =
-        config.election_config.clone().unwrap_or_else(|| {
-            <TestTypes as NodeType>::Membership::default_election_config(
-                config.total_nodes.get() as u64
-            )
-        });
+    let committee_election_config = config.election_config.clone().unwrap_or_else(|| {
+        <TestTypes as NodeType>::Membership::default_election_config(
+            config.total_nodes.get() as u64,
+            Topic::DA,
+        )
+    });
     let networks_bundle = Networks {
         quorum_network: networks.0.clone(),
         da_network: networks.1.clone(),

--- a/crates/testing/src/task_helpers.rs
+++ b/crates/testing/src/task_helpers.rs
@@ -22,7 +22,13 @@ use hotshot_types::{
     simple_certificate::{DACertificate, QuorumCertificate},
     simple_vote::{DAData, DAVote, SimpleVote},
     traits::{
-        block_contents::{vid_commitment, BlockHeader, TestableBlock}, consensus_api::ConsensusApi, election::Membership, network::Topic, node_implementation::{ConsensusTime, NodeType}, states::ValidatedState, BlockPayload
+        block_contents::{vid_commitment, BlockHeader, TestableBlock},
+        consensus_api::ConsensusApi,
+        election::Membership,
+        network::Topic,
+        node_implementation::{ConsensusTime, NodeType},
+        states::ValidatedState,
+        BlockPayload,
     },
     vid::{vid_scheme, VidCommitment, VidSchemeType},
     vote::HasViewNumber,

--- a/crates/testing/src/test_builder.rs
+++ b/crates/testing/src/test_builder.rs
@@ -1,6 +1,7 @@
 use hotshot::traits::NetworkReliability;
 use hotshot_orchestrator::config::ValidatorConfigFile;
 use hotshot_types::traits::election::Membership;
+use hotshot_types::traits::network::Topic;
 use std::{num::NonZeroUsize, sync::Arc, time::Duration};
 
 use hotshot::traits::{NodeImplementation, TestableNodeImplementation};
@@ -265,6 +266,7 @@ impl TestMetadata {
             // TODO what's the difference between this and the second config?
             election_config: Some(TYPES::Membership::default_election_config(
                 total_nodes as u64,
+                Topic::Global,
             )),
         };
         let TimingData {

--- a/crates/testing/src/test_runner.rs
+++ b/crates/testing/src/test_runner.rs
@@ -26,6 +26,7 @@ use hotshot_types::{
     data::Leaf,
     traits::{
         election::Membership,
+        network::Topic,
         node_implementation::{ConsensusTime, NodeType},
     },
     HotShotConfig, ValidatorConfig,
@@ -328,7 +329,10 @@ where
             let config = self.launcher.resource_generator.config.clone();
             let known_nodes_with_stake = config.known_nodes_with_stake.clone();
             let quorum_election_config = config.election_config.clone().unwrap_or_else(|| {
-                TYPES::Membership::default_election_config(config.total_nodes.get() as u64)
+                TYPES::Membership::default_election_config(
+                    config.total_nodes.get() as u64,
+                    Topic::Global,
+                )
             });
             let committee_election_config = I::committee_election_config_generator();
             let memberships = Memberships {
@@ -338,7 +342,7 @@ where
                 ),
                 da_membership: <TYPES as NodeType>::Membership::create_election(
                     known_nodes_with_stake.clone(),
-                    committee_election_config(config.da_committee_size as u64),
+                    committee_election_config(config.da_committee_size as u64, Topic::DA),
                 ),
                 vid_membership: <TYPES as NodeType>::Membership::create_election(
                     known_nodes_with_stake.clone(),

--- a/crates/types/src/traits/election.rs
+++ b/crates/types/src/traits/election.rs
@@ -3,7 +3,7 @@
 // Needed to avoid the non-binding `let` warning.
 #![allow(clippy::let_underscore_untyped)]
 
-use super::node_implementation::NodeType;
+use super::{network::Topic, node_implementation::NodeType};
 
 use crate::{traits::signature_key::SignatureKey, PeerConfig};
 
@@ -37,8 +37,8 @@ pub trait ElectionConfig:
 pub trait Membership<TYPES: NodeType>:
     Clone + Debug + Eq + PartialEq + Send + Sync + Hash + 'static
 {
-    /// generate a default election configuration
-    fn default_election_config(num_nodes: u64) -> TYPES::ElectionConfigType;
+    /// Generate a default election configuration
+    fn default_election_config(num_nodes: u64, topic: Topic) -> TYPES::ElectionConfigType;
 
     /// create an election
     /// TODO may want to move this to a testableelection trait
@@ -57,6 +57,9 @@ pub trait Membership<TYPES: NodeType>:
 
     /// The members of the committee for view `view_number`.
     fn get_committee(&self, view_number: TYPES::Time) -> BTreeSet<TYPES::SignatureKey>;
+
+    /// Get the networking "topic" pertaining to the committee.
+    fn get_committee_topic(&self) -> Topic;
 
     /// Check if a key has stake
     fn has_stake(&self, pub_key: &TYPES::SignatureKey) -> bool;

--- a/crates/types/src/traits/network.rs
+++ b/crates/types/src/traits/network.rs
@@ -39,6 +39,26 @@ impl From<NetworkNodeHandleError> for NetworkError {
     }
 }
 
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, Default)]
+/// A network topic pertaining to a particular committee.
+pub enum Topic {
+    /// The DA committee. If we are in this committee, subscribe to this topic.
+    DA,
+    /// The global committee. All consensus messages are sent here.
+    #[default]
+    Global,
+}
+
+/// This helps us convert the `Topic` to a string, which Libp2p needs.
+impl std::fmt::Display for Topic {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Topic::DA => write!(f, "DA"),
+            Topic::Global => write!(f, "global"),
+        }
+    }
+}
+
 /// for any errors we decide to add to memory network
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub))]

--- a/crates/types/src/traits/node_implementation.rs
+++ b/crates/types/src/traits/node_implementation.rs
@@ -6,7 +6,7 @@
 use super::{
     block_contents::{BlockHeader, TestableBlock, Transaction},
     election::ElectionConfig,
-    network::{ConnectedNetwork, NetworkReliability, TestableNetworkingImplementation},
+    network::{ConnectedNetwork, NetworkReliability, TestableNetworkingImplementation, Topic},
     states::TestableState,
     storage::{StorageError, StorageState, TestableStorage},
     ValidatedState,
@@ -59,7 +59,7 @@ pub trait TestableNodeImplementation<TYPES: NodeType>: NodeImplementation<TYPES>
 
     /// Generates a committee-specific election
     fn committee_election_config_generator(
-    ) -> Box<dyn Fn(u64) -> Self::CommitteeElectionConfig + 'static>;
+    ) -> Box<dyn Fn(u64, Topic) -> Self::CommitteeElectionConfig + 'static>;
 
     /// Creates random transaction if possible
     /// otherwise panics
@@ -115,8 +115,10 @@ where
     type CommitteeElectionConfig = TYPES::ElectionConfigType;
 
     fn committee_election_config_generator(
-    ) -> Box<dyn Fn(u64) -> Self::CommitteeElectionConfig + 'static> {
-        Box::new(|num_nodes| <TYPES as NodeType>::Membership::default_election_config(num_nodes))
+    ) -> Box<dyn Fn(u64, Topic) -> Self::CommitteeElectionConfig + 'static> {
+        Box::new(|num_nodes, topic| {
+            <TYPES as NodeType>::Membership::default_election_config(num_nodes, topic)
+        })
     }
 
     fn state_create_random_transaction(


### PR DESCRIPTION
### This PR: 
<!-- Describe what this PR adds to HotSHot -->
<!-- E.g. -->
<!-- * Implements feature 1 -->
<!-- * Implements feature 2 -->
<!-- * Fixes bug 3 -->

Adds a network topic as a function of a committee. This lets us remove Libp2p's slightly hacky static topic map in favor of something more in concert with the pub-sub model, and not have to have one for the pCDN.

This is one of the changes made for the pCDN but broken out into a smaller PR.

### This PR does not: 
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->
Change where messages are routed at all, or interfere with the direct -> all networking.

### Key places to review: 
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->
`libp2p_network.rs` -> to make sure we aren't routing messages improperly

Key question: do we need this change? Is there a better way?

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
