### PR TITLE
Delete self-hosted tests

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -50,35 +50,6 @@ jobs:
         env:
           RUST_BACKTRACE: full
 
-
-  test-self-hosted:
-    strategy:
-      matrix:
-        just_variants:
-          - async-std
-          - tokio
-      fail-fast: false
-    runs-on: [self-hosted]
-    container: ghcr.io/espressosystems/devops-rust:stable
-    steps:
-      - uses: actions/checkout@v4
-        name: Checkout Repository
-
-      - uses: Swatinem/rust-cache@v2
-        name: Enable Rust Caching
-        with:
-          shared-key: "build-and-test"
-          prefix-key: ${{ matrix.just_variants }}
-          cache-on-failure: "true"
-          save-if: ${{ github.ref == 'refs/heads/main' }}
-
-      - name: Unit and integration tests for all crates in workspace
-        run: |
-          just ${{ matrix.just_variants }} test-ci-fail-fast
-        timeout-minutes: 60
-        env:
-          RUST_BACKTRACE: full
-
   build-release:
     strategy:
       matrix:


### PR DESCRIPTION
No linked issue.

### This PR: 
I don't think the self-hosted runners provide much value when it comes to testing. And since we have a limited number of test runners, the self-hosted tests frequently get stuck waiting on one to free up.

I'm also not sure if we share the self-hosted runners with other repositories, and are potentially eating into CI time for no reason.

### This PR does not: 

### Key places to review: 
Is there a reason to keep them?
