### PR TITLE
[Deps] Remove nonbreaking pins

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,16 +35,16 @@ ark-ed-on-bn254 = "0.4"
 ark-ff = "0.4"
 ark-serialize = "0.4"
 ark-std = { version = "0.4", default-features = false }
-async-broadcast = "0.7.0"
+async-broadcast = "0.7"
 async-compatibility-layer = { git = "https://github.com/EspressoSystems/async-compatibility-layer.git", tag = "1.4.2", default-features = false, features = [
   "logging-utils",
 ] }
 task = { git = "https://github.com/EspressoSystems/HotShotTasks.git" }
-async-lock = "2.8"
-async-std = { version = "1.12.0", features = ["attributes"] }
-async-trait = "0.1.79"
-bincode = "1.3.3"
-bitvec = { version = "1.0.1", default-features = false, features = [
+async-lock = "2"
+async-std = { version = "1", features = ["attributes"] }
+async-trait = "0.1"
+bincode = "1"
+bitvec = { version = "1", default-features = false, features = [
   "alloc",
   "atomic",
   "serde",
@@ -55,8 +55,8 @@ custom_debug = "0.5"
 digest = "0.10"
 either = "1.10"
 espresso-systems-common = { git = "https://github.com/espressosystems/espresso-systems-common", tag = "0.4.1" }
-ethereum-types = { version = "0.14.1", features = ["impl-serde"] }
-futures = "0.3.30"
+ethereum-types = { version = "0.14", features = ["impl-serde"] }
+futures = "0.3"
 # TODO generic-array should not be a direct dependency
 # https://github.com/EspressoSystems/HotShot/issues/1850
 generic-array = { version = "0.14.7", features = ["serde"] }
@@ -66,30 +66,31 @@ jf-primitives = { git = "https://github.com/EspressoSystems/jellyfish", tag = "0
 jf-plonk = { git = "https://github.com/EspressoSystems/jellyfish", tag = "0.4.2" }
 jf-relation = { git = "https://github.com/EspressoSystems/jellyfish", tag = "0.4.2" }
 jf-utils = { git = "https://github.com/espressosystems/jellyfish", tag = "0.4.2" }
-lazy_static = "1.4.0"
+lazy_static = "1"
 libp2p-identity = "0.2"
-libp2p-networking = { path = "./crates/libp2p-networking", version = "0.5.26", default-features = false }
-libp2p-swarm-derive = { version = "0.34.1" }
-lru = "0.12.2"
-portpicker = "0.1.1"
-rand = { version = "0.8.5", features = ["small_rng"] }
-rand_chacha = { version = "0.3.1", default-features = false }
-serde = { version = "1.0.197", features = ["derive"] }
+libp2p-networking = { path = "./crates/libp2p-networking", version = "0.5", default-features = false }
+libp2p-swarm-derive = { version = "0.34" }
+lru = "0.12"
+portpicker = "0.1"
+rand = { version = "0.8", features = ["small_rng"] }
+rand_chacha = { version = "0.3", default-features = false }
+serde = { version = "1", features = ["derive"] }
 serde_bytes = { version = "0.11" }
-serde_json = { version = "1.0.115" }
+serde_json = { version = "1.0" }
 sha2 = "0.10"
 snafu = "0.8"
 surf-disco = { git = "https://github.com/EspressoSystems/surf-disco.git", tag = "v0.5.0" }
 tagged-base64 = { git = "https://github.com/EspressoSystems/tagged-base64", tag = "0.3.4" }
 tide-disco = { git = "https://github.com/EspressoSystems/tide-disco.git", tag = "v0.5.0" }
-time = "0.3.34"
-toml = "0.8.11"
-tracing = "0.1.40"
-typenum = "1.17.0"
-memoize = { version = "0.4.2", features = ["full"] }
+time = "0.3"
+toml = "0.8"
+tracing = "0.1"
+typenum = "1"
+memoize = { version = "0.4", features = ["full"] }
 versioned-binary-serialization = { git = "https://github.com/EspressoSystems/versioned-binary-serialization.git", tag = "0.1.2" }
+clap = { version = "4", features = ["derive", "env"] }
 
-libp2p = { package = "libp2p", version = "0.53.2", features = [
+libp2p = { package = "libp2p", version = "0.53", features = [
   "macros",
   "autonat",
   "cbor",
@@ -114,7 +115,7 @@ libp2p = { package = "libp2p", version = "0.53.2", features = [
   "websocket",
   "yamux",
 ] }
-tokio = { version = "1.36.0", features = [
+tokio = { version = "1", features = [
   "fs",
   "io-util",
   "io-std",
@@ -129,7 +130,7 @@ tokio = { version = "1.36.0", features = [
   "time",
   "tracing",
 ] }
-anyhow = "1.0.81"
+anyhow = "1"
 
 
 # Push CDN imports

--- a/crates/builder-api/Cargo.toml
+++ b/crates/builder-api/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 async-trait = { workspace = true }
-clap = { version = "4.5", features = ["derive", "env"] }
+clap.workspace = true
 derive_more = "0.99"
 futures = "0.3"
 hotshot-types = { path = "../types" }

--- a/crates/examples/Cargo.toml
+++ b/crates/examples/Cargo.toml
@@ -105,11 +105,11 @@ async-broadcast = { workspace = true }
 async-compatibility-layer = { workspace = true }
 async-lock = { workspace = true }
 async-trait = { workspace = true }
-bimap = "0.6.3"
-clap = { version = "4.5", features = ["derive", "env"], optional = true }
+bimap = "0.6"
+clap = { workspace = true, optional = true }
 commit = { workspace = true }
 custom_debug = { workspace = true }
-dashmap = "5.5.1"
+dashmap = "5"
 either = { workspace = true }
 futures = { workspace = true }
 hotshot-web-server = { version = "0.5.26", path = "../web_server", default-features = false }
@@ -123,9 +123,9 @@ serde = { workspace = true, features = ["rc"] }
 snafu = { workspace = true }
 surf-disco = { workspace = true }
 time = { workspace = true }
-derive_more = "0.99.17"
-portpicker = "0.1.1"
-lru = "0.12.3"
+derive_more = "0.99"
+portpicker = "0.1"
+lru = "0.12"
 hotshot-task = { path = "../task" }
 hotshot = { path = "../hotshot" }
 hotshot-example-types = { path = "../example-types" }
@@ -156,11 +156,11 @@ cdn-broker = { workspace = true, features = [
 cdn-marshal = { workspace = true, features = ["runtime-async-std"] }
 
 [dev-dependencies]
-clap = { version = "4.5", features = ["derive", "env"] }
+clap.workspace = true
 toml = { workspace = true }
 blake3 = { workspace = true }
 anyhow.workspace = true
-tracing-subscriber = "0.3.18"
+tracing-subscriber = "0.3"
 
 [lints]
 workspace = true

--- a/crates/hotshot-qc/Cargo.toml
+++ b/crates/hotshot-qc/Cargo.toml
@@ -7,10 +7,10 @@ edition = { workspace = true }
 rust-version = { workspace = true }
 
 [dependencies]
-ark-bls12-377 = "0.4.0"
-ark-bn254 = "0.4.0"
+ark-bls12-377 = "0.4"
+ark-bn254 = "0.4"
 ark-ec = { workspace = true }
-ark-ff = "0.4.0"
+ark-ff = "0.4"
 ark-std = { workspace = true }
 bitvec = { workspace = true }
 ethereum-types = { workspace = true }

--- a/crates/hotshot-stake-table/Cargo.toml
+++ b/crates/hotshot-stake-table/Cargo.toml
@@ -7,9 +7,9 @@ edition = { workspace = true }
 rust-version = { workspace = true }
 
 [dependencies]
-ark-bn254 = "0.4.0"
-ark-ed-on-bn254 = "0.4.0"
-ark-ff = "0.4.0"
+ark-bn254 = "0.4"
+ark-ed-on-bn254 = "0.4"
+ark-ff = "0.4"
 ark-serialize = { workspace = true }
 ark-std = { workspace = true }
 digest = { workspace = true }

--- a/crates/hotshot/Cargo.toml
+++ b/crates/hotshot/Cargo.toml
@@ -26,13 +26,13 @@ async-broadcast = { workspace = true }
 async-compatibility-layer = { workspace = true }
 async-lock = { workspace = true }
 async-trait = { workspace = true }
-bimap = "0.6.3"
+bimap = "0.6"
 bincode = { workspace = true }
-clap = { version = "4.5", features = ["derive", "env"], optional = true }
+clap = { workspace = true, optional = true }
 commit = { workspace = true }
 custom_debug = { workspace = true }
-dashmap = "5.5.1"
-derive_more = "0.99.17"
+dashmap = "5"
+derive_more = "0.99"
 either = { workspace = true }
 ethereum-types = { workspace = true }
 futures = { workspace = true }
@@ -42,8 +42,8 @@ hotshot-types = { path = "../types" }
 hotshot-web-server = { version = "0.5.26", path = "../web_server", default-features = false }
 libp2p-identity = { workspace = true }
 libp2p-networking = { workspace = true }
-lru = "0.12.3"
-portpicker = "0.1.1"
+lru = "0.12"
+portpicker = "0.1"
 rand = { workspace = true }
 serde = { workspace = true, features = ["rc"] }
 snafu = { workspace = true }
@@ -76,7 +76,7 @@ cdn-marshal = { workspace = true, features = ["runtime-async-std"] }
 
 [dev-dependencies]
 blake3 = { workspace = true }
-clap = { version = "4.5", features = ["derive", "env"] }
+clap.workspace = true
 toml = { workspace = true }
 
 [lints]

--- a/crates/libp2p-networking/Cargo.toml
+++ b/crates/libp2p-networking/Cargo.toml
@@ -18,7 +18,7 @@ async-lock = { workspace = true }
 async-trait = { workspace = true }
 blake3 = { workspace = true }
 custom_debug = { workspace = true }
-derive_builder = "0.20.0"
+derive_builder = "0.20"
 either = { workspace = true }
 futures = { workspace = true }
 hotshot-types = { path = "../types" }
@@ -34,13 +34,13 @@ tide = { version = "0.16", optional = true, default-features = false, features =
 ] }
 tracing = { workspace = true }
 versioned-binary-serialization = { workspace = true }
-void = "1.0.2"
+void = "1"
 lazy_static = { workspace = true }
 
 [target.'cfg(all(async_executor_impl = "tokio"))'.dependencies]
 libp2p = { workspace = true, features = ["tokio"] }
 tokio = { workspace = true }
-tokio-stream = "0.1.14"
+tokio-stream = "0.1"
 [target.'cfg(all(async_executor_impl = "async-std"))'.dependencies]
 libp2p = { workspace = true, features = ["async-std"] }
 async-std = { workspace = true }

--- a/crates/macros/Cargo.toml
+++ b/crates/macros/Cargo.toml
@@ -6,9 +6,9 @@ description = "Macros for hotshot tests"
 
 [dependencies]
 # proc macro stuff
-quote = "1.0.33"
-syn = { version = "2.0.55", features = ["full", "extra-traits"] }
-proc-macro2 = "1.0.79"
+quote = "1"
+syn = { version = "2", features = ["full", "extra-traits"] }
+proc-macro2 = "1"
 
 [lib]
 proc-macro = true

--- a/crates/orchestrator/Cargo.toml
+++ b/crates/orchestrator/Cargo.toml
@@ -6,7 +6,7 @@ edition = { workspace = true }
 [dependencies]
 async-compatibility-layer = { workspace = true }
 async-lock = { workspace = true }
-clap = { version = "4.0", features = ["derive", "env"], optional = false }
+clap.workspace = true
 futures = { workspace = true }
 libp2p = { workspace = true }
 blake3 = { workspace = true }
@@ -17,11 +17,11 @@ tracing = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 toml = { workspace = true }
-thiserror = "1.0.50"
-serde-inline-default = "0.1.1"
-csv = "1.3.0"
+thiserror = "1"
+serde-inline-default = "0.1"
+csv = "1"
 versioned-binary-serialization = { workspace = true }
-multiaddr = "0.18.1"
+multiaddr = "0.18"
 anyhow.workspace = true
 bincode.workspace = true
 

--- a/crates/task/Cargo.toml
+++ b/crates/task/Cargo.toml
@@ -8,8 +8,8 @@ edition = { workspace = true }
 
 [dependencies]
 
-futures = "0.3.30"
-async-broadcast = "0.7.0"
+futures = "0.3"
+async-broadcast = "0.7"
 tracing = { workspace = true }
 async-compatibility-layer = { workspace = true }
 

--- a/crates/testing-macros/Cargo.toml
+++ b/crates/testing-macros/Cargo.toml
@@ -24,10 +24,10 @@ snafu = { workspace = true }
 tracing = { workspace = true }
 serde = { workspace = true }
 # proc macro stuff
-quote = "1.0.33"
-syn = { version = "2.0.55", features = ["full", "extra-traits"] }
-proc-macro2 = "1.0.79"
-derive_builder = "0.20.0"
+quote = "1"
+syn = { version = "2", features = ["full", "extra-traits"] }
+proc-macro2 = "1"
+derive_builder = "0.20"
 
 [dev-dependencies]
 async-lock = { workspace = true }

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -41,7 +41,7 @@ snafu = { workspace = true }
 time = { workspace = true }
 tracing = { workspace = true }
 typenum = { workspace = true }
-derivative = "2.2.0"
+derivative = "2"
 jf-primitives = { workspace = true }
 jf-plonk = { workspace = true }
 jf-utils = { workspace = true }

--- a/crates/web_server/Cargo.toml
+++ b/crates/web_server/Cargo.toml
@@ -8,7 +8,7 @@ edition = { workspace = true }
 [dependencies]
 async-compatibility-layer = { workspace = true }
 async-lock = { workspace = true }
-clap = { version = "4.0", features = ["derive", "env"], optional = false }
+clap.workspace = true
 futures = { workspace = true }
 hotshot-types = { path = "../types" }
 tide-disco = { workspace = true }


### PR DESCRIPTION
Should make upstream crates (like the sequencer) easier to update in the future. E.g. if there are incompatible patch dependencies (e.g. syn ==2.0.53 vs syn ^2.0.10 is currently blocking the sequencer update) this would solve that by allowing us to have a version that satisfies both.

This doesn't change the version of anything, everything is still the same in the `Cargo.lock`.