### PR TITLE
CI fixes

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -32,8 +32,9 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         name: Enable Rust Caching
         with:
-          shared-key: ""
-          prefix-key: ${{ matrix.just_variants }}
+          shared-key: "build-and-test"
+          cache-on-failure: "true"
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install Just
         run: |
@@ -65,7 +66,9 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         name: Enable Rust Caching
         with:
-          prefix-key: ${{ matrix.just_variants }}
+          shared-key: "build-and-test"
+          cache-on-failure: "true"
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Unit and integration tests for all crates in workspace
         run: |
@@ -92,8 +95,9 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         name: Enable Rust Caching
         with:
-          shared-key: ""
-          prefix-key: ${{ matrix.just_variants }}
+          shared-key: "build-and-test"
+          cache-on-failure: "true"
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install Just
         run: |
@@ -140,8 +144,9 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         name: Enable Rust Caching
         with:
-          shared-key: ""
-          prefix-key: ${{ matrix.just_variants }}
+          shared-key: "build-and-test"
+          cache-on-failure: "true"
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install Just
         run: |
@@ -169,8 +174,9 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         name: Enable Rust Caching
         with:
-          shared-key: ""
-          prefix-key: arm-${{ matrix.just_variants }}
+          shared-key: "build-and-test"
+          cache-on-failure: "true"
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Build examples in release mode
         run: just ${{ matrix.just_variants }} build_release --examples --package hotshot-examples --no-default-features
@@ -390,8 +396,9 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         name: Enable Rust Caching
         with:
-          shared-key: ""
-          prefix-key: ${{ matrix.just_variants }}
+          shared-key: "build-and-test"
+          cache-on-failure: "true"
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install Just
         run: |

--- a/.github/workflows/build_nix.yml
+++ b/.github/workflows/build_nix.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Enable Rust Cache
         uses: Swatinem/rust-cache@v2
         with:
-          workspaces: ". -> target_dirs/nix_rustc"
+          shared-key: "nix-build"
 
       # sanity check that repository builds with nix
       - name: Initialize Nix Environment

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -29,6 +29,10 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         name: Enable Rust Caching
+        with:
+          shared-key: "build-and-test"
+          cache-on-failure: "true"
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Test Docs
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,8 +31,9 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         name: Enable Rust Caching
         with:
-          shared-key: ""
-          prefix-key: ${{ matrix.just_variants }}
+          shared-key: "build-and-test"
+          cache-on-failure: "true"
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install Just
         run: |

--- a/.github/workflows/semver-check.yml
+++ b/.github/workflows/semver-check.yml
@@ -45,9 +45,9 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         name: Enable Rust Caching
         with:
-          shared-key: ""
-          prefix-key: semver
-          workspaces: "current -> target"
+          shared-key: "build-and-test"
+          cache-on-failure: "true"
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install cargo-semver-checks and cargo-workspaces
         run: |

--- a/justfile
+++ b/justfile
@@ -47,11 +47,11 @@ test *ARGS:
 
 test-ci *ARGS:
   echo Testing {{ARGS}}
-  RUST_LOG=hotshot=debug,libp2p-networking=debug cargo test --verbose --lib --bins --tests --benches --workspace --no-fail-fast {{ARGS}} -- --test-threads=1
+  RUST_LOG=error,hotshot=debug,libp2p-networking=debug cargo test --verbose --lib --bins --tests --benches --workspace --no-fail-fast {{ARGS}} -- --test-threads=1
 
 test-ci-fail-fast *ARGS:
   echo Testing {{ARGS}}
-  RUST_LOG=hotshot=debug,libp2p-networking=debug cargo test --verbose --lib --bins --tests --benches --workspace {{ARGS}} -- --test-threads=1
+  RUST_LOG=error,hotshot=debug,libp2p-networking=debug cargo test --verbose --lib --bins --tests --benches --workspace {{ARGS}} -- --test-threads=1
 
 test_basic: test_success test_with_failures test_network_task test_consensus_task test_da_task test_vid_task test_view_sync_task
 


### PR DESCRIPTION
No linked issue.

### This PR: 
- Makes some changes to rust caching in CI across the board, to hopefully speed up some of the extremely long CI runs. Now, all build jobs share a common rust cache that is only written from `main`.
- Adds error logs to all CI test runs for all crates (previously these were being overridden).

### This PR does not: 

### Key places to review: 
