### PR TITLE
[NETWORKING] Fixes for Combined Network

### DIFF
--- a/crates/hotshot/src/traits.rs
+++ b/crates/hotshot/src/traits.rs
@@ -13,9 +13,7 @@ pub use storage::{Result as StorageResult, Storage};
 pub mod implementations {
     pub use super::{
         networking::{
-            combined_network::{
-                calculate_hash_of, Cache, CombinedNetworks, UnderlyingCombinedNetworks,
-            },
+            combined_network::{calculate_hash_of, CombinedNetworks, UnderlyingCombinedNetworks},
             libp2p_network::{Libp2pNetwork, PeerInfoVec},
             memory_network::{MasterMap, MemoryNetwork},
             web_server_network::WebServerNetwork,

--- a/crates/hotshot/src/traits.rs
+++ b/crates/hotshot/src/traits.rs
@@ -13,7 +13,7 @@ pub use storage::{Result as StorageResult, Storage};
 pub mod implementations {
     pub use super::{
         networking::{
-            combined_network::{calculate_hash_of, CombinedNetworks, UnderlyingCombinedNetworks},
+            combined_network::{CombinedNetworks, UnderlyingCombinedNetworks},
             libp2p_network::{Libp2pNetwork, PeerInfoVec},
             memory_network::{MasterMap, MemoryNetwork},
             web_server_network::WebServerNetwork,

--- a/crates/hotshot/src/traits/networking/combined_network.rs
+++ b/crates/hotshot/src/traits/networking/combined_network.rs
@@ -7,9 +7,11 @@ use hotshot_constants::{
     COMBINED_NETWORK_CACHE_SIZE, COMBINED_NETWORK_MIN_PRIMARY_FAILURES,
     COMBINED_NETWORK_PRIMARY_CHECK_INTERVAL,
 };
+use lru::LruCache;
 use std::{
-    collections::{BTreeSet, HashSet},
+    collections::BTreeSet,
     hash::Hasher,
+    num::NonZeroUsize,
     sync::atomic::{AtomicU64, Ordering},
 };
 use tracing::warn;
@@ -49,67 +51,6 @@ use std::time::Duration;
 #[cfg(async_executor_impl = "tokio")]
 use tokio::task::JoinHandle;
 
-/// A cache to keep track of the last n messages we've seen, avoids reprocessing duplicates
-/// from multiple networks
-#[derive(Clone, Debug)]
-pub struct Cache {
-    /// The maximum number of items to store in the cache
-    capacity: usize,
-    /// The cache itself
-    inner: HashSet<u64>,
-    /// The hashes of the messages in the cache, in order of insertion
-    hashes: Vec<u64>,
-}
-
-impl Cache {
-    /// Create a new cache with the given capacity
-    #[must_use]
-    pub fn new(capacity: usize) -> Self {
-        Self {
-            capacity,
-            inner: HashSet::with_capacity(capacity),
-            hashes: Vec::with_capacity(capacity),
-        }
-    }
-
-    /// Insert a hash into the cache
-    pub fn insert(&mut self, hash: u64) {
-        if self.inner.contains(&hash) {
-            return;
-        }
-
-        // calculate how much we are over and remove that many elements from the cache. deal with overflow
-        let over = (self.hashes.len() + 1).saturating_sub(self.capacity);
-        if over > 0 {
-            for _ in 0..over {
-                let hash = self.hashes.remove(0);
-                self.inner.remove(&hash);
-            }
-        }
-
-        self.inner.insert(hash);
-        self.hashes.push(hash);
-    }
-
-    /// Check if the cache contains a hash
-    #[must_use]
-    pub fn contains(&self, hash: u64) -> bool {
-        self.inner.contains(&hash)
-    }
-
-    /// Get the number of items in the cache
-    #[must_use]
-    pub fn len(&self) -> usize {
-        self.inner.len()
-    }
-
-    /// True if the cache is empty false otherwise
-    #[must_use]
-    pub fn is_empty(&self) -> bool {
-        self.inner.is_empty()
-    }
-}
-
 /// Helper function to calculate a hash of a type that implements Hash
 pub fn calculate_hash_of<T: Hash>(t: &T) -> u64 {
     let mut s = DefaultHasher::new();
@@ -128,7 +69,7 @@ pub struct CombinedNetworks<TYPES: NodeType> {
     networks: Arc<UnderlyingCombinedNetworks<TYPES>>,
 
     /// Last n seen messages to prevent processing duplicates
-    message_cache: Arc<RwLock<Cache>>,
+    message_cache: Arc<RwLock<LruCache<u64, ()>>>,
 
     /// If the primary network is down (0) or not, and for how many messages
     primary_down: Arc<AtomicU64>,
@@ -142,11 +83,17 @@ pub struct CombinedNetworks<TYPES: NodeType> {
 
 impl<TYPES: NodeType> CombinedNetworks<TYPES> {
     /// Constructor
+    ///
+    /// # Panics
+    ///
+    /// Panics if `COMBINED_NETWORK_CACHE_SIZE` is 0
     #[must_use]
     pub fn new(networks: Arc<UnderlyingCombinedNetworks<TYPES>>) -> Self {
         Self {
             networks,
-            message_cache: Arc::new(RwLock::new(Cache::new(COMBINED_NETWORK_CACHE_SIZE))),
+            message_cache: Arc::new(RwLock::new(LruCache::new(
+                NonZeroUsize::new(COMBINED_NETWORK_CACHE_SIZE).unwrap(),
+            ))),
             primary_down: Arc::new(AtomicU64::new(0)),
             delayed_tasks: Arc::default(),
             delay_duration: Arc::new(RwLock::new(Duration::from_millis(1000))),
@@ -276,14 +223,18 @@ impl<TYPES: NodeType> TestableNetworkingImplementation<TYPES> for CombinedNetwor
             );
             let quorum_net = Self {
                 networks: Arc::new(quorum_networks),
-                message_cache: Arc::new(RwLock::new(Cache::new(COMBINED_NETWORK_CACHE_SIZE))),
+                message_cache: Arc::new(RwLock::new(LruCache::new(
+                    NonZeroUsize::new(COMBINED_NETWORK_CACHE_SIZE).unwrap(),
+                ))),
                 primary_down: Arc::new(AtomicU64::new(0)),
                 delayed_tasks: Arc::default(),
                 delay_duration: Arc::new(RwLock::new(Duration::from_millis(1000))),
             };
             let da_net = Self {
                 networks: Arc::new(da_networks),
-                message_cache: Arc::new(RwLock::new(Cache::new(COMBINED_NETWORK_CACHE_SIZE))),
+                message_cache: Arc::new(RwLock::new(LruCache::new(
+                    NonZeroUsize::new(COMBINED_NETWORK_CACHE_SIZE).unwrap(),
+                ))),
                 primary_down: Arc::new(AtomicU64::new(0)),
                 delayed_tasks: Arc::default(),
                 delay_duration: Arc::new(RwLock::new(Duration::from_millis(1000))),
@@ -430,13 +381,13 @@ impl<TYPES: NodeType> ConnectedNetwork<Message<TYPES>, TYPES::SignatureKey>
                 .message_cache
                 .read()
                 .await
-                .contains(calculate_hash_of(&msg))
+                .contains(&calculate_hash_of(&msg))
             {
                 filtered_msgs.push(msg.clone());
                 self.message_cache
                     .write()
                     .await
-                    .insert(calculate_hash_of(&msg));
+                    .put(calculate_hash_of(&msg), ());
             }
         }
 
@@ -483,33 +434,5 @@ impl<TYPES: NodeType> ConnectedNetwork<Message<TYPES>, TYPES::SignatureKey>
             }
             join_all(cancel_tasks).await;
         });
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use super::*;
-    use tracing::instrument;
-
-    /// cache eviction test
-    #[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
-    #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
-    #[instrument]
-    async fn test_cache_eviction() {
-        let mut cache = Cache::new(3);
-        cache.insert(1);
-        cache.insert(2);
-        cache.insert(3);
-        cache.insert(4);
-        assert_eq!(cache.inner.len(), 3);
-        assert_eq!(cache.hashes.len(), 3);
-        assert!(!cache.inner.contains(&1));
-        assert!(cache.inner.contains(&2));
-        assert!(cache.inner.contains(&3));
-        assert!(cache.inner.contains(&4));
-        assert!(!cache.hashes.contains(&1));
-        assert!(cache.hashes.contains(&2));
-        assert!(cache.hashes.contains(&3));
-        assert!(cache.hashes.contains(&4));
     }
 }

--- a/crates/task-impls/src/network.rs
+++ b/crates/task-impls/src/network.rs
@@ -354,7 +354,7 @@ impl<TYPES: NodeType, COMMCHANNEL: ConnectedNetwork<Message<TYPES>, TYPES::Signa
             ),
             HotShotEvent::ViewChange(view) => {
                 self.view = view;
-                self.channel.update_view(&self.view.get_u64()).await;
+                self.channel.update_view(self.view.get_u64());
                 return None;
             }
             HotShotEvent::Shutdown => {

--- a/crates/testing/tests/combined_network.rs
+++ b/crates/testing/tests/combined_network.rs
@@ -10,45 +10,6 @@ use hotshot_testing::{
 use rand::Rng;
 use tracing::instrument;
 
-use hotshot::traits::implementations::{calculate_hash_of, Cache};
-use hotshot_example_types::block_types::TestTransaction;
-
-#[cfg(test)]
-#[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
-#[cfg_attr(async_executor_impl = "async-std", async_std::test)]
-#[instrument]
-async fn test_hash_calculation() {
-    let message1 = TestTransaction(vec![0; 32]);
-    let message2 = TestTransaction(vec![1; 32]);
-
-    assert_eq!(calculate_hash_of(&message1), calculate_hash_of(&message1));
-    assert_ne!(calculate_hash_of(&message1), calculate_hash_of(&message2));
-}
-
-#[cfg(test)]
-#[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
-#[cfg_attr(async_executor_impl = "async-std", async_std::test)]
-#[instrument]
-async fn test_cache_integrity() {
-    let message1 = TestTransaction(vec![0; 32]);
-    let message2 = TestTransaction(vec![1; 32]);
-
-    let mut cache = Cache::new(3);
-
-    // test insertion integrity
-    cache.insert(calculate_hash_of(&message1));
-    cache.insert(calculate_hash_of(&message2));
-
-    assert!(cache.contains(calculate_hash_of(&message1)));
-    assert!(cache.contains(calculate_hash_of(&message2)));
-
-    // check that the cache is not modified on duplicate entries
-    cache.insert(calculate_hash_of(&message1));
-    assert!(cache.contains(calculate_hash_of(&message1)));
-    assert!(cache.contains(calculate_hash_of(&message2)));
-    assert_eq!(cache.len(), 2);
-}
-
 /// A run with both the webserver and libp2p functioning properly
 #[cfg(test)]
 #[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]

--- a/crates/types/src/traits/network.rs
+++ b/crates/types/src/traits/network.rs
@@ -298,7 +298,7 @@ pub trait ConnectedNetwork<M: NetworkMsg, K: SignatureKey + 'static>:
     async fn inject_consensus_info(&self, _event: ConsensusIntentEvent<K>) {}
 
     /// handles view update
-    async fn update_view(&self, _view: &u64) {}
+    fn update_view(&self, _view: u64) {}
 }
 
 /// Describes additional functionality needed by the test network implementation


### PR DESCRIPTION
When debugging some issues with the combined network we found a few issues.  This PR fixes these issues.  They are:

- Network task was blocked on collecting and cancelling delayed tasks in the combined network when updating view
  - Fixed by spawning a task 
  - Make `update_view` non-async so we know it's not a blocking call
- Recv was blocking until a message was received on both the primary and fallback, this can slow things down greatly if all messages for view come in from the primary, then after the delay expires we get the first non fallback.
  - fixed by adding a `select` between the two networks
- We implemented our our LRU cache, this just replace it with the LruCache crate.
