### PR TITLE
Remove excessive logging

### DIFF
--- a/crates/hotshot/src/traits/networking/libp2p_network.rs
+++ b/crates/hotshot/src/traits/networking/libp2p_network.rs
@@ -66,7 +66,7 @@ use std::{
     },
     time::Duration,
 };
-use tracing::{error, info, instrument, warn};
+use tracing::{debug, error, info, instrument, warn};
 
 /// convienence alias for the type for bootstrap addresses
 /// concurrency primitives are needed for having tests

--- a/crates/hotshot/src/traits/networking/libp2p_network.rs
+++ b/crates/hotshot/src/traits/networking/libp2p_network.rs
@@ -451,13 +451,8 @@ impl<M: NetworkMsg, K: SignatureKey + 'static> Libp2pNetwork<M, K> {
                     if bs_addrs.len() >= num_bootstrap {
                         break bs_addrs;
                     }
-                    info!(
-                        "NODE {:?} bs addr len {:?}, number of bootstrap expected {:?}",
-                        id,
-                        bs_addrs.len(),
-                        num_bootstrap
-                    );
                 };
+                debug!("Finished adding bootstrap addresses.");
                 handle.add_known_peers(bs_addrs).await.unwrap();
 
                 handle.begin_bootstrap().await?;

--- a/crates/hotshot/src/traits/networking/web_server_network.rs
+++ b/crates/hotshot/src/traits/networking/web_server_network.rs
@@ -541,9 +541,7 @@ impl<TYPES: NodeType> Inner<TYPES> {
                     }
                 }
                 // Nothing on receiving channel
-                Err(_) => {
-                    debug!("Nothing on receiving channel");
-                }
+                Err(_) => {}
             }
         }
         Err(NetworkError::ShutDown)


### PR DESCRIPTION
No linked issue.

### This PR: 
- Removes logging from adding bootstrap addresses in `hotshot/src/traits/libp2p_network.rs`. This is probably the biggest polluter of log files in our integration tests, creating about ~20 MB of logs (over 50% of the total log) for no reason. We now only log when bootstrapping is completed.
- Removes logging from failing to receive messages in a loop in `hotshot/src/traits/web_server_network.rs`. This is also a significant polluter in logs, and is not logging anything helpful.

### This PR does not: 

### Key places to review: 
