### PR TITLE
Update the CDN to `0.1.23`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1298,7 +1298,7 @@ checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
 [[package]]
 name = "cdn-broker"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/Push-CDN?tag=0.1.22#8dbc3a424b95edca2485aa6dd77d6d05a8e3be50"
+source = "git+https://github.com/EspressoSystems/Push-CDN?tag=0.1.23#c709b7b6f6f93534b458fcbb994c61c2cdebeadf"
 dependencies = [
  "async-std",
  "cdn-proto",
@@ -1321,7 +1321,7 @@ dependencies = [
 [[package]]
 name = "cdn-client"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/Push-CDN?tag=0.1.22#8dbc3a424b95edca2485aa6dd77d6d05a8e3be50"
+source = "git+https://github.com/EspressoSystems/Push-CDN?tag=0.1.23#c709b7b6f6f93534b458fcbb994c61c2cdebeadf"
 dependencies = [
  "async-std",
  "cdn-proto",
@@ -1337,7 +1337,7 @@ dependencies = [
 [[package]]
 name = "cdn-marshal"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/Push-CDN?tag=0.1.22#8dbc3a424b95edca2485aa6dd77d6d05a8e3be50"
+source = "git+https://github.com/EspressoSystems/Push-CDN?tag=0.1.23#c709b7b6f6f93534b458fcbb994c61c2cdebeadf"
 dependencies = [
  "async-std",
  "cdn-proto",
@@ -1352,7 +1352,7 @@ dependencies = [
 [[package]]
 name = "cdn-proto"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/Push-CDN?tag=0.1.22#8dbc3a424b95edca2485aa6dd77d6d05a8e3be50"
+source = "git+https://github.com/EspressoSystems/Push-CDN?tag=0.1.23#c709b7b6f6f93534b458fcbb994c61c2cdebeadf"
 dependencies = [
  "anyhow",
  "ark-serialize",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -133,9 +133,9 @@ anyhow = "1"
 
 
 # Push CDN imports
-cdn-client = { git = "https://github.com/EspressoSystems/Push-CDN", tag = "0.1.22" }
-cdn-broker = { git = "https://github.com/EspressoSystems/Push-CDN", tag = "0.1.22" }
-cdn-marshal = { git = "https://github.com/EspressoSystems/Push-CDN", tag = "0.1.22" }
+cdn-client = { git = "https://github.com/EspressoSystems/Push-CDN", tag = "0.1.23" }
+cdn-broker = { git = "https://github.com/EspressoSystems/Push-CDN", tag = "0.1.23" }
+cdn-marshal = { git = "https://github.com/EspressoSystems/Push-CDN", tag = "0.1.23" }
 
 ### Profiles
 ###

--- a/crates/examples/Cargo.toml
+++ b/crates/examples/Cargo.toml
@@ -141,9 +141,9 @@ tracing = { workspace = true }
 tokio = { workspace = true }
 cdn-client = { workspace = true, features = ["runtime-tokio"] }
 cdn-broker = { workspace = true, features = [
-
   "runtime-tokio",
-  "strong_consistency",
+  "strong-consistency",
+  "global-permits",
 ] }
 cdn-marshal = { workspace = true, features = ["runtime-tokio"] }
 
@@ -152,7 +152,8 @@ async-std = { workspace = true }
 cdn-client = { workspace = true, features = ["runtime-async-std"] }
 cdn-broker = { workspace = true, features = [
   "runtime-async-std",
-  "strong_consistency",
+  "strong-consistency",
+  "global-permits",
 ] }
 cdn-marshal = { workspace = true, features = ["runtime-async-std"] }
 

--- a/crates/hotshot/Cargo.toml
+++ b/crates/hotshot/Cargo.toml
@@ -62,7 +62,8 @@ tokio = { workspace = true }
 cdn-client = { workspace = true, features = ["runtime-tokio"] }
 cdn-broker = { workspace = true, features = [
   "runtime-tokio",
-  "strong_consistency",
+  "strong-consistency",
+  "global-permits",
 ] }
 cdn-marshal = { workspace = true, features = ["runtime-tokio"] }
 
@@ -71,7 +72,8 @@ async-std = { workspace = true }
 cdn-client = { workspace = true, features = ["runtime-async-std"] }
 cdn-broker = { workspace = true, features = [
   "runtime-async-std",
-  "strong_consistency",
+  "strong-consistency",
+  "global-permits",
 ] }
 cdn-marshal = { workspace = true, features = ["runtime-async-std"] }
 


### PR DESCRIPTION
Adds the feature flag `global-permits`, which allows permits to be issued for all brokers at the same time. Makes deployment easier.