### PR TITLE
[Crypto] Allow signing and verifying data of arbitrary length

### DIFF
--- a/crates/hotshot-qc/src/bit_vector.rs
+++ b/crates/hotshot-qc/src/bit_vector.rs
@@ -57,13 +57,14 @@ where
     type MessageLength = U32;
     type QuorumSize = U256;
 
-    fn sign<R: CryptoRng + RngCore>(
-        agg_sig_pp: &A::PublicParameter,
-        message: &GenericArray<A::MessageUnit, Self::MessageLength>,
+    /// Sign a message with the signing key
+    fn sign<R: CryptoRng + RngCore, M: AsRef<[A::MessageUnit]>>(
+        pp: &A::PublicParameter,
         sk: &A::SigningKey,
+        msg: M,
         prng: &mut R,
     ) -> Result<A::Signature, PrimitivesError> {
-        A::sign(agg_sig_pp, sk, message, prng)
+        A::sign(pp, sk, msg, prng)
     }
 
     fn assemble(

--- a/crates/types/src/qc.rs
+++ b/crates/types/src/qc.rs
@@ -55,13 +55,14 @@ where
     type MessageLength = U32;
     type QuorumSize = U256;
 
-    fn sign<R: CryptoRng + RngCore>(
-        agg_sig_pp: &A::PublicParameter,
-        message: &GenericArray<A::MessageUnit, Self::MessageLength>,
+    /// Sign a message with the signing key
+    fn sign<R: CryptoRng + RngCore, M: AsRef<[A::MessageUnit]>>(
+        pp: &A::PublicParameter,
         sk: &A::SigningKey,
+        msg: M,
         prng: &mut R,
     ) -> Result<A::Signature, PrimitivesError> {
-        A::sign(agg_sig_pp, sk, message, prng)
+        A::sign(pp, sk, msg, prng)
     }
 
     fn assemble(
@@ -214,27 +215,15 @@ mod tests {
                 agg_sig_pp,
             };
             let msg = [72u8; 32];
-            let sig1 = BitVectorQC::<$aggsig>::sign(
-                &agg_sig_pp,
-                &msg.into(),
-                key_pair1.sign_key_ref(),
-                &mut rng,
-            )
-            .unwrap();
-            let sig2 = BitVectorQC::<$aggsig>::sign(
-                &agg_sig_pp,
-                &msg.into(),
-                key_pair2.sign_key_ref(),
-                &mut rng,
-            )
-            .unwrap();
-            let sig3 = BitVectorQC::<$aggsig>::sign(
-                &agg_sig_pp,
-                &msg.into(),
-                key_pair3.sign_key_ref(),
-                &mut rng,
-            )
-            .unwrap();
+            let sig1 =
+                BitVectorQC::<$aggsig>::sign(&agg_sig_pp, key_pair1.sign_key_ref(), &msg, &mut rng)
+                    .unwrap();
+            let sig2 =
+                BitVectorQC::<$aggsig>::sign(&agg_sig_pp, key_pair2.sign_key_ref(), &msg, &mut rng)
+                    .unwrap();
+            let sig3 =
+                BitVectorQC::<$aggsig>::sign(&agg_sig_pp, key_pair3.sign_key_ref(), &msg, &mut rng)
+                    .unwrap();
 
             // happy path
             let signers = bitvec![0, 1, 1];

--- a/crates/types/src/signature_key.rs
+++ b/crates/types/src/signature_key.rs
@@ -44,6 +44,15 @@ impl SignatureKey for BLSPubKey {
         BLSOverBN254CurveSignatureScheme::verify(&(), self, generic_msg, signature).is_ok()
     }
 
+    /// Validate a signature of an arbitrary number of bytes, returning on success.
+    fn validate_arbitrary(
+        &self,
+        signature: &Self::PureAssembledSignatureType,
+        data: &[u8],
+    ) -> bool {
+        BLSOverBN254CurveSignatureScheme::verify(&(), self, data, signature).is_ok()
+    }
+
     fn sign(
         sk: &Self::PrivateKey,
         data: &[u8],
@@ -55,6 +64,17 @@ impl SignatureKey for BLSPubKey {
             sk,
             &mut rand::thread_rng(),
         )
+    }
+
+    /// Sign an arbitrary array of bytes.
+    ///
+    /// # Errors
+    /// - If we fail to sign
+    fn sign_arbitrary(
+        sk: &Self::PrivateKey,
+        data: &[u8],
+    ) -> Result<Self::PureAssembledSignatureType, Self::SignError> {
+        BLSOverBN254CurveSignatureScheme::sign(&(), sk, data, &mut rand::thread_rng())
     }
 
     fn from_private(private_key: &Self::PrivateKey) -> Self {

--- a/crates/types/src/traits/qc.rs
+++ b/crates/types/src/traits/qc.rs
@@ -42,12 +42,14 @@ pub trait QuorumCertificateScheme<
     /// # Errors
     ///
     /// Should return error if the underlying signature scheme fail to sign.
-    fn sign<R: CryptoRng + RngCore>(
-        agg_sig_pp: &A::PublicParameter,
-        message: &GenericArray<A::MessageUnit, Self::MessageLength>,
+    fn sign<R: CryptoRng + RngCore, M: AsRef<[A::MessageUnit]>>(
+        pp: &A::PublicParameter,
         sk: &A::SigningKey,
+        msg: M,
         prng: &mut R,
-    ) -> Result<A::Signature, PrimitivesError>;
+    ) -> Result<A::Signature, PrimitivesError> {
+        A::sign(pp, sk, msg, prng)
+    }
 
     /// Computes an aggregated signature from a set of partial signatures and the verification keys involved
     /// * `qc_pp` - public parameters for generating the QC

--- a/crates/types/src/traits/signature_key.rs
+++ b/crates/types/src/traits/signature_key.rs
@@ -88,23 +88,10 @@ pub trait SignatureKey:
     /// Validate a signature
     fn validate(&self, signature: &Self::PureAssembledSignatureType, data: &[u8]) -> bool;
 
-    /// Validate a signature of an arbitrary number of bytes, returning on success.
-    fn validate_arbitrary(&self, signature: &Self::PureAssembledSignatureType, data: &[u8])
-        -> bool;
-
     /// Produce a signature
     /// # Errors
     /// If unable to sign the data with the key
     fn sign(
-        private_key: &Self::PrivateKey,
-        data: &[u8],
-    ) -> Result<Self::PureAssembledSignatureType, Self::SignError>;
-
-    /// Sign an arbitrary array of bytes.
-    ///
-    /// # Errors
-    /// - If we fail to sign
-    fn sign_arbitrary(
         private_key: &Self::PrivateKey,
         data: &[u8],
     ) -> Result<Self::PureAssembledSignatureType, Self::SignError>;

--- a/crates/types/src/traits/signature_key.rs
+++ b/crates/types/src/traits/signature_key.rs
@@ -87,6 +87,11 @@ pub trait SignatureKey:
     // of serialization, to avoid Cryptographic pitfalls
     /// Validate a signature
     fn validate(&self, signature: &Self::PureAssembledSignatureType, data: &[u8]) -> bool;
+
+    /// Validate a signature of an arbitrary number of bytes, returning on success.
+    fn validate_arbitrary(&self, signature: &Self::PureAssembledSignatureType, data: &[u8])
+        -> bool;
+
     /// Produce a signature
     /// # Errors
     /// If unable to sign the data with the key
@@ -94,6 +99,16 @@ pub trait SignatureKey:
         private_key: &Self::PrivateKey,
         data: &[u8],
     ) -> Result<Self::PureAssembledSignatureType, Self::SignError>;
+
+    /// Sign an arbitrary array of bytes.
+    ///
+    /// # Errors
+    /// - If we fail to sign
+    fn sign_arbitrary(
+        private_key: &Self::PrivateKey,
+        data: &[u8],
+    ) -> Result<Self::PureAssembledSignatureType, Self::SignError>;
+
     /// Produce a public key from a private key
     fn from_private(private_key: &Self::PrivateKey) -> Self;
     /// Serialize a public key to bytes


### PR DESCRIPTION
### This PR: 
<!-- Describe what this PR adds to HotSHot -->
<!-- E.g. -->
<!-- * Implements feature 1 -->
<!-- * Implements feature 2 -->
<!-- * Fixes bug 3 -->

~~Adds two functions, `sign_arbitrary` and `verify_arbitrary`. Instead of casting to a `GenericArray` (locking us to length defined in `BitVectorQC`), they will allow signing of arbitrary data. This is needed for the Push CDN, where the messages are a different size.~~

Changes the two functions, `sign` and `verify` to operate over arbitrary data, removing the need for a `GenericArray` cast. This is needed for the Push CDN, where the messages are a different size.


### This PR does not: 
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->
~~- Use the `sign_arbitrary` and `verify_arbitrary` functions~~
~~- Change the existing sign and validate functions~~

~~### Question for crypto folk:~~
~~Do we need this? It looks like `BitVectorQC`'s sign just proxies to the underlying scheme anyway. But maybe there is a reason we cast to the array of specific length. If not, I can just update the existing functions to work for arbitrary data.~~