### PR TITLE
[Important] Fix mistake in test script

### DIFF
--- a/crates/testing/src/script.rs
+++ b/crates/testing/src/script.rs
@@ -64,11 +64,10 @@ where
         PredicateResult::Pass => result,
         PredicateResult::Incomplete => result,
         PredicateResult::Fail => {
-            format!(
+            panic!(
                 "Stage {} | Output failed to satisfy: {:?}.\n\nReceived:\n\n{:?}",
                 stage_number, assert, output
-            );
-            result
+            )
         }
     }
 }


### PR DESCRIPTION
### This PR: 
I apparently dropped the `panic` part of `validate_output_or_panic`. This means the task tests passed in more cases than they should have.

### This PR does not: 

### Key places to review: 
