### PR TITLE
Only calculate VID shares when Asked

### DIFF
--- a/crates/hotshot/src/tasks/mod.rs
+++ b/crates/hotshot/src/tasks/mod.rs
@@ -73,8 +73,9 @@ pub async fn add_response_task<TYPES: NodeType, I: NodeImplementation<TYPES>>(
     let state = NetworkResponseState::<TYPES>::new(
         handle.hotshot.get_consensus(),
         rx,
-        handle.hotshot.memberships.quorum_membership.clone(),
+        handle.hotshot.memberships.quorum_membership.clone().into(),
         handle.public_key().clone(),
+        handle.private_key().clone(),
     );
     task_reg
         .register(run_response_task::<TYPES, Version01>(state, hs_rx))

--- a/crates/task-impls/src/consensus.rs
+++ b/crates/task-impls/src/consensus.rs
@@ -850,7 +850,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                                         .vid_shares
                                         .get(&leaf.get_view_number())
                                         .unwrap_or(&HashMap::new())
-                                        .get(&self.public_key).map(|proposal| proposal.data.clone());
+                                        .get(&self.public_key).cloned();
 
                                 // Add our data into a new `LeafInfo`
                                 leaf_views.push(LeafInfo::new(leaf.clone(), state.clone(), delta.clone(), vid_share));
@@ -1174,7 +1174,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                     .vid_shares
                     .entry(view)
                     .or_default()
-                    .insert(disperse.data.recipient_key.clone(), disperse.clone());
+                    .insert(disperse.data.recipient_key.clone(), disperse.data.clone());
 
                 if self.vote_if_able(&event_stream).await {
                     self.current_proposal = None;

--- a/crates/task-impls/src/helpers.rs
+++ b/crates/task-impls/src/helpers.rs
@@ -1,8 +1,16 @@
+use std::sync::Arc;
+
 use async_broadcast::{SendError, Sender};
 #[cfg(async_executor_impl = "async-std")]
-use async_std::task::JoinHandle;
+use async_std::task::{spawn_blocking, JoinHandle};
+use hotshot_types::{
+    data::VidDisperse,
+    traits::{election::Membership, node_implementation::NodeType},
+    vid::vid_scheme,
+};
+use jf_primitives::vid::VidScheme;
 #[cfg(async_executor_impl = "tokio")]
-use tokio::task::JoinHandle;
+use tokio::task::{spawn_blocking, JoinHandle};
 
 /// Cancel a task
 pub async fn cancel_task<T>(task: JoinHandle<T>) {
@@ -29,4 +37,25 @@ pub async fn broadcast_event<E: Clone + std::fmt::Debug>(event: E, sender: &Send
             );
         }
     }
+}
+/// Calculate the vid disperse information from the payload given a view and membership
+///
+/// # Panics
+/// Panics if the VID calculation fails, this should not happen.
+pub async fn calculate_vid_disperse<TYPES: NodeType>(
+    txns: Vec<u8>,
+    membership: Arc<TYPES::Membership>,
+    view: TYPES::Time,
+) -> VidDisperse<TYPES> {
+    let num_nodes = membership.total_nodes();
+    let vid_disperse = spawn_blocking(move || {
+        #[allow(clippy::panic)]
+        vid_scheme(num_nodes).disperse(&txns).unwrap_or_else(|err|panic!("VID disperse failure:\n\t(num_storage nodes,payload_byte_len)=({num_nodes},{})\n\terror: : {err}", txns.len()))
+    })
+    .await;
+    #[cfg(async_executor_impl = "tokio")]
+    // Unwrap here will just propagate any panic from the spawned task, it's not a new place we can panic.
+    let vid_disperse = vid_disperse.unwrap();
+
+    VidDisperse::from_membership(view, vid_disperse, membership)
 }

--- a/crates/task-impls/src/response.rs
+++ b/crates/task-impls/src/response.rs
@@ -1,10 +1,9 @@
-use std::collections::HashMap;
 use std::sync::Arc;
 
-use crate::events::HotShotEvent;
+use crate::{events::HotShotEvent, helpers::calculate_vid_disperse};
 use async_broadcast::Receiver;
 use async_compatibility_layer::art::async_spawn;
-use async_lock::RwLock;
+use async_lock::{RwLock, RwLockUpgradableReadGuard};
 #[cfg(async_executor_impl = "async-std")]
 use async_std::task::JoinHandle;
 use futures::{channel::mpsc, FutureExt, StreamExt};
@@ -12,9 +11,7 @@ use hotshot_task::dependency::{Dependency, EventDependency};
 use hotshot_types::{
     consensus::Consensus,
     data::VidDisperseShare,
-    message::{
-        CommitteeConsensusMessage, DataMessage, Message, MessageKind, Proposal, SequencingMessage,
-    },
+    message::{CommitteeConsensusMessage, DataMessage, Message, MessageKind, SequencingMessage},
     traits::{
         election::Membership,
         network::{DataRequest, RequestKind, ResponseChannel, ResponseMessage},
@@ -42,9 +39,11 @@ pub struct NetworkResponseState<TYPES: NodeType> {
     /// Receiver for requests
     receiver: RequestReceiver<TYPES>,
     /// Quorum membership for checking if requesters have state
-    quorum: TYPES::Membership,
+    quorum: Arc<TYPES::Membership>,
     /// This replicas public key
     pub_key: TYPES::SignatureKey,
+    /// This replicas private key
+    private_key: <TYPES::SignatureKey as SignatureKey>::PrivateKey,
 }
 
 impl<TYPES: NodeType> NetworkResponseState<TYPES> {
@@ -52,14 +51,16 @@ impl<TYPES: NodeType> NetworkResponseState<TYPES> {
     pub fn new(
         consensus: LockedConsensusState<TYPES>,
         receiver: RequestReceiver<TYPES>,
-        quorum: TYPES::Membership,
+        quorum: Arc<TYPES::Membership>,
         pub_key: TYPES::SignatureKey,
+        private_key: <TYPES::SignatureKey as SignatureKey>::PrivateKey,
     ) -> Self {
         Self {
             consensus,
             receiver,
             quorum,
             pub_key,
+            private_key,
         }
     }
 
@@ -114,38 +115,62 @@ impl<TYPES: NodeType> NetworkResponseState<TYPES> {
         }
     }
 
+    /// Get the VID share from conensus storage, or calculate it from a the payload for
+    /// the view, if we have the payload.  Stores all the shares calculated from the payload
+    /// if the calculation was done
+    async fn get_or_calc_vid_share(
+        &self,
+        view: TYPES::Time,
+        key: &TYPES::SignatureKey,
+    ) -> Option<VidDisperseShare<TYPES>> {
+        let consensus = self.consensus.upgradable_read().await;
+        let contained = consensus
+            .vid_shares
+            .get(&view)
+            .is_some_and(|m| m.contains_key(key));
+        if !contained {
+            let txns = consensus.saved_payloads.get(&view)?;
+            let vid = calculate_vid_disperse(txns.clone(), self.quorum.clone(), view).await;
+            let shares = VidDisperseShare::from_vid_disperse(vid);
+            let mut consensus = RwLockUpgradableReadGuard::upgrade(consensus).await;
+            for share in shares {
+                let s = share.clone();
+                let key: <TYPES as NodeType>::SignatureKey = s.recipient_key;
+                consensus
+                    .vid_shares
+                    .entry(view)
+                    .or_default()
+                    .insert(key, share);
+            }
+        }
+        self.consensus
+            .read()
+            .await
+            .vid_shares
+            .get(&view)?
+            .get(key)
+            .cloned()
+    }
+
     /// Handle the request contained in the message. Returns the response we should send
     /// First parses the kind and passes to the appropriate handler for the specific type
     /// of the request.
     async fn handle_request(&self, req: DataRequest<TYPES>) -> Message<TYPES> {
         match req.request {
             RequestKind::VID(view, pub_key) => {
-                let state = self.consensus.read().await;
-                let Some(proposals_map) = state.vid_shares.get(&view) else {
+                let Some(share) = self.get_or_calc_vid_share(view, &pub_key).await else {
                     return self.make_msg(ResponseMessage::NotFound);
                 };
-                self.handle_vid(proposals_map, &pub_key)
+                let Some(prop) = share.to_proposal(&self.private_key) else {
+                    return self.make_msg(ResponseMessage::NotFound);
+                };
+                let seq_msg =
+                    SequencingMessage::Committee(CommitteeConsensusMessage::VidDisperseMsg(prop));
+                self.make_msg(ResponseMessage::Found(seq_msg))
             }
             // TODO impl for DA Proposal: https://github.com/EspressoSystems/HotShot/issues/2651
             RequestKind::DAProposal(_view) => self.make_msg(ResponseMessage::NotFound),
         }
-    }
-
-    /// Handle a vid request by looking up the the share for the key.  If a share is found
-    /// build the response and return it
-    fn handle_vid(
-        &self,
-        proposals_map: &HashMap<TYPES::SignatureKey, Proposal<TYPES, VidDisperseShare<TYPES>>>,
-        key: &TYPES::SignatureKey,
-    ) -> Message<TYPES> {
-        if !proposals_map.contains_key(key) {
-            return self.make_msg(ResponseMessage::NotFound);
-        }
-
-        let seq_msg = SequencingMessage::Committee(CommitteeConsensusMessage::VidDisperseMsg(
-            proposals_map.get(key).unwrap().clone(),
-        ));
-        self.make_msg(ResponseMessage::Found(seq_msg))
     }
 
     /// Helper to turn a `ResponseMessage` into a `Message` by filling

--- a/crates/task-impls/src/response.rs
+++ b/crates/task-impls/src/response.rs
@@ -142,14 +142,9 @@ impl<TYPES: NodeType> NetworkResponseState<TYPES> {
                     .or_default()
                     .insert(key, share);
             }
+            return consensus.vid_shares.get(&view)?.get(key).cloned();
         }
-        self.consensus
-            .read()
-            .await
-            .vid_shares
-            .get(&view)?
-            .get(key)
-            .cloned()
+        consensus.vid_shares.get(&view)?.get(key).cloned()
     }
 
     /// Handle the request contained in the message. Returns the response we should send

--- a/crates/task-impls/src/vid.rs
+++ b/crates/task-impls/src/vid.rs
@@ -1,15 +1,11 @@
 use crate::events::{HotShotEvent, HotShotTaskCompleted};
-use crate::helpers::broadcast_event;
+use crate::helpers::{broadcast_event, calculate_vid_disperse};
 use async_broadcast::Sender;
 use async_lock::RwLock;
-#[cfg(async_executor_impl = "async-std")]
-use async_std::task::spawn_blocking;
 
-use futures::future::join_all;
 use hotshot_task::task::{Task, TaskState};
 use hotshot_types::{
     consensus::Consensus,
-    data::{VidDisperse, VidDisperseShare},
     message::Proposal,
     traits::{
         consensus_api::ConsensusApi,
@@ -18,11 +14,7 @@ use hotshot_types::{
         node_implementation::{NodeImplementation, NodeType},
         signature_key::SignatureKey,
     },
-    vid::vid_scheme,
 };
-use jf_primitives::vid::VidScheme;
-#[cfg(async_executor_impl = "tokio")]
-use tokio::task::spawn_blocking;
 
 use std::marker::PhantomData;
 use std::sync::Arc;
@@ -68,24 +60,16 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
     ) -> Option<HotShotTaskCompleted> {
         match event.as_ref() {
             HotShotEvent::TransactionsSequenced(encoded_transactions, metadata, view_number) => {
-                let encoded_transactions = encoded_transactions.clone();
-                // get the number of quorum committee members to be used for VID calculation
-                let num_storage_nodes = self.membership.total_nodes();
-
-                // calculate vid shares
-                let vid_disperse = spawn_blocking(move || {
-                    #[allow(clippy::panic)]
-                    vid_scheme(num_storage_nodes).disperse(&encoded_transactions).unwrap_or_else(|err|panic!("VID disperse failure:\n\t(num_storage nodes,payload_byte_len)=({num_storage_nodes},{})\n\terror: : {err}", encoded_transactions.len()))
-                })
+                let vid_disperse = calculate_vid_disperse(
+                    encoded_transactions.clone(),
+                    self.membership.clone(),
+                    *view_number,
+                )
                 .await;
-
-                #[cfg(async_executor_impl = "tokio")]
-                // Unwrap here will just propagate any panic from the spawned task, it's not a new place we can panic.
-                let vid_disperse = vid_disperse.unwrap();
                 // send the commitment and metadata to consensus for block building
                 broadcast_event(
                     Arc::new(HotShotEvent::SendPayloadCommitmentAndMetadata(
-                        vid_disperse.commit,
+                        vid_disperse.payload_commitment,
                         metadata.clone(),
                         *view_number,
                     )),
@@ -95,10 +79,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
 
                 // send the block to the VID dispersal function
                 broadcast_event(
-                    Arc::new(HotShotEvent::BlockReady(
-                        VidDisperse::from_membership(*view_number, vid_disperse, &self.membership),
-                        *view_number,
-                    )),
+                    Arc::new(HotShotEvent::BlockReady(vid_disperse, *view_number)),
                     &event_stream,
                 )
                 .await;
@@ -155,37 +136,6 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                 return None;
             }
 
-            HotShotEvent::DAProposalValidated(proposal, _sender) => {
-                let txns = proposal.data.encoded_transactions.clone();
-                let num_nodes = self.membership.total_nodes();
-                let vid_disperse = spawn_blocking(move || {
-                    #[allow(clippy::panic)]
-                    vid_scheme(num_nodes).disperse(&txns).unwrap_or_else(|err|panic!("VID disperse failure:\n\t(num_storage nodes,payload_byte_len)=({num_nodes},{})\n\terror: : {err}", txns.len()))
-                })
-                .await;
-                #[cfg(async_executor_impl = "tokio")]
-                let vid_disperse = vid_disperse.unwrap();
-
-                let vid_disperse = VidDisperse::from_membership(
-                    proposal.data.view_number,
-                    vid_disperse,
-                    &self.membership,
-                );
-
-                let vid_disperse_tasks = VidDisperseShare::from_vid_disperse(vid_disperse)
-                    .into_iter()
-                    .filter_map(|vid_share| {
-                        Some(broadcast_event(
-                            Arc::new(HotShotEvent::VidDisperseRecv(
-                                vid_share.to_proposal(&self.private_key)?,
-                            )),
-                            &event_stream,
-                        ))
-                    });
-
-                join_all(vid_disperse_tasks).await;
-            }
-
             HotShotEvent::Shutdown => {
                 return Some(HotShotTaskCompleted);
             }
@@ -220,7 +170,6 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                 | HotShotEvent::TransactionsSequenced(_, _, _)
                 | HotShotEvent::BlockReady(_, _)
                 | HotShotEvent::ViewChange(_)
-                | HotShotEvent::DAProposalValidated(_, _)
         )
     }
     fn should_shutdown(event: &Self::Event) -> bool {

--- a/crates/testing/src/task_helpers.rs
+++ b/crates/testing/src/task_helpers.rs
@@ -398,7 +398,7 @@ pub fn build_vid_proposal(
     let vid_disperse = VidDisperse::from_membership(
         view_number,
         vid.disperse(encoded_transactions).unwrap(),
-        &quorum_membership.clone().into(),
+        quorum_membership.clone().into(),
     );
 
     VidDisperseShare::from_vid_disperse(vid_disperse)

--- a/crates/testing/tests/tests_1/vid_task.rs
+++ b/crates/testing/tests/tests_1/vid_task.rs
@@ -54,7 +54,7 @@ async fn test_vid_task() {
     let vid_disperse = VidDisperse::from_membership(
         message.data.view_number,
         vid_disperse,
-        &quorum_membership.clone().into(),
+        quorum_membership.clone().into(),
     );
 
     let vid_proposal = Proposal {
@@ -71,10 +71,6 @@ async fn test_vid_task() {
         })
         .collect();
     let vid_share_proposal = vid_share_proposals[0].clone();
-    let disperse_receives: Vec<_> = vid_share_proposals
-        .into_iter()
-        .map(HotShotEvent::VidDisperseRecv)
-        .collect();
 
     let mut input = Vec::new();
     let mut output = HashMap::new();
@@ -91,10 +87,7 @@ async fn test_vid_task() {
         vid_disperse.clone(),
         ViewNumber::new(2),
     ));
-    input.push(HotShotEvent::DAProposalValidated(
-        message,
-        *handle.public_key(),
-    ));
+
     input.push(HotShotEvent::VidDisperseSend(vid_proposal.clone(), pub_key));
     input.push(HotShotEvent::VidDisperseRecv(vid_share_proposal.clone()));
     input.push(HotShotEvent::Shutdown);
@@ -112,9 +105,6 @@ async fn test_vid_task() {
         HotShotEvent::VidDisperseSend(vid_proposal.clone(), pub_key),
         1,
     );
-    for disperse_receive in disperse_receives {
-        output.insert(disperse_receive, 1);
-    }
 
     let vid_state = VIDTaskState {
         api: handle.clone(),

--- a/crates/types/src/consensus.rs
+++ b/crates/types/src/consensus.rs
@@ -6,7 +6,6 @@ use displaydoc::Display;
 use crate::{
     data::{Leaf, VidDisperseShare},
     error::HotShotError,
-    message::Proposal,
     simple_certificate::{DACertificate, QuorumCertificate, UpgradeCertificate},
     traits::{
         metrics::{Counter, Gauge, Histogram, Label, Metrics, NoMetrics},
@@ -27,9 +26,9 @@ use tracing::error;
 pub type CommitmentMap<T> = HashMap<Commitment<T>, T>;
 
 /// A type alias for `BTreeMap<T::Time, HashMap<T::SignatureKey, Proposal<T, VidDisperseShare<T>>>>`
-type VidShares<TYPES> = BTreeMap<
+pub type VidShares<TYPES> = BTreeMap<
     <TYPES as NodeType>::Time,
-    HashMap<<TYPES as NodeType>::SignatureKey, Proposal<TYPES, VidDisperseShare<TYPES>>>,
+    HashMap<<TYPES as NodeType>::SignatureKey, VidDisperseShare<TYPES>>,
 >;
 
 /// A reference to the consensus algorithm

--- a/crates/types/src/data.rs
+++ b/crates/types/src/data.rs
@@ -209,7 +209,7 @@ pub struct VidDisperseShare<TYPES: NodeType> {
 
 impl<TYPES: NodeType> VidDisperseShare<TYPES> {
     /// Create a vector of `VidDisperseShare` from `VidDisperse`
-    pub fn from_vid_disperse(vid_disperse: VidDisperse<TYPES>) -> Vec<VidDisperseShare<TYPES>> {
+    pub fn from_vid_disperse(vid_disperse: VidDisperse<TYPES>) -> Vec<Self> {
         vid_disperse
             .shares
             .into_iter()

--- a/crates/types/src/data.rs
+++ b/crates/types/src/data.rs
@@ -156,7 +156,7 @@ impl<TYPES: NodeType> VidDisperse<TYPES> {
     pub fn from_membership(
         view_number: TYPES::Time,
         mut vid_disperse: JfVidDisperse<VidSchemeType>,
-        membership: &Arc<TYPES::Membership>,
+        membership: Arc<TYPES::Membership>,
     ) -> Self {
         let shares = membership
             .get_staked_committee(view_number)
@@ -209,7 +209,7 @@ pub struct VidDisperseShare<TYPES: NodeType> {
 
 impl<TYPES: NodeType> VidDisperseShare<TYPES> {
     /// Create a vector of `VidDisperseShare` from `VidDisperse`
-    pub fn from_vid_disperse(vid_disperse: VidDisperse<TYPES>) -> Vec<Self> {
+    pub fn from_vid_disperse(vid_disperse: VidDisperse<TYPES>) -> Vec<VidDisperseShare<TYPES>> {
         vid_disperse
             .shares
             .into_iter()


### PR DESCRIPTION

### This PR: 

- Calculates VID shares from Payloads only when requested
- Only emit the `VIDDisperseRecv` event when it's received from the network
  -  Remove handling for `DAProposalValidated` in the VID task
- Create a helper function for calculating the dispersal (do the spawn_blocking in one spot)
- Update VID task test

### This PR does not: 

This should not touch the path where we get a VID share from the network

### Key places to review: 

Changes to the Response task

