### PR TITLE
[Builder] Make simple builder generic over `NodeType`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3353,6 +3353,7 @@ dependencies = [
  "sha2 0.10.8",
  "sha3",
  "snafu 0.8.2",
+ "tagged-base64 0.4.0",
  "tide-disco",
  "tokio",
  "tracing",

--- a/crates/builder-api/src/block_info.rs
+++ b/crates/builder-api/src/block_info.rs
@@ -20,12 +20,11 @@ pub struct AvailableBlockInfo<I: NodeType> {
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq, Hash)]
 #[serde(bound = "")]
-pub struct AvailableBlockData<I: NodeType> {
-    pub block_payload: <I as NodeType>::BlockPayload,
-    pub metadata: <<I as NodeType>::BlockPayload as BlockPayload>::Metadata,
-    pub signature: <<I as NodeType>::SignatureKey as SignatureKey>::PureAssembledSignatureType,
-    pub sender: <I as NodeType>::SignatureKey,
-    pub _phantom: PhantomData<I>,
+pub struct AvailableBlockData<TYPES: NodeType> {
+    pub block_payload: TYPES::BlockPayload,
+    pub metadata: <TYPES::BlockPayload as BlockPayload>::Metadata,
+    pub signature: <TYPES::SignatureKey as SignatureKey>::PureAssembledSignatureType,
+    pub sender: TYPES::SignatureKey,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq, Hash)]

--- a/crates/builder-api/src/builder.rs
+++ b/crates/builder-api/src/builder.rs
@@ -122,9 +122,7 @@ where
     State: 'static + Send + Sync + ReadState,
     <State as ReadState>::State: Send + Sync + BuilderDataSource<Types>,
     Types: NodeType,
-    <<Types as NodeType>::SignatureKey as SignatureKey>::PureAssembledSignatureType:
-        for<'a> TryFrom<&'a TaggedBase64> + Into<TaggedBase64> + Display,
-    for<'a> <<<Types as NodeType>::SignatureKey as SignatureKey>::PureAssembledSignatureType as TryFrom<
+    for<'a> <<Types::SignatureKey as SignatureKey>::PureAssembledSignatureType as TryFrom<
         &'a TaggedBase64,
     >>::Error: Display,
 {

--- a/crates/builder-api/src/data_source.rs
+++ b/crates/builder-api/src/data_source.rs
@@ -4,7 +4,6 @@ use hotshot_types::{
     utils::BuilderCommitment,
     vid::VidCommitment,
 };
-use tagged_base64::TaggedBase64;
 
 use crate::{
     block_info::{AvailableBlockData, AvailableBlockHeaderInput, AvailableBlockInfo},
@@ -12,34 +11,29 @@ use crate::{
 };
 
 #[async_trait]
-pub trait BuilderDataSource<I>
-where
-    I: NodeType,
-    <<I as NodeType>::SignatureKey as SignatureKey>::PureAssembledSignatureType:
-        for<'a> TryFrom<&'a TaggedBase64> + Into<TaggedBase64>,
-{
+pub trait BuilderDataSource<TYPES: NodeType> {
     // To get the list of available blocks
     async fn get_available_blocks(
         &self,
         for_parent: &VidCommitment,
-    ) -> Result<Vec<AvailableBlockInfo<I>>, BuildError>;
+    ) -> Result<Vec<AvailableBlockInfo<TYPES>>, BuildError>;
 
     // to claim a block from the list of provided available blocks
     async fn claim_block(
         &self,
         block_hash: &BuilderCommitment,
-        signature: &<<I as NodeType>::SignatureKey as SignatureKey>::PureAssembledSignatureType,
-    ) -> Result<AvailableBlockData<I>, BuildError>;
+        signature: &<TYPES::SignatureKey as SignatureKey>::PureAssembledSignatureType,
+    ) -> Result<AvailableBlockData<TYPES>, BuildError>;
 
     // To claim a block header input
     async fn claim_block_header_input(
         &self,
         block_hash: &BuilderCommitment,
-        signature: &<<I as NodeType>::SignatureKey as SignatureKey>::PureAssembledSignatureType,
-    ) -> Result<AvailableBlockHeaderInput<I>, BuildError>;
+        signature: &<TYPES::SignatureKey as SignatureKey>::PureAssembledSignatureType,
+    ) -> Result<AvailableBlockHeaderInput<TYPES>, BuildError>;
 
     // To get the builder address
-    async fn get_builder_address(&self) -> Result<<I as NodeType>::SignatureKey, BuildError>;
+    async fn get_builder_address(&self) -> Result<TYPES::SignatureKey, BuildError>;
 }
 
 #[async_trait]

--- a/crates/example-types/src/block_types.rs
+++ b/crates/example-types/src/block_types.rs
@@ -74,6 +74,11 @@ impl Transaction for TestTransaction {
     fn len(&self) -> usize {
         self.0.len()
     }
+
+    /// Returns whether or not the transaction is empty
+    fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
 }
 
 /// A [`BlockPayload`] that contains a list of `TestTransaction`.

--- a/crates/example-types/src/block_types.rs
+++ b/crates/example-types/src/block_types.rs
@@ -64,7 +64,17 @@ impl Committable for TestTransaction {
     }
 }
 
-impl Transaction for TestTransaction {}
+impl Transaction for TestTransaction {
+    /// Create a transaction from bytes
+    fn from_bytes(bytes: &[u8]) -> Self {
+        Self(bytes.to_vec())
+    }
+
+    /// Get the length of the transaction in bytes
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+}
 
 /// A [`BlockPayload`] that contains a list of `TestTransaction`.
 #[derive(PartialEq, Eq, Hash, Serialize, Deserialize, Clone, Debug)]

--- a/crates/macros/src/lib.rs
+++ b/crates/macros/src/lib.rs
@@ -119,7 +119,7 @@ impl TestData {
             async fn #test_name() {
                 async_compatibility_layer::logging::setup_logging();
                 async_compatibility_layer::logging::setup_backtrace();
-                (#metadata).gen_launcher::<#ty, #imply>(0).launch().run_test::<SimpleBuilderImplementation<#imply>>().await;
+                (#metadata).gen_launcher::<#ty, #imply>(0).launch().run_test::<SimpleBuilderImplementation>().await;
             }
         }
     }

--- a/crates/testing/Cargo.toml
+++ b/crates/testing/Cargo.toml
@@ -41,6 +41,7 @@ tide-disco = { workspace = true }
 tracing = { workspace = true }
 vbs = { workspace = true }
 lru = { workspace = true }
+tagged-base64.workspace = true
 
 [target.'cfg(all(async_executor_impl = "tokio"))'.dependencies]
 tokio = { workspace = true }

--- a/crates/testing/src/block_builder.rs
+++ b/crates/testing/src/block_builder.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::HashMap,
+    fmt::Display,
     num::NonZeroUsize,
     ops::{Deref, Range},
     sync::Arc,
@@ -12,7 +13,7 @@ use async_trait::async_trait;
 use committable::{Commitment, Committable};
 use futures::{future::BoxFuture, Stream, StreamExt};
 use hotshot::{
-    traits::{BlockPayload, TestableNodeImplementation},
+    traits::BlockPayload,
     types::{Event, EventType, SignatureKey},
 };
 use hotshot_builder_api::{
@@ -20,10 +21,8 @@ use hotshot_builder_api::{
     builder::{BuildError, Error, Options},
     data_source::BuilderDataSource,
 };
-use hotshot_example_types::{
-    block_types::{TestBlockPayload, TestTransaction},
-    node_types::TestTypes,
-};
+use hotshot_types::traits::block_contents::BlockHeader;
+use hotshot_types::traits::block_contents::Transaction;
 use hotshot_types::{
     constants::{Version01, STATIC_VER_0_1},
     traits::{block_contents::vid_commitment, election::Membership, node_implementation::NodeType},
@@ -32,62 +31,58 @@ use hotshot_types::{
 };
 use lru::LruCache;
 use rand::{rngs::SmallRng, Rng, RngCore, SeedableRng};
+use tagged_base64::TaggedBase64;
 use tide_disco::{method::ReadState, App, Url};
 
 #[async_trait]
-pub trait TestBuilderImplementation {
-    type TYPES: NodeType;
-    type I: TestableNodeImplementation<Self::TYPES>;
+pub trait TestBuilderImplementation<TYPES: NodeType> {
     async fn start(
-        membership: Arc<<Self::TYPES as NodeType>::Membership>,
-    ) -> (Option<Box<dyn BuilderTask<TYPES = Self::TYPES>>>, Url);
+        membership: Arc<<TYPES>::Membership>,
+    ) -> (Option<Box<dyn BuilderTask<TYPES>>>, Url);
 }
 
-pub struct RandomBuilderImplementation<I: TestableNodeImplementation<TestTypes>> {
-    _marker: std::marker::PhantomData<I>,
-}
+pub struct RandomBuilderImplementation;
 
 #[async_trait]
-impl<I: TestableNodeImplementation<TestTypes>> TestBuilderImplementation
-    for RandomBuilderImplementation<I>
+impl<TYPES: NodeType> TestBuilderImplementation<TYPES> for RandomBuilderImplementation
+where
+    for<'a> <<TYPES::SignatureKey as SignatureKey>::PureAssembledSignatureType as TryFrom<
+        &'a TaggedBase64,
+    >>::Error: Display,
 {
-    type TYPES = TestTypes;
-    type I = I;
-
     async fn start(
-        _membership: Arc<<TestTypes as NodeType>::Membership>,
-    ) -> (Option<Box<dyn BuilderTask<TYPES = Self::TYPES>>>, Url) {
+        _membership: Arc<TYPES::Membership>,
+    ) -> (Option<Box<dyn BuilderTask<TYPES>>>, Url) {
         let port = portpicker::pick_unused_port().expect("No free ports");
         let url = Url::parse(&format!("http://localhost:{port}")).expect("Valid URL");
-        run_random_builder(url.clone());
+        run_random_builder::<TYPES>(url.clone());
         (None, url)
     }
 }
 
-pub struct SimpleBuilderImplementation<I: TestableNodeImplementation<TestTypes>> {
-    _marker: std::marker::PhantomData<I>,
-}
+pub struct SimpleBuilderImplementation;
 
 #[async_trait]
-impl<I: TestableNodeImplementation<TestTypes>> TestBuilderImplementation
-    for SimpleBuilderImplementation<I>
+impl<TYPES: NodeType> TestBuilderImplementation<TYPES> for SimpleBuilderImplementation
+where
+    for<'a> <<TYPES::SignatureKey as SignatureKey>::PureAssembledSignatureType as TryFrom<
+        &'a TaggedBase64,
+    >>::Error: Display,
 {
-    type TYPES = TestTypes;
-    type I = I;
-
     async fn start(
-        membership: Arc<<TestTypes as NodeType>::Membership>,
-    ) -> (Option<Box<dyn BuilderTask<TYPES = Self::TYPES>>>, Url) {
+        membership: Arc<TYPES::Membership>,
+    ) -> (Option<Box<dyn BuilderTask<TYPES>>>, Url) {
         let port = portpicker::pick_unused_port().expect("No free ports");
         let url = Url::parse(&format!("http://localhost:{port}")).expect("Valid URL");
         let (source, task) = make_simple_builder(membership).await;
 
-        let builder_api =
-            hotshot_builder_api::builder::define_api::<SimpleBuilderSource, TestTypes, Version01>(
-                &Options::default(),
-            )
-            .expect("Failed to construct the builder API");
-        let mut app: App<SimpleBuilderSource, hotshot_builder_api::builder::Error> =
+        let builder_api = hotshot_builder_api::builder::define_api::<
+            SimpleBuilderSource<TYPES>,
+            TYPES,
+            Version01,
+        >(&Options::default())
+        .expect("Failed to construct the builder API");
+        let mut app: App<SimpleBuilderSource<TYPES>, hotshot_builder_api::builder::Error> =
             App::with_state(source);
         app.register_module("api", builder_api)
             .expect("Failed to register the builder API");
@@ -98,10 +93,10 @@ impl<I: TestableNodeImplementation<TestTypes>> TestBuilderImplementation
 }
 
 /// Entry for a built block
-struct BlockEntry {
-    metadata: AvailableBlockInfo<TestTypes>,
-    payload: Option<AvailableBlockData<TestTypes>>,
-    header_input: Option<AvailableBlockHeaderInput<TestTypes>>,
+struct BlockEntry<TYPES: NodeType> {
+    metadata: AvailableBlockInfo<TYPES>,
+    payload: Option<AvailableBlockData<TYPES>>,
+    header_input: Option<AvailableBlockHeaderInput<TYPES>>,
 }
 
 /// Options controlling how the random builder generates blocks
@@ -132,26 +127,26 @@ impl Default for RandomBuilderOptions {
 /// Builds random blocks, doesn't track HotShot state at all.
 /// Evicts old available blocks if HotShot doesn't keep up.
 #[derive(Clone, Debug)]
-pub struct RandomBuilderSource {
+pub struct RandomBuilderSource<TYPES: NodeType> {
     /// Built blocks
     blocks: Arc<
         RwLock<
             // Isn't strictly speaking used as a cache,
             // just as a HashMap that evicts old blocks
-            LruCache<BuilderCommitment, BlockEntry>,
+            LruCache<BuilderCommitment, BlockEntry<TYPES>>,
         >,
     >,
-    pub_key: <TestTypes as NodeType>::SignatureKey,
-    priv_key: <<TestTypes as NodeType>::SignatureKey as SignatureKey>::PrivateKey,
+    pub_key: TYPES::SignatureKey,
+    priv_key: <TYPES::SignatureKey as SignatureKey>::PrivateKey,
 }
 
-impl RandomBuilderSource {
+impl<TYPES: NodeType> RandomBuilderSource<TYPES> {
     /// Create new [`RandomBuilderSource`]
     #[must_use]
     #[allow(clippy::missing_panics_doc)] // ony panics if 256 == 0
     pub fn new(
-        pub_key: <TestTypes as NodeType>::SignatureKey,
-        priv_key: <<TestTypes as NodeType>::SignatureKey as SignatureKey>::PrivateKey,
+        pub_key: TYPES::SignatureKey,
+        priv_key: <TYPES::SignatureKey as SignatureKey>::PrivateKey,
     ) -> Self {
         Self {
             blocks: Arc::new(RwLock::new(LruCache::new(NonZeroUsize::new(256).unwrap()))),
@@ -164,13 +159,13 @@ impl RandomBuilderSource {
     #[allow(clippy::missing_panics_doc)] // ony panics on 16-bit platforms
     pub fn run(&self, options: RandomBuilderOptions) {
         let blocks = self.blocks.clone();
-        let (priv_key, pub_key) = (self.priv_key.clone(), self.pub_key);
+        let (priv_key, pub_key) = (self.priv_key.clone(), self.pub_key.clone());
         async_spawn(async move {
             let mut rng = SmallRng::from_entropy();
             let time_per_block = Duration::from_secs(1) / options.blocks_per_second;
             loop {
                 let start = std::time::Instant::now();
-                let transactions: Vec<TestTransaction> = (0..options.txn_in_block)
+                let transactions: Vec<TYPES::Transaction> = (0..options.txn_in_block)
                     .map(|_| {
                         let mut bytes = vec![
                             0;
@@ -179,14 +174,14 @@ impl RandomBuilderSource {
                                 .expect("We are NOT running on a 16-bit platform")
                         ];
                         rng.fill_bytes(&mut bytes);
-                        TestTransaction(bytes)
+                        TYPES::Transaction::from_bytes(&bytes)
                     })
                     .collect();
 
                 let (metadata, payload, header_input) = build_block(
                     transactions,
                     options.num_storage_nodes,
-                    pub_key,
+                    pub_key.clone(),
                     priv_key.clone(),
                 );
 
@@ -207,7 +202,7 @@ impl RandomBuilderSource {
 }
 
 #[async_trait]
-impl ReadState for RandomBuilderSource {
+impl<TYPES: NodeType> ReadState for RandomBuilderSource<TYPES> {
     type State = Self;
 
     async fn read<T>(
@@ -219,11 +214,11 @@ impl ReadState for RandomBuilderSource {
 }
 
 #[async_trait]
-impl BuilderDataSource<TestTypes> for RandomBuilderSource {
+impl<TYPES: NodeType> BuilderDataSource<TYPES> for RandomBuilderSource<TYPES> {
     async fn get_available_blocks(
         &self,
         _for_parent: &VidCommitment,
-    ) -> Result<Vec<AvailableBlockInfo<TestTypes>>, BuildError> {
+    ) -> Result<Vec<AvailableBlockInfo<TYPES>>, BuildError> {
         Ok(self
             .blocks
             .deref()
@@ -237,8 +232,8 @@ impl BuilderDataSource<TestTypes> for RandomBuilderSource {
     async fn claim_block(
         &self,
         block_hash: &BuilderCommitment,
-        _signature: &<<TestTypes as NodeType>::SignatureKey as SignatureKey>::PureAssembledSignatureType,
-    ) -> Result<AvailableBlockData<TestTypes>, BuildError> {
+        _signature: &<TYPES::SignatureKey as SignatureKey>::PureAssembledSignatureType,
+    ) -> Result<AvailableBlockData<TYPES>, BuildError> {
         let mut blocks = self.blocks.write().await;
         let entry = blocks.get_mut(block_hash).ok_or(BuildError::NotFound)?;
         let payload = entry.payload.take().ok_or(BuildError::Missing)?;
@@ -252,8 +247,8 @@ impl BuilderDataSource<TestTypes> for RandomBuilderSource {
     async fn claim_block_header_input(
         &self,
         block_hash: &BuilderCommitment,
-        _signature: &<<TestTypes as NodeType>::SignatureKey as SignatureKey>::PureAssembledSignatureType,
-    ) -> Result<AvailableBlockHeaderInput<TestTypes>, BuildError> {
+        _signature: &<TYPES::SignatureKey as SignatureKey>::PureAssembledSignatureType,
+    ) -> Result<AvailableBlockHeaderInput<TYPES>, BuildError> {
         let mut blocks = self.blocks.write().await;
         let entry = blocks.get_mut(block_hash).ok_or(BuildError::NotFound)?;
         let header_input = entry.header_input.take().ok_or(BuildError::Missing)?;
@@ -264,10 +259,8 @@ impl BuilderDataSource<TestTypes> for RandomBuilderSource {
         Ok(header_input)
     }
 
-    async fn get_builder_address(
-        &self,
-    ) -> Result<<TestTypes as NodeType>::SignatureKey, BuildError> {
-        Ok(self.pub_key)
+    async fn get_builder_address(&self) -> Result<TYPES::SignatureKey, BuildError> {
+        Ok(self.pub_key.clone())
     }
 }
 
@@ -275,34 +268,38 @@ impl BuilderDataSource<TestTypes> for RandomBuilderSource {
 ///
 /// # Panics
 /// If constructing and launching the builder fails for any reason
-pub fn run_random_builder(url: Url) {
-    let (pub_key, priv_key) =
-        <TestTypes as NodeType>::SignatureKey::generated_from_seed_indexed([1; 32], 0);
+pub fn run_random_builder<TYPES: NodeType>(url: Url)
+where
+    for<'a> <<TYPES::SignatureKey as SignatureKey>::PureAssembledSignatureType as TryFrom<
+        &'a TaggedBase64,
+    >>::Error: Display,
+{
+    let (pub_key, priv_key) = TYPES::SignatureKey::generated_from_seed_indexed([1; 32], 0);
     let source = RandomBuilderSource::new(pub_key, priv_key);
     source.run(RandomBuilderOptions::default());
 
     let builder_api =
-        hotshot_builder_api::builder::define_api::<RandomBuilderSource, TestTypes, Version01>(
+        hotshot_builder_api::builder::define_api::<RandomBuilderSource<TYPES>, TYPES, Version01>(
             &Options::default(),
         )
         .expect("Failed to construct the builder API");
-    let mut app: App<RandomBuilderSource, Error> = App::with_state(source);
+    let mut app: App<RandomBuilderSource<TYPES>, Error> = App::with_state(source);
     app.register_module::<Error, Version01>("api", builder_api)
         .expect("Failed to register the builder API");
 
     async_spawn(app.serve(url, STATIC_VER_0_1));
 }
 
-pub struct SimpleBuilderSource {
-    pub_key: <TestTypes as NodeType>::SignatureKey,
-    priv_key: <<TestTypes as NodeType>::SignatureKey as SignatureKey>::PrivateKey,
-    membership: Arc<<TestTypes as NodeType>::Membership>,
-    transactions: Arc<RwLock<HashMap<Commitment<TestTransaction>, TestTransaction>>>,
-    blocks: Arc<RwLock<HashMap<BuilderCommitment, BlockEntry>>>,
+pub struct SimpleBuilderSource<TYPES: NodeType> {
+    pub_key: TYPES::SignatureKey,
+    priv_key: <TYPES::SignatureKey as SignatureKey>::PrivateKey,
+    membership: Arc<TYPES::Membership>,
+    transactions: Arc<RwLock<HashMap<Commitment<TYPES::Transaction>, TYPES::Transaction>>>,
+    blocks: Arc<RwLock<HashMap<BuilderCommitment, BlockEntry<TYPES>>>>,
 }
 
 #[async_trait]
-impl ReadState for SimpleBuilderSource {
+impl<TYPES: NodeType> ReadState for SimpleBuilderSource<TYPES> {
     type State = Self;
 
     async fn read<T>(
@@ -314,21 +311,21 @@ impl ReadState for SimpleBuilderSource {
 }
 
 #[async_trait]
-impl BuilderDataSource<TestTypes> for SimpleBuilderSource {
+impl<TYPES: NodeType> BuilderDataSource<TYPES> for SimpleBuilderSource<TYPES> {
     async fn get_available_blocks(
         &self,
         _for_parent: &VidCommitment,
-    ) -> Result<Vec<AvailableBlockInfo<TestTypes>>, BuildError> {
+    ) -> Result<Vec<AvailableBlockInfo<TYPES>>, BuildError> {
         let transactions = self
             .transactions
             .read(|txns| {
-                Box::pin(async { txns.values().cloned().collect::<Vec<TestTransaction>>() })
+                Box::pin(async { txns.values().cloned().collect::<Vec<TYPES::Transaction>>() })
             })
             .await;
         let (metadata, payload, header_input) = build_block(
             transactions,
             self.membership.total_nodes(),
-            self.pub_key,
+            self.pub_key.clone(),
             self.priv_key.clone(),
         );
 
@@ -347,8 +344,8 @@ impl BuilderDataSource<TestTypes> for SimpleBuilderSource {
     async fn claim_block(
         &self,
         block_hash: &BuilderCommitment,
-        _signature: &<<TestTypes as NodeType>::SignatureKey as SignatureKey>::PureAssembledSignatureType,
-    ) -> Result<AvailableBlockData<TestTypes>, BuildError> {
+        _signature: &<TYPES::SignatureKey as SignatureKey>::PureAssembledSignatureType,
+    ) -> Result<AvailableBlockData<TYPES>, BuildError> {
         let mut blocks = self.blocks.write().await;
         let entry = blocks.get_mut(block_hash).ok_or(BuildError::NotFound)?;
         entry.payload.take().ok_or(BuildError::Missing)
@@ -357,28 +354,32 @@ impl BuilderDataSource<TestTypes> for SimpleBuilderSource {
     async fn claim_block_header_input(
         &self,
         block_hash: &BuilderCommitment,
-        _signature: &<<TestTypes as NodeType>::SignatureKey as SignatureKey>::PureAssembledSignatureType,
-    ) -> Result<AvailableBlockHeaderInput<TestTypes>, BuildError> {
+        _signature: &<TYPES::SignatureKey as SignatureKey>::PureAssembledSignatureType,
+    ) -> Result<AvailableBlockHeaderInput<TYPES>, BuildError> {
         let mut blocks = self.blocks.write().await;
         let entry = blocks.get_mut(block_hash).ok_or(BuildError::NotFound)?;
         entry.header_input.take().ok_or(BuildError::Missing)
     }
 
-    async fn get_builder_address(
-        &self,
-    ) -> Result<<TestTypes as NodeType>::SignatureKey, BuildError> {
-        Ok(self.pub_key)
+    async fn get_builder_address(&self) -> Result<TYPES::SignatureKey, BuildError> {
+        Ok(self.pub_key.clone())
     }
 }
 
-impl SimpleBuilderSource {
+impl<TYPES: NodeType> SimpleBuilderSource<TYPES>
+where
+    for<'a> <<TYPES::SignatureKey as SignatureKey>::PureAssembledSignatureType as TryFrom<
+        &'a TaggedBase64,
+    >>::Error: Display,
+{
     pub async fn run(self, url: Url) {
-        let builder_api =
-            hotshot_builder_api::builder::define_api::<SimpleBuilderSource, TestTypes, Version01>(
-                &Options::default(),
-            )
-            .expect("Failed to construct the builder API");
-        let mut app: App<SimpleBuilderSource, Error> = App::with_state(self);
+        let builder_api = hotshot_builder_api::builder::define_api::<
+            SimpleBuilderSource<TYPES>,
+            TYPES,
+            Version01,
+        >(&Options::default())
+        .expect("Failed to construct the builder API");
+        let mut app: App<SimpleBuilderSource<TYPES>, Error> = App::with_state(self);
         app.register_module::<Error, Version01>("api", builder_api)
             .expect("Failed to register the builder API");
 
@@ -387,29 +388,23 @@ impl SimpleBuilderSource {
 }
 
 #[derive(Clone)]
-pub struct SimpleBuilderTask {
-    transactions: Arc<RwLock<HashMap<Commitment<TestTransaction>, TestTransaction>>>,
-    blocks: Arc<RwLock<HashMap<BuilderCommitment, BlockEntry>>>,
-    decided_transactions: LruCache<Commitment<TestTransaction>, ()>,
+pub struct SimpleBuilderTask<TYPES: NodeType> {
+    transactions: Arc<RwLock<HashMap<Commitment<TYPES::Transaction>, TYPES::Transaction>>>,
+    blocks: Arc<RwLock<HashMap<BuilderCommitment, BlockEntry<TYPES>>>>,
+    decided_transactions: LruCache<Commitment<TYPES::Transaction>, ()>,
 }
 
-pub trait BuilderTask: Send + Sync {
-    type TYPES: NodeType;
-
+pub trait BuilderTask<TYPES: NodeType>: Send + Sync {
     fn start(
         self: Box<Self>,
-        stream: Box<dyn Stream<Item = Event<Self::TYPES>> + std::marker::Unpin + Send + 'static>,
+        stream: Box<dyn Stream<Item = Event<TYPES>> + std::marker::Unpin + Send + 'static>,
     );
 }
 
-impl BuilderTask for SimpleBuilderTask {
-    type TYPES = TestTypes;
-
+impl<TYPES: NodeType> BuilderTask<TYPES> for SimpleBuilderTask<TYPES> {
     fn start(
         mut self: Box<Self>,
-        mut stream: Box<
-            dyn Stream<Item = Event<Self::TYPES>> + std::marker::Unpin + Send + 'static,
-        >,
+        mut stream: Box<dyn Stream<Item = Event<TYPES>> + std::marker::Unpin + Send + 'static>,
     ) {
         async_spawn(async move {
             loop {
@@ -422,7 +417,9 @@ impl BuilderTask for SimpleBuilderTask {
                             let mut queue = self.transactions.write().await;
                             for leaf_info in leaf_chain.iter() {
                                 if let Some(ref payload) = leaf_info.leaf.get_block_payload() {
-                                    for txn in payload.transaction_commitments(&()) {
+                                    for txn in payload.transaction_commitments(
+                                        leaf_info.leaf.get_block_header().metadata(),
+                                    ) {
                                         self.decided_transactions.put(txn, ());
                                         queue.remove(&txn);
                                     }
@@ -446,11 +443,10 @@ impl BuilderTask for SimpleBuilderTask {
     }
 }
 
-pub async fn make_simple_builder(
-    membership: Arc<<TestTypes as NodeType>::Membership>,
-) -> (SimpleBuilderSource, SimpleBuilderTask) {
-    let (pub_key, priv_key) =
-        <TestTypes as NodeType>::SignatureKey::generated_from_seed_indexed([1; 32], 0);
+pub async fn make_simple_builder<TYPES: NodeType>(
+    membership: Arc<TYPES::Membership>,
+) -> (SimpleBuilderSource<TYPES>, SimpleBuilderTask<TYPES>) {
+    let (pub_key, priv_key) = TYPES::SignatureKey::generated_from_seed_indexed([1; 32], 0);
 
     let transactions = Arc::new(RwLock::new(HashMap::new()));
     let blocks = Arc::new(RwLock::new(HashMap::new()));
@@ -473,21 +469,22 @@ pub async fn make_simple_builder(
 }
 
 /// Helper function to construct all builder data structures from a list of transactions
-fn build_block(
-    transactions: Vec<TestTransaction>,
+fn build_block<TYPES: NodeType>(
+    transactions: Vec<TYPES::Transaction>,
     num_storage_nodes: usize,
-    pub_key: <TestTypes as NodeType>::SignatureKey,
-    priv_key: <<TestTypes as NodeType>::SignatureKey as SignatureKey>::PrivateKey,
+    pub_key: TYPES::SignatureKey,
+    priv_key: <TYPES::SignatureKey as SignatureKey>::PrivateKey,
 ) -> (
-    AvailableBlockInfo<TestTypes>,
-    AvailableBlockData<TestTypes>,
-    AvailableBlockHeaderInput<TestTypes>,
+    AvailableBlockInfo<TYPES>,
+    AvailableBlockData<TYPES>,
+    AvailableBlockHeaderInput<TYPES>,
 ) {
-    let block_size = transactions.iter().map(|t| t.0.len() as u64).sum::<u64>();
+    let block_size = transactions.iter().map(|t| t.len() as u64).sum::<u64>();
 
-    let block_payload = TestBlockPayload { transactions };
+    let (block_payload, metadata) = TYPES::BlockPayload::from_transactions(transactions)
+        .expect("failed to build block payload from transactions");
 
-    let commitment = block_payload.builder_commitment(&());
+    let commitment = block_payload.builder_commitment(&metadata);
 
     let vid_commitment = vid_commitment(
         &block_payload.encode().unwrap().collect(),
@@ -499,7 +496,7 @@ fn build_block(
         block_info.extend_from_slice(block_size.to_be_bytes().as_ref());
         block_info.extend_from_slice(123_u64.to_be_bytes().as_ref());
         block_info.extend_from_slice(commitment.as_ref());
-        match <TestTypes as NodeType>::SignatureKey::sign(&priv_key, &block_info) {
+        match TYPES::SignatureKey::sign(&priv_key, &block_info) {
             Ok(sig) => sig,
             Err(e) => {
                 panic!("Failed to sign block: {}", e);
@@ -508,7 +505,7 @@ fn build_block(
     };
 
     let signature_over_builder_commitment =
-        match <TestTypes as NodeType>::SignatureKey::sign(&priv_key, commitment.as_ref()) {
+        match TYPES::SignatureKey::sign(&priv_key, commitment.as_ref()) {
             Ok(sig) => sig,
             Err(e) => {
                 panic!("Failed to sign block: {}", e);
@@ -516,7 +513,7 @@ fn build_block(
         };
 
     let signature_over_vid_commitment =
-        match <TestTypes as NodeType>::SignatureKey::sign(&priv_key, vid_commitment.as_ref()) {
+        match TYPES::SignatureKey::sign(&priv_key, vid_commitment.as_ref()) {
             Ok(sig) => sig,
             Err(e) => {
                 panic!("Failed to sign block: {}", e);
@@ -525,13 +522,12 @@ fn build_block(
 
     let block = AvailableBlockData {
         block_payload,
-        metadata: (),
-        sender: pub_key,
+        metadata,
+        sender: pub_key.clone(),
         signature: signature_over_block_info,
-        _phantom: std::marker::PhantomData,
     };
     let metadata = AvailableBlockInfo {
-        sender: pub_key,
+        sender: pub_key.clone(),
         signature: signature_over_builder_commitment,
         block_hash: commitment,
         block_size,

--- a/crates/testing/src/block_builder.rs
+++ b/crates/testing/src/block_builder.rs
@@ -294,6 +294,7 @@ pub struct SimpleBuilderSource<TYPES: NodeType> {
     pub_key: TYPES::SignatureKey,
     priv_key: <TYPES::SignatureKey as SignatureKey>::PrivateKey,
     membership: Arc<TYPES::Membership>,
+    #[allow(clippy::type_complexity)]
     transactions: Arc<RwLock<HashMap<Commitment<TYPES::Transaction>, TYPES::Transaction>>>,
     blocks: Arc<RwLock<HashMap<BuilderCommitment, BlockEntry<TYPES>>>>,
 }
@@ -389,6 +390,7 @@ where
 
 #[derive(Clone)]
 pub struct SimpleBuilderTask<TYPES: NodeType> {
+    #[allow(clippy::type_complexity)]
     transactions: Arc<RwLock<HashMap<Commitment<TYPES::Transaction>, TYPES::Transaction>>>,
     blocks: Arc<RwLock<HashMap<BuilderCommitment, BlockEntry<TYPES>>>>,
     decided_transactions: LruCache<Commitment<TYPES::Transaction>, ()>,

--- a/crates/testing/src/test_runner.rs
+++ b/crates/testing/src/test_runner.rs
@@ -132,7 +132,7 @@ where
     /// # Panics
     /// if the test fails
     #[allow(clippy::too_many_lines)]
-    pub async fn run_test<B: TestBuilderImplementation<TYPES = TYPES, I = I>>(mut self) {
+    pub async fn run_test<B: TestBuilderImplementation<TYPES>>(mut self) {
         let (tx, rx) = broadcast(EVENT_CHANNEL_SIZE);
         let spinning_changes = self
             .launcher
@@ -327,7 +327,7 @@ where
     ///
     /// # Panics
     /// Panics if unable to create a [`HotShotInitializer`]
-    pub async fn add_nodes<B: TestBuilderImplementation<TYPES = TYPES, I = I>>(
+    pub async fn add_nodes<B: TestBuilderImplementation<TYPES>>(
         &mut self,
         total: usize,
         late_start: &HashSet<u64>,

--- a/crates/testing/tests/tests_1/block_builder.rs
+++ b/crates/testing/tests/tests_1/block_builder.rs
@@ -29,7 +29,7 @@ async fn test_random_block_builder() {
     let port = portpicker::pick_unused_port().expect("Could not find an open port");
     let api_url = Url::parse(format!("http://localhost:{port}").as_str()).unwrap();
 
-    run_random_builder(api_url.clone());
+    run_random_builder::<TestTypes>(api_url.clone());
     let builder_started = Instant::now();
 
     let client: BuilderClient<TestTypes, Version01> = BuilderClient::new(api_url);

--- a/crates/testing/tests/tests_1/libp2p.rs
+++ b/crates/testing/tests/tests_1/libp2p.rs
@@ -37,7 +37,7 @@ async fn libp2p_network() {
     metadata
         .gen_launcher::<TestTypes, Libp2pImpl>(0)
         .launch()
-        .run_test::<SimpleBuilderImplementation<Libp2pImpl>>()
+        .run_test::<SimpleBuilderImplementation>()
         .await;
 }
 
@@ -84,7 +84,7 @@ async fn libp2p_network_failures_2() {
     metadata
         .gen_launcher::<TestTypes, Libp2pImpl>(0)
         .launch()
-        .run_test::<SimpleBuilderImplementation<Libp2pImpl>>()
+        .run_test::<SimpleBuilderImplementation>()
         .await;
 }
 
@@ -100,6 +100,6 @@ async fn test_stress_libp2p_network() {
     metadata
         .gen_launcher::<TestTypes, Libp2pImpl>(0)
         .launch()
-        .run_test::<SimpleBuilderImplementation<Libp2pImpl>>()
+        .run_test::<SimpleBuilderImplementation>()
         .await;
 }

--- a/crates/testing/tests/tests_2/catchup.rs
+++ b/crates/testing/tests/tests_2/catchup.rs
@@ -52,7 +52,7 @@ async fn test_catchup() {
     metadata
         .gen_launcher::<TestTypes, MemoryImpl>(0)
         .launch()
-        .run_test::<SimpleBuilderImplementation<MemoryImpl>>()
+        .run_test::<SimpleBuilderImplementation>()
         .await;
 }
 
@@ -105,7 +105,7 @@ async fn test_catchup_cdn() {
     metadata
         .gen_launcher::<TestTypes, PushCdnImpl>(0)
         .launch()
-        .run_test::<SimpleBuilderImplementation<PushCdnImpl>>()
+        .run_test::<SimpleBuilderImplementation>()
         .await;
 }
 
@@ -160,7 +160,7 @@ async fn test_catchup_one_node() {
     metadata
         .gen_launcher::<TestTypes, MemoryImpl>(0)
         .launch()
-        .run_test::<SimpleBuilderImplementation<MemoryImpl>>()
+        .run_test::<SimpleBuilderImplementation>()
         .await;
 }
 
@@ -221,7 +221,7 @@ async fn test_catchup_in_view_sync() {
     metadata
         .gen_launcher::<TestTypes, MemoryImpl>(0)
         .launch()
-        .run_test::<SimpleBuilderImplementation<MemoryImpl>>()
+        .run_test::<SimpleBuilderImplementation>()
         .await;
 }
 
@@ -282,6 +282,6 @@ async fn test_catchup_reload() {
     metadata
         .gen_launcher::<TestTypes, MemoryImpl>(0)
         .launch()
-        .run_test::<SimpleBuilderImplementation<MemoryImpl>>()
+        .run_test::<SimpleBuilderImplementation>()
         .await;
 }

--- a/crates/testing/tests/tests_2/push_cdn.rs
+++ b/crates/testing/tests/tests_2/push_cdn.rs
@@ -40,7 +40,7 @@ async fn push_cdn_network() {
     metadata
         .gen_launcher::<TestTypes, PushCdnImpl>(0)
         .launch()
-        .run_test::<SimpleBuilderImplementation<PushCdnImpl>>()
+        .run_test::<SimpleBuilderImplementation>()
         .await;
     shutdown_logging();
 }

--- a/crates/testing/tests/tests_5/combined_network.rs
+++ b/crates/testing/tests/tests_5/combined_network.rs
@@ -45,7 +45,7 @@ async fn test_combined_network() {
     metadata
         .gen_launcher::<TestTypes, CombinedImpl>(0)
         .launch()
-        .run_test::<SimpleBuilderImplementation<CombinedImpl>>()
+        .run_test::<SimpleBuilderImplementation>()
         .await;
 }
 
@@ -93,7 +93,7 @@ async fn test_combined_network_cdn_crash() {
     metadata
         .gen_launcher::<TestTypes, CombinedImpl>(0)
         .launch()
-        .run_test::<SimpleBuilderImplementation<CombinedImpl>>()
+        .run_test::<SimpleBuilderImplementation>()
         .await;
 }
 
@@ -147,7 +147,7 @@ async fn test_combined_network_reup() {
     metadata
         .gen_launcher::<TestTypes, CombinedImpl>(0)
         .launch()
-        .run_test::<SimpleBuilderImplementation<CombinedImpl>>()
+        .run_test::<SimpleBuilderImplementation>()
         .await;
 }
 
@@ -195,7 +195,7 @@ async fn test_combined_network_half_dc() {
     metadata
         .gen_launcher::<TestTypes, CombinedImpl>(0)
         .launch()
-        .run_test::<SimpleBuilderImplementation<CombinedImpl>>()
+        .run_test::<SimpleBuilderImplementation>()
         .await;
 }
 
@@ -265,6 +265,6 @@ async fn test_stress_combined_network_fuzzy() {
     metadata
         .gen_launcher::<TestTypes, CombinedImpl>(0)
         .launch()
-        .run_test::<SimpleBuilderImplementation<CombinedImpl>>()
+        .run_test::<SimpleBuilderImplementation>()
         .await;
 }

--- a/crates/testing/tests/tests_5/timeout.rs
+++ b/crates/testing/tests/tests_5/timeout.rs
@@ -57,7 +57,7 @@ async fn test_timeout_web() {
     metadata
         .gen_launcher::<TestTypes, WebImpl>(0)
         .launch()
-        .run_test::<SimpleBuilderImplementation<WebImpl>>()
+        .run_test::<SimpleBuilderImplementation>()
         .await;
 }
 
@@ -124,6 +124,6 @@ async fn test_timeout_libp2p() {
     metadata
         .gen_launcher::<TestTypes, Libp2pImpl>(0)
         .launch()
-        .run_test::<SimpleBuilderImplementation<Libp2pImpl>>()
+        .run_test::<SimpleBuilderImplementation>()
         .await;
 }

--- a/crates/testing/tests/tests_5/unreliable_network.rs
+++ b/crates/testing/tests/tests_5/unreliable_network.rs
@@ -41,7 +41,7 @@ async fn libp2p_network_sync() {
     metadata
         .gen_launcher::<TestTypes, Libp2pImpl>(0)
         .launch()
-        .run_test::<SimpleBuilderImplementation<Libp2pImpl>>()
+        .run_test::<SimpleBuilderImplementation>()
         .await;
 }
 
@@ -74,7 +74,7 @@ async fn test_memory_network_sync() {
     metadata
         .gen_launcher::<TestTypes, MemoryImpl>(0)
         .launch()
-        .run_test::<SimpleBuilderImplementation<MemoryImpl>>()
+        .run_test::<SimpleBuilderImplementation>()
         .await;
 }
 
@@ -113,7 +113,7 @@ async fn libp2p_network_async() {
     metadata
         .gen_launcher::<TestTypes, Libp2pImpl>(0)
         .launch()
-        .run_test::<SimpleBuilderImplementation<Libp2pImpl>>()
+        .run_test::<SimpleBuilderImplementation>()
         .await;
 }
 
@@ -160,7 +160,7 @@ async fn test_memory_network_async() {
     metadata
         .gen_launcher::<TestTypes, MemoryImpl>(0)
         .launch()
-        .run_test::<SimpleBuilderImplementation<_>>()
+        .run_test::<SimpleBuilderImplementation>()
         .await;
 }
 
@@ -212,7 +212,7 @@ async fn test_memory_network_partially_sync() {
     metadata
         .gen_launcher::<TestTypes, MemoryImpl>(0)
         .launch()
-        .run_test::<SimpleBuilderImplementation<_>>()
+        .run_test::<SimpleBuilderImplementation>()
         .await;
 }
 
@@ -252,7 +252,7 @@ async fn libp2p_network_partially_sync() {
     metadata
         .gen_launcher::<TestTypes, Libp2pImpl>(0)
         .launch()
-        .run_test::<SimpleBuilderImplementation<_>>()
+        .run_test::<SimpleBuilderImplementation>()
         .await;
 }
 
@@ -290,7 +290,7 @@ async fn test_memory_network_chaos() {
     metadata
         .gen_launcher::<TestTypes, MemoryImpl>(0)
         .launch()
-        .run_test::<SimpleBuilderImplementation<_>>()
+        .run_test::<SimpleBuilderImplementation>()
         .await;
 }
 
@@ -325,6 +325,6 @@ async fn libp2p_network_chaos() {
     metadata
         .gen_launcher::<TestTypes, Libp2pImpl>(0)
         .launch()
-        .run_test::<SimpleBuilderImplementation<_>>()
+        .run_test::<SimpleBuilderImplementation>()
         .await;
 }

--- a/crates/testing/tests/tests_5/web_server.rs
+++ b/crates/testing/tests/tests_5/web_server.rs
@@ -40,7 +40,7 @@ async fn web_server_network() {
     metadata
         .gen_launcher::<TestTypes, WebImpl>(0)
         .launch()
-        .run_test::<SimpleBuilderImplementation<_>>()
+        .run_test::<SimpleBuilderImplementation>()
         .await;
     shutdown_logging();
 }

--- a/crates/types/src/traits/block_contents.rs
+++ b/crates/types/src/traits/block_contents.rs
@@ -29,6 +29,9 @@ pub trait Transaction:
 
     /// Get the length of the transaction
     fn len(&self) -> usize;
+
+    /// Whether or not the transaction is empty
+    fn is_empty(&self) -> bool;
 }
 
 /// Abstraction over the full contents of a block

--- a/crates/types/src/traits/block_contents.rs
+++ b/crates/types/src/traits/block_contents.rs
@@ -24,6 +24,11 @@ use std::{
 pub trait Transaction:
     Clone + Serialize + DeserializeOwned + Debug + PartialEq + Eq + Sync + Send + Committable + Hash
 {
+    /// Build a transaction from bytes
+    fn from_bytes(bytes: &[u8]) -> Self;
+
+    /// Get the length of the transaction
+    fn len(&self) -> usize;
 }
 
 /// Abstraction over the full contents of a block

--- a/crates/types/src/traits/signature_key.rs
+++ b/crates/types/src/traits/signature_key.rs
@@ -68,7 +68,8 @@ pub trait SignatureKey:
         + Eq
         + Serialize
         + for<'a> Deserialize<'a>
-        + Into<TaggedBase64>;
+        + Into<TaggedBase64>
+        + for<'a> TryFrom<&'a TaggedBase64>;
     /// The type of the assembled qc: assembled signature + `BitVec`
     type QCType: Send
         + Sync


### PR DESCRIPTION
No linked issue
<!-- See here for keywords in Github -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

### This PR: 
<!-- Describe what this PR adds to HotSHot -->
<!-- E.g. -->
<!-- * Implements feature 1 -->
<!-- * Implements feature 2 -->
<!-- * Fixes bug 3 -->

Makes `SimpleBuilderImplementation` generic over `NodeType`, instead of being pinned to `TestTypes`. We need this for testing purposes in the sequencer and `hotshot-query-service`, which use its own `MockTypes`.

Because of this, I had to make some slight changes to the `Transaction` trait.

### This PR does not: 
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->

- Change builder functionality
- Remove compatibility with `TestTypes`

### Key places to review: 
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->
- `block_builder.rs`
- `block_contents.rs`


<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
