### PR TITLE
[CX-CLEANUP] - DA Integrated Storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3540,8 +3540,8 @@ dependencies = [
 
 [[package]]
 name = "hotshot-types"
-version = "0.1.9"
-source = "git+https://github.com/EspressoSystems/hotshot-types?tag=0.1.9#4c8dffbb3b47c35d9bc465cc6520d06da578f9ec"
+version = "0.1.10"
+source = "git+https://github.com/EspressoSystems/hotshot-types?tag=0.1.10#06b29799e0c5a9ea5c96221f54597b8936680866"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -3611,8 +3611,8 @@ dependencies = [
 
 [[package]]
 name = "hs-builder-api"
-version = "0.1.4"
-source = "git+https://github.com/EspressoSystems/hs-builder-api?tag=0.1.4#e0dd5c5748b06167fe84dfce91f31dc6646ff7f0"
+version = "0.1.5"
+source = "git+https://github.com/EspressoSystems/hs-builder-api?tag=0.1.5#4d2b07335ff2fff8e959b0f6b6f05ecb8cdae54e"
 dependencies = [
  "async-trait",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3541,7 +3541,7 @@ dependencies = [
 [[package]]
 name = "hotshot-types"
 version = "0.1.9"
-source = "git+https://github.com/EspressoSystems/hotshot-types?branch=jparr721/issue-2621#b8ec0be4f0ce2a7779bb85d9d9e2dcaebb08aa81"
+source = "git+https://github.com/EspressoSystems/hotshot-types?tag=0.1.9#4c8dffbb3b47c35d9bc465cc6520d06da578f9ec"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -3611,8 +3611,8 @@ dependencies = [
 
 [[package]]
 name = "hs-builder-api"
-version = "0.1.3"
-source = "git+https://github.com/EspressoSystems/hs-builder-api?branch=jp/issue-2621#194211c22fbf08b4e20a136604ce8cef526d09b0"
+version = "0.1.4"
+source = "git+https://github.com/EspressoSystems/hs-builder-api?tag=0.1.4#e0dd5c5748b06167fe84dfce91f31dc6646ff7f0"
 dependencies = [
  "async-trait",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3292,7 +3292,7 @@ dependencies = [
  "surf-disco",
  "time 0.3.34",
  "tokio",
- "toml 0.8.11",
+ "toml 0.8.12",
  "tracing",
 ]
 
@@ -3300,10 +3300,12 @@ dependencies = [
 name = "hotshot-example-types"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "async-broadcast",
  "async-compatibility-layer 1.0.0 (git+https://github.com/EspressoSystems/async-compatibility-layer.git?tag=1.4.2)",
  "async-lock 2.8.0",
  "async-std",
+ "async-trait",
  "bincode",
  "bitvec",
  "commit",
@@ -3369,7 +3371,7 @@ dependencies = [
  "surf-disco",
  "time 0.3.34",
  "tokio",
- "toml 0.8.11",
+ "toml 0.8.12",
  "tracing",
 ]
 
@@ -3405,7 +3407,7 @@ dependencies = [
  "thiserror",
  "tide-disco",
  "tokio",
- "toml 0.8.11",
+ "toml 0.8.12",
  "tracing",
 ]
 
@@ -3538,9 +3540,10 @@ dependencies = [
 
 [[package]]
 name = "hotshot-types"
-version = "0.1.8"
-source = "git+https://github.com/EspressoSystems/hotshot-types?tag=0.1.8#db908cc340bc9db9ec193c2400ee9594e04c93f0"
+version = "0.1.9"
+source = "git+https://github.com/EspressoSystems/hotshot-types?branch=jparr721/issue-2621#b8ec0be4f0ce2a7779bb85d9d9e2dcaebb08aa81"
 dependencies = [
+ "anyhow",
  "ark-bn254",
  "ark-ec",
  "ark-ed-on-bn254",
@@ -3602,14 +3605,14 @@ dependencies = [
  "rand 0.8.5",
  "tide-disco",
  "tokio",
- "toml 0.8.11",
+ "toml 0.8.12",
  "tracing",
 ]
 
 [[package]]
 name = "hs-builder-api"
 version = "0.1.3"
-source = "git+https://github.com/EspressoSystems/hs-builder-api?tag=0.1.3#cf429b2cf97d51c29174e3c44304422f04f4be76"
+source = "git+https://github.com/EspressoSystems/hs-builder-api?branch=jp/issue-2621#194211c22fbf08b4e20a136604ce8cef526d09b0"
 dependencies = [
  "async-trait",
  "clap",
@@ -3620,7 +3623,7 @@ dependencies = [
  "snafu 0.7.5",
  "tagged-base64",
  "tide-disco",
- "toml 0.8.11",
+ "toml 0.8.12",
 ]
 
 [[package]]
@@ -8068,7 +8071,7 @@ dependencies = [
  "tagged-base64",
  "tide",
  "tide-websockets",
- "toml 0.8.11",
+ "toml 0.8.12",
  "tracing",
  "tracing-distributed",
  "tracing-futures",
@@ -8288,14 +8291,14 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af06656561d28735e9c1cd63dfd57132c8155426aa6af24f36a00a351f88c48e"
+checksum = "e9dd1545e8208b4a5af1aa9bbd0b4cf7e9ea08fabc5d0a5c67fcaafa17433aa3"
 dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.7",
+ "toml_edit 0.22.8",
 ]
 
 [[package]]
@@ -8320,9 +8323,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.7"
+version = "0.22.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18769cd1cec395d70860ceb4d932812a0b4d06b1a4bb336745a4d21b9496e992"
+checksum = "c12219811e0c1ba077867254e5ad62ee2c9c190b0d957110750ac0cda1ae96cd"
 dependencies = [
  "indexmap 2.2.5",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,13 +60,13 @@ futures = "0.3.30"
 # TODO generic-array should not be a direct dependency
 # https://github.com/EspressoSystems/HotShot/issues/1850
 generic-array = { version = "0.14.7", features = ["serde"] }
-hotshot-types = { git = "https://github.com/EspressoSystems/hotshot-types", branch = "jparr721/issue-2621" }
+hotshot-types = { git = "https://github.com/EspressoSystems/hotshot-types", tag = "0.1.9" }
 
 jf-primitives = { git = "https://github.com/EspressoSystems/jellyfish", tag = "0.4.2" }
 jf-plonk = { git = "https://github.com/EspressoSystems/jellyfish", tag = "0.4.2" }
 jf-relation = { git = "https://github.com/EspressoSystems/jellyfish", tag = "0.4.2" }
 jf-utils = { git = "https://github.com/espressosystems/jellyfish", tag = "0.4.2" }
-hs-builder-api = { git = "https://github.com/EspressoSystems/hs-builder-api", branch = "jp/issue-2621" }
+hs-builder-api = { git = "https://github.com/EspressoSystems/hs-builder-api", tag = "0.1.4" }
 lazy_static = "1.4.0"
 libp2p-identity = "0.2"
 libp2p-networking = { path = "./crates/libp2p-networking", version = "0.1.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ async-broadcast = "0.7.0"
 async-compatibility-layer = { git = "https://github.com/EspressoSystems/async-compatibility-layer.git", tag = "1.4.2", default-features = false, features = [
   "logging-utils",
 ] }
+anyhow = "1.0.81"
 task = { git = "https://github.com/EspressoSystems/HotShotTasks.git" }
 async-lock = "2.8"
 async-trait = "0.1.77"
@@ -59,13 +60,13 @@ futures = "0.3.30"
 # TODO generic-array should not be a direct dependency
 # https://github.com/EspressoSystems/HotShot/issues/1850
 generic-array = { version = "0.14.7", features = ["serde"] }
-hotshot-types = { git = "https://github.com/EspressoSystems/hotshot-types", tag = "0.1.8" }
+hotshot-types = { git = "https://github.com/EspressoSystems/hotshot-types", branch = "jparr721/issue-2621" }
 
 jf-primitives = { git = "https://github.com/EspressoSystems/jellyfish", tag = "0.4.2" }
 jf-plonk = { git = "https://github.com/EspressoSystems/jellyfish", tag = "0.4.2" }
 jf-relation = { git = "https://github.com/EspressoSystems/jellyfish", tag = "0.4.2" }
 jf-utils = { git = "https://github.com/espressosystems/jellyfish", tag = "0.4.2" }
-hs-builder-api = { git = "https://github.com/EspressoSystems/hs-builder-api", tag = "0.1.3" }
+hs-builder-api = { git = "https://github.com/EspressoSystems/hs-builder-api", branch = "jp/issue-2621" }
 lazy_static = "1.4.0"
 libp2p-identity = "0.2"
 libp2p-networking = { path = "./crates/libp2p-networking", version = "0.1.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,13 +60,13 @@ futures = "0.3.30"
 # TODO generic-array should not be a direct dependency
 # https://github.com/EspressoSystems/HotShot/issues/1850
 generic-array = { version = "0.14.7", features = ["serde"] }
-hotshot-types = { git = "https://github.com/EspressoSystems/hotshot-types", tag = "0.1.9" }
+hotshot-types = { git = "https://github.com/EspressoSystems/hotshot-types", tag = "0.1.10" }
 
 jf-primitives = { git = "https://github.com/EspressoSystems/jellyfish", tag = "0.4.2" }
 jf-plonk = { git = "https://github.com/EspressoSystems/jellyfish", tag = "0.4.2" }
 jf-relation = { git = "https://github.com/EspressoSystems/jellyfish", tag = "0.4.2" }
 jf-utils = { git = "https://github.com/espressosystems/jellyfish", tag = "0.4.2" }
-hs-builder-api = { git = "https://github.com/EspressoSystems/hs-builder-api", tag = "0.1.4" }
+hs-builder-api = { git = "https://github.com/EspressoSystems/hs-builder-api", tag = "0.1.5" }
 lazy_static = "1.4.0"
 libp2p-identity = "0.2"
 libp2p-networking = { path = "./crates/libp2p-networking", version = "0.1.0", default-features = false }

--- a/crates/example-types/Cargo.toml
+++ b/crates/example-types/Cargo.toml
@@ -16,6 +16,8 @@ gpu-vid = [
 [dependencies]
 async-broadcast = { workspace = true }
 async-compatibility-layer = { workspace = true }
+async-trait = { workspace = true }
+anyhow = { workspace  = true }
 sha3 = "^0.10"
 bincode = { workspace = true }
 commit = { workspace = true }

--- a/crates/example-types/src/lib.rs
+++ b/crates/example-types/src/lib.rs
@@ -6,3 +6,6 @@ pub mod state_types;
 
 /// node types
 pub mod node_types;
+
+/// storage types for hotshot storage
+pub mod storage_types;

--- a/crates/example-types/src/node_types.rs
+++ b/crates/example-types/src/node_types.rs
@@ -5,6 +5,7 @@ use hotshot::traits::{
 use crate::{
     block_types::{TestBlockHeader, TestBlockPayload, TestTransaction},
     state_types::{TestInstanceState, TestValidatedState},
+    storage_types::TestStorage,
 };
 
 use hotshot::traits::{
@@ -103,24 +104,29 @@ type StaticCombinedQuorumComm = CombinedNetworks<TestTypes>;
 impl NodeImplementation<TestTypes> for PushCdnImpl {
     type QuorumNetwork = StaticPushCdnQuorumComm;
     type CommitteeNetwork = StaticPushCdnDAComm;
+    type Storage = TestStorage<TestTypes>;
 }
 
 impl NodeImplementation<TestTypes> for Libp2pImpl {
     type QuorumNetwork = StaticLibp2pQuorumComm;
     type CommitteeNetwork = StaticLibp2pDAComm;
+    type Storage = TestStorage<TestTypes>;
 }
 
 impl NodeImplementation<TestTypes> for MemoryImpl {
     type QuorumNetwork = StaticMemoryQuorumComm;
     type CommitteeNetwork = StaticMemoryDAComm;
+    type Storage = TestStorage<TestTypes>;
 }
 
 impl NodeImplementation<TestTypes> for WebImpl {
     type QuorumNetwork = StaticWebQuorumComm;
     type CommitteeNetwork = StaticWebDAComm;
+    type Storage = TestStorage<TestTypes>;
 }
 
 impl NodeImplementation<TestTypes> for CombinedImpl {
     type QuorumNetwork = StaticCombinedQuorumComm;
     type CommitteeNetwork = StaticCombinedDAComm;
+    type Storage = TestStorage<TestTypes>;
 }

--- a/crates/example-types/src/storage_types.rs
+++ b/crates/example-types/src/storage_types.rs
@@ -1,0 +1,56 @@
+use anyhow::Result;
+use async_lock::RwLock;
+use async_trait::async_trait;
+use hotshot_types::{
+    data::{DAProposal, VidDisperse},
+    message::Proposal,
+    traits::{node_implementation::NodeType, storage::Storage},
+};
+use std::collections::HashMap;
+use std::sync::Arc;
+
+#[derive(Clone, Debug)]
+pub struct TestStorageState<TYPES: NodeType> {
+    vids: HashMap<TYPES::Time, Proposal<TYPES, VidDisperse<TYPES>>>,
+    das: HashMap<TYPES::Time, Proposal<TYPES, DAProposal<TYPES>>>,
+}
+
+impl<TYPES: NodeType> Default for TestStorageState<TYPES> {
+    fn default() -> Self {
+        Self {
+            vids: HashMap::new(),
+            das: HashMap::new(),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct TestStorage<TYPES: NodeType> {
+    inner: Arc<RwLock<TestStorageState<TYPES>>>,
+}
+
+impl<TYPES: NodeType> Default for TestStorage<TYPES> {
+    fn default() -> Self {
+        Self {
+            inner: Arc::new(RwLock::new(TestStorageState::default())),
+        }
+    }
+}
+
+#[async_trait]
+impl<TYPES: NodeType> Storage<TYPES> for TestStorage<TYPES> {
+    async fn append_vid(&self, proposal: &Proposal<TYPES, DAProposal<TYPES>>) -> Result<()> {
+        let mut inner = self.inner.write().await;
+        inner
+            .das
+            .insert(proposal.data.view_number, proposal.clone());
+        Ok(())
+    }
+    async fn append_da(&self, proposal: &Proposal<TYPES, VidDisperse<TYPES>>) -> Result<()> {
+        let mut inner = self.inner.write().await;
+        inner
+            .vids
+            .insert(proposal.data.view_number, proposal.clone());
+        Ok(())
+    }
+}

--- a/crates/example-types/src/storage_types.rs
+++ b/crates/example-types/src/storage_types.rs
@@ -39,17 +39,17 @@ impl<TYPES: NodeType> Default for TestStorage<TYPES> {
 
 #[async_trait]
 impl<TYPES: NodeType> Storage<TYPES> for TestStorage<TYPES> {
-    async fn append_vid(&self, proposal: &Proposal<TYPES, DAProposal<TYPES>>) -> Result<()> {
-        let mut inner = self.inner.write().await;
-        inner
-            .das
-            .insert(proposal.data.view_number, proposal.clone());
-        Ok(())
-    }
-    async fn append_da(&self, proposal: &Proposal<TYPES, VidDisperse<TYPES>>) -> Result<()> {
+    async fn append_vid(&self, proposal: &Proposal<TYPES, VidDisperse<TYPES>>) -> Result<()> {
         let mut inner = self.inner.write().await;
         inner
             .vids
+            .insert(proposal.data.view_number, proposal.clone());
+        Ok(())
+    }
+    async fn append_da(&self, proposal: &Proposal<TYPES, DAProposal<TYPES>>) -> Result<()> {
+        let mut inner = self.inner.write().await;
+        inner
+            .das
             .insert(proposal.data.view_number, proposal.clone());
         Ok(())
     }

--- a/crates/example-types/src/storage_types.rs
+++ b/crates/example-types/src/storage_types.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{bail, Result};
 use async_lock::RwLock;
 use async_trait::async_trait;
 use hotshot_types::{
@@ -27,12 +27,16 @@ impl<TYPES: NodeType> Default for TestStorageState<TYPES> {
 #[derive(Clone, Debug)]
 pub struct TestStorage<TYPES: NodeType> {
     inner: Arc<RwLock<TestStorageState<TYPES>>>,
+
+    /// `should_return_err` is a testing utility to validate negative cases.
+    pub should_return_err: bool,
 }
 
 impl<TYPES: NodeType> Default for TestStorage<TYPES> {
     fn default() -> Self {
         Self {
             inner: Arc::new(RwLock::new(TestStorageState::default())),
+            should_return_err: false,
         }
     }
 }
@@ -40,13 +44,20 @@ impl<TYPES: NodeType> Default for TestStorage<TYPES> {
 #[async_trait]
 impl<TYPES: NodeType> Storage<TYPES> for TestStorage<TYPES> {
     async fn append_vid(&self, proposal: &Proposal<TYPES, VidDisperse<TYPES>>) -> Result<()> {
+        if self.should_return_err {
+            bail!("Failed to append VID proposal to storage");
+        }
         let mut inner = self.inner.write().await;
         inner
             .vids
             .insert(proposal.data.view_number, proposal.clone());
         Ok(())
     }
+
     async fn append_da(&self, proposal: &Proposal<TYPES, DAProposal<TYPES>>) -> Result<()> {
+        if self.should_return_err {
+            bail!("Failed to append VID proposal to storage");
+        }
         let mut inner = self.inner.write().await;
         inner
             .das

--- a/crates/examples/combined/types.rs
+++ b/crates/examples/combined/types.rs
@@ -1,6 +1,6 @@
 use crate::infra::CombinedDARun;
 use hotshot::traits::implementations::CombinedNetworks;
-use hotshot_example_types::state_types::TestTypes;
+use hotshot_example_types::{state_types::TestTypes, storage_types::TestStorage};
 use hotshot_types::traits::node_implementation::NodeImplementation;
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
@@ -21,6 +21,7 @@ pub type ViewSyncNetwork = CombinedNetworks<TestTypes>;
 impl NodeImplementation<TestTypes> for NodeImpl {
     type QuorumNetwork = QuorumNetwork;
     type CommitteeNetwork = DANetwork;
+    type Storage = TestStorage<TestTypes>;
 }
 /// convenience type alias
 pub type ThisRun = CombinedDARun<TestTypes>;

--- a/crates/examples/infra/mod.rs
+++ b/crates/examples/infra/mod.rs
@@ -20,6 +20,7 @@ use hotshot::{
     types::{SignatureKey, SystemContextHandle},
     Memberships, Networks, SystemContext,
 };
+use hotshot_example_types::storage_types::TestStorage;
 use hotshot_example_types::{
     block_types::{TestBlockHeader, TestBlockPayload, TestTransaction},
     state_types::TestInstanceState,
@@ -429,7 +430,12 @@ pub trait RunDA<
     TYPES: NodeType<InstanceState = TestInstanceState>,
     DANET: ConnectedNetwork<Message<TYPES>, TYPES::SignatureKey>,
     QUORUMNET: ConnectedNetwork<Message<TYPES>, TYPES::SignatureKey>,
-    NODE: NodeImplementation<TYPES, QuorumNetwork = QUORUMNET, CommitteeNetwork = DANET>,
+    NODE: NodeImplementation<
+        TYPES,
+        QuorumNetwork = QUORUMNET,
+        CommitteeNetwork = DANET,
+        Storage = TestStorage<TYPES>,
+    >,
 > where
     <TYPES as NodeType>::ValidatedState: TestableState<TYPES>,
     <TYPES as NodeType>::BlockPayload: TestableBlock,
@@ -506,6 +512,7 @@ pub trait RunDA<
             networks_bundle,
             initializer,
             ConsensusMetricsValue::default(),
+            TestStorage::<TYPES>::default(),
         )
         .await
         .expect("Could not init hotshot")
@@ -705,6 +712,7 @@ impl<
             TYPES,
             QuorumNetwork = WebServerNetwork<TYPES>,
             CommitteeNetwork = WebServerNetwork<TYPES>,
+            Storage = TestStorage<TYPES>,
         >,
     > RunDA<TYPES, WebServerNetwork<TYPES>, WebServerNetwork<TYPES>, NODE> for WebServerDARun<TYPES>
 where
@@ -778,6 +786,7 @@ impl<
             TYPES,
             QuorumNetwork = PushCdnNetwork<TYPES>,
             CommitteeNetwork = PushCdnNetwork<TYPES>,
+            Storage = TestStorage<TYPES>,
         >,
     > RunDA<TYPES, PushCdnNetwork<TYPES>, PushCdnNetwork<TYPES>, NODE> for PushCdnDaRun<TYPES>
 where
@@ -860,6 +869,7 @@ impl<
             TYPES,
             QuorumNetwork = Libp2pNetwork<Message<TYPES>, TYPES::SignatureKey>,
             CommitteeNetwork = Libp2pNetwork<Message<TYPES>, TYPES::SignatureKey>,
+            Storage = TestStorage<TYPES>,
         >,
     >
     RunDA<
@@ -929,6 +939,7 @@ impl<
             TYPES,
             QuorumNetwork = CombinedNetworks<TYPES>,
             CommitteeNetwork = CombinedNetworks<TYPES>,
+            Storage = TestStorage<TYPES>,
         >,
     > RunDA<TYPES, CombinedNetworks<TYPES>, CombinedNetworks<TYPES>, NODE> for CombinedDARun<TYPES>
 where
@@ -1014,7 +1025,12 @@ pub async fn main_entry_point<
     >,
     DACHANNEL: ConnectedNetwork<Message<TYPES>, TYPES::SignatureKey>,
     QUORUMCHANNEL: ConnectedNetwork<Message<TYPES>, TYPES::SignatureKey>,
-    NODE: NodeImplementation<TYPES, QuorumNetwork = QUORUMCHANNEL, CommitteeNetwork = DACHANNEL>,
+    NODE: NodeImplementation<
+        TYPES,
+        QuorumNetwork = QUORUMCHANNEL,
+        CommitteeNetwork = DACHANNEL,
+        Storage = TestStorage<TYPES>,
+    >,
     RUNDA: RunDA<TYPES, DACHANNEL, QUORUMCHANNEL, NODE>,
 >(
     args: ValidatorArgs,

--- a/crates/examples/libp2p/types.rs
+++ b/crates/examples/libp2p/types.rs
@@ -1,6 +1,6 @@
 use crate::infra::Libp2pDARun;
 use hotshot::traits::implementations::Libp2pNetwork;
-use hotshot_example_types::state_types::TestTypes;
+use hotshot_example_types::{state_types::TestTypes, storage_types::TestStorage};
 use hotshot_types::{
     message::Message,
     traits::node_implementation::{NodeImplementation, NodeType},
@@ -20,6 +20,7 @@ pub type QuorumNetwork = Libp2pNetwork<Message<TestTypes>, <TestTypes as NodeTyp
 impl NodeImplementation<TestTypes> for NodeImpl {
     type QuorumNetwork = QuorumNetwork;
     type CommitteeNetwork = DANetwork;
+    type Storage = TestStorage<TestTypes>;
 }
 /// convenience type alias
 pub type ThisRun = Libp2pDARun<TestTypes>;

--- a/crates/examples/push-cdn/types.rs
+++ b/crates/examples/push-cdn/types.rs
@@ -1,6 +1,6 @@
 use crate::infra::PushCdnDaRun;
 use hotshot::traits::implementations::PushCdnNetwork;
-use hotshot_example_types::state_types::TestTypes;
+use hotshot_example_types::{state_types::TestTypes, storage_types::TestStorage};
 use hotshot_types::traits::node_implementation::NodeImplementation;
 use serde::{Deserialize, Serialize};
 
@@ -20,6 +20,7 @@ pub type ViewSyncNetwork = PushCdnNetwork<TestTypes>;
 impl NodeImplementation<TestTypes> for NodeImpl {
     type CommitteeNetwork = DANetwork;
     type QuorumNetwork = QuorumNetwork;
+    type Storage = TestStorage<TestTypes>;
 }
 
 /// Convenience type alias

--- a/crates/examples/webserver/types.rs
+++ b/crates/examples/webserver/types.rs
@@ -1,6 +1,6 @@
 use crate::infra::WebServerDARun;
 use hotshot::traits::implementations::WebServerNetwork;
-use hotshot_example_types::state_types::TestTypes;
+use hotshot_example_types::{state_types::TestTypes, storage_types::TestStorage};
 use hotshot_types::traits::node_implementation::NodeImplementation;
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
@@ -21,6 +21,7 @@ pub type ViewSyncNetwork = WebServerNetwork<TestTypes>;
 impl NodeImplementation<TestTypes> for NodeImpl {
     type CommitteeNetwork = DANetwork;
     type QuorumNetwork = QuorumNetwork;
+    type Storage = TestStorage<TestTypes>;
 }
 /// convenience type alias
 pub type ThisRun = WebServerDARun<TestTypes>;

--- a/crates/hotshot/Cargo.toml
+++ b/crates/hotshot/Cargo.toml
@@ -54,7 +54,7 @@ snafu = { workspace = true }
 surf-disco = { workspace = true }
 time = { workspace = true }
 tracing = { workspace = true }
-anyhow = "1.0.81"
+anyhow = { workspace = true }
 
 [target.'cfg(all(async_executor_impl = "tokio"))'.dependencies]
 tokio = { workspace = true }

--- a/crates/hotshot/src/lib.rs
+++ b/crates/hotshot/src/lib.rs
@@ -148,6 +148,9 @@ pub struct SystemContext<TYPES: NodeType, I: NodeImplementation<TYPES>> {
 
     /// uid for instrumentation
     pub id: u64,
+
+    /// Reference to the internal storage for consensus datum.
+    pub storage: Arc<RwLock<I::Storage>>,
 }
 
 impl<TYPES: NodeType, I: NodeImplementation<TYPES>> SystemContext<TYPES, I> {
@@ -156,7 +159,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> SystemContext<TYPES, I> {
     /// To do a full initialization, use `fn init` instead, which will set up background tasks as
     /// well.
     #[allow(clippy::too_many_arguments)]
-    #[instrument(skip(private_key, memberships, networks, initializer, metrics))]
+    #[instrument(skip(private_key, memberships, networks, initializer, metrics, storage))]
     pub async fn new(
         public_key: TYPES::SignatureKey,
         private_key: <TYPES::SignatureKey as SignatureKey>::PrivateKey,
@@ -166,6 +169,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> SystemContext<TYPES, I> {
         networks: Networks<TYPES, I>,
         initializer: HotShotInitializer<TYPES>,
         metrics: ConsensusMetricsValue,
+        storage: I::Storage,
     ) -> Result<Arc<Self>, HotShotError<TYPES>> {
         debug!("Creating a new hotshot");
 
@@ -248,6 +252,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> SystemContext<TYPES, I> {
             _metrics: consensus_metrics.clone(),
             internal_event_stream: (internal_tx, internal_rx.deactivate()),
             output_event_stream: (external_tx, external_rx.deactivate()),
+            storage: Arc::new(RwLock::new(storage)),
         });
 
         Ok(inner)
@@ -396,6 +401,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> SystemContext<TYPES, I> {
         networks: Networks<TYPES, I>,
         initializer: HotShotInitializer<TYPES>,
         metrics: ConsensusMetricsValue,
+        storage: I::Storage,
     ) -> Result<
         (
             SystemContextHandle<TYPES, I>,
@@ -413,6 +419,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> SystemContext<TYPES, I> {
             networks,
             initializer,
             metrics,
+            storage,
         )
         .await?;
         let handle = hotshot.clone().run_tasks().await;
@@ -459,6 +466,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> SystemContext<TYPES, I> {
             output_event_stream: output_event_stream.clone(),
             internal_event_stream: internal_event_stream.clone(),
             hotshot: self.clone().into(),
+            storage: self.storage.clone(),
         };
 
         add_network_message_task(registry.clone(), event_tx.clone(), quorum_network.clone()).await;

--- a/crates/hotshot/src/tasks/task_state.rs
+++ b/crates/hotshot/src/tasks/task_state.rs
@@ -87,6 +87,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> CreateTaskState<TYPES, I>
             public_key: handle.public_key().clone(),
             private_key: handle.private_key().clone(),
             id: handle.hotshot.id,
+            storage: handle.storage.clone(),
         }
     }
 }
@@ -180,6 +181,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> CreateTaskState<TYPES, I>
             timeout_membership: handle.hotshot.memberships.quorum_membership.clone().into(),
             quorum_membership: handle.hotshot.memberships.quorum_membership.clone().into(),
             committee_membership: handle.hotshot.memberships.da_membership.clone().into(),
+            storage: handle.storage.clone(),
         }
     }
 }

--- a/crates/hotshot/src/types/handle.rs
+++ b/crates/hotshot/src/types/handle.rs
@@ -27,6 +27,7 @@ pub struct SystemContextHandle<TYPES: NodeType, I: NodeImplementation<TYPES>> {
     /// The Channel will output all the events.  Subscribers will get an activated
     /// clone of the `Receiver` when they get output stream.
     pub(crate) output_event_stream: (Sender<Event<TYPES>>, InactiveReceiver<Event<TYPES>>),
+
     /// access to the internal event stream, in case we need to, say, shut something down
     #[allow(clippy::type_complexity)]
     pub(crate) internal_event_stream: (
@@ -38,6 +39,9 @@ pub struct SystemContextHandle<TYPES: NodeType, I: NodeImplementation<TYPES>> {
 
     /// Internal reference to the underlying [`SystemContext`]
     pub hotshot: Arc<SystemContext<TYPES, I>>,
+
+    /// Reference to the internal storage for consensus datum.
+    pub(crate) storage: Arc<RwLock<I::Storage>>,
 }
 
 impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static> SystemContextHandle<TYPES, I> {
@@ -169,5 +173,11 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static> SystemContextHandl
     /// Wrapper to get the view number this node is on.
     pub async fn get_cur_view(&self) -> TYPES::Time {
         self.hotshot.consensus.read().await.cur_view
+    }
+
+    /// Provides a reference to the underlying storage for this [`SystemContext`], allowing access to
+    /// historical data
+    pub fn get_storage(&self) -> Arc<RwLock<I::Storage>> {
+        self.storage.clone()
     }
 }

--- a/crates/hotshot/src/types/handle.rs
+++ b/crates/hotshot/src/types/handle.rs
@@ -177,6 +177,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static> SystemContextHandl
 
     /// Provides a reference to the underlying storage for this [`SystemContext`], allowing access to
     /// historical data
+    #[must_use]
     pub fn get_storage(&self) -> Arc<RwLock<I::Storage>> {
         self.storage.clone()
     }

--- a/crates/task-impls/src/consensus.rs
+++ b/crates/task-impls/src/consensus.rs
@@ -1074,6 +1074,13 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                     );
                     return;
                 }
+
+                self.consensus
+                    .write()
+                    .await
+                    .vid_shares
+                    .insert(view, disperse.clone());
+
                 if self.vote_if_able(&event_stream).await {
                     self.current_proposal = None;
                 }

--- a/crates/task-impls/src/consensus.rs
+++ b/crates/task-impls/src/consensus.rs
@@ -31,6 +31,7 @@ use hotshot_types::{
         node_implementation::{ConsensusTime, NodeImplementation, NodeType},
         signature_key::SignatureKey,
         states::ValidatedState,
+        storage::Storage,
         BlockPayload,
     },
     utils::{Terminator, ViewInner},
@@ -137,6 +138,9 @@ pub struct ConsensusTaskState<
     // ED Should replace this with config information since we need it anyway
     /// The node's id
     pub id: u64,
+
+    /// This node's storage ref
+    pub storage: Arc<RwLock<I::Storage>>,
 }
 
 impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 'static>
@@ -1063,11 +1067,13 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                     .await;
 
                 // Add to the storage that we have received the VID disperse for a specific view
-                self.consensus
-                    .write()
-                    .await
-                    .vid_shares
-                    .insert(view, disperse.clone());
+                if let Err(e) = self.storage.write().await.append_vid(disperse).await {
+                    error!(
+                        "Failed to store VID Disperse Proposal with error {:?}, aborting vote",
+                        e
+                    );
+                    return;
+                }
                 if self.vote_if_able(&event_stream).await {
                     self.current_proposal = None;
                 }

--- a/crates/task-impls/src/da.rs
+++ b/crates/task-impls/src/da.rs
@@ -21,6 +21,7 @@ use hotshot_types::{
         network::{ConnectedNetwork, ConsensusIntentEvent},
         node_implementation::{ConsensusTime, NodeImplementation, NodeType},
         signature_key::SignatureKey,
+        storage::Storage,
     },
     utils::ViewInner,
     vote::HasViewNumber,
@@ -71,6 +72,9 @@ pub struct DATaskState<
 
     /// This state's ID
     pub id: u64,
+
+    /// This node's storage ref
+    pub storage: Arc<RwLock<I::Storage>>,
 }
 
 impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 'static>
@@ -148,6 +152,15 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                     );
                     return None;
                 }
+
+                if let Err(e) = self.storage.write().await.append_da(proposal).await {
+                    error!(
+                        "Failed to store DA Proposal with error {:?}, aborting vote",
+                        e
+                    );
+                    return None;
+                }
+
                 // Generate and send vote
                 let Ok(vote) = DAVote::create_signed_vote(
                     DAData {

--- a/crates/testing/src/spinning_task.rs
+++ b/crates/testing/src/spinning_task.rs
@@ -5,6 +5,7 @@ use crate::test_runner::{LateStartNode, Node, TestRunner};
 use either::{Left, Right};
 use hotshot::{traits::TestableNodeImplementation, HotShotInitializer};
 use hotshot_example_types::state_types::TestInstanceState;
+use hotshot_example_types::storage_types::TestStorage;
 use hotshot_task::task::{Task, TaskState, TestTaskState};
 use hotshot_types::{data::Leaf, ValidatorConfig};
 use hotshot_types::{
@@ -64,7 +65,12 @@ impl<
     > TestTaskState for SpinningTask<TYPES, I>
 where
     I: TestableNodeImplementation<TYPES, CommitteeElectionConfig = TYPES::ElectionConfigType>,
-    I: NodeImplementation<TYPES, QuorumNetwork = N, CommitteeNetwork = N>,
+    I: NodeImplementation<
+        TYPES,
+        QuorumNetwork = N,
+        CommitteeNetwork = N,
+        Storage = TestStorage<TYPES>,
+    >,
 {
     type Message = Event<TYPES>;
 
@@ -99,7 +105,7 @@ where
                                     Left(context) => context,
                                     // Node not initialized. Initialize it
                                     // based on the received leaf.
-                                    Right((memberships, config)) => {
+                                    Right((storage, memberships, config)) => {
                                         let initializer = HotShotInitializer::<TYPES>::from_reload(
                                             state.last_decided_leaf.clone(),
                                             TestInstanceState {},
@@ -118,6 +124,7 @@ where
                                             initializer,
                                             config,
                                             validator_config,
+                                            storage,
                                         )
                                         .await
                                     }

--- a/crates/testing/src/task_helpers.rs
+++ b/crates/testing/src/task_helpers.rs
@@ -63,6 +63,7 @@ pub async fn build_system_handle(
     let launcher = builder.gen_launcher::<TestTypes, MemoryImpl>(node_id);
 
     let networks = (launcher.resource_generator.channel_generator)(node_id);
+    let storage = (launcher.resource_generator.storage)(node_id);
     let config = launcher.resource_generator.config.clone();
 
     let initializer = HotShotInitializer::<TestTypes>::from_genesis(TestInstanceState {}).unwrap();
@@ -120,6 +121,7 @@ pub async fn build_system_handle(
         networks_bundle,
         initializer,
         ConsensusMetricsValue::default(),
+        storage,
     )
     .await
     .expect("Could not init hotshot")

--- a/crates/testing/src/test_builder.rs
+++ b/crates/testing/src/test_builder.rs
@@ -1,4 +1,5 @@
 use hotshot::traits::NetworkReliability;
+use hotshot_example_types::storage_types::TestStorage;
 use hotshot_orchestrator::config::ValidatorConfigFile;
 use hotshot_types::traits::election::Membership;
 use std::{num::NonZeroUsize, sync::Arc, time::Duration};
@@ -329,6 +330,7 @@ impl TestMetadata {
                     unreliable_network,
                     secondary_network_delay,
                 ),
+                storage: Box::new(|_| TestStorage::<TYPES>::default()),
                 config,
             },
             metadata: self,

--- a/crates/testing/src/test_launcher.rs
+++ b/crates/testing/src/test_launcher.rs
@@ -1,6 +1,7 @@
 use std::{collections::HashMap, marker::PhantomData, sync::Arc};
 
 use hotshot::traits::{NodeImplementation, TestableNodeImplementation};
+use hotshot_example_types::storage_types::TestStorage;
 use hotshot_types::{
     message::Message,
     traits::{network::ConnectedNetwork, node_implementation::NodeType},
@@ -22,6 +23,8 @@ pub type Generator<T> = Box<dyn Fn(u64) -> T + 'static>;
 pub struct ResourceGenerators<TYPES: NodeType, I: TestableNodeImplementation<TYPES>> {
     /// generate channels
     pub channel_generator: Generator<Networks<TYPES, I>>,
+    /// generate new storage for each node
+    pub storage: Generator<TestStorage<TYPES>>,
     /// configuration used to generate each hotshot node
     pub config: HotShotConfig<TYPES::SignatureKey, TYPES::ElectionConfigType>,
 }

--- a/crates/testing/src/view_generator.rs
+++ b/crates/testing/src/view_generator.rs
@@ -5,6 +5,7 @@ use hotshot_example_types::{
     node_types::{MemoryImpl, TestTypes},
     state_types::TestInstanceState,
 };
+use sha2::{Digest, Sha256};
 
 use crate::task_helpers::{
     build_cert, build_da_certificate, build_vid_proposal, da_payload_commitment, key_pair_for_id,
@@ -14,15 +15,15 @@ use commit::Committable;
 use hotshot::types::{BLSPubKey, SignatureKey, SystemContextHandle};
 
 use hotshot_types::{
-    data::{Leaf, QuorumProposal, VidDisperse, ViewNumber},
+    data::{DAProposal, Leaf, QuorumProposal, VidDisperse, ViewNumber},
     message::Proposal,
     simple_certificate::{
         DACertificate, QuorumCertificate, TimeoutCertificate, UpgradeCertificate,
         ViewSyncFinalizeCertificate2,
     },
     simple_vote::{
-        TimeoutData, TimeoutVote, UpgradeProposalData, UpgradeVote, ViewSyncFinalizeData,
-        ViewSyncFinalizeVote,
+        DAData, DAVote, TimeoutData, TimeoutVote, UpgradeProposalData, UpgradeVote,
+        ViewSyncFinalizeData, ViewSyncFinalizeVote,
     },
     traits::{
         consensus_api::ConsensusApi,
@@ -35,6 +36,7 @@ use hotshot_types::simple_vote::QuorumVote;
 
 #[derive(Clone)]
 pub struct TestView {
+    pub da_proposal: Proposal<TestTypes, DAProposal<TestTypes>>,
     pub quorum_proposal: Proposal<TestTypes, QuorumProposal<TestTypes>>,
     pub leaf: Leaf<TestTypes>,
     pub view_number: ViewNumber,
@@ -84,7 +86,7 @@ impl TestView {
             payload_commitment,
         };
 
-        let proposal = QuorumProposal::<TestTypes> {
+        let quorum_proposal_inner = QuorumProposal::<TestTypes> {
             block_header: block_header.clone(),
             view_number: genesis_view,
             justify_qc: QuorumCertificate::genesis(),
@@ -92,6 +94,25 @@ impl TestView {
             upgrade_certificate: None,
             view_sync_certificate: None,
             proposer_id: public_key,
+        };
+
+        let transactions = vec![TestTransaction(vec![0])];
+        let encoded_transactions = TestTransaction::encode(transactions.clone()).unwrap();
+        let encoded_transactions_hash = Sha256::digest(&encoded_transactions);
+        let block_payload_signature =
+            <TestTypes as NodeType>::SignatureKey::sign(&private_key, &encoded_transactions_hash)
+                .expect("Failed to sign block payload");
+
+        let da_proposal_inner = DAProposal::<TestTypes> {
+            encoded_transactions: encoded_transactions.clone(),
+            metadata: (),
+            view_number: genesis_view,
+        };
+
+        let da_proposal = Proposal {
+            data: da_proposal_inner,
+            signature: block_payload_signature,
+            _pd: PhantomData,
         };
 
         let leaf = Leaf {
@@ -111,7 +132,7 @@ impl TestView {
             .expect("Failed to sign leaf commitment!");
 
         let quorum_proposal = Proposal {
-            data: proposal,
+            data: quorum_proposal_inner,
             signature,
             _pd: PhantomData,
         };
@@ -128,6 +149,7 @@ impl TestView {
             upgrade_data: None,
             view_sync_finalize_data: None,
             timeout_cert_data: None,
+            da_proposal,
         }
     }
 
@@ -282,6 +304,25 @@ impl TestView {
             _pd: PhantomData,
         };
 
+        let transactions = vec![TestTransaction(vec![0])];
+        let encoded_transactions = TestTransaction::encode(transactions.clone()).unwrap();
+        let encoded_transactions_hash = Sha256::digest(&encoded_transactions);
+        let block_payload_signature =
+            <TestTypes as NodeType>::SignatureKey::sign(&private_key, &encoded_transactions_hash)
+                .expect("Failed to sign block payload");
+
+        let da_proposal_inner = DAProposal::<TestTypes> {
+            encoded_transactions: encoded_transactions.clone(),
+            metadata: (),
+            view_number: next_view,
+        };
+
+        let da_proposal = Proposal {
+            data: da_proposal_inner,
+            signature: block_payload_signature,
+            _pd: PhantomData,
+        };
+
         TestView {
             quorum_proposal,
             leaf,
@@ -296,6 +337,7 @@ impl TestView {
             upgrade_data: None,
             view_sync_finalize_data: None,
             timeout_cert_data: None,
+            da_proposal,
         }
     }
 
@@ -330,6 +372,20 @@ impl TestView {
             handle.private_key(),
         )
         .expect("Failed to generate a signature on UpgradVote")
+    }
+
+    pub fn create_da_vote(
+        &self,
+        data: DAData,
+        handle: &SystemContextHandle<TestTypes, MemoryImpl>,
+    ) -> DAVote<TestTypes> {
+        DAVote::create_signed_vote(
+            data,
+            self.view_number,
+            handle.public_key(),
+            handle.private_key(),
+        )
+        .expect("Failed to sign DAData")
     }
 }
 

--- a/crates/testing/tests/consensus_task.rs
+++ b/crates/testing/tests/consensus_task.rs
@@ -1,4 +1,3 @@
-#![allow(clippy::panic)]
 use hotshot::tasks::{inject_consensus_polls, task_state::CreateTaskState};
 use hotshot::types::SystemContextHandle;
 use hotshot_example_types::node_types::{MemoryImpl, TestTypes};
@@ -6,9 +5,9 @@ use hotshot_task_impls::{consensus::ConsensusTaskState, events::HotShotEvent::*}
 use hotshot_testing::task_helpers::key_pair_for_id;
 use hotshot_testing::test_helpers::permute_input_with_index_order;
 use hotshot_testing::{
-    predicates::{exact, is_at_view_number, quorum_vote_send},
+    predicates::{exact, is_at_view_number, quorum_proposal_send, quorum_vote_send},
     script::{run_test_script, TestScriptStage},
-    task_helpers::build_system_handle,
+    task_helpers::{build_system_handle, vid_scheme_from_view_number},
     view_generator::TestViewGenerator,
 };
 use hotshot_types::simple_vote::ViewSyncFinalizeData;
@@ -19,15 +18,6 @@ use jf_primitives::vid::VidScheme;
 #[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 async fn test_consensus_task() {
-    use hotshot::tasks::{inject_consensus_polls, task_state::CreateTaskState};
-    use hotshot_task_impls::{consensus::ConsensusTaskState, events::HotShotEvent::*};
-    use hotshot_testing::{
-        predicates::{exact, is_at_view_number, quorum_proposal_send},
-        script::{run_test_script, TestScriptStage},
-        task_helpers::{build_system_handle, vid_scheme_from_view_number},
-        view_generator::TestViewGenerator,
-    };
-
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
 
@@ -595,4 +585,58 @@ async fn test_view_sync_finalize_vote_fail_view_number() {
 
     inject_consensus_polls(&consensus_state).await;
     run_test_script(stages, consensus_state).await;
+}
+
+#[cfg(test)]
+#[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
+#[cfg_attr(async_executor_impl = "async-std", async_std::test)]
+async fn test_vid_disperse_storage_failure() {
+    async_compatibility_layer::logging::setup_logging();
+    async_compatibility_layer::logging::setup_backtrace();
+
+    let handle = build_system_handle(2).await.0;
+
+    // Set the error flag here for the system handle. This causes it to emit an error on append.
+    handle.get_storage().write().await.should_return_err = true;
+    let quorum_membership = handle.hotshot.memberships.quorum_membership.clone();
+    let mut generator = TestViewGenerator::generate(quorum_membership.clone());
+
+    let mut proposals = Vec::new();
+    let mut leaders = Vec::new();
+    let mut votes = Vec::new();
+    let mut dacs = Vec::new();
+    let mut vids = Vec::new();
+    for view in (&mut generator).take(1) {
+        proposals.push(view.quorum_proposal.clone());
+        leaders.push(view.leader_public_key);
+        votes.push(view.create_quorum_vote(&handle));
+        dacs.push(view.da_certificate.clone());
+        vids.push(view.vid_proposal.clone());
+    }
+
+    // Run view 1 (the genesis stage).
+    let view_1 = TestScriptStage {
+        inputs: vec![
+            QuorumProposalRecv(proposals[0].clone(), leaders[0]),
+            DACRecv(dacs[0].clone()),
+            VidDisperseRecv(vids[0].0.clone()),
+        ],
+        outputs: vec![
+            exact(ViewChange(ViewNumber::new(1))),
+            exact(QuorumProposalValidated(proposals[0].data.clone())),
+            /* Does not vote */
+        ],
+        asserts: vec![is_at_view_number(1)],
+    };
+
+    let consensus_state = ConsensusTaskState::<
+        TestTypes,
+        MemoryImpl,
+        SystemContextHandle<TestTypes, MemoryImpl>,
+    >::create_from(&handle)
+    .await;
+
+    inject_consensus_polls(&consensus_state).await;
+
+    run_test_script(vec![view_1], consensus_state).await;
 }

--- a/crates/testing/tests/da_task.rs
+++ b/crates/testing/tests/da_task.rs
@@ -1,90 +1,140 @@
 use hotshot::tasks::task_state::CreateTaskState;
-use hotshot::types::SignatureKey;
 use hotshot::types::SystemContextHandle;
-use hotshot_example_types::node_types::MemoryImpl;
-use hotshot_example_types::{block_types::TestTransaction, node_types::TestTypes};
-use hotshot_task_impls::{da::DATaskState, events::HotShotEvent};
+use hotshot_example_types::{
+    block_types::TestTransaction,
+    node_types::{MemoryImpl, TestTypes},
+};
+use hotshot_task_impls::da::DATaskState;
+use hotshot_task_impls::events::HotShotEvent::*;
+use hotshot_testing::{
+    predicates::exact,
+    script::{run_test_script, TestScriptStage},
+    task_helpers::build_system_handle,
+    view_generator::TestViewGenerator,
+};
 use hotshot_types::{
-    data::{DAProposal, ViewNumber},
-    simple_vote::{DAData, DAVote},
+    data::ViewNumber,
+    simple_vote::DAData,
     traits::{
-        block_contents::vid_commitment,
-        consensus_api::ConsensusApi,
-        election::Membership,
-        node_implementation::{ConsensusTime, NodeType},
+        block_contents::vid_commitment, election::Membership, node_implementation::ConsensusTime,
     },
 };
-use sha2::{Digest, Sha256};
-use std::{collections::HashMap, marker::PhantomData};
 
 #[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 async fn test_da_task() {
-    use hotshot_task_impls::harness::run_harness;
-    use hotshot_testing::task_helpers::build_system_handle;
-    use hotshot_types::message::Proposal;
-
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
 
-    // Build the API for node 2.
     let handle = build_system_handle(2).await.0;
-    let pub_key = *handle.public_key();
+    let quorum_membership = handle.hotshot.memberships.quorum_membership.clone();
+
+    // Make some empty encoded transactions, we just care about having a commitment handy for the
+    // later calls. We need the VID commitment to be able to propose later.
     let transactions = vec![TestTransaction(vec![0])];
     let encoded_transactions = TestTransaction::encode(transactions.clone()).unwrap();
-    let payload_commitment = vid_commitment(
+    let payload_commit = vid_commitment(
         &encoded_transactions,
         handle.hotshot.memberships.quorum_membership.total_nodes(),
     );
-    let encoded_transactions_hash = Sha256::digest(&encoded_transactions);
 
-    let signature = <TestTypes as NodeType>::SignatureKey::sign(
-        handle.private_key(),
-        &encoded_transactions_hash,
-    )
-    .expect("Failed to sign block payload");
-    let proposal = DAProposal {
-        encoded_transactions: encoded_transactions.clone(),
-        metadata: (),
-        view_number: ViewNumber::new(2),
+    let mut generator = TestViewGenerator::generate(quorum_membership.clone());
+
+    let mut proposals = Vec::new();
+    let mut leaders = Vec::new();
+    let mut votes = Vec::new();
+    let mut dacs = Vec::new();
+    let mut vids = Vec::new();
+    for view in (&mut generator).take(2) {
+        proposals.push(view.da_proposal.clone());
+        leaders.push(view.leader_public_key);
+        votes.push(view.create_da_vote(DAData { payload_commit }, &handle));
+        dacs.push(view.da_certificate.clone());
+        vids.push(view.vid_proposal.clone());
+    }
+
+    // Run view 1 (the genesis stage).
+    let view_1 = TestScriptStage {
+        inputs: vec![
+            ViewChange(ViewNumber::new(1)),
+            ViewChange(ViewNumber::new(2)),
+            TransactionsSequenced(encoded_transactions.clone(), (), ViewNumber::new(2)),
+        ],
+        outputs: vec![exact(DAProposalSend(proposals[1].clone(), leaders[1]))],
+        asserts: vec![],
     };
-    let message = Proposal {
-        data: proposal,
-        signature,
-        _pd: PhantomData,
+
+    // Run view 2 and propose.
+    let view_2 = TestScriptStage {
+        inputs: vec![DAProposalRecv(proposals[1].clone(), leaders[1])],
+        outputs: vec![exact(DAVoteSend(votes[1].clone()))],
+        asserts: vec![],
     };
-
-    // TODO for now reuse the same block payload commitment and signature as DA committee
-    // https://github.com/EspressoSystems/jellyfish/issues/369
-
-    // Every event input is seen on the event stream in the output.
-    let mut input = Vec::new();
-    let mut output = HashMap::new();
-
-    // In view 1, node 2 is the next leader.
-    input.push(HotShotEvent::ViewChange(ViewNumber::new(1)));
-    input.push(HotShotEvent::ViewChange(ViewNumber::new(2)));
-    input.push(HotShotEvent::TransactionsSequenced(
-        encoded_transactions.clone(),
-        (),
-        ViewNumber::new(2),
-    ));
-    input.push(HotShotEvent::DAProposalRecv(message.clone(), pub_key));
-
-    input.push(HotShotEvent::Shutdown);
-
-    output.insert(HotShotEvent::DAProposalSend(message.clone(), pub_key), 1);
-    let da_vote = DAVote::create_signed_vote(
-        DAData {
-            payload_commit: payload_commitment,
-        },
-        ViewNumber::new(2),
-        handle.public_key(),
-        handle.private_key(),
-    )
-    .expect("Failed to sign DAData");
-    output.insert(HotShotEvent::DAVoteSend(da_vote), 1);
 
     let da_state = DATaskState::<TestTypes, MemoryImpl, SystemContextHandle<TestTypes, MemoryImpl>>::create_from(&handle).await;
-    run_harness(input, output, da_state, false).await;
+    let stages = vec![view_1, view_2];
+
+    run_test_script(stages, da_state).await;
+}
+
+#[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
+#[cfg_attr(async_executor_impl = "async-std", async_std::test)]
+async fn test_da_task_storage_failure() {
+    async_compatibility_layer::logging::setup_logging();
+    async_compatibility_layer::logging::setup_backtrace();
+
+    let handle = build_system_handle(2).await.0;
+
+    // Set the error flag here for the system handle. This causes it to emit an error on append.
+    handle.get_storage().write().await.should_return_err = true;
+    let quorum_membership = handle.hotshot.memberships.quorum_membership.clone();
+
+    // Make some empty encoded transactions, we just care about having a commitment handy for the
+    // later calls. We need the VID commitment to be able to propose later.
+    let transactions = vec![TestTransaction(vec![0])];
+    let encoded_transactions = TestTransaction::encode(transactions.clone()).unwrap();
+    let payload_commit = vid_commitment(
+        &encoded_transactions,
+        handle.hotshot.memberships.quorum_membership.total_nodes(),
+    );
+
+    let mut generator = TestViewGenerator::generate(quorum_membership.clone());
+
+    let mut proposals = Vec::new();
+    let mut leaders = Vec::new();
+    let mut votes = Vec::new();
+    let mut dacs = Vec::new();
+    let mut vids = Vec::new();
+    for view in (&mut generator).take(2) {
+        proposals.push(view.da_proposal.clone());
+        leaders.push(view.leader_public_key);
+        votes.push(view.create_da_vote(DAData { payload_commit }, &handle));
+        dacs.push(view.da_certificate.clone());
+        vids.push(view.vid_proposal.clone());
+    }
+
+    // Run view 1 (the genesis stage).
+    let view_1 = TestScriptStage {
+        inputs: vec![
+            ViewChange(ViewNumber::new(1)),
+            ViewChange(ViewNumber::new(2)),
+            TransactionsSequenced(encoded_transactions.clone(), (), ViewNumber::new(2)),
+        ],
+        outputs: vec![exact(DAProposalSend(proposals[1].clone(), leaders[1]))],
+        asserts: vec![],
+    };
+
+    // Run view 2 and propose.
+    let view_2 = TestScriptStage {
+        inputs: vec![DAProposalRecv(proposals[1].clone(), leaders[1])],
+        outputs: vec![
+            /* No vote was sent due to the storage failure */
+        ],
+        asserts: vec![],
+    };
+
+    let da_state = DATaskState::<TestTypes, MemoryImpl, SystemContextHandle<TestTypes, MemoryImpl>>::create_from(&handle).await;
+    let stages = vec![view_1, view_2];
+
+    run_test_script(stages, da_state).await;
 }

--- a/crates/testing/tests/memory_network.rs
+++ b/crates/testing/tests/memory_network.rs
@@ -8,6 +8,7 @@ use hotshot::traits::implementations::{MasterMap, MemoryNetwork, NetworkingMetri
 use hotshot::traits::NodeImplementation;
 use hotshot::types::SignatureKey;
 use hotshot_example_types::state_types::TestInstanceState;
+use hotshot_example_types::storage_types::TestStorage;
 use hotshot_example_types::{
     block_types::{TestBlockHeader, TestBlockPayload, TestTransaction},
     state_types::TestValidatedState,
@@ -67,6 +68,7 @@ pub type VIDNetwork = MemoryNetwork<Message<Test>, <Test as NodeType>::Signature
 impl NodeImplementation<Test> for TestImpl {
     type QuorumNetwork = QuorumNetwork;
     type CommitteeNetwork = DANetwork;
+    type Storage = TestStorage<Test>;
 }
 
 /// fake Eq


### PR DESCRIPTION
Closes #2621 
<!-- See here for keywords in Github -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
We want to integrate a persistent storage interface within HotShot to enable the application to manage data storage effectively. This feature aims to address potential data storage issues (e.g., full disk space) that can prevent nodes from storing DA blobs or VID shares.

### This PR: 
1. **Creates `Storage` Trait**
2. **Initializes `Storage` in `SystemTask`'s init**
3. **Add Storage Operations on DA Proposals**
    - If this fails, do not vote on the proposal and exit the event handler.
4. **Add Storage Operations on DA Proposals VID Shares**
   - If this fails, do not vote on the VID disperse, otherwise, use the old logic to vote.
5. **Refactor In-memory Payload/VID Stores**: (Tracking #2808)

This code also implements a number of changes to introduce a `TestBlockStorage` type for use in the various testing components.


### This PR does not: 
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->

### Key places to review: 
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->
All of the tests and test interface changes. I had to update the `view_generator` to support the various DA related things that we wanted to add.

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
