### PR TITLE
Add Nix shell without rust-analyzer

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,5 +1,0 @@
-# reload when these files change
-watch_file flake.nix
-watch_file flake.lock
-# load the flake devShell
-use nix

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.envrc
 **/target
 **/result
 **/out*.txt

--- a/flake.nix
+++ b/flake.nix
@@ -177,7 +177,6 @@
             python3
             zlib.dev
             zlib.out
-            fenix.packages.${system}.rust-analyzer
             just
             pkg-config
             openssl.dev
@@ -191,10 +190,16 @@
       in {
         devShell = pkgs.mkShell {
           inherit CARGO_TARGET_DIR;
-          buildInputs = [ fenixStable ] ++ buildDeps;
+          buildInputs = [ fenixStable fenix.packages.${system}.rust-analyzer ] ++ buildDeps;
         };
 
         devShells = {
+          # A simple shell without rust-analyzer
+          simpleShell = pkgs.mkShell {
+            inherit CARGO_TARGET_DIR;
+            buildInputs = [ fenixStable ] ++ buildDeps;
+          };
+
           # usage: check correctness
           correctnessShell = pkgs.mkShell {
             inherit CARGO_TARGET_DIR;

--- a/flake.nix
+++ b/flake.nix
@@ -163,7 +163,7 @@
         # # programmatically generate output packages based on what exists in the workspace
         # pkgsAndChecksAttrSet = pkgs.lib.foldAttrs (n: a: pkgs.lib.recursiveUpdate n a) { } pkgsAndChecksList;
 
-        buildDeps = with pkgs;
+        buildDepsSimple = with pkgs;
           [
             cargo-vet
             curl.out
@@ -173,7 +173,6 @@
             nixpkgs-fmt
             git-chglog
             protobuf
-            capnproto
             python3
             zlib.dev
             zlib.out
@@ -187,17 +186,19 @@
             pkgs.libiconv
             darwin.apple_sdk.frameworks.SystemConfiguration
           ];
+
+        buildDeps = buildDepsSimple ++ [ fenix.packages.${system}.rust-analyzer ];
       in {
         devShell = pkgs.mkShell {
           inherit CARGO_TARGET_DIR;
-          buildInputs = [ fenixStable fenix.packages.${system}.rust-analyzer ] ++ buildDeps;
+          buildInputs = [ fenixStable ] ++ buildDeps;
         };
 
         devShells = {
           # A simple shell without rust-analyzer
           simpleShell = pkgs.mkShell {
             inherit CARGO_TARGET_DIR;
-            buildInputs = [ fenixStable ] ++ buildDeps;
+            buildInputs = [ fenixStable ] ++ buildDepsSimple;
           };
 
           # usage: check correctness


### PR DESCRIPTION
### This PR: 
This is probably just a personal pain point, but I find myself often waiting a very long time on `rust-analyzer` (which I don't use) to compile after a `flake.lock` update (which happens weekly).

This PR adds a shell without `rust-analyzer`, and uncommits `.envrc`. 

For `.envrc`: given that we a) use Nix and b) don't do anything interesting in `.envrc`, I don't think committing the latter makes sense -- it effectively just prevents you from creating your own `.envrc` to choose a non-default shell. 

Note also that our `.envrc` is very straightforward to recreate -- e.g. 1 line: `use flake .#simpleShell` -- and should only have to be done once per repository clone (and only if you use `direnv`).

### This PR does not: 

### Key places to review:
Would this affect your own workflow?
