### PR TITLE
Add upgrade certificate to Leaf

### DIFF
--- a/crates/example-types/src/block_types.rs
+++ b/crates/example-types/src/block_types.rs
@@ -197,7 +197,7 @@ impl<TYPES: NodeType<BlockHeader = Self, BlockPayload = TestBlockPayload>> Block
         payload_commitment: VidCommitment,
         _metadata: <TYPES::BlockPayload as BlockPayload>::Metadata,
     ) -> Self {
-        let parent = &parent_leaf.block_header;
+        let parent = parent_leaf.get_block_header();
 
         let mut timestamp = OffsetDateTime::now_utc().unix_timestamp() as u64;
         if timestamp < parent.timestamp {

--- a/crates/hotshot/src/lib.rs
+++ b/crates/hotshot/src/lib.rs
@@ -182,7 +182,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> SystemContext<TYPES, I> {
         let validated_state = match initializer.validated_state {
             Some(state) => state,
             None => Arc::new(TYPES::ValidatedState::from_header(
-                &anchored_leaf.block_header,
+                anchored_leaf.get_block_header(),
             )),
         };
 

--- a/crates/task-impls/src/consensus.rs
+++ b/crates/task-impls/src/consensus.rs
@@ -195,13 +195,12 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                 };
                 let parent_commitment = parent.commit();
 
-                let leaf: Leaf<_> = Leaf {
-                    view_number: view,
-                    justify_qc: proposal.justify_qc.clone(),
-                    parent_commitment,
-                    block_header: proposal.block_header.clone(),
-                    block_payload: None,
-                };
+                let proposed_leaf = Leaf::from_quorum_proposal(proposal);
+
+                if proposed_leaf.get_parent_commitment() != parent_commitment {
+                    info!("Quorum proposal's parent commitment does not match expected parent commitment!");
+                    return false;
+                }
 
                 // Validate the DAC.
                 let message = if cert.is_valid_cert(self.committee_membership.as_ref()) {
@@ -215,7 +214,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                     }
                     if let Ok(vote) = QuorumVote::<TYPES>::create_signed_vote(
                         QuorumData {
-                            leaf_commit: leaf.commit(),
+                            leaf_commit: proposed_leaf.commit(),
                         },
                         view,
                         &self.public_key,
@@ -501,7 +500,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                     {
                         Some(leaf) => {
                             if let (Some(state), _) =
-                                consensus.get_state_and_delta(leaf.view_number)
+                                consensus.get_state_and_delta(leaf.get_view_number())
                             {
                                 Some((leaf, state.clone()))
                             } else {
@@ -539,13 +538,8 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                         "Proposal's parent missing from storage with commitment: {:?}",
                         justify_qc.get_data().leaf_commit
                     );
-                    let leaf = Leaf {
-                        view_number: view,
-                        justify_qc: justify_qc.clone(),
-                        parent_commitment: justify_qc.get_data().leaf_commit,
-                        block_header: proposal.data.block_header.clone(),
-                        block_payload: None,
-                    };
+                    let leaf = Leaf::from_proposal(proposal);
+
                     let state = Arc::new(
                         <TYPES::ValidatedState as ValidatedState<TYPES>>::from_header(
                             &proposal.data.block_header,
@@ -626,20 +620,20 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                 let state = Arc::new(validated_state);
                 let delta = Arc::new(state_delta);
                 let parent_commitment = parent_leaf.commit();
-                let leaf: Leaf<_> = Leaf {
-                    view_number: view,
-                    justify_qc: justify_qc.clone(),
-                    parent_commitment,
-                    block_header: proposal.data.block_header.clone(),
-                    block_payload: None,
-                };
-                let leaf_commitment = leaf.commit();
+
+                let proposed_leaf = Leaf::from_quorum_proposal(&proposal.data);
+
+                if proposed_leaf.get_parent_commitment() != parent_commitment {
+                    info!("Quorum proposal's parent commitment does not match expected parent commitment!");
+                    return;
+                }
 
                 // Validate the signature. This should also catch if the leaf_commitment does not equal our calculated parent commitment
-                if !view_leader_key.validate(&proposal.signature, leaf_commitment.as_ref()) {
+                if !view_leader_key.validate(&proposal.signature, proposed_leaf.commit().as_ref()) {
                     error!(?proposal.signature, "Could not verify proposal.");
                     return;
                 }
+
                 // Create a positive vote if either liveness or safety check
                 // passes.
 
@@ -655,7 +649,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                     |leaf, _, _| {
                         // if leaf view no == locked view no then we're done, report success by
                         // returning true
-                        leaf.view_number != consensus.locked_view
+                        leaf.get_view_number() != consensus.locked_view
                     },
                 );
                 let safety_check = outcome.is_ok();
@@ -703,7 +697,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                 let mut leafs_decided = Vec::new();
                 let mut included_txns = HashSet::new();
                 let old_anchor_view = consensus.last_decided_view;
-                let parent_view = leaf.justify_qc.get_view_number();
+                let parent_view = proposed_leaf.get_justify_qc().get_view_number();
                 let mut current_chain_length = 0usize;
                 if parent_view + 1 == view {
                     current_chain_length += 1;
@@ -713,17 +707,17 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                         true,
                         |leaf, state, delta| {
                             if !new_decide_reached {
-                                if last_view_number_visited == leaf.view_number + 1 {
-                                    last_view_number_visited = leaf.view_number;
+                                if last_view_number_visited == leaf.get_view_number() + 1 {
+                                    last_view_number_visited = leaf.get_view_number();
                                     current_chain_length += 1;
                                     if current_chain_length == 2 {
-                                        new_locked_view = leaf.view_number;
+                                        new_locked_view = leaf.get_view_number();
                                         new_commit_reached = true;
                                         // The next leaf in the chain, if there is one, is decided, so this
                                         // leaf's justify_qc would become the QC for the decided chain.
-                                        new_decide_qc = Some(leaf.justify_qc.clone());
+                                        new_decide_qc = Some(leaf.get_justify_qc().clone());
                                     } else if current_chain_length == 3 {
-                                        new_anchor_view = leaf.view_number;
+                                        new_anchor_view = leaf.get_view_number();
                                         new_decide_reached = true;
                                     }
                                 } else {
@@ -734,7 +728,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                             // starting from the first iteration with a three chain, e.g. right after the else if case nested in the if case above
                             if new_decide_reached {
                                 let mut leaf = leaf.clone();
-                                if leaf.view_number == new_anchor_view {
+                                if leaf.get_view_number() == new_anchor_view {
                                     consensus
                                         .metrics
                                         .last_synced_block_height
@@ -768,7 +762,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
 
                                 leaf_views.push(LeafInfo::new(leaf.clone(), state.clone(), delta.clone(), vid));
                                 leafs_decided.push(leaf.clone());
-                                if let Some(ref payload) = leaf.block_payload {
+                                if let Some(ref payload) = leaf.get_block_payload() {
                                     for txn in payload
                                         .transaction_commitments(leaf.get_block_header().metadata())
                                     {
@@ -801,13 +795,13 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                     view,
                     View {
                         view_inner: ViewInner::Leaf {
-                            leaf: leaf.commit(),
+                            leaf: proposed_leaf.commit(),
                             state: state.clone(),
                             delta: Some(delta.clone()),
                         },
                     },
                 );
-                consensus.saved_leaves.insert(leaf.commit(), leaf.clone());
+                consensus.saved_leaves.insert(proposed_leaf.commit(), proposed_leaf.clone());
 
                 if let Err(e) = self
                     .storage
@@ -1339,7 +1333,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
             error!("Failed to find high QC of parent.");
             return false;
         };
-        if leaf.view_number == consensus.last_decided_view {
+        if leaf.get_view_number() == consensus.last_decided_view {
             reached_decided = true;
         }
 
@@ -1353,10 +1347,10 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
         if !reached_decided {
             debug!("We have not reached decide from view {:?}", self.cur_view);
             while let Some(next_parent_leaf) = consensus.saved_leaves.get(&next_parent_hash) {
-                if next_parent_leaf.view_number <= consensus.last_decided_view {
+                if next_parent_leaf.get_view_number() <= consensus.last_decided_view {
                     break;
                 }
-                next_parent_hash = next_parent_leaf.parent_commitment;
+                next_parent_hash = next_parent_leaf.get_parent_commitment();
             }
             debug!("updated saved leaves");
             // TODO do some sort of sanity check on the view number that it matches decided
@@ -1371,21 +1365,6 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                 commit_and_metadata.metadata.clone(),
             )
             .await;
-            let leaf = Leaf {
-                view_number: view,
-                justify_qc: consensus.high_qc.clone(),
-                parent_commitment: parent_leaf.commit(),
-                block_header: block_header.clone(),
-                block_payload: None,
-            };
-
-            let Ok(signature) =
-                TYPES::SignatureKey::sign(&self.private_key, leaf.commit().as_ref())
-            else {
-                error!("Failed to sign leaf.commit()!");
-                return false;
-            };
-
             let upgrade_cert = if self
                 .upgrade_cert
                 .as_ref()
@@ -1410,11 +1389,20 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
 
             // TODO: DA cert is sent as part of the proposal here, we should split this out so we don't have to wait for it.
             let proposal = QuorumProposal {
-                block_header,
-                view_number: leaf.view_number,
+                block_header: block_header.clone(),
+                view_number: view,
                 justify_qc: consensus.high_qc.clone(),
                 proposal_certificate,
-                upgrade_certificate: upgrade_cert,
+                upgrade_certificate: upgrade_cert.clone(),
+            };
+
+            let new_leaf = Leaf::from_quorum_proposal(&proposal);
+
+            let Ok(signature) =
+                TYPES::SignatureKey::sign(&self.private_key, new_leaf.commit().as_ref())
+            else {
+                error!("Failed to sign new_leaf.commit()!");
+                return false;
             };
 
             self.proposal_cert = None;
@@ -1423,7 +1411,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                 signature,
                 _pd: PhantomData,
             };
-            debug!("Sending proposal for view {:?}", leaf.view_number);
+            debug!("Sending proposal for view {:?}", view);
 
             broadcast_event(
                 Arc::new(HotShotEvent::QuorumProposalSend(

--- a/crates/task-impls/src/transactions.rs
+++ b/crates/task-impls/src/transactions.rs
@@ -127,7 +127,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                 let mut included_txn_size = 0;
                 let mut included_txn_count = 0;
                 for leaf in leaf_chain {
-                    if let Some(ref payload) = leaf.block_payload {
+                    if let Some(ref payload) = leaf.get_block_payload() {
                         for txn in
                             payload.transaction_commitments(leaf.get_block_header().metadata())
                         {

--- a/crates/testing/src/block_builder.rs
+++ b/crates/testing/src/block_builder.rs
@@ -348,7 +348,7 @@ impl TaskState for SimpleBuilderTask {
             HotShotEvent::LeafDecided(leaf_chain) => {
                 let mut queue = this.transactions.write().await;
                 for leaf in leaf_chain.iter() {
-                    if let Some(ref payload) = leaf.block_payload {
+                    if let Some(ref payload) = leaf.get_block_payload() {
                         for txn in payload.transaction_commitments(&()) {
                             queue.remove(&txn);
                         }

--- a/crates/testing/src/task_helpers.rs
+++ b/crates/testing/src/task_helpers.rs
@@ -240,7 +240,7 @@ async fn build_quorum_proposal_and_signature(
         handle.hotshot.memberships.quorum_membership.total_nodes(),
     );
     let mut parent_state = Arc::new(
-        <TestValidatedState as ValidatedState<TestTypes>>::from_header(&parent_leaf.block_header),
+        <TestValidatedState as ValidatedState<TestTypes>>::from_header(parent_leaf.get_block_header()),
     );
     let block_header = TestBlockHeader::new(
         &*parent_state,
@@ -250,17 +250,6 @@ async fn build_quorum_proposal_and_signature(
         (),
     )
     .await;
-    // current leaf that can be re-assigned everytime when entering a new view
-    let mut leaf = Leaf {
-        view_number: ViewNumber::new(1),
-        justify_qc: consensus.high_qc.clone(),
-        parent_commitment: parent_leaf.commit(),
-        block_header: block_header.clone(),
-        block_payload: None,
-    };
-
-    let mut signature = <BLSPubKey as SignatureKey>::sign(private_key, leaf.commit().as_ref())
-        .expect("Failed to sign leaf commitment!");
     let mut proposal = QuorumProposal::<TestTypes> {
         block_header: block_header.clone(),
         view_number: ViewNumber::new(1),
@@ -268,6 +257,11 @@ async fn build_quorum_proposal_and_signature(
         upgrade_certificate: None,
         proposal_certificate: None,
     };
+    // current leaf that can be re-assigned everytime when entering a new view
+    let mut leaf = Leaf::from_quorum_proposal(&proposal);
+
+    let mut signature = <BLSPubKey as SignatureKey>::sign(private_key, leaf.commit().as_ref())
+        .expect("Failed to sign leaf commitment!");
 
     // Only view 2 is tested, higher views are not tested
     for cur_view in 2..=view {
@@ -307,17 +301,6 @@ async fn build_quorum_proposal_and_signature(
             private_key,
         );
         // create a new leaf for the current view
-        let parent_leaf = leaf.clone();
-        let leaf_new_view = Leaf {
-            view_number: ViewNumber::new(cur_view),
-            justify_qc: created_qc.clone(),
-            parent_commitment: parent_leaf.commit(),
-            block_header: block_header.clone(),
-            block_payload: None,
-        };
-        let signature_new_view =
-            <BLSPubKey as SignatureKey>::sign(private_key, leaf_new_view.commit().as_ref())
-                .expect("Failed to sign leaf commitment!");
         let proposal_new_view = QuorumProposal::<TestTypes> {
             block_header: block_header.clone(),
             view_number: ViewNumber::new(cur_view),
@@ -325,6 +308,10 @@ async fn build_quorum_proposal_and_signature(
             upgrade_certificate: None,
             proposal_certificate: None,
         };
+        let leaf_new_view = Leaf::from_quorum_proposal(&proposal_new_view);
+        let signature_new_view =
+            <BLSPubKey as SignatureKey>::sign(private_key, leaf_new_view.commit().as_ref())
+                .expect("Failed to sign leaf commitment!");
         proposal = proposal_new_view;
         signature = signature_new_view;
         leaf = leaf_new_view;
@@ -443,39 +430,9 @@ pub async fn build_vote(
     handle: &SystemContextHandle<TestTypes, MemoryImpl>,
     proposal: QuorumProposal<TestTypes>,
 ) -> GeneralConsensusMessage<TestTypes> {
-    let consensus_lock = handle.get_consensus();
-    let consensus = consensus_lock.read().await;
-
-    let justify_qc = proposal.justify_qc.clone();
     let view = ViewNumber::new(*proposal.view_number);
-    let parent = if justify_qc.is_genesis {
-        let Some(genesis_view) = consensus.validated_state_map.get(&ViewNumber::new(0)) else {
-            panic!("Couldn't find genesis view in state map.");
-        };
-        let Some(leaf) = genesis_view.get_leaf_commitment() else {
-            panic!("Genesis view points to a view without a leaf");
-        };
-        let Some(leaf) = consensus.saved_leaves.get(&leaf) else {
-            panic!("Failed to find genesis leaf.");
-        };
-        leaf.clone()
-    } else {
-        consensus
-            .saved_leaves
-            .get(&justify_qc.get_data().leaf_commit)
-            .cloned()
-            .unwrap()
-    };
 
-    let parent_commitment = parent.commit();
-
-    let leaf: Leaf<_> = Leaf {
-        view_number: view,
-        justify_qc: proposal.justify_qc.clone(),
-        parent_commitment,
-        block_header: proposal.block_header,
-        block_payload: None,
-    };
+    let leaf: Leaf<_> = Leaf::from_quorum_proposal(&proposal);
     let vote = QuorumVote::<TestTypes>::create_signed_vote(
         QuorumData {
             leaf_commit: leaf.commit(),

--- a/crates/testing/src/view_generator.rs
+++ b/crates/testing/src/view_generator.rs
@@ -3,7 +3,6 @@ use std::{cmp::max, marker::PhantomData};
 use hotshot_example_types::{
     block_types::{TestBlockHeader, TestBlockPayload, TestTransaction},
     node_types::{MemoryImpl, TestTypes},
-    state_types::TestInstanceState,
 };
 use sha2::{Digest, Sha256};
 
@@ -113,16 +112,10 @@ impl TestView {
             _pd: PhantomData,
         };
 
-        let leaf = Leaf {
-            view_number: genesis_view,
-            justify_qc: QuorumCertificate::genesis(),
-            parent_commitment: Leaf::genesis(&TestInstanceState {}).commit(),
-            block_header: block_header.clone(),
-            // Note: this field is not relevant in calculating the leaf commitment.
-            block_payload: Some(TestBlockPayload {
-                transactions: transactions.clone(),
-            }),
-        };
+        let mut leaf = Leaf::from_quorum_proposal(&quorum_proposal_inner);
+        leaf.fill_block_payload_unchecked(TestBlockPayload {
+            transactions: transactions.clone(),
+        });
 
         let signature = <BLSPubKey as SignatureKey>::sign(&private_key, leaf.commit().as_ref())
             .expect("Failed to sign leaf commitment!");
@@ -274,20 +267,6 @@ impl TestView {
             payload_commitment,
         };
 
-        let leaf = Leaf {
-            view_number: next_view,
-            justify_qc: quorum_certificate.clone(),
-            parent_commitment: old.leaf.commit(),
-            block_header: block_header.clone(),
-            // Note: this field is not relevant in calculating the leaf commitment.
-            block_payload: Some(TestBlockPayload {
-                transactions: transactions.clone(),
-            }),
-        };
-
-        let signature = <BLSPubKey as SignatureKey>::sign(&private_key, leaf.commit().as_ref())
-            .expect("Failed to sign leaf commitment.");
-
         let proposal = QuorumProposal::<TestTypes> {
             block_header: block_header.clone(),
             view_number: next_view,
@@ -295,6 +274,14 @@ impl TestView {
             upgrade_certificate,
             proposal_certificate,
         };
+
+        let mut leaf = Leaf::from_quorum_proposal(&proposal);
+        leaf.fill_block_payload_unchecked(TestBlockPayload {
+            transactions: transactions.clone(),
+        });
+
+        let signature = <BLSPubKey as SignatureKey>::sign(&private_key, leaf.commit().as_ref())
+            .expect("Failed to sign leaf commitment.");
 
         let quorum_proposal = Proposal {
             data: proposal,

--- a/crates/types/src/data.rs
+++ b/crates/types/src/data.rs
@@ -373,22 +373,25 @@ pub trait TestableLeaf {
 #[serde(bound(deserialize = ""))]
 pub struct Leaf<TYPES: NodeType> {
     /// CurView from leader when proposing leaf
-    pub view_number: TYPES::Time,
+    view_number: TYPES::Time,
 
     /// Per spec, justification
-    pub justify_qc: QuorumCertificate<TYPES>,
+    justify_qc: QuorumCertificate<TYPES>,
 
     /// The hash of the parent `Leaf`
     /// So we can ask if it extends
-    pub parent_commitment: Commitment<Self>,
+    parent_commitment: Commitment<Self>,
 
     /// Block header.
-    pub block_header: TYPES::BlockHeader,
+    block_header: TYPES::BlockHeader,
+
+    /// Optional upgrade certificate, if one was attached to the quorum proposal for this view.
+    upgrade_certificate: Option<UpgradeCertificate<TYPES>>,
 
     /// Optional block payload.
     ///
     /// It may be empty for nodes not in the DA committee.
-    pub block_payload: Option<TYPES::BlockPayload>,
+    block_payload: Option<TYPES::BlockPayload>,
 }
 
 impl<TYPES: NodeType> PartialEq for Leaf<TYPES> {
@@ -442,6 +445,7 @@ impl<TYPES: NodeType> Leaf<TYPES> {
             view_number: TYPES::Time::genesis(),
             justify_qc: QuorumCertificate::<TYPES>::genesis(),
             parent_commitment: fake_commitment(),
+            upgrade_certificate: None,
             block_header: block_header.clone(),
             block_payload: Some(payload),
         }
@@ -460,6 +464,10 @@ impl<TYPES: NodeType> Leaf<TYPES> {
     /// The QC linking this leaf to its parent in the chain.
     pub fn get_justify_qc(&self) -> QuorumCertificate<TYPES> {
         self.justify_qc.clone()
+    }
+    /// The QC linking this leaf to its parent in the chain.
+    pub fn get_upgrade_certificate(&self) -> Option<UpgradeCertificate<TYPES>> {
+        self.upgrade_certificate.clone()
     }
     /// Commitment to this leaf's parent.
     pub fn get_parent_commitment(&self) -> Commitment<Self> {
@@ -567,29 +575,40 @@ pub fn serialize_signature2<TYPES: NodeType>(
 
 impl<TYPES: NodeType> Committable for Leaf<TYPES> {
     fn commit(&self) -> commit::Commitment<Self> {
-        let signatures_bytes = if self.justify_qc.is_genesis {
-            let mut bytes = vec![];
-            bytes.extend("genesis".as_bytes());
-            bytes
-        } else {
-            serialize_signature2::<TYPES>(self.justify_qc.signatures.as_ref().unwrap())
-        };
-
         // Skip the transaction commitments, so that the repliacs can reconstruct the leaf.
         RawCommitmentBuilder::new("leaf commitment")
             .u64_field("view number", *self.view_number)
             .u64_field("block number", self.get_height())
             .field("parent Leaf commitment", self.parent_commitment)
-            .constant_str("block payload commitment")
-            .fixed_size_bytes(self.get_payload_commitment().as_ref().as_ref())
-            .constant_str("justify_qc view number")
-            .u64(*self.justify_qc.view_number)
-            .field(
-                "justify_qc leaf commitment",
-                self.justify_qc.get_data().leaf_commit,
-            )
-            .constant_str("justify_qc signatures")
-            .var_size_bytes(&signatures_bytes)
+            .fixed_size_field("block payload commitment", self.get_payload_commitment().as_ref().as_ref())
+            .field("justify qc", self.justify_qc.commit())
+            .optional("upgrade certificate", &self.upgrade_certificate)
             .finalize()
     }
 }
+
+
+impl<TYPES: NodeType> Leaf<TYPES> {
+  pub fn from_proposal(proposal: &Proposal<TYPES, QuorumProposal<TYPES>>) -> Self {
+    Self::from_quorum_proposal(&proposal.data)
+  }
+
+  pub fn from_quorum_proposal(quorum_proposal: &QuorumProposal<TYPES>) -> Self {
+    // WARNING: Do NOT change this to a wildcard match, or reference the fields directly in the construction of the leaf.
+    // The point of this match is that we will get a compile-time error if we add a field without updating this.
+    let QuorumProposal { view_number, justify_qc, block_header, upgrade_certificate, proposal_certificate: _ } = quorum_proposal;
+    Leaf {
+      view_number: *view_number,
+      justify_qc: justify_qc.clone(),
+      parent_commitment: justify_qc.get_data().leaf_commit,
+      block_header: block_header.clone(),
+      upgrade_certificate: upgrade_certificate.clone(),
+      block_payload: None,
+    }
+  }
+
+  pub fn commit_from_proposal(proposal: &Proposal<TYPES, QuorumProposal<TYPES>>) -> Commitment<Self> {
+    Leaf::from_proposal(proposal).commit()
+  }
+}
+

--- a/crates/types/src/simple_vote.rs
+++ b/crates/types/src/simple_vote.rs
@@ -162,7 +162,7 @@ impl<TYPES: NodeType, DATA: Voteable + 'static> SimpleVote<TYPES, DATA> {
 
 impl<TYPES: NodeType> Committable for QuorumData<TYPES> {
     fn commit(&self) -> Commitment<Self> {
-        commit::RawCommitmentBuilder::new("Yes Vote")
+        commit::RawCommitmentBuilder::new("Quorum data")
             .var_size_bytes(self.leaf_commit.as_ref())
             .finalize()
     }
@@ -170,7 +170,7 @@ impl<TYPES: NodeType> Committable for QuorumData<TYPES> {
 
 impl<TYPES: NodeType> Committable for TimeoutData<TYPES> {
     fn commit(&self) -> Commitment<Self> {
-        commit::RawCommitmentBuilder::new("Timeout Vote")
+        commit::RawCommitmentBuilder::new("Timeout data")
             .u64(*self.view)
             .finalize()
     }
@@ -178,7 +178,7 @@ impl<TYPES: NodeType> Committable for TimeoutData<TYPES> {
 
 impl Committable for DAData {
     fn commit(&self) -> Commitment<Self> {
-        commit::RawCommitmentBuilder::new("DA Vote")
+        commit::RawCommitmentBuilder::new("DA data")
             .var_size_bytes(self.payload_commit.as_ref())
             .finalize()
     }
@@ -186,7 +186,7 @@ impl Committable for DAData {
 
 impl Committable for VIDData {
     fn commit(&self) -> Commitment<Self> {
-        commit::RawCommitmentBuilder::new("VID Vote")
+        commit::RawCommitmentBuilder::new("VID data")
             .var_size_bytes(self.payload_commit.as_ref())
             .finalize()
     }
@@ -194,7 +194,7 @@ impl Committable for VIDData {
 
 impl<TYPES: NodeType> Committable for UpgradeProposalData<TYPES> {
     fn commit(&self) -> Commitment<Self> {
-        let builder = commit::RawCommitmentBuilder::new("Upgrade Vote");
+        let builder = commit::RawCommitmentBuilder::new("Upgrade data");
         builder
             .u64(*self.new_version_first_block)
             .u64(*self.old_version_last_block)


### PR DESCRIPTION
Closes #2702

### This PR: 
- Adds upgrade certificates to the `Leaf` struct.
- Adds upgrade certificates to the `Leaf::commit` calculation.

While doing this, I also did some minor cleanup around the `Leaf` struct. Notably:
- `Leaf` now has a method `from_quorum_proposal`, which constructs the leaf directly from the quorum proposal.
- All fields of `Leaf` are private, and access to the fields now happens via the (already existing) field methods. The primary benefit here is that it should be much harder to construct invalid leaves by accident.

### This PR does not: 
The issues around the leaf commit/signature calculation are not addressed. The logic around leaf calculations should not have changed.

### Key places to review: 
The most important thing to verify is that the `consensus` logic hasn't actually changed. Previously, we were constructing leaves with some fields from our own internal state and some fields from the received quorum proposal. Now, the leaf is produced directly from the received quorum proposal and the parent commitment check happens separately.
