### PR TITLE
[Sequencer] Prepare for update

### DIFF
--- a/crates/examples/infra/mod.rs
+++ b/crates/examples/infra/mod.rs
@@ -335,10 +335,9 @@ fn webserver_network_from_config<TYPES: NodeType, NetworkVersion: StaticVersionT
 /// # Panics
 /// If unable to create bootstrap nodes multiaddres or the libp2p config is invalid
 async fn libp2p_network_from_config<TYPES: NodeType>(
-    config: NetworkConfig<TYPES::SignatureKey, TYPES::ElectionConfigType>,
+    mut config: NetworkConfig<TYPES::SignatureKey, TYPES::ElectionConfigType>,
     pub_key: TYPES::SignatureKey,
 ) -> Libp2pNetwork<Message<TYPES>, TYPES::SignatureKey> {
-    let mut config = config;
     let libp2p_config = config
         .libp2p_config
         .take()

--- a/crates/types/src/data.rs
+++ b/crates/types/src/data.rs
@@ -477,9 +477,14 @@ impl<TYPES: NodeType> Leaf<TYPES> {
     pub fn set_parent_commitment(&mut self, commitment: Commitment<Self>) {
         self.parent_commitment = commitment;
     }
-    /// The block header contained in this leaf.
+    /// Get a reference to the block header contained in this leaf.
     pub fn get_block_header(&self) -> &<TYPES as NodeType>::BlockHeader {
         &self.block_header
+    }
+
+    /// Get a mutable reference to the block header contained in this leaf.
+    pub fn get_block_header_mut(&mut self) -> &mut <TYPES as NodeType>::BlockHeader {
+        &mut self.block_header
     }
     /// Fill this leaf with the block payload.
     ///


### PR DESCRIPTION
Needed to make one really tiny change to better support the sequencer. It looks like we changed `Leaf` to have private fields with getters and setters, but the sequencer likes to mutate fields during tests and the like. 

This PR just makes the change to add the ability to get a mutable reference to the header. I considered a setter but this seems more ergonomic.

The other change is unrelated, but removes an unnecessary clone.

