### PR TITLE
[Draft][CX-CLEANUP] - DA Integrated Storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3425,7 +3425,7 @@ dependencies = [
 [[package]]
 name = "hotshot-types"
 version = "0.1.5"
-source = "git+https://github.com/EspressoSystems/hotshot-types?branch=jparr721/issue-2621#f75c8da63d461685e6b7c5370a58bfdc3f345a25"
+source = "git+https://github.com/EspressoSystems/hotshot-types?branch=jparr721/issue-2621#cb4419edb6fc28c1e55a783c575ef40c93282c2f"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1451,9 +1451,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.2"
+version = "4.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b230ab84b0ffdf890d5a10abdbc8b83ae1c4918275daea1ab8801f71536b2651"
+checksum = "949626d00e063efc93b6dca932419ceb5432f99769911c0b995f7e884c778813"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1473,11 +1473,11 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.0"
+version = "4.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "307bc0538d5f0f83b8248db3087aa92fe504e4691294d0c96c0eabc33f47ba47"
+checksum = "90239a040c80f5e14809ca132ddc4176ab33d5e17e49691793296e3fcb34d72f"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.52",
@@ -2386,7 +2386,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ffccbb6966c05b32ef8fbac435df276c4ae4d3dc55a8cd0eb9745e6c12f546a"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.52",
@@ -2996,6 +2996,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3419,7 +3425,7 @@ dependencies = [
 [[package]]
 name = "hotshot-types"
 version = "0.1.5"
-source = "git+https://github.com/EspressoSystems/hotshot-types?branch=jparr721/issue-2621#d79a257dee022d16749b8518666389172ffd9b27"
+source = "git+https://github.com/EspressoSystems/hotshot-types?branch=jparr721/issue-2621#f75c8da63d461685e6b7c5370a58bfdc3f345a25"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -4654,7 +4660,7 @@ version = "0.34.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b644268b4acfdaa6a6100b31226ee7a36d96ab4c43287d113bfd2308607d8b6f"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.52",
@@ -7095,7 +7101,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "990079665f075b699031e9c08fd3ab99be5029b96f3b78dc0709e8f77e4efebf"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -7272,7 +7278,7 @@ checksum = "5833ef53aaa16d860e92123292f1f6a3d53c34ba8b1969f152ef1a7bb803f3c8"
 dependencies = [
  "dotenvy",
  "either",
- "heck",
+ "heck 0.4.1",
  "hex",
  "once_cell",
  "proc-macro2",
@@ -7495,7 +7501,7 @@ version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "rustversion",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1491,9 +1491,9 @@ checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 
 [[package]]
 name = "color-eyre"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a667583cca8c4f8436db8de46ea8233c42a7d9ae424a82d338f2e4675229204"
+checksum = "55146f5e46f237f7423d74111267d4597b59b0dad0ffaf7303bce9945d843ad5"
 dependencies = [
  "backtrace",
  "color-spantrace",
@@ -3192,6 +3192,7 @@ dependencies = [
  "async-compatibility-layer 1.0.0 (git+https://github.com/EspressoSystems/async-compatibility-layer.git?tag=1.4.2)",
  "async-lock 2.8.0",
  "async-std",
+ "async-trait",
  "bincode",
  "bitvec",
  "commit",
@@ -3417,8 +3418,8 @@ dependencies = [
 
 [[package]]
 name = "hotshot-types"
-version = "0.1.4"
-source = "git+https://github.com/EspressoSystems/hotshot-types?tag=0.1.4#76a21095f7c39f0aaf5a08b2f8540448c97728c1"
+version = "0.1.5"
+source = "git+https://github.com/EspressoSystems/hotshot-types?branch=jparr721/issue-2621#d79a257dee022d16749b8518666389172ffd9b27"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -8009,9 +8010,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "397c988d37662c7dda6d2208364a706264bf3d6138b11d436cbac0ad38832842"
+checksum = "267ac89e0bec6e691e5813911606935d77c476ff49024f98abcea3e7b15e37af"
 dependencies = [
  "futures-core",
  "pin-project-lite 0.2.13",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ futures = "0.3.30"
 # TODO generic-array should not be a direct dependency
 # https://github.com/EspressoSystems/HotShot/issues/1850
 generic-array = { version = "0.14.7", features = ["serde"] }
-hotshot-types = { git = "https://github.com/EspressoSystems/hotshot-types", tag = "0.1.4" }
+hotshot-types = { git = "https://github.com/EspressoSystems/hotshot-types", branch = "jparr721/issue-2621" }
 
 jf-primitives = { git = "https://github.com/EspressoSystems/jellyfish", tag = "0.4.1" }
 jf-plonk = { git = "https://github.com/EspressoSystems/jellyfish", tag = "0.4.1" }

--- a/crates/example-types/Cargo.toml
+++ b/crates/example-types/Cargo.toml
@@ -13,6 +13,7 @@ slow-tests = []
 [dependencies]
 async-broadcast = { workspace = true }
 async-compatibility-layer = { workspace = true }
+async-trait = { workspace = true }
 sha3 = "^0.10"
 bincode = { workspace = true }
 commit = { workspace = true }

--- a/crates/example-types/src/lib.rs
+++ b/crates/example-types/src/lib.rs
@@ -6,3 +6,5 @@ pub mod state_types;
 
 /// node types
 pub mod node_types;
+
+pub mod storage_types;

--- a/crates/example-types/src/node_types.rs
+++ b/crates/example-types/src/node_types.rs
@@ -5,6 +5,7 @@ use hotshot::traits::{
 use crate::{
     block_types::{TestBlockHeader, TestBlockPayload, TestTransaction},
     state_types::{TestInstanceState, TestValidatedState},
+    storage_types::TestBlockStorage,
 };
 
 use hotshot::traits::{
@@ -106,28 +107,33 @@ impl NodeImplementation<TestTypes> for PushCdnImpl {
     type Storage = MemoryStorage<TestTypes>;
     type QuorumNetwork = StaticPushCdnQuorumComm;
     type CommitteeNetwork = StaticPushCdnDAComm;
+    type BlockStorage = TestBlockStorage<TestTypes>;
 }
 
 impl NodeImplementation<TestTypes> for Libp2pImpl {
     type Storage = MemoryStorage<TestTypes>;
     type QuorumNetwork = StaticLibp2pQuorumComm;
     type CommitteeNetwork = StaticLibp2pDAComm;
+    type BlockStorage = TestBlockStorage<TestTypes>;
 }
 
 impl NodeImplementation<TestTypes> for MemoryImpl {
     type Storage = MemoryStorage<TestTypes>;
     type QuorumNetwork = StaticMemoryQuorumComm;
     type CommitteeNetwork = StaticMemoryDAComm;
+    type BlockStorage = TestBlockStorage<TestTypes>;
 }
 
 impl NodeImplementation<TestTypes> for WebImpl {
     type Storage = MemoryStorage<TestTypes>;
     type QuorumNetwork = StaticWebQuorumComm;
     type CommitteeNetwork = StaticWebDAComm;
+    type BlockStorage = TestBlockStorage<TestTypes>;
 }
 
 impl NodeImplementation<TestTypes> for CombinedImpl {
     type Storage = MemoryStorage<TestTypes>;
     type QuorumNetwork = StaticCombinedQuorumComm;
     type CommitteeNetwork = StaticCombinedDAComm;
+    type BlockStorage = TestBlockStorage<TestTypes>;
 }

--- a/crates/example-types/src/state_types.rs
+++ b/crates/example-types/src/state_types.rs
@@ -24,7 +24,7 @@ pub struct TestInstanceState {}
 impl InstanceState for TestInstanceState {}
 
 /// Application-specific state delta implementation for testing purposes.
-#[derive(Clone, Copy, Debug, Default)]
+#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize)]
 pub struct TestStateDelta {}
 
 impl StateDelta for TestStateDelta {}

--- a/crates/example-types/src/storage_types.rs
+++ b/crates/example-types/src/storage_types.rs
@@ -62,4 +62,8 @@ impl<TYPES: NodeType> BlockStorage<TYPES> for TestBlockStorage<TYPES> {
 
         Ok(())
     }
+
+    fn empty() -> Self {
+        Self::default()
+    }
 }

--- a/crates/example-types/src/storage_types.rs
+++ b/crates/example-types/src/storage_types.rs
@@ -1,0 +1,47 @@
+use async_lock::RwLock;
+use async_trait::async_trait;
+use std::{collections::HashMap, sync::Arc};
+
+use hotshot_types::{
+    data::{DAProposal, VidDisperse},
+    message::Proposal,
+    traits::{
+        block_storage::{BlockStorage, BlockStorageError, ProposalType},
+        node_implementation::NodeType,
+    },
+};
+
+#[derive(Clone, Debug)]
+pub struct TestBlockStorageInternal<TYPES: NodeType> {
+    da_storage: HashMap<TYPES::Time, Proposal<TYPES, DAProposal<TYPES>>>,
+    vid_storage: HashMap<TYPES::Time, Proposal<TYPES, VidDisperse<TYPES>>>,
+}
+
+impl<TYPES: NodeType> Default for TestBlockStorageInternal<TYPES> {
+    fn default() -> Self {
+        Self {
+            da_storage: Default::default(),
+            vid_storage: Default::default(),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct TestBlockStorage<TYPES: NodeType> {
+    inner: Arc<RwLock<TestBlockStorageInternal<TYPES>>>,
+}
+
+impl<TYPES: NodeType> Default for TestBlockStorage<TYPES> {
+    fn default() -> Self {
+        Self {
+            inner: Arc::new(RwLock::new(Default::default())),
+        }
+    }
+}
+
+#[async_trait]
+impl<TYPES: NodeType> BlockStorage<TYPES> for TestBlockStorage<TYPES> {
+    async fn append(&self, _proposal: &ProposalType<TYPES>) -> Result<(), BlockStorageError> {
+        Ok(())
+    }
+}

--- a/crates/example-types/src/storage_types.rs
+++ b/crates/example-types/src/storage_types.rs
@@ -9,6 +9,7 @@ use hotshot_types::{
         block_storage::{BlockStorage, BlockStorageError, ProposalType},
         node_implementation::NodeType,
     },
+    vote::HasViewNumber,
 };
 
 #[derive(Clone, Debug)]
@@ -41,7 +42,24 @@ impl<TYPES: NodeType> Default for TestBlockStorage<TYPES> {
 
 #[async_trait]
 impl<TYPES: NodeType> BlockStorage<TYPES> for TestBlockStorage<TYPES> {
-    async fn append(&self, _proposal: &ProposalType<TYPES>) -> Result<(), BlockStorageError> {
+    async fn append(&self, proposal: &ProposalType<TYPES>) -> Result<(), BlockStorageError> {
+        match proposal {
+            ProposalType::DAProposal(p) => {
+                self.inner
+                    .write()
+                    .await
+                    .da_storage
+                    .insert(p.data.get_view_number(), p.clone());
+            }
+            ProposalType::VidDisperse(p) => {
+                self.inner
+                    .write()
+                    .await
+                    .vid_storage
+                    .insert(p.data.get_view_number(), p.clone());
+            }
+        };
+
         Ok(())
     }
 }

--- a/crates/examples/combined/types.rs
+++ b/crates/examples/combined/types.rs
@@ -1,6 +1,6 @@
 use crate::infra::CombinedDARun;
 use hotshot::traits::implementations::{CombinedNetworks, MemoryStorage};
-use hotshot_example_types::state_types::TestTypes;
+use hotshot_example_types::{state_types::TestTypes, storage_types::TestBlockStorage};
 use hotshot_types::traits::node_implementation::NodeImplementation;
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
@@ -22,6 +22,7 @@ impl NodeImplementation<TestTypes> for NodeImpl {
     type Storage = MemoryStorage<TestTypes>;
     type QuorumNetwork = QuorumNetwork;
     type CommitteeNetwork = DANetwork;
+    type BlockStorage = TestBlockStorage<TestTypes>;
 }
 /// convenience type alias
 pub type ThisRun = CombinedDARun<TestTypes>;

--- a/crates/examples/infra/mod.rs
+++ b/crates/examples/infra/mod.rs
@@ -31,6 +31,7 @@ use hotshot_orchestrator::{
     config::{CombinedNetworkConfig, NetworkConfig, NetworkConfigFile, WebServerConfig},
 };
 use hotshot_types::message::Message;
+use hotshot_types::traits::block_storage;
 use hotshot_types::traits::network::ConnectedNetwork;
 use hotshot_types::PeerConfig;
 use hotshot_types::ValidatorConfig;
@@ -451,7 +452,10 @@ pub trait RunDA<
     /// # Panics if it cannot generate a genesis block, fails to initialize HotShot, or cannot
     /// get the anchored view
     /// Note: sequencing leaf does not have state, so does not return state
-    async fn initialize_state_and_hotshot(&self) -> SystemContextHandle<TYPES, NODE> {
+    async fn initialize_state_and_hotshot(
+        &self,
+        block_storage: NODE::BlockStorage,
+    ) -> SystemContextHandle<TYPES, NODE> {
         let initializer = hotshot::HotShotInitializer::<TYPES>::from_genesis(TestInstanceState {})
             .expect("Couldn't generate genesis block");
 
@@ -512,6 +516,7 @@ pub trait RunDA<
             networks_bundle,
             initializer,
             ConsensusMetricsValue::default(),
+            block_storage,
         )
         .await
         .expect("Could not init hotshot")

--- a/crates/examples/libp2p/types.rs
+++ b/crates/examples/libp2p/types.rs
@@ -1,6 +1,6 @@
 use crate::infra::Libp2pDARun;
 use hotshot::traits::implementations::{Libp2pNetwork, MemoryStorage};
-use hotshot_example_types::state_types::TestTypes;
+use hotshot_example_types::{state_types::TestTypes, storage_types::TestBlockStorage};
 use hotshot_types::{
     message::Message,
     traits::node_implementation::{NodeImplementation, NodeType},
@@ -21,6 +21,7 @@ impl NodeImplementation<TestTypes> for NodeImpl {
     type Storage = MemoryStorage<TestTypes>;
     type QuorumNetwork = QuorumNetwork;
     type CommitteeNetwork = DANetwork;
+    type BlockStorage = TestBlockStorage<TestTypes>;
 }
 /// convenience type alias
 pub type ThisRun = Libp2pDARun<TestTypes>;

--- a/crates/examples/push-cdn/types.rs
+++ b/crates/examples/push-cdn/types.rs
@@ -1,6 +1,6 @@
 use crate::infra::PushCdnDaRun;
 use hotshot::traits::implementations::{MemoryStorage, PushCdnNetwork};
-use hotshot_example_types::state_types::TestTypes;
+use hotshot_example_types::{state_types::TestTypes, storage_types::TestBlockStorage};
 use hotshot_types::traits::node_implementation::NodeImplementation;
 use serde::{Deserialize, Serialize};
 
@@ -21,6 +21,7 @@ impl NodeImplementation<TestTypes> for NodeImpl {
     type Storage = MemoryStorage<TestTypes>;
     type CommitteeNetwork = DANetwork;
     type QuorumNetwork = QuorumNetwork;
+    type BlockStorage = TestBlockStorage<TestTypes>;
 }
 
 /// Convenience type alias

--- a/crates/examples/webserver/types.rs
+++ b/crates/examples/webserver/types.rs
@@ -1,6 +1,6 @@
 use crate::infra::WebServerDARun;
 use hotshot::traits::implementations::{MemoryStorage, WebServerNetwork};
-use hotshot_example_types::state_types::TestTypes;
+use hotshot_example_types::{state_types::TestTypes, storage_types::TestBlockStorage};
 use hotshot_types::traits::node_implementation::NodeImplementation;
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
@@ -22,6 +22,7 @@ impl NodeImplementation<TestTypes> for NodeImpl {
     type Storage = MemoryStorage<TestTypes>;
     type CommitteeNetwork = DANetwork;
     type QuorumNetwork = QuorumNetwork;
+    type BlockStorage = TestBlockStorage<TestTypes>;
 }
 /// convenience type alias
 pub type ThisRun = WebServerDARun<TestTypes>;

--- a/crates/hotshot/src/lib.rs
+++ b/crates/hotshot/src/lib.rs
@@ -412,6 +412,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> SystemContext<TYPES, I> {
         networks: Networks<TYPES, I>,
         initializer: HotShotInitializer<TYPES>,
         metrics: ConsensusMetricsValue,
+        block_storage: I::BlockStorage,
     ) -> Result<
         (
             SystemContextHandle<TYPES, I>,

--- a/crates/hotshot/src/tasks/task_state.rs
+++ b/crates/hotshot/src/tasks/task_state.rs
@@ -88,6 +88,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> CreateTaskState<TYPES, I>
             public_key: handle.public_key().clone(),
             private_key: handle.private_key().clone(),
             id: handle.hotshot.id,
+            block_storage: handle.block_storage.clone(),
         }
     }
 }

--- a/crates/hotshot/src/types/handle.rs
+++ b/crates/hotshot/src/types/handle.rs
@@ -41,6 +41,9 @@ pub struct SystemContextHandle<TYPES: NodeType, I: NodeImplementation<TYPES>> {
 
     /// Our copy of the `Storage` view for a hotshot
     pub(crate) storage: I::Storage,
+
+    /// DA and VID storage for hotshot
+    pub(crate) block_storage: Arc<RwLock<I::BlockStorage>>,
 }
 
 impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static> SystemContextHandle<TYPES, I> {

--- a/crates/task-impls/src/da.rs
+++ b/crates/task-impls/src/da.rs
@@ -71,6 +71,9 @@ pub struct DATaskState<
 
     /// This state's ID
     pub id: u64,
+
+    /// The block storage for the DA task
+    pub block_storage: Arc<RwLock<I::BlockStorage>>,
 }
 
 impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 'static>
@@ -148,6 +151,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                     );
                     return None;
                 }
+
                 // Generate and send vote
                 let Ok(vote) = DAVote::create_signed_vote(
                     DAData {

--- a/crates/testing/src/spinning_task.rs
+++ b/crates/testing/src/spinning_task.rs
@@ -99,7 +99,7 @@ where
                                     Left(context) => context,
                                     // Node not initialized. Initialize it
                                     // based on the received leaf.
-                                    Right((storage, memberships, config)) => {
+                                    Right((storage, memberships, config, block_storage)) => {
                                         let initializer = HotShotInitializer::<TYPES>::from_reload(
                                             state.last_decided_leaf.clone(),
                                             TestInstanceState {},
@@ -119,6 +119,7 @@ where
                                             initializer,
                                             config,
                                             validator_config,
+                                            block_storage,
                                         )
                                         .await
                                     }

--- a/crates/testing/src/task_helpers.rs
+++ b/crates/testing/src/task_helpers.rs
@@ -5,6 +5,7 @@ use hotshot_example_types::{
     block_types::{TestBlockHeader, TestBlockPayload, TestTransaction},
     node_types::{MemoryImpl, TestTypes},
     state_types::{TestInstanceState, TestValidatedState},
+    storage_types::TestBlockStorage,
 };
 
 use crate::test_builder::TestMetadata;
@@ -122,6 +123,7 @@ pub async fn build_system_handle(
         networks_bundle,
         initializer,
         ConsensusMetricsValue::default(),
+        TestBlockStorage::default(),
     )
     .await
     .expect("Could not init hotshot")

--- a/crates/testing/src/test_builder.rs
+++ b/crates/testing/src/test_builder.rs
@@ -1,4 +1,5 @@
 use hotshot::traits::NetworkReliability;
+use hotshot_example_types::storage_types::TestBlockStorage;
 use hotshot_orchestrator::config::ValidatorConfigFile;
 use hotshot_types::traits::election::Membership;
 use std::{num::NonZeroUsize, sync::Arc, time::Duration};
@@ -236,7 +237,7 @@ impl TestMetadata {
         node_id: u64,
     ) -> TestLauncher<TYPES, I>
     where
-        I: NodeImplementation<TYPES>,
+        I: NodeImplementation<TYPES, BlockStorage = TestBlockStorage<TYPES>>,
     {
         let TestMetadata {
             num_nodes_with_stake,
@@ -325,6 +326,7 @@ impl TestMetadata {
                 ),
                 storage: Box::new(|_| I::construct_tmp_storage().unwrap()),
                 config,
+                block_storage: Box::new(|_| TestBlockStorage::default()),
             },
             metadata: self,
         }

--- a/crates/testing/src/test_launcher.rs
+++ b/crates/testing/src/test_launcher.rs
@@ -26,6 +26,8 @@ pub struct ResourceGenerators<TYPES: NodeType, I: TestableNodeImplementation<TYP
     pub storage: Generator<<I as NodeImplementation<TYPES>>::Storage>,
     /// configuration used to generate each hotshot node
     pub config: HotShotConfig<TYPES::SignatureKey, TYPES::ElectionConfigType>,
+    /// generate new block storage for each node
+    pub block_storage: Generator<<I as NodeImplementation<TYPES>>::BlockStorage>,
 }
 
 /// test launcher

--- a/crates/testing/src/test_runner.rs
+++ b/crates/testing/src/test_runner.rs
@@ -412,6 +412,7 @@ where
     /// add a specific node with a config
     /// # Panics
     /// if unable to initialize the node's `SystemContext` based on the config
+    #[allow(clippy::too_many_arguments)]
     pub async fn add_node_with_config(
         node_id: u64,
         networks: Networks<TYPES, I>,

--- a/crates/testing/tests/memory_network.rs
+++ b/crates/testing/tests/memory_network.rs
@@ -10,6 +10,7 @@ use hotshot::traits::implementations::{
 use hotshot::traits::NodeImplementation;
 use hotshot::types::SignatureKey;
 use hotshot_example_types::state_types::TestInstanceState;
+use hotshot_example_types::storage_types::TestBlockStorage;
 use hotshot_example_types::{
     block_types::{TestBlockHeader, TestBlockPayload, TestTransaction},
     state_types::TestValidatedState,
@@ -70,6 +71,7 @@ impl NodeImplementation<Test> for TestImpl {
     type Storage = MemoryStorage<Test>;
     type QuorumNetwork = QuorumNetwork;
     type CommitteeNetwork = DANetwork;
+    type BlockStorage = TestBlockStorage<Test>;
 }
 
 /// fake Eq


### PR DESCRIPTION
Closes #2621 
<!-- See here for keywords in Github -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
We want to integrate a persistent storage interface within HotShot to enable the application to manage data storage effectively. This feature aims to address potential data storage issues (e.g., full disk space) that can prevent nodes from storing DA blobs or VID shares.

### This PR: 
1. **Creates `BlockStorage` Trait**
2. **Initializes `BlockStorage` in HotShot's init**
3. **Add Storage Operations on DA Proposals**
    - If this fails, do not vote on the proposal and exit the event handler.
4. **Add Storage Operations on DA Proposals VID Shares**
   - If this fails, do not vote on the VID disperse, otherwise, use the old logic to vote.
5. **Refactor In-memory Payload/VID Stores**:
   - Remove in-memory storage for payloads and VID shares from HotShot. This involves removing the `self.consensus.write().await.vid_shares.insert(view, disperse.clone());` call from the code for VID disperse events.

This code also implements a number of changes to introduce a `TestBlockStorage` type for use in the various testing components.


### This PR does not: 
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->

### Key places to review: 
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
