### PR TITLE
Spawn task for proposing

### DIFF
--- a/crates/macros/src/lib.rs
+++ b/crates/macros/src/lib.rs
@@ -354,7 +354,7 @@ pub fn test_scripts(input: proc_macro::TokenStream) -> TokenStream {
                         #task_names.state().handle_result(&res).await;
                     }
 
-                    while let Ok(received_output) = test_receiver.try_recv() {
+                    while let Ok(Ok(received_output)) = async_timeout(Duration::from_millis(35), test_receiver.recv_direct()).await {
                         tracing::debug!("Test received: {:?}", received_output);
 
                         let output_asserts = &mut #task_expectations[stage_number].output_asserts;

--- a/crates/task-impls/src/consensus.rs
+++ b/crates/task-impls/src/consensus.rs
@@ -184,6 +184,69 @@ async fn validate_proposal<TYPES: NodeType>(
     }
 }
 
+/// Create the header for a proposal, build the proposal, and broadcast
+/// the proposal send evnet.
+#[allow(clippy::too_many_arguments)]
+async fn create_and_send_proposal<TYPES: NodeType>(
+    pub_key: TYPES::SignatureKey,
+    private_key: <TYPES::SignatureKey as SignatureKey>::PrivateKey,
+    consensus: Arc<RwLock<Consensus<TYPES>>>,
+    event_stream: Sender<Arc<HotShotEvent<TYPES>>>,
+    view: TYPES::Time,
+    commitment: VidCommitment,
+    metadata: <TYPES::BlockPayload as BlockPayload>::Metadata,
+    parent_leaf: Leaf<TYPES>,
+    state: Arc<TYPES::ValidatedState>,
+    upgrade_cert: Option<UpgradeCertificate<TYPES>>,
+    proposal_cert: Option<ViewChangeEvidence<TYPES>>,
+    round_start_delay: u64,
+) {
+    let block_header = TYPES::BlockHeader::new(
+        state.as_ref(),
+        &consensus.read().await.instance_state,
+        &parent_leaf,
+        commitment,
+        metadata,
+    )
+    .await;
+
+    let proposal = QuorumProposal {
+        block_header,
+        view_number: view,
+        justify_qc: consensus.read().await.high_qc.clone(),
+        proposal_certificate: proposal_cert,
+        upgrade_certificate: upgrade_cert,
+    };
+
+    let mut proposed_leaf = Leaf::from_quorum_proposal(&proposal);
+    proposed_leaf.set_parent_commitment(parent_leaf.commit());
+
+    let Ok(signature) = TYPES::SignatureKey::sign(&private_key, proposed_leaf.commit().as_ref())
+    else {
+        // This should never happen.
+        error!("Failed to sign proposed_leaf.commit()!");
+        return;
+    };
+
+    let message = Proposal {
+        data: proposal,
+        signature,
+        _pd: PhantomData,
+    };
+    debug!(
+        "Sending null proposal for view {:?} \n {:?}",
+        proposed_leaf.get_view_number(),
+        ""
+    );
+
+    async_sleep(Duration::from_millis(round_start_delay)).await;
+    broadcast_event(
+        Arc::new(HotShotEvent::QuorumProposalSend(message.clone(), pub_key)),
+        &event_stream,
+    )
+    .await;
+}
+
 /// The state for the consensus task.  Contains all of the information for the implementation
 /// of consensus
 pub struct ConsensusTaskState<
@@ -1059,9 +1122,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
 
                     let view = qc.view_number + 1;
 
-                    if !self.publish_proposal_if_able(view, &event_stream).await {
-                        warn!("Wasn't able to publish proposal");
-                    }
+                    self.publish_proposal_if_able(view, &event_stream).await;
                 }
                 if let either::Left(qc) = cert {
                     if let Err(e) = self.storage.write().await.update_high_qc(qc.clone()).await {
@@ -1084,14 +1145,8 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                         *qc.view_number
                     );
 
-                    if !self
-                        .publish_proposal_if_able(qc.view_number + 1, &event_stream)
-                        .await
-                    {
-                        debug!(
-                            "Wasn't able to publish proposal when QC was formed, still may publish"
-                        );
-                    }
+                    self.publish_proposal_if_able(qc.view_number + 1, &event_stream)
+                        .await;
                 }
             }
             HotShotEvent::UpgradeCertificateFormed(cert) => {
@@ -1363,7 +1418,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
         &mut self,
         view: TYPES::Time,
         event_stream: &Sender<Arc<HotShotEvent<TYPES>>>,
-    ) -> bool {
+    ) {
         if self.quorum_membership.get_leader(view) != self.public_key {
             // This is expected for view 1, so skipping the logging.
             if view != TYPES::Time::new(1) {
@@ -1372,7 +1427,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                     view
                 );
             }
-            return false;
+            return;
         }
 
         let consensus = self.consensus.read().await;
@@ -1382,7 +1437,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
         let Some(parent_view) = consensus.validated_state_map.get(parent_view_number) else {
             // This should have been added by the replica?
             error!("Couldn't find parent view in state map, waiting for replica to see proposal\n parent view number: {}", **parent_view_number);
-            return false;
+            return;
         };
         // Leaf hash in view inner does not match high qc hash - Why?
         let Some((leaf_commitment, state)) = parent_view.get_leaf_and_state() else {
@@ -1391,7 +1446,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                 ?parent_view,
                 "Parent of high QC points to a view without a proposal"
             );
-            return false;
+            return;
         };
         if leaf_commitment != consensus.high_qc.get_data().leaf_commit {
             // NOTE: This happens on the genesis block
@@ -1403,7 +1458,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
         }
         let Some(leaf) = consensus.saved_leaves.get(&leaf_commitment) else {
             error!("Failed to find high QC of parent.");
-            return false;
+            return;
         };
         if leaf.get_view_number() == consensus.last_decided_view {
             reached_decided = true;
@@ -1435,7 +1490,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                     <TYPES::BlockPayload as BlockPayload>::from_transactions(Vec::new())
                 else {
                     error!("Failed to build null block payload and metadata");
-                    return false;
+                    return;
                 };
 
                 let Some(null_block_commitment) =
@@ -1443,70 +1498,37 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                 else {
                     // This should never happen.
                     error!("Failed to calculate null block commitment");
-                    return false;
+                    return;
                 };
 
-                let block_header = TYPES::BlockHeader::new(
-                    state,
-                    &consensus.instance_state,
-                    &parent_leaf,
-                    null_block_commitment,
-                    metadata,
-                )
-                .await;
-
-                let proposal = QuorumProposal {
-                    block_header,
-                    view_number: view,
-                    justify_qc: consensus.high_qc.clone(),
-                    proposal_certificate: None,
-                    upgrade_certificate: None,
-                };
-
-                let mut proposed_leaf = Leaf::from_quorum_proposal(&proposal);
-                proposed_leaf.set_parent_commitment(parent_leaf.commit());
-
-                let Ok(signature) =
-                    TYPES::SignatureKey::sign(&self.private_key, proposed_leaf.commit().as_ref())
-                else {
-                    // This should never happen.
-                    error!("Failed to sign proposed_leaf.commit()!");
-                    return false;
-                };
-
-                let message = Proposal {
-                    data: proposal,
-                    signature,
-                    _pd: PhantomData,
-                };
-                debug!(
-                    "Sending null proposal for view {:?} \n {:?}",
-                    proposed_leaf.get_view_number(),
-                    ""
-                );
-
-                broadcast_event(
-                    Arc::new(HotShotEvent::QuorumProposalSend(
-                        message.clone(),
-                        self.public_key.clone(),
-                    )),
-                    event_stream,
-                )
-                .await;
-
-                return true;
+                let pub_key = self.public_key.clone();
+                let priv_key = self.private_key.clone();
+                let consensus = self.consensus.clone();
+                let sender = event_stream.clone();
+                let delay = self.round_start_delay;
+                let parent = parent_leaf.clone();
+                let state = state.clone();
+                async_spawn(async move {
+                    create_and_send_proposal(
+                        pub_key,
+                        priv_key,
+                        consensus,
+                        sender,
+                        view,
+                        null_block_commitment,
+                        metadata,
+                        parent,
+                        state,
+                        None,
+                        None,
+                        delay,
+                    )
+                    .await;
+                });
             }
         }
 
         if let Some(commit_and_metadata) = &self.payload_commitment_and_metadata {
-            let block_header = TYPES::BlockHeader::new(
-                state,
-                &consensus.instance_state,
-                &parent_leaf,
-                commit_and_metadata.commitment,
-                commit_and_metadata.metadata.clone(),
-            )
-            .await;
             let upgrade_cert = if self
                 .upgrade_cert
                 .as_ref()
@@ -1529,49 +1551,36 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                 .as_ref()
                 .filter(|cert| cert.is_valid_for_view(&view))
                 .cloned();
-
-            // TODO: DA cert is sent as part of the proposal here, we should split this out so we don't have to wait for it.
-            let proposal = QuorumProposal {
-                block_header: block_header.clone(),
-                view_number: view,
-                justify_qc: consensus.high_qc.clone(),
-                proposal_certificate,
-                upgrade_certificate: upgrade_cert.clone(),
-            };
-
-            let mut new_leaf = Leaf::from_quorum_proposal(&proposal);
-            new_leaf.set_parent_commitment(parent_leaf.commit());
-
-            let Ok(signature) =
-                TYPES::SignatureKey::sign(&self.private_key, new_leaf.commit().as_ref())
-            else {
-                error!("Failed to sign new_leaf.commit()!");
-                return false;
-            };
+            let pub_key = self.public_key.clone();
+            let priv_key = self.private_key.clone();
+            let consensus = self.consensus.clone();
+            let sender = event_stream.clone();
+            let commit = commit_and_metadata.commitment;
+            let metadata = commit_and_metadata.metadata.clone();
+            let state = state.clone();
+            let delay = self.round_start_delay;
+            async_spawn(async move {
+                create_and_send_proposal(
+                    pub_key,
+                    priv_key,
+                    consensus,
+                    sender,
+                    view,
+                    commit,
+                    metadata,
+                    parent_leaf.clone(),
+                    state,
+                    upgrade_cert,
+                    proposal_certificate,
+                    delay,
+                )
+                .await;
+            });
 
             self.proposal_cert = None;
-            let message = Proposal {
-                data: proposal,
-                signature,
-                _pd: PhantomData,
-            };
-            debug!("Sending proposal for view {:?}", view);
-
-            async_sleep(Duration::from_millis(self.round_start_delay)).await;
-            broadcast_event(
-                Arc::new(HotShotEvent::QuorumProposalSend(
-                    message.clone(),
-                    self.public_key.clone(),
-                )),
-                event_stream,
-            )
-            .await;
-
             self.payload_commitment_and_metadata = None;
-            return true;
         }
         debug!("Cannot propose because we don't have the VID payload commitment and metadata");
-        false
     }
 }
 

--- a/crates/task-impls/src/consensus.rs
+++ b/crates/task-impls/src/consensus.rs
@@ -1525,6 +1525,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                     )
                     .await;
                 });
+                return;
             }
         }
 

--- a/crates/task-impls/src/consensus.rs
+++ b/crates/task-impls/src/consensus.rs
@@ -1545,7 +1545,6 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
         }
 
         if let Some(commit_and_metadata) = &self.payload_commitment_and_metadata {
-
             // In order of priority, we should try to attach:
             //   - the parent certificate if it exists, or
             //   - our own certificate that we formed.

--- a/crates/testing/tests/tests_1/proposal_ordering.rs
+++ b/crates/testing/tests/tests_1/proposal_ordering.rs
@@ -70,22 +70,12 @@ async fn test_ordering_with_specific_order(input_permutation: Vec<usize>) {
         SendPayloadCommitmentAndMetadata(payload_commitment, (), ViewNumber::new(node_id)),
     ];
 
-    // The consensus task does not like it when the proposal received is the last thing to happen,
-    // at least not while keeping an arbitrary ordering. The testing framework does not allow us to
-    // check events out of order, so we instead just give the test what it wants, but this should
-    // still be okay.
-    let view_2_outputs = if input_permutation[2] == 0 {
-        vec![
-            quorum_proposal_send(),
-            exact(ViewChange(ViewNumber::new(2))),
-        ]
-    } else {
+    let view_2_outputs = 
         vec![
             exact(ViewChange(ViewNumber::new(2))),
             exact(QuorumProposalValidated(proposals[1].data.clone())),
             quorum_proposal_send(),
-        ]
-    };
+        ];
 
     let view_2_inputs = permute_input_with_index_order(inputs, input_permutation);
 

--- a/crates/testing/tests/tests_1/upgrade_task.rs
+++ b/crates/testing/tests/tests_1/upgrade_task.rs
@@ -19,6 +19,7 @@ use hotshot_types::{
     traits::{election::Membership, node_implementation::ConsensusTime},
 };
 use versioned_binary_serialization::version::Version;
+use std::time::Duration;
 
 #[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]


### PR DESCRIPTION


### This PR: 
The `BlockHeader::new` function is async and the way it's implemented in the sequencer means that it can run for a really long time.  We don't want to block the consensus task this whole time because we fall infinitely far behind

- Moves the last step of proposal creation onto it's own async task
- Removes the return value from `publish_proposal_if_able` because it is not really useful
- Updates the tests to pass after the changes
- Updates the test script macro to await the receiver rather then `try_recv`


### This PR does not: 
This should not change how or what is proposed but might slightly change the timing of the proposal

### Key places to review: 

All changes in consensus task
