### PR TITLE
Update types for testable builders

### DIFF
--- a/crates/macros/src/lib.rs
+++ b/crates/macros/src/lib.rs
@@ -119,7 +119,7 @@ impl TestData {
             async fn #test_name() {
                 async_compatibility_layer::logging::setup_logging();
                 async_compatibility_layer::logging::setup_backtrace();
-                (#metadata).gen_launcher::<#ty, #imply>(0).launch().run_test::<SimpleBuilderImplementation<#imply>>().await;
+                (#metadata).gen_launcher::<#ty, #imply>(0).launch().run_test::<SimpleBuilderImplementation<#ty>>().await;
             }
         }
     }

--- a/crates/testing/src/block_builder.rs
+++ b/crates/testing/src/block_builder.rs
@@ -12,7 +12,7 @@ use async_trait::async_trait;
 use committable::{Commitment, Committable};
 use futures::{future::BoxFuture, Stream, StreamExt};
 use hotshot::{
-    traits::{BlockPayload, TestableNodeImplementation},
+    traits::BlockPayload,
     types::{Event, EventType, SignatureKey},
 };
 use hotshot_builder_api::{
@@ -37,25 +37,21 @@ use tide_disco::{method::ReadState, App, Url};
 #[async_trait]
 pub trait TestBuilderImplementation {
     type TYPES: NodeType;
-    type I: TestableNodeImplementation<Self::TYPES>;
     async fn start(
         membership: Arc<<Self::TYPES as NodeType>::Membership>,
     ) -> (Option<Box<dyn BuilderTask<TYPES = Self::TYPES>>>, Url);
 }
 
-pub struct RandomBuilderImplementation<I: TestableNodeImplementation<TestTypes>> {
-    _marker: std::marker::PhantomData<I>,
+pub struct RandomBuilderImplementation<TYPES: NodeType> {
+    _marker: std::marker::PhantomData<TYPES>,
 }
 
 #[async_trait]
-impl<I: TestableNodeImplementation<TestTypes>> TestBuilderImplementation
-    for RandomBuilderImplementation<I>
-{
-    type TYPES = TestTypes;
-    type I = I;
+impl<TYPES: NodeType> TestBuilderImplementation for RandomBuilderImplementation<TYPES> {
+    type TYPES = TYPES;
 
     async fn start(
-        _membership: Arc<<TestTypes as NodeType>::Membership>,
+        _membership: Arc<<TYPES as NodeType>::Membership>,
     ) -> (Option<Box<dyn BuilderTask<TYPES = Self::TYPES>>>, Url) {
         let port = portpicker::pick_unused_port().expect("No free ports");
         let url = Url::parse(&format!("http://localhost:{port}")).expect("Valid URL");
@@ -64,16 +60,13 @@ impl<I: TestableNodeImplementation<TestTypes>> TestBuilderImplementation
     }
 }
 
-pub struct SimpleBuilderImplementation<I: TestableNodeImplementation<TestTypes>> {
-    _marker: std::marker::PhantomData<I>,
+pub struct SimpleBuilderImplementation<TYPES: NodeType> {
+    _marker: std::marker::PhantomData<TYPES>,
 }
 
 #[async_trait]
-impl<I: TestableNodeImplementation<TestTypes>> TestBuilderImplementation
-    for SimpleBuilderImplementation<I>
-{
+impl<TYPES: NodeType> TestBuilderImplementation for SimpleBuilderImplementation<TYPES> {
     type TYPES = TestTypes;
-    type I = I;
 
     async fn start(
         membership: Arc<<TestTypes as NodeType>::Membership>,

--- a/crates/testing/src/test_runner.rs
+++ b/crates/testing/src/test_runner.rs
@@ -132,7 +132,7 @@ where
     /// # Panics
     /// if the test fails
     #[allow(clippy::too_many_lines)]
-    pub async fn run_test<B: TestBuilderImplementation<TYPES = TYPES, I = I>>(mut self) {
+    pub async fn run_test<B: TestBuilderImplementation<TYPES = TYPES>>(mut self) {
         let (tx, rx) = broadcast(EVENT_CHANNEL_SIZE);
         let spinning_changes = self
             .launcher
@@ -327,7 +327,7 @@ where
     ///
     /// # Panics
     /// Panics if unable to create a [`HotShotInitializer`]
-    pub async fn add_nodes<B: TestBuilderImplementation<TYPES = TYPES, I = I>>(
+    pub async fn add_nodes<B: TestBuilderImplementation<TYPES = TYPES>>(
         &mut self,
         total: usize,
         late_start: &HashSet<u64>,

--- a/crates/testing/tests/tests_1/libp2p.rs
+++ b/crates/testing/tests/tests_1/libp2p.rs
@@ -37,7 +37,7 @@ async fn libp2p_network() {
     metadata
         .gen_launcher::<TestTypes, Libp2pImpl>(0)
         .launch()
-        .run_test::<SimpleBuilderImplementation<Libp2pImpl>>()
+        .run_test::<SimpleBuilderImplementation<TestTypes>>()
         .await;
 }
 
@@ -84,7 +84,7 @@ async fn libp2p_network_failures_2() {
     metadata
         .gen_launcher::<TestTypes, Libp2pImpl>(0)
         .launch()
-        .run_test::<SimpleBuilderImplementation<Libp2pImpl>>()
+        .run_test::<SimpleBuilderImplementation<TestTypes>>()
         .await;
 }
 
@@ -100,6 +100,6 @@ async fn test_stress_libp2p_network() {
     metadata
         .gen_launcher::<TestTypes, Libp2pImpl>(0)
         .launch()
-        .run_test::<SimpleBuilderImplementation<Libp2pImpl>>()
+        .run_test::<SimpleBuilderImplementation<TestTypes>>()
         .await;
 }

--- a/crates/testing/tests/tests_2/catchup.rs
+++ b/crates/testing/tests/tests_2/catchup.rs
@@ -52,7 +52,7 @@ async fn test_catchup() {
     metadata
         .gen_launcher::<TestTypes, MemoryImpl>(0)
         .launch()
-        .run_test::<SimpleBuilderImplementation<MemoryImpl>>()
+        .run_test::<SimpleBuilderImplementation<TestTypes>>()
         .await;
 }
 
@@ -105,7 +105,7 @@ async fn test_catchup_cdn() {
     metadata
         .gen_launcher::<TestTypes, PushCdnImpl>(0)
         .launch()
-        .run_test::<SimpleBuilderImplementation<PushCdnImpl>>()
+        .run_test::<SimpleBuilderImplementation<TestTypes>>()
         .await;
 }
 
@@ -160,7 +160,7 @@ async fn test_catchup_one_node() {
     metadata
         .gen_launcher::<TestTypes, MemoryImpl>(0)
         .launch()
-        .run_test::<SimpleBuilderImplementation<MemoryImpl>>()
+        .run_test::<SimpleBuilderImplementation<TestTypes>>()
         .await;
 }
 
@@ -221,7 +221,7 @@ async fn test_catchup_in_view_sync() {
     metadata
         .gen_launcher::<TestTypes, MemoryImpl>(0)
         .launch()
-        .run_test::<SimpleBuilderImplementation<MemoryImpl>>()
+        .run_test::<SimpleBuilderImplementation<TestTypes>>()
         .await;
 }
 
@@ -282,6 +282,6 @@ async fn test_catchup_reload() {
     metadata
         .gen_launcher::<TestTypes, MemoryImpl>(0)
         .launch()
-        .run_test::<SimpleBuilderImplementation<MemoryImpl>>()
+        .run_test::<SimpleBuilderImplementation<TestTypes>>()
         .await;
 }

--- a/crates/testing/tests/tests_2/push_cdn.rs
+++ b/crates/testing/tests/tests_2/push_cdn.rs
@@ -40,7 +40,7 @@ async fn push_cdn_network() {
     metadata
         .gen_launcher::<TestTypes, PushCdnImpl>(0)
         .launch()
-        .run_test::<SimpleBuilderImplementation<PushCdnImpl>>()
+        .run_test::<SimpleBuilderImplementation<TestTypes>>()
         .await;
     shutdown_logging();
 }

--- a/crates/testing/tests/tests_5/combined_network.rs
+++ b/crates/testing/tests/tests_5/combined_network.rs
@@ -45,7 +45,7 @@ async fn test_combined_network() {
     metadata
         .gen_launcher::<TestTypes, CombinedImpl>(0)
         .launch()
-        .run_test::<SimpleBuilderImplementation<CombinedImpl>>()
+        .run_test::<SimpleBuilderImplementation<TestTypes>>()
         .await;
 }
 
@@ -93,7 +93,7 @@ async fn test_combined_network_cdn_crash() {
     metadata
         .gen_launcher::<TestTypes, CombinedImpl>(0)
         .launch()
-        .run_test::<SimpleBuilderImplementation<CombinedImpl>>()
+        .run_test::<SimpleBuilderImplementation<TestTypes>>()
         .await;
 }
 
@@ -147,7 +147,7 @@ async fn test_combined_network_reup() {
     metadata
         .gen_launcher::<TestTypes, CombinedImpl>(0)
         .launch()
-        .run_test::<SimpleBuilderImplementation<CombinedImpl>>()
+        .run_test::<SimpleBuilderImplementation<TestTypes>>()
         .await;
 }
 
@@ -195,7 +195,7 @@ async fn test_combined_network_half_dc() {
     metadata
         .gen_launcher::<TestTypes, CombinedImpl>(0)
         .launch()
-        .run_test::<SimpleBuilderImplementation<CombinedImpl>>()
+        .run_test::<SimpleBuilderImplementation<TestTypes>>()
         .await;
 }
 
@@ -265,6 +265,6 @@ async fn test_stress_combined_network_fuzzy() {
     metadata
         .gen_launcher::<TestTypes, CombinedImpl>(0)
         .launch()
-        .run_test::<SimpleBuilderImplementation<CombinedImpl>>()
+        .run_test::<SimpleBuilderImplementation<TestTypes>>()
         .await;
 }

--- a/crates/testing/tests/tests_5/timeout.rs
+++ b/crates/testing/tests/tests_5/timeout.rs
@@ -57,7 +57,7 @@ async fn test_timeout_web() {
     metadata
         .gen_launcher::<TestTypes, WebImpl>(0)
         .launch()
-        .run_test::<SimpleBuilderImplementation<WebImpl>>()
+        .run_test::<SimpleBuilderImplementation<TestTypes>>()
         .await;
 }
 
@@ -124,6 +124,6 @@ async fn test_timeout_libp2p() {
     metadata
         .gen_launcher::<TestTypes, Libp2pImpl>(0)
         .launch()
-        .run_test::<SimpleBuilderImplementation<Libp2pImpl>>()
+        .run_test::<SimpleBuilderImplementation<TestTypes>>()
         .await;
 }

--- a/crates/testing/tests/tests_5/unreliable_network.rs
+++ b/crates/testing/tests/tests_5/unreliable_network.rs
@@ -41,7 +41,7 @@ async fn libp2p_network_sync() {
     metadata
         .gen_launcher::<TestTypes, Libp2pImpl>(0)
         .launch()
-        .run_test::<SimpleBuilderImplementation<Libp2pImpl>>()
+        .run_test::<SimpleBuilderImplementation<TestTypes>>()
         .await;
 }
 
@@ -74,7 +74,7 @@ async fn test_memory_network_sync() {
     metadata
         .gen_launcher::<TestTypes, MemoryImpl>(0)
         .launch()
-        .run_test::<SimpleBuilderImplementation<MemoryImpl>>()
+        .run_test::<SimpleBuilderImplementation<TestTypes>>()
         .await;
 }
 
@@ -113,7 +113,7 @@ async fn libp2p_network_async() {
     metadata
         .gen_launcher::<TestTypes, Libp2pImpl>(0)
         .launch()
-        .run_test::<SimpleBuilderImplementation<Libp2pImpl>>()
+        .run_test::<SimpleBuilderImplementation<TestTypes>>()
         .await;
 }
 
@@ -160,7 +160,7 @@ async fn test_memory_network_async() {
     metadata
         .gen_launcher::<TestTypes, MemoryImpl>(0)
         .launch()
-        .run_test::<SimpleBuilderImplementation<_>>()
+        .run_test::<SimpleBuilderImplementation<TestTypes>>()
         .await;
 }
 
@@ -212,7 +212,7 @@ async fn test_memory_network_partially_sync() {
     metadata
         .gen_launcher::<TestTypes, MemoryImpl>(0)
         .launch()
-        .run_test::<SimpleBuilderImplementation<_>>()
+        .run_test::<SimpleBuilderImplementation<TestTypes>>()
         .await;
 }
 
@@ -252,7 +252,7 @@ async fn libp2p_network_partially_sync() {
     metadata
         .gen_launcher::<TestTypes, Libp2pImpl>(0)
         .launch()
-        .run_test::<SimpleBuilderImplementation<_>>()
+        .run_test::<SimpleBuilderImplementation<TestTypes>>()
         .await;
 }
 
@@ -290,7 +290,7 @@ async fn test_memory_network_chaos() {
     metadata
         .gen_launcher::<TestTypes, MemoryImpl>(0)
         .launch()
-        .run_test::<SimpleBuilderImplementation<_>>()
+        .run_test::<SimpleBuilderImplementation<TestTypes>>()
         .await;
 }
 
@@ -325,6 +325,6 @@ async fn libp2p_network_chaos() {
     metadata
         .gen_launcher::<TestTypes, Libp2pImpl>(0)
         .launch()
-        .run_test::<SimpleBuilderImplementation<_>>()
+        .run_test::<SimpleBuilderImplementation<TestTypes>>()
         .await;
 }

--- a/crates/testing/tests/tests_5/web_server.rs
+++ b/crates/testing/tests/tests_5/web_server.rs
@@ -40,7 +40,7 @@ async fn web_server_network() {
     metadata
         .gen_launcher::<TestTypes, WebImpl>(0)
         .launch()
-        .run_test::<SimpleBuilderImplementation<_>>()
+        .run_test::<SimpleBuilderImplementation<TestTypes>>()
         .await;
     shutdown_logging();
 }


### PR DESCRIPTION
We need a builder to run tests for `hotshot-query-service`. However, it cannot be pinned to `TestTypes` as we use query-service-specific types there.

This lets us use arbitrary types in the builder implementations.