### PR TITLE
[Push CDN] Combined network to new CDN

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1286,7 +1286,7 @@ checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
 [[package]]
 name = "cdn-broker"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/Push-CDN?tag=0.1.15#c44a9a45488d5230f33d3725e57bf193ad212786"
+source = "git+https://github.com/EspressoSystems/Push-CDN?tag=0.1.16#8ab0a124d82c2d18a99185b186c47658ac97907a"
 dependencies = [
  "async-std",
  "cdn-proto",
@@ -1309,7 +1309,7 @@ dependencies = [
 [[package]]
 name = "cdn-client"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/Push-CDN?tag=0.1.15#c44a9a45488d5230f33d3725e57bf193ad212786"
+source = "git+https://github.com/EspressoSystems/Push-CDN?tag=0.1.16#8ab0a124d82c2d18a99185b186c47658ac97907a"
 dependencies = [
  "async-std",
  "cdn-proto",
@@ -1325,7 +1325,7 @@ dependencies = [
 [[package]]
 name = "cdn-marshal"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/Push-CDN?tag=0.1.15#c44a9a45488d5230f33d3725e57bf193ad212786"
+source = "git+https://github.com/EspressoSystems/Push-CDN?tag=0.1.16#8ab0a124d82c2d18a99185b186c47658ac97907a"
 dependencies = [
  "async-std",
  "cdn-proto",
@@ -1340,7 +1340,7 @@ dependencies = [
 [[package]]
 name = "cdn-proto"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/Push-CDN?tag=0.1.15#c44a9a45488d5230f33d3725e57bf193ad212786"
+source = "git+https://github.com/EspressoSystems/Push-CDN?tag=0.1.16#8ab0a124d82c2d18a99185b186c47658ac97907a"
 dependencies = [
  "anyhow",
  "ark-serialize",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1286,7 +1286,7 @@ checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
 [[package]]
 name = "cdn-broker"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/Push-CDN?tag=0.1.16#8ab0a124d82c2d18a99185b186c47658ac97907a"
+source = "git+https://github.com/EspressoSystems/Push-CDN?tag=0.1.17#6b0b86340a117bb55781cb0362388b824d0973df"
 dependencies = [
  "async-std",
  "cdn-proto",
@@ -1309,7 +1309,7 @@ dependencies = [
 [[package]]
 name = "cdn-client"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/Push-CDN?tag=0.1.16#8ab0a124d82c2d18a99185b186c47658ac97907a"
+source = "git+https://github.com/EspressoSystems/Push-CDN?tag=0.1.17#6b0b86340a117bb55781cb0362388b824d0973df"
 dependencies = [
  "async-std",
  "cdn-proto",
@@ -1325,7 +1325,7 @@ dependencies = [
 [[package]]
 name = "cdn-marshal"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/Push-CDN?tag=0.1.16#8ab0a124d82c2d18a99185b186c47658ac97907a"
+source = "git+https://github.com/EspressoSystems/Push-CDN?tag=0.1.17#6b0b86340a117bb55781cb0362388b824d0973df"
 dependencies = [
  "async-std",
  "cdn-proto",
@@ -1340,7 +1340,7 @@ dependencies = [
 [[package]]
 name = "cdn-proto"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/Push-CDN?tag=0.1.16#8ab0a124d82c2d18a99185b186c47658ac97907a"
+source = "git+https://github.com/EspressoSystems/Push-CDN?tag=0.1.17#6b0b86340a117bb55781cb0362388b824d0973df"
 dependencies = [
  "anyhow",
  "ark-serialize",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,9 +132,9 @@ anyhow = "1.0.81"
 
 
 # Push CDN imports
-cdn-client = { git = "https://github.com/EspressoSystems/Push-CDN", tag = "0.1.15" }
-cdn-broker = { git = "https://github.com/EspressoSystems/Push-CDN", tag = "0.1.15" }
-cdn-marshal = { git = "https://github.com/EspressoSystems/Push-CDN", tag = "0.1.15" }
+cdn-client = { git = "https://github.com/EspressoSystems/Push-CDN", tag = "0.1.16" }
+cdn-broker = { git = "https://github.com/EspressoSystems/Push-CDN", tag = "0.1.16" }
+cdn-marshal = { git = "https://github.com/EspressoSystems/Push-CDN", tag = "0.1.16" }
 
 ### Profiles
 ###

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,9 +132,9 @@ anyhow = "1.0.81"
 
 
 # Push CDN imports
-cdn-client = { git = "https://github.com/EspressoSystems/Push-CDN", tag = "0.1.16" }
-cdn-broker = { git = "https://github.com/EspressoSystems/Push-CDN", tag = "0.1.16" }
-cdn-marshal = { git = "https://github.com/EspressoSystems/Push-CDN", tag = "0.1.16" }
+cdn-client = { git = "https://github.com/EspressoSystems/Push-CDN", tag = "0.1.17" }
+cdn-broker = { git = "https://github.com/EspressoSystems/Push-CDN", tag = "0.1.17" }
+cdn-marshal = { git = "https://github.com/EspressoSystems/Push-CDN", tag = "0.1.17" }
 
 ### Profiles
 ###

--- a/crates/example-types/src/node_types.rs
+++ b/crates/example-types/src/node_types.rs
@@ -88,7 +88,7 @@ type StaticLibp2pDAComm = Libp2pNetwork<Message<TestTypes>, <TestTypes as NodeTy
 type StaticWebDAComm = WebServerNetwork<TestTypes, WebServerVersion>;
 
 /// combined network
-type StaticCombinedDAComm = CombinedNetworks<TestTypes, WebServerVersion>;
+type StaticCombinedDAComm = CombinedNetworks<TestTypes>;
 
 /// memory comm channel
 pub type StaticMemoryQuorumComm =
@@ -102,7 +102,7 @@ type StaticLibp2pQuorumComm =
 type StaticWebQuorumComm = WebServerNetwork<TestTypes, WebServerVersion>;
 
 /// combined network (libp2p + web server)
-type StaticCombinedQuorumComm = CombinedNetworks<TestTypes, WebServerVersion>;
+type StaticCombinedQuorumComm = CombinedNetworks<TestTypes>;
 
 impl NodeImplementation<TestTypes> for PushCdnImpl {
     type QuorumNetwork = StaticPushCdnQuorumComm;

--- a/crates/examples/combined/types.rs
+++ b/crates/examples/combined/types.rs
@@ -1,7 +1,6 @@
 use crate::infra::CombinedDARun;
 use hotshot::traits::implementations::CombinedNetworks;
 use hotshot_example_types::{state_types::TestTypes, storage_types::TestStorage};
-use hotshot_types::constants::WebServerVersion;
 use hotshot_types::traits::node_implementation::NodeImplementation;
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
@@ -11,13 +10,13 @@ use std::fmt::Debug;
 pub struct NodeImpl {}
 
 /// convenience type alias
-pub type DANetwork = CombinedNetworks<TestTypes, WebServerVersion>;
+pub type DANetwork = CombinedNetworks<TestTypes>;
 /// convenience type alias
-pub type VIDNetwork = CombinedNetworks<TestTypes, WebServerVersion>;
+pub type VIDNetwork = CombinedNetworks<TestTypes>;
 /// convenience type alias
-pub type QuorumNetwork = CombinedNetworks<TestTypes, WebServerVersion>;
+pub type QuorumNetwork = CombinedNetworks<TestTypes>;
 /// convenience type alias
-pub type ViewSyncNetwork = CombinedNetworks<TestTypes, WebServerVersion>;
+pub type ViewSyncNetwork = CombinedNetworks<TestTypes>;
 
 impl NodeImplementation<TestTypes> for NodeImpl {
     type QuorumNetwork = QuorumNetwork;
@@ -25,4 +24,4 @@ impl NodeImplementation<TestTypes> for NodeImpl {
     type Storage = TestStorage<TestTypes>;
 }
 /// convenience type alias
-pub type ThisRun = CombinedDARun<TestTypes, WebServerVersion>;
+pub type ThisRun = CombinedDARun<TestTypes>;

--- a/crates/examples/push-cdn/all.rs
+++ b/crates/examples/push-cdn/all.rs
@@ -96,6 +96,7 @@ async fn main() {
     let marshal_config = cdn_marshal::ConfigBuilder::default()
         .bind_address(marshal_endpoint.clone())
         .discovery_endpoint("test.sqlite".to_string())
+        .metrics_enabled(false)
         .build()
         .expect("failed to build marshal config");
 

--- a/crates/hotshot/src/traits/networking/push_cdn_network.rs
+++ b/crates/hotshot/src/traits/networking/push_cdn_network.rs
@@ -43,6 +43,7 @@ use rand::{RngCore, SeedableRng};
 use std::collections::BTreeSet;
 use std::marker::PhantomData;
 #[cfg(feature = "hotshot-testing")]
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::{path::Path, sync::Arc, time::Duration};
 use tracing::{error, warn};
 use versioned_binary_serialization::{
@@ -128,7 +129,13 @@ impl<TYPES: NodeType> RunDef for ProductionDef<TYPES> {
 /// that helps organize them all.
 #[derive(Clone)]
 /// Is generic over both the type of key and the network protocol.
-pub struct PushCdnNetwork<TYPES: NodeType>(Client<WrappedSignatureKey<TYPES::SignatureKey>, Quic>);
+pub struct PushCdnNetwork<TYPES: NodeType> {
+    /// The underlying client
+    client: Client<WrappedSignatureKey<TYPES::SignatureKey>, Quic>,
+    /// Whether or not the underlying network is supposed to be paused
+    #[cfg(feature = "hotshot-testing")]
+    is_paused: Arc<AtomicBool>,
+}
 
 impl<TYPES: NodeType> PushCdnNetwork<TYPES> {
     /// Create a new `PushCdnNetwork` (really a client) from a marshal endpoint, a list of initial
@@ -158,7 +165,12 @@ impl<TYPES: NodeType> PushCdnNetwork<TYPES> {
         // Create the client, performing the initial connection
         let client = Client::new(config).await?;
 
-        Ok(Self(client))
+        Ok(Self {
+            client,
+            // Start unpaused
+            #[cfg(feature = "hotshot-testing")]
+            is_paused: Arc::from(AtomicBool::new(false)),
+        })
     }
 
     /// Broadcast a message to members of the particular topic. Does not retry.
@@ -172,6 +184,12 @@ impl<TYPES: NodeType> PushCdnNetwork<TYPES> {
         topic: Topic,
         _: Ver,
     ) -> Result<(), NetworkError> {
+        // If we're paused, don't send the message
+        #[cfg(feature = "hotshot-testing")]
+        if self.is_paused.load(Ordering::Relaxed) {
+            return Ok(());
+        }
+
         // Bincode the message
         let serialized_message = match Serializer::<Ver>::serialize(&message) {
             Ok(serialized) => serialized,
@@ -184,7 +202,7 @@ impl<TYPES: NodeType> PushCdnNetwork<TYPES> {
         // Send the message
         // TODO: check if we need to print this error
         if self
-            .0
+            .client
             .send_broadcast_message(vec![topic], serialized_message)
             .await
             .is_err()
@@ -271,6 +289,7 @@ impl<TYPES: NodeType> TestableNetworkingImplementation<TYPES> for PushCdnNetwork
         let marshal_endpoint = format!("127.0.0.1:{marshal_port}");
         let marshal_config = MarshalConfigBuilder::default()
             .bind_address(marshal_endpoint.clone())
+            .metrics_enabled(false)
             .discovery_endpoint(discovery_endpoint)
             .build()
             .expect("failed to build marshal config");
@@ -318,11 +337,13 @@ impl<TYPES: NodeType> TestableNetworkingImplementation<TYPES> for PushCdnNetwork
                         .expect("failed to build client config");
 
                     // Create our client
-                    let client = Arc::new(PushCdnNetwork(
-                        Client::new(client_config)
+                    let client = Arc::new(PushCdnNetwork {
+                        client: Client::new(client_config)
                             .await
                             .expect("failed to create client"),
-                    ));
+                        #[cfg(feature = "hotshot-testing")]
+                        is_paused: Arc::from(AtomicBool::new(false)),
+                    });
 
                     (client.clone(), client)
                 })
@@ -330,9 +351,7 @@ impl<TYPES: NodeType> TestableNetworkingImplementation<TYPES> for PushCdnNetwork
         })
     }
 
-    /// Get the number of messages in-flight.
-    ///
-    /// Some implementations will not be able to tell how many messages there are in-flight. These implementations should return `None`.
+    /// The PushCDN does not support in-flight message counts
     fn in_flight_message_count(&self) -> Option<usize> {
         None
     }
@@ -342,11 +361,17 @@ impl<TYPES: NodeType> TestableNetworkingImplementation<TYPES> for PushCdnNetwork
 impl<TYPES: NodeType> ConnectedNetwork<Message<TYPES>, TYPES::SignatureKey>
     for PushCdnNetwork<TYPES>
 {
-    /// We do not support pausing the PushCDN network right now, but it is possible.
-    fn pause(&self) {}
+    /// Pause sending and receiving on the PushCDN network.
+    fn pause(&self) {
+        #[cfg(feature = "hotshot-testing")]
+        self.is_paused.store(true, Ordering::Relaxed);
+    }
 
-    /// We do not support resuming the PushCDN network right now, but it is possible.
-    fn resume(&self) {}
+    /// Resumse sending and receiving on the PushCDN network.
+    fn resume(&self) {
+        #[cfg(feature = "hotshot-testing")]
+        self.is_paused.store(false, Ordering::Relaxed);
+    }
 
     /// The clients form an initial connection when created, so we don't have to wait.
     async fn wait_for_ready(&self) {}
@@ -406,6 +431,12 @@ impl<TYPES: NodeType> ConnectedNetwork<Message<TYPES>, TYPES::SignatureKey>
         recipient: TYPES::SignatureKey,
         _: Ver,
     ) -> Result<(), NetworkError> {
+        // If we're paused, don't send the message
+        #[cfg(feature = "hotshot-testing")]
+        if self.is_paused.load(Ordering::Relaxed) {
+            return Ok(());
+        }
+
         // Bincode the message
         let serialized_message = match Serializer::<Ver>::serialize(&message) {
             Ok(serialized) => serialized,
@@ -418,7 +449,7 @@ impl<TYPES: NodeType> ConnectedNetwork<Message<TYPES>, TYPES::SignatureKey>
         // Send the message
         // TODO: check if we need to print this error
         if self
-            .0
+            .client
             .send_direct_message(&WrappedSignatureKey(recipient), serialized_message)
             .await
             .is_err()
@@ -436,7 +467,13 @@ impl<TYPES: NodeType> ConnectedNetwork<Message<TYPES>, TYPES::SignatureKey>
     /// - If we fail to receive messages. Will trigger a retry automatically.
     async fn recv_msgs(&self) -> Result<Vec<Message<TYPES>>, NetworkError> {
         // Receive a message
-        let message = self.0.receive_message().await;
+        let message = self.client.receive_message().await;
+
+        // If we're paused, receive but don't process messages
+        #[cfg(feature = "hotshot-testing")]
+        if self.is_paused.load(Ordering::Relaxed) {
+            return Ok(vec![]);
+        }
 
         // If it was an error, wait a bit and retry
         let message = match message {

--- a/crates/libp2p-networking/src/network/behaviours/dht/mod.rs
+++ b/crates/libp2p-networking/src/network/behaviours/dht/mod.rs
@@ -575,7 +575,7 @@ impl NetworkBehaviour for DHTBehaviour {
                     info!("Starting bootstrap");
                 }
                 Err(e) => {
-                    error!(
+                    warn!(
                         "peer id {:?} FAILED TO START BOOTSTRAP {:?} adding peers {:?}",
                         self.peer_id, e, self.bootstrap_nodes
                     );

--- a/crates/testing/src/task_helpers.rs
+++ b/crates/testing/src/task_helpers.rs
@@ -63,7 +63,7 @@ pub async fn build_system_handle(
 
     let launcher = builder.gen_launcher::<TestTypes, MemoryImpl>(node_id);
 
-    let networks = (launcher.resource_generator.channel_generator)(node_id);
+    let networks = (launcher.resource_generator.channel_generator)(node_id).await;
     let storage = (launcher.resource_generator.storage)(node_id);
     let config = launcher.resource_generator.config.clone();
 

--- a/crates/testing/src/test_launcher.rs
+++ b/crates/testing/src/test_launcher.rs
@@ -4,7 +4,10 @@ use hotshot::traits::{NodeImplementation, TestableNodeImplementation};
 use hotshot_example_types::storage_types::TestStorage;
 use hotshot_types::{
     message::Message,
-    traits::{network::ConnectedNetwork, node_implementation::NodeType},
+    traits::{
+        network::{AsyncGenerator, ConnectedNetwork},
+        node_implementation::NodeType,
+    },
     HotShotConfig,
 };
 
@@ -22,7 +25,7 @@ pub type Generator<T> = Box<dyn Fn(u64) -> T + 'static>;
 /// generators for resources used by each node
 pub struct ResourceGenerators<TYPES: NodeType, I: TestableNodeImplementation<TYPES>> {
     /// generate channels
-    pub channel_generator: Generator<Networks<TYPES, I>>,
+    pub channel_generator: AsyncGenerator<Networks<TYPES, I>>,
     /// generate new storage for each node
     pub storage: Generator<TestStorage<TYPES>>,
     /// configuration used to generate each hotshot node

--- a/crates/testing/src/test_runner.rs
+++ b/crates/testing/src/test_runner.rs
@@ -363,7 +363,7 @@ where
                     quorum_election_config,
                 ),
             };
-            let networks = (self.launcher.resource_generator.channel_generator)(node_id);
+            let networks = (self.launcher.resource_generator.channel_generator)(node_id).await;
             let storage = (self.launcher.resource_generator.storage)(node_id);
 
             if self.launcher.metadata.skip_late && late_start.contains(&node_id) {

--- a/crates/testing/tests/combined_network.rs
+++ b/crates/testing/tests/combined_network.rs
@@ -10,7 +10,7 @@ use hotshot_testing::{
 use rand::Rng;
 use tracing::instrument;
 
-/// A run with both the webserver and libp2p functioning properly
+/// A run with both the CDN and libp2p functioning properly
 #[cfg(test)]
 #[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
@@ -46,11 +46,11 @@ async fn test_combined_network() {
         .await;
 }
 
-// A run where the webserver crashes part-way through
+// A run where the CDN crashes part-way through
 #[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 #[instrument]
-async fn test_combined_network_webserver_crash() {
+async fn test_combined_network_cdn_crash() {
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
     let mut metadata: TestMetadata = TestMetadata {
@@ -94,7 +94,7 @@ async fn test_combined_network_webserver_crash() {
         .await;
 }
 
-// A run where the webserver crashes partway through
+// A run where the CDN crashes partway through
 // and then comes back up
 #[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
@@ -148,7 +148,7 @@ async fn test_combined_network_reup() {
         .await;
 }
 
-// A run where half of the nodes disconnect from the webserver
+// A run where half of the nodes disconnect from the CDN
 #[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 #[instrument]

--- a/crates/testing/tests/network_task.rs
+++ b/crates/testing/tests/network_task.rs
@@ -33,7 +33,7 @@ async fn test_network_task() {
 
     let launcher = builder.gen_launcher::<TestTypes, MemoryImpl>(node_id);
 
-    let networks = (launcher.resource_generator.channel_generator)(node_id);
+    let networks = (launcher.resource_generator.channel_generator)(node_id).await;
 
     let storage = Arc::new(RwLock::new((launcher.resource_generator.storage)(node_id)));
     let config = launcher.resource_generator.config.clone();
@@ -99,7 +99,7 @@ async fn test_network_storage_fail() {
 
     let launcher = builder.gen_launcher::<TestTypes, MemoryImpl>(node_id);
 
-    let networks = (launcher.resource_generator.channel_generator)(node_id);
+    let networks = (launcher.resource_generator.channel_generator)(node_id).await;
 
     let storage = Arc::new(RwLock::new((launcher.resource_generator.storage)(node_id)));
     storage.write().await.should_return_err = true;

--- a/crates/types/src/traits/network.rs
+++ b/crates/types/src/traits/network.rs
@@ -7,7 +7,10 @@ use async_compatibility_layer::art::async_sleep;
 use async_std::future::TimeoutError;
 use derivative::Derivative;
 use dyn_clone::DynClone;
-use futures::channel::{mpsc, oneshot};
+use futures::{
+    channel::{mpsc, oneshot},
+    Future,
+};
 #[cfg(async_executor_impl = "tokio")]
 use tokio::time::error::Elapsed as TimeoutError;
 #[cfg(not(any(async_executor_impl = "async-std", async_executor_impl = "tokio")))]
@@ -31,6 +34,7 @@ use std::{
     collections::{BTreeSet, HashMap},
     fmt::Debug,
     hash::Hash,
+    pin::Pin,
     sync::Arc,
     time::Duration,
 };
@@ -416,6 +420,9 @@ pub trait ConnectedNetwork<M: NetworkMsg, K: SignatureKey + 'static>:
     fn update_view(&self, _view: u64) {}
 }
 
+/// A channel generator for types that need asynchronous execution
+pub type AsyncGenerator<T> = Pin<Box<dyn Fn(u64) -> Pin<Box<dyn Future<Output = T>>>>>;
+
 /// Describes additional functionality needed by the test network implementation
 pub trait TestableNetworkingImplementation<TYPES: NodeType>
 where
@@ -431,7 +438,7 @@ where
         is_da: bool,
         reliability_config: Option<Box<dyn NetworkReliability>>,
         secondary_network_delay: Duration,
-    ) -> Box<dyn Fn(u64) -> (Arc<Self>, Arc<Self>) + 'static>;
+    ) -> AsyncGenerator<(Arc<Self>, Arc<Self>)>;
 
     /// Get the number of messages in-flight.
     ///

--- a/crates/types/src/traits/node_implementation.rs
+++ b/crates/types/src/traits/node_implementation.rs
@@ -6,7 +6,9 @@
 use super::{
     block_contents::{BlockHeader, TestableBlock, Transaction},
     election::ElectionConfig,
-    network::{ConnectedNetwork, NetworkReliability, TestableNetworkingImplementation},
+    network::{
+        AsyncGenerator, ConnectedNetwork, NetworkReliability, TestableNetworkingImplementation,
+    },
     states::TestableState,
     storage::Storage,
     ValidatedState,
@@ -24,8 +26,7 @@ use serde::{Deserialize, Serialize};
 use std::{
     fmt::Debug,
     hash::Hash,
-    ops,
-    ops::{Deref, Sub},
+    ops::{self, Deref, Sub},
     sync::Arc,
     time::Duration,
 };
@@ -93,7 +94,7 @@ pub trait TestableNodeImplementation<TYPES: NodeType>: NodeImplementation<TYPES>
         da_committee_size: usize,
         reliability_config: Option<Box<dyn NetworkReliability>>,
         secondary_network_delay: Duration,
-    ) -> Box<dyn Fn(u64) -> (Arc<Self::QuorumNetwork>, Arc<Self::QuorumNetwork>)>;
+    ) -> AsyncGenerator<(Arc<Self::QuorumNetwork>, Arc<Self::QuorumNetwork>)>;
 }
 
 #[async_trait]
@@ -148,7 +149,7 @@ where
         da_committee_size: usize,
         reliability_config: Option<Box<dyn NetworkReliability>>,
         secondary_network_delay: Duration,
-    ) -> Box<dyn Fn(u64) -> (Arc<Self::QuorumNetwork>, Arc<Self::QuorumNetwork>)> {
+    ) -> AsyncGenerator<(Arc<Self::QuorumNetwork>, Arc<Self::QuorumNetwork>)> {
         <I::QuorumNetwork as TestableNetworkingImplementation<TYPES>>::generator(
             expected_node_count,
             num_bootstrap,


### PR DESCRIPTION
Closes #2850 

### This PR: 
<!-- Describe what this PR adds to HotSHot -->
<!-- E.g. -->
<!-- * Implements feature 1 -->
<!-- * Implements feature 2 -->
<!-- * Fixes bug 3 -->

- Updates the combined network to use the Push CDN instead of the webserver.
- Adds pause and resume capability to the push cdn network for combined tests
- Makes a change to allow for asynchronous network generators.
  - Needed because both libp2p and the push CDN used blocking operations to set up the network, which broke when combined in the combined network. 
- Fixes a spinlock issue with Libp2p that was starving the executor from doing anything else

### This PR does not: 
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->

Touch anything else.

### Key places to review: 
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->

`traits/networking/combined_network.rs`
The async generator changes at `traits/network.rs`

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
