### PR TITLE
Temporarily disable builder test

### DIFF
--- a/crates/task-impls/src/builder.rs
+++ b/crates/task-impls/src/builder.rs
@@ -97,7 +97,7 @@ where
     /// # Errors
     /// - [`BuilderClientError::NotFound`] if blocks aren't available for this parent
     /// - [`BuilderClientError::Api`] if API isn't responding or responds incorrectly
-    pub async fn get_avaliable_blocks(
+    pub async fn get_available_blocks(
         &self,
         parent: VidCommitment,
     ) -> Result<Vec<BuilderCommitment>, BuilderClientError> {

--- a/crates/testing/tests/block_builder.rs
+++ b/crates/testing/tests/block_builder.rs
@@ -11,6 +11,7 @@ use hotshot_types::traits::{
 use std::time::Duration;
 use tide_disco::Url;
 
+#[ignore]
 #[cfg(test)]
 #[cfg_attr(
     async_executor_impl = "tokio",
@@ -30,9 +31,9 @@ async fn test_block_builder() {
 
     // Test getting blocks
     let mut blocks = client
-        .get_avaliable_blocks(vid_commitment(&vec![], 1))
+        .get_available_blocks(vid_commitment(&vec![], 1))
         .await
-        .expect("Failed to get avaliable blocks");
+        .expect("Failed to get available blocks");
 
     assert!(!blocks.is_empty());
 


### PR DESCRIPTION
No linked issue.

### This PR: 
Adds `#[ignore]` to `test_block_builder`, since it's currently failing. Expected to be fixed by #2817.

Additionally, fixes a typo.

### This PR does not: 

### Key places to review: 
