### PR TITLE
[Hotfix] Fix VID supplied in leaf

### DIFF
--- a/crates/task-impls/src/consensus.rs
+++ b/crates/task-impls/src/consensus.rs
@@ -849,8 +849,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                                         .vid_shares
                                         .get(&leaf.get_view_number())
                                         .unwrap_or(&HashMap::new())
-                                        .iter()
-                                        .filter_map(|(key, proposal)| if *key == self.public_key {Some(&proposal.data) } else {None})
+                                        .get(&self.public_key).map(|f| &f.data).into_iter()
                                 );
 
                                 leaf_views.push(LeafInfo::new(leaf.clone(), state.clone(), delta.clone(), vid));

--- a/crates/task-impls/src/consensus.rs
+++ b/crates/task-impls/src/consensus.rs
@@ -850,7 +850,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                                         .get(&leaf.get_view_number())
                                         .unwrap_or(&HashMap::new())
                                         .iter()
-                                        .map(|(_key, proposal)| &proposal.data)
+                                        .filter_map(|(key, proposal)| if *key == self.public_key {Some(&proposal.data) } else {None})
                                 );
 
                                 leaf_views.push(LeafInfo::new(leaf.clone(), state.clone(), delta.clone(), vid));


### PR DESCRIPTION
No linked issue

### This PR: 
<!-- Describe what this PR adds to HotSHot -->
<!-- E.g. -->
<!-- * Implements feature 1 -->
<!-- * Implements feature 2 -->
<!-- * Fixes bug 3 -->
Changes `LeafInfo` to only return VID shares linked to our key for a particular view.

