### PR TITLE
[EASY] remove `Clone` requirement from `InstanceState`

### DIFF
--- a/crates/types/src/traits/states.rs
+++ b/crates/types/src/traits/states.rs
@@ -16,7 +16,7 @@ use serde::{de::DeserializeOwned, Serialize};
 use std::{error::Error, fmt::Debug, future::Future, hash::Hash};
 
 /// Instance-level state, which allows us to fetch missing validated state.
-pub trait InstanceState: Clone + Debug + Send + Sync {}
+pub trait InstanceState: Debug + Send + Sync {}
 
 /// Abstraction over the state that blocks modify
 ///


### PR DESCRIPTION
Closes #2540

### This PR: 

Clone isn't needed for InstanceState

### This PR does not: 

Just changes the trait nothing else
