### PR TITLE
[EASY]Remove the `proposer_id` from all structs in the codebase.

### DIFF
--- a/crates/task-impls/src/consensus.rs
+++ b/crates/task-impls/src/consensus.rs
@@ -201,7 +201,6 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                     parent_commitment,
                     block_header: proposal.block_header.clone(),
                     block_payload: None,
-                    proposer_id: self.quorum_membership.get_leader(view),
                 };
 
                 // Validate the DAC.
@@ -533,7 +532,6 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                         parent_commitment: justify_qc.get_data().leaf_commit,
                         block_header: proposal.data.block_header.clone(),
                         block_payload: None,
-                        proposer_id: sender,
                     };
                     let state = Arc::new(
                         <TYPES::ValidatedState as ValidatedState<TYPES>>::from_header(
@@ -608,7 +606,6 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                     parent_commitment,
                     block_header: proposal.data.block_header.clone(),
                     block_payload: None,
-                    proposer_id: sender.clone(),
                 };
                 let leaf_commitment = leaf.commit();
 
@@ -1336,7 +1333,6 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                 parent_commitment: parent_leaf.commit(),
                 block_header: block_header.clone(),
                 block_payload: None,
-                proposer_id: self.api.public_key().clone(),
             };
 
             let Ok(signature) =
@@ -1375,7 +1371,6 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                 justify_qc: consensus.high_qc.clone(),
                 proposal_certificate,
                 upgrade_certificate: upgrade_cert,
-                proposer_id: leaf.proposer_id,
             };
 
             self.proposal_cert = None;

--- a/crates/testing/src/task_helpers.rs
+++ b/crates/testing/src/task_helpers.rs
@@ -257,7 +257,6 @@ async fn build_quorum_proposal_and_signature(
         parent_commitment: parent_leaf.commit(),
         block_header: block_header.clone(),
         block_payload: None,
-        proposer_id: *handle.public_key(),
     };
 
     let mut signature = <BLSPubKey as SignatureKey>::sign(private_key, leaf.commit().as_ref())
@@ -268,7 +267,6 @@ async fn build_quorum_proposal_and_signature(
         justify_qc: QuorumCertificate::genesis(),
         upgrade_certificate: None,
         proposal_certificate: None,
-        proposer_id: leaf.proposer_id,
     };
 
     // Only view 2 is tested, higher views are not tested
@@ -316,7 +314,6 @@ async fn build_quorum_proposal_and_signature(
             parent_commitment: parent_leaf.commit(),
             block_header: block_header.clone(),
             block_payload: None,
-            proposer_id: quorum_membership.get_leader(ViewNumber::new(cur_view)),
         };
         let signature_new_view =
             <BLSPubKey as SignatureKey>::sign(private_key, leaf_new_view.commit().as_ref())
@@ -327,7 +324,6 @@ async fn build_quorum_proposal_and_signature(
             justify_qc: created_qc,
             upgrade_certificate: None,
             proposal_certificate: None,
-            proposer_id: leaf_new_view.clone().proposer_id,
         };
         proposal = proposal_new_view;
         signature = signature_new_view;
@@ -449,7 +445,6 @@ pub async fn build_vote(
 ) -> GeneralConsensusMessage<TestTypes> {
     let consensus_lock = handle.get_consensus();
     let consensus = consensus_lock.read().await;
-    let membership = handle.hotshot.memberships.quorum_membership.clone();
 
     let justify_qc = proposal.justify_qc.clone();
     let view = ViewNumber::new(*proposal.view_number);
@@ -480,7 +475,6 @@ pub async fn build_vote(
         parent_commitment,
         block_header: proposal.block_header,
         block_payload: None,
-        proposer_id: membership.get_leader(view),
     };
     let vote = QuorumVote::<TestTypes>::create_signed_vote(
         QuorumData {

--- a/crates/testing/src/view_generator.rs
+++ b/crates/testing/src/view_generator.rs
@@ -92,7 +92,6 @@ impl TestView {
             justify_qc: QuorumCertificate::genesis(),
             upgrade_certificate: None,
             proposal_certificate: None,
-            proposer_id: public_key,
         };
 
         let transactions = vec![TestTransaction(vec![0])];
@@ -123,8 +122,6 @@ impl TestView {
             block_payload: Some(TestBlockPayload {
                 transactions: transactions.clone(),
             }),
-            // Note: this field is not relevant in calculating the leaf commitment.
-            proposer_id: public_key,
         };
 
         let signature = <BLSPubKey as SignatureKey>::sign(&private_key, leaf.commit().as_ref())
@@ -286,8 +283,6 @@ impl TestView {
             block_payload: Some(TestBlockPayload {
                 transactions: transactions.clone(),
             }),
-            // Note: this field is not relevant in calculating the leaf commitment.
-            proposer_id: public_key,
         };
 
         let signature = <BLSPubKey as SignatureKey>::sign(&private_key, leaf.commit().as_ref())
@@ -299,7 +294,6 @@ impl TestView {
             justify_qc: quorum_certificate.clone(),
             upgrade_certificate,
             proposal_certificate,
-            proposer_id: public_key,
         };
 
         let quorum_proposal = Proposal {

--- a/crates/testing/tests/consensus_task.rs
+++ b/crates/testing/tests/consensus_task.rs
@@ -451,10 +451,6 @@ async fn test_view_sync_finalize_vote() {
         _ => panic!("Found a TC when there should have been a view sync cert"),
     };
 
-    // Highest qc so far is actually from view 1, so re-assign proposal 0 to the slot of proposal
-    // 3.
-    proposals[0].data.proposer_id = proposals[3].data.proposer_id;
-
     // Now at view 3 we receive the proposal received response.
     let view_3 = TestScriptStage {
         inputs: vec![
@@ -562,10 +558,6 @@ async fn test_view_sync_finalize_vote_fail_view_number() {
     // Force this to fail by making the cert happen for a view we've never seen. This will
     // intentionally skip the proposal for this node so we can get the proposal and fail to vote.
     cert.view_number = ViewNumber::new(10);
-
-    // Highest qc so far is actually from view 1, so re-assign proposal 0 to the slot of proposal
-    // 3.
-    proposals[0].data.proposer_id = proposals[3].data.proposer_id;
 
     // We introduce an error by setting a different view number as well, this makes the task check
     // for a view sync or timeout cert. This value could be anything as long as it is not the

--- a/crates/types/src/data.rs
+++ b/crates/types/src/data.rs
@@ -310,9 +310,6 @@ pub struct QuorumProposal<TYPES: NodeType> {
     /// - A view sync certificate is only present if the justify_qc and timeout_cert are not
     /// present.
     pub proposal_certificate: Option<ViewChangeEvidence<TYPES>>,
-
-    /// the propser id
-    pub proposer_id: TYPES::SignatureKey,
 }
 
 impl<TYPES: NodeType> HasViewNumber<TYPES> for DAProposal<TYPES> {
@@ -392,9 +389,6 @@ pub struct Leaf<TYPES: NodeType> {
     ///
     /// It may be empty for nodes not in the DA committee.
     pub block_payload: Option<TYPES::BlockPayload>,
-
-    /// the proposer id of the leaf
-    pub proposer_id: TYPES::SignatureKey,
 }
 
 impl<TYPES: NodeType> PartialEq for Leaf<TYPES> {
@@ -450,7 +444,6 @@ impl<TYPES: NodeType> Leaf<TYPES> {
             parent_commitment: fake_commitment(),
             block_header: block_header.clone(),
             block_payload: Some(payload),
-            proposer_id: <<TYPES as NodeType>::SignatureKey as SignatureKey>::genesis_proposer_pk(),
         }
     }
 
@@ -515,11 +508,6 @@ impl<TYPES: NodeType> Leaf<TYPES> {
     /// A commitment to the block payload contained in this leaf.
     pub fn get_payload_commitment(&self) -> VidCommitment {
         self.get_block_header().payload_commitment()
-    }
-
-    /// Identity of the network participant who proposed this leaf.
-    pub fn get_proposer_id(&self) -> TYPES::SignatureKey {
-        self.proposer_id.clone()
     }
 }
 


### PR DESCRIPTION
Closes N/A
<!-- See here for keywords in Github -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

### This PR: 
Removes the `proposer_id` from the codebase. This field was never used and was planning to be potentially repurposed in a different form at a later date. To avoid complexity when implementing the new tasks (specifically generating payload commitments), we remove this field for now.

### This PR does not: 
Add any new testing or functionality, it is exclusively destructive.

### Key places to review: 
All touched files.

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
