### PR TITLE
Fix cargo warnings and docs

### DIFF
--- a/crates/example-types/Cargo.toml
+++ b/crates/example-types/Cargo.toml
@@ -19,7 +19,7 @@ commit = { workspace = true }
 either = { workspace = true }
 futures = { workspace = true }
 hotshot = { path = "../hotshot" }
-hotshot-types = { workspace = true, default-features = false }
+hotshot-types = { workspace = true }
 hotshot-utils = { path = "../utils" }
 hotshot-orchestrator = { version = "0.1.1", path = "../orchestrator", default-features = false }
 hotshot-task-impls = { path = "../task-impls", version = "0.1.0", default-features = false }

--- a/crates/examples/Cargo.toml
+++ b/crates/examples/Cargo.toml
@@ -94,7 +94,7 @@ embed-doc-image = "0.1.4"
 futures = { workspace = true }
 hotshot-web-server = { version = "0.1.1", path = "../web_server", default-features = false }
 hotshot-orchestrator = { version = "0.1.1", path = "../orchestrator", default-features = false }
-hotshot-types = { workspace = true, version = "0.1.0", default-features = false }
+hotshot-types = { workspace = true }
 hotshot-utils = { path = "../utils" }
 hotshot-task-impls = { path = "../task-impls", version = "0.1.0", default-features = false }
 libp2p-identity = { workspace = true }

--- a/crates/hotshot/Cargo.toml
+++ b/crates/hotshot/Cargo.toml
@@ -37,7 +37,7 @@ ethereum-types = { workspace = true }
 futures = { workspace = true }
 hotshot-web-server = { version = "0.1.1", path = "../web_server", default-features = false }
 hotshot-orchestrator = { version = "0.1.1", path = "../orchestrator", default-features = false }
-hotshot-types = { workspace = true, version = "0.1.0", default-features = false }
+hotshot-types = { workspace = true }
 hotshot-task = { path = "../task" }
 hotshot-utils = { path = "../utils" }
 hotshot-task-impls = { path = "../task-impls", version = "0.1.0", default-features = false }

--- a/crates/orchestrator/Cargo.toml
+++ b/crates/orchestrator/Cargo.toml
@@ -10,7 +10,7 @@ clap = { version = "4.0", features = ["derive", "env"], optional = false }
 futures = { workspace = true }
 libp2p = { workspace = true }
 blake3 = { workspace = true }
-hotshot-types = { workspace = true, version = "0.1.0" , default-features = false }
+hotshot-types = { workspace = true }
 hotshot-utils = { path = "../utils" }
 tide-disco = { workspace = true }
 surf-disco = { workspace = true }

--- a/crates/task-impls/Cargo.toml
+++ b/crates/task-impls/Cargo.toml
@@ -13,7 +13,7 @@ futures = { workspace = true }
 snafu = { workspace = true }
 async-lock = { workspace = true }
 tracing = { workspace = true }
-hotshot-types = { workspace = true, default-features = false }
+hotshot-types = { workspace = true }
 hotshot-utils = { path = "../utils" }
 jf-primitives = { workspace = true }
 time = { workspace = true }

--- a/crates/testing-macros/Cargo.toml
+++ b/crates/testing-macros/Cargo.toml
@@ -15,7 +15,7 @@ commit = { workspace = true }
 either = { workspace = true }
 futures = { workspace = true }
 hotshot = { path = "../hotshot", default-features = false }
-hotshot-types = { workspace = true, default-features = false }
+hotshot-types = { workspace = true }
 hotshot-testing = { path = "../testing", default-features = false }
 hotshot-example-types = { path = "../example-types" }
 jf-primitives = { workspace = true }

--- a/crates/testing/Cargo.toml
+++ b/crates/testing/Cargo.toml
@@ -19,7 +19,7 @@ commit = { workspace = true }
 either = { workspace = true }
 futures = { workspace = true }
 hotshot = { path = "../hotshot", features = ["hotshot-testing"] }
-hotshot-types = { workspace = true, default-features = false }
+hotshot-types = { workspace = true }
 hotshot-utils = { path = "../utils" }
 hotshot-orchestrator = { version = "0.1.1", path = "../orchestrator", default-features = false }
 hotshot-task-impls = { path = "../task-impls", version = "0.1.0", default-features = false }

--- a/crates/web_server/Cargo.toml
+++ b/crates/web_server/Cargo.toml
@@ -10,7 +10,7 @@ async-compatibility-layer = { workspace = true }
 async-lock = { workspace = true }
 clap = { version = "4.0", features = ["derive", "env"], optional = false }
 futures = { workspace = true }
-hotshot-types = { workspace = true, default-features = false }
+hotshot-types = { workspace = true }
 tide-disco = { workspace = true }
 tracing = { workspace = true }
 rand = { workspace = true }

--- a/justfile
+++ b/justfile
@@ -160,7 +160,7 @@ fix:
 
 doc:
   echo Generating docs {{env_var('RUSTFLAGS')}}
-  cargo doc --no-deps --workspace --document-private-items --bins --examples --lib
+  cargo doc --workspace --document-private-items --bins --examples --lib
 
 doc_test:
   echo Test docs

--- a/justfile
+++ b/justfile
@@ -160,7 +160,8 @@ fix:
 
 doc:
   echo Generating docs {{env_var('RUSTFLAGS')}}
-  cargo doc --workspace --document-private-items --bins --examples --lib
+  cargo doc --no-deps --workspace --document-private-items --bins --examples --lib
+  cargo doc --no-deps -p hotshot-types
 
 doc_test:
   echo Test docs

--- a/justfile
+++ b/justfile
@@ -160,8 +160,8 @@ fix:
 
 doc:
   echo Generating docs {{env_var('RUSTFLAGS')}}
+  cargo doc --no-deps --bins --examples --lib -p 'hotshot-types'
   cargo doc --no-deps --workspace --document-private-items --bins --examples --lib
-  cargo doc --no-deps -p hotshot-types
 
 doc_test:
   echo Test docs


### PR DESCRIPTION
No linked issue.

### This PR: 
- Makes `cargo doc` build and link to documentation for dependencies in CI. With the separation of `hotshot-types`, we were missing documentation for the types.
- Fixes cargo warnings caused by extra fields in the `hotshot-types` workspace dependency in workspace packages.

### This PR does not: 

### Key places to review: 
