### PR TITLE
Update Testing Framework to Support Async

### DIFF
--- a/crates/macros/src/lib.rs
+++ b/crates/macros/src/lib.rs
@@ -364,7 +364,7 @@ pub fn test_scripts(input: proc_macro::TokenStream) -> TokenStream {
 
                         let assert = &mut output_asserts[#output_index_names];
 
-                        validate_output_or_panic_in_script(stage_number, #script_names.to_string(), &received_output, assert);
+                        validate_output_or_panic_in_script(stage_number, #script_names.to_string(), &received_output, &**assert).await;
 
                         #output_index_names += 1;
                     }
@@ -392,7 +392,7 @@ pub fn test_scripts(input: proc_macro::TokenStream) -> TokenStream {
 
                         let mut assert = &mut output_asserts[#output_index_names];
 
-                        validate_output_or_panic_in_script(stage_number, #script_names.to_string(), &received_output, assert);
+                        validate_output_or_panic_in_script(stage_number, #script_names.to_string(), &received_output, &**assert).await;
 
                         #output_index_names += 1;
                     }
@@ -410,7 +410,7 @@ pub fn test_scripts(input: proc_macro::TokenStream) -> TokenStream {
             let task_state_asserts = &mut #task_expectations[stage_number].task_state_asserts;
 
             for assert in task_state_asserts {
-                validate_task_state_or_panic_in_script(stage_number, #script_names.to_string(), #task_names.state(), assert);
+                validate_task_state_or_panic_in_script(stage_number, #script_names.to_string(), #task_names.state(), &**assert).await;
             }
         )*
     } }

--- a/crates/testing/src/predicates.rs
+++ b/crates/testing/src/predicates.rs
@@ -1,7 +1,6 @@
-use std::{collections::HashSet, pin::Pin, sync::Arc};
+use std::sync::Arc;
 
 use async_trait::async_trait;
-use futures::Future;
 use hotshot::types::SystemContextHandle;
 use hotshot_example_types::node_types::{MemoryImpl, TestTypes};
 use hotshot_task_impls::{
@@ -60,7 +59,7 @@ where
     TYPES: NodeType + Send + Sync + 'static,
 {
     async fn evaluate(&self, input: &Arc<HotShotEvent<TYPES>>) -> PredicateResult {
-        PredicateResult::from((self.check)(input.clone().into()))
+        PredicateResult::from((self.check)(input.clone()))
     }
 
     async fn info(&self) -> String {

--- a/crates/testing/src/predicates.rs
+++ b/crates/testing/src/predicates.rs
@@ -1,5 +1,7 @@
-use std::{collections::HashSet, sync::Arc};
+use std::{collections::HashSet, pin::Pin, sync::Arc};
 
+use async_trait::async_trait;
+use futures::Future;
 use hotshot::types::SystemContextHandle;
 use hotshot_example_types::node_types::{MemoryImpl, TestTypes};
 use hotshot_task_impls::{
@@ -8,6 +10,7 @@ use hotshot_task_impls::{
 };
 use hotshot_types::{
     data::null_block,
+    simple_certificate::UpgradeCertificate,
     traits::{block_contents::BlockHeader, node_implementation::NodeType},
 };
 
@@ -29,247 +32,199 @@ impl From<bool> for PredicateResult {
     }
 }
 
-pub struct Predicate<INPUT> {
-    pub function: Box<dyn FnMut(&INPUT) -> PredicateResult>,
-    pub info: String,
+#[async_trait]
+pub trait Predicate<INPUT>: std::fmt::Debug {
+    async fn evaluate(&self, input: &INPUT) -> PredicateResult;
+    async fn info(&self) -> String;
 }
 
-pub fn all<TYPES>(events: Vec<HotShotEvent<TYPES>>) -> Predicate<Arc<HotShotEvent<TYPES>>>
+type AsyncBooleanCallback<TYPES> = Arc<dyn Fn(Arc<HotShotEvent<TYPES>>) -> bool + Send + Sync>;
+
+pub struct EventBooleanPredicate<TYPES>
 where
-    TYPES: NodeType,
+    TYPES: NodeType + Send + Sync,
 {
-    let info = format!("{:?}", events);
-    let mut set: HashSet<_> = events.into_iter().collect();
-
-    let function = move |e: &Arc<HotShotEvent<TYPES>>| match set.take(e.as_ref()) {
-        Some(_) => {
-            if set.is_empty() {
-                PredicateResult::Pass
-            } else {
-                PredicateResult::Incomplete
-            }
-        }
-        None => PredicateResult::Fail,
-    };
-
-    Predicate {
-        function: Box::new(function),
-        info,
-    }
+    check: AsyncBooleanCallback<TYPES>,
+    info: String,
 }
 
-impl<INPUT> std::fmt::Debug for Predicate<INPUT> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+impl<TYPES: NodeType> std::fmt::Debug for EventBooleanPredicate<TYPES> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.info)
     }
 }
 
-pub fn exact<TYPES>(event: HotShotEvent<TYPES>) -> Predicate<Arc<HotShotEvent<TYPES>>>
+#[async_trait]
+impl<TYPES> Predicate<Arc<HotShotEvent<TYPES>>> for EventBooleanPredicate<TYPES>
+where
+    TYPES: NodeType + Send + Sync + 'static,
+{
+    async fn evaluate(&self, input: &Arc<HotShotEvent<TYPES>>) -> PredicateResult {
+        PredicateResult::from((self.check)(input.clone().into()))
+    }
+
+    async fn info(&self) -> String {
+        self.info.clone()
+    }
+}
+
+pub fn exact<TYPES>(event: HotShotEvent<TYPES>) -> Box<EventBooleanPredicate<TYPES>>
 where
     TYPES: NodeType,
 {
     let info = format!("{:?}", event);
     let event = Arc::new(event);
 
-    Predicate {
-        function: Box::new(move |e| PredicateResult::from(e == &event)),
-        info,
-    }
+    let check: AsyncBooleanCallback<TYPES> = Arc::new(move |e: Arc<HotShotEvent<TYPES>>| {
+        let event_clone = event.clone();
+        *e == *event_clone
+    });
+
+    Box::new(EventBooleanPredicate { check, info })
 }
 
-pub fn multi_exact<TYPES>(
-    events: Vec<HotShotEvent<TYPES>>,
-) -> Vec<Predicate<Arc<HotShotEvent<TYPES>>>>
-where
-    TYPES: NodeType,
-{
-    events
-        .into_iter()
-        .map(|event| {
-            let event = Arc::new(event);
-            let info = format!("{:?}", event);
-            Predicate {
-                function: Box::new(move |e| PredicateResult::from(e == &event)),
-                info,
-            }
-        })
-        .collect()
-}
-
-pub fn leaf_decided<TYPES>() -> Predicate<Arc<HotShotEvent<TYPES>>>
+pub fn leaf_decided<TYPES>() -> Box<EventBooleanPredicate<TYPES>>
 where
     TYPES: NodeType,
 {
     let info = "LeafDecided".to_string();
-    let function =
-        |e: &Arc<HotShotEvent<TYPES>>| PredicateResult::from(matches!(e.as_ref(), LeafDecided(_)));
+    let check: AsyncBooleanCallback<TYPES> =
+        Arc::new(move |e: Arc<HotShotEvent<TYPES>>| matches!(e.as_ref(), LeafDecided(_)));
 
-    Predicate {
-        function: Box::new(function),
-        info,
-    }
+    Box::new(EventBooleanPredicate { check, info })
 }
 
-pub fn quorum_vote_send<TYPES>() -> Predicate<Arc<HotShotEvent<TYPES>>>
+pub fn quorum_vote_send<TYPES>() -> Box<EventBooleanPredicate<TYPES>>
 where
     TYPES: NodeType,
 {
     let info = "QuorumVoteSend".to_string();
-    let function = |e: &Arc<HotShotEvent<TYPES>>| {
-        PredicateResult::from(matches!(e.as_ref(), QuorumVoteSend(_)))
-    };
+    let check: AsyncBooleanCallback<TYPES> =
+        Arc::new(move |e: Arc<HotShotEvent<TYPES>>| matches!(e.as_ref(), QuorumVoteSend(_)));
 
-    Predicate {
-        function: Box::new(function),
-        info,
-    }
+    Box::new(EventBooleanPredicate { check, info })
 }
 
-pub fn view_change<TYPES>() -> Predicate<Arc<HotShotEvent<TYPES>>>
+pub fn view_change<TYPES>() -> Box<EventBooleanPredicate<TYPES>>
 where
     TYPES: NodeType,
 {
     let info = "ViewChange".to_string();
-    let function =
-        |e: &Arc<HotShotEvent<TYPES>>| PredicateResult::from(matches!(e.as_ref(), ViewChange(_)));
-
-    Predicate {
-        function: Box::new(function),
-        info,
-    }
+    let check: AsyncBooleanCallback<TYPES> =
+        Arc::new(move |e: Arc<HotShotEvent<TYPES>>| matches!(e.as_ref(), ViewChange(_)));
+    Box::new(EventBooleanPredicate { check, info })
 }
 
-pub fn upgrade_certificate_formed<TYPES>() -> Predicate<Arc<HotShotEvent<TYPES>>>
+pub fn upgrade_certificate_formed<TYPES>() -> Box<EventBooleanPredicate<TYPES>>
 where
     TYPES: NodeType,
 {
     let info = "UpgradeCertificateFormed".to_string();
-    let function = |e: &Arc<HotShotEvent<TYPES>>| {
-        PredicateResult::from(matches!(e.as_ref(), UpgradeCertificateFormed(_)))
-    };
-
-    Predicate {
-        function: Box::new(function),
-        info,
-    }
+    let check: AsyncBooleanCallback<TYPES> = Arc::new(move |e: Arc<HotShotEvent<TYPES>>| {
+        matches!(e.as_ref(), UpgradeCertificateFormed(_))
+    });
+    Box::new(EventBooleanPredicate { check, info })
 }
 
-pub fn quorum_proposal_send_with_upgrade_certificate<TYPES>() -> Predicate<Arc<HotShotEvent<TYPES>>>
+pub fn quorum_proposal_send_with_upgrade_certificate<TYPES>() -> Box<EventBooleanPredicate<TYPES>>
 where
     TYPES: NodeType,
 {
     let info = "QuorumProposalSend with UpgradeCertificate attached".to_string();
-    let function = |e: &Arc<HotShotEvent<TYPES>>| match e.as_ref() {
-        QuorumProposalSend(proposal, _) => {
-            PredicateResult::from(proposal.data.upgrade_certificate.is_some())
-        }
-        _ => PredicateResult::Fail,
-    };
-
-    Predicate {
-        function: Box::new(function),
-        info,
-    }
+    let check: AsyncBooleanCallback<TYPES> =
+        Arc::new(move |e: Arc<HotShotEvent<TYPES>>| match e.as_ref() {
+            QuorumProposalSend(proposal, _) => proposal.data.upgrade_certificate.is_some(),
+            _ => false,
+        });
+    Box::new(EventBooleanPredicate { info, check })
 }
 
-pub fn quorum_proposal_validated<TYPES>() -> Predicate<Arc<HotShotEvent<TYPES>>>
+pub fn quorum_proposal_validated<TYPES>() -> Box<EventBooleanPredicate<TYPES>>
 where
     TYPES: NodeType,
 {
     let info = "QuorumProposalValidated".to_string();
-    let function = |e: &Arc<HotShotEvent<TYPES>>| {
-        PredicateResult::from(matches!(e.as_ref(), QuorumProposalValidated(..)))
-    };
-
-    Predicate {
-        function: Box::new(function),
-        info,
-    }
+    let check: AsyncBooleanCallback<TYPES> = Arc::new(move |e: Arc<HotShotEvent<TYPES>>| {
+        matches!(*e.clone(), QuorumProposalValidated(..))
+    });
+    Box::new(EventBooleanPredicate { check, info })
 }
 
-pub fn quorum_proposal_send<TYPES>() -> Predicate<Arc<HotShotEvent<TYPES>>>
+pub fn quorum_proposal_send<TYPES>() -> Box<EventBooleanPredicate<TYPES>>
 where
     TYPES: NodeType,
 {
     let info = "QuorumProposalSend".to_string();
-    let function = |e: &Arc<HotShotEvent<TYPES>>| {
-        PredicateResult::from(matches!(e.as_ref(), QuorumProposalSend(_, _)))
-    };
-
-    Predicate {
-        function: Box::new(function),
-        info,
-    }
+    let check: AsyncBooleanCallback<TYPES> =
+        Arc::new(move |e: Arc<HotShotEvent<TYPES>>| matches!(e.as_ref(), QuorumProposalSend(..)));
+    Box::new(EventBooleanPredicate { check, info })
 }
 
 pub fn quorum_proposal_send_with_null_block<TYPES>(
     num_storage_nodes: usize,
-) -> Predicate<Arc<HotShotEvent<TYPES>>>
+) -> Box<EventBooleanPredicate<TYPES>>
 where
     TYPES: NodeType,
 {
     let info = "QuorumProposalSend with null block payload".to_string();
-    let function = move |e: &Arc<HotShotEvent<TYPES>>| match e.as_ref() {
-        QuorumProposalSend(proposal, _) => PredicateResult::from(
-            Some(proposal.data.block_header.payload_commitment())
-                == null_block::commitment(num_storage_nodes),
-        ),
-        _ => PredicateResult::Fail,
-    };
-
-    Predicate {
-        function: Box::new(function),
-        info,
-    }
+    let check: AsyncBooleanCallback<TYPES> =
+        Arc::new(move |e: Arc<HotShotEvent<TYPES>>| match e.as_ref() {
+            QuorumProposalSend(proposal, _) => {
+                Some(proposal.data.block_header.payload_commitment())
+                    == null_block::commitment(num_storage_nodes)
+            }
+            _ => false,
+        });
+    Box::new(EventBooleanPredicate { check, info })
 }
 
-pub fn timeout_vote_send<TYPES>() -> Predicate<Arc<HotShotEvent<TYPES>>>
+pub fn timeout_vote_send<TYPES>() -> Box<EventBooleanPredicate<TYPES>>
 where
     TYPES: NodeType,
 {
     let info = "TimeoutVoteSend".to_string();
-    let function = |e: &Arc<HotShotEvent<TYPES>>| {
-        PredicateResult::from(matches!(e.as_ref(), TimeoutVoteSend(_)))
-    };
-
-    Predicate {
-        function: Box::new(function),
-        info,
-    }
+    let check: AsyncBooleanCallback<TYPES> =
+        Arc::new(move |e: Arc<HotShotEvent<TYPES>>| matches!(e.as_ref(), TimeoutVoteSend(..)));
+    Box::new(EventBooleanPredicate { check, info })
 }
 
 type ConsensusTaskTestState =
     ConsensusTaskState<TestTypes, MemoryImpl, SystemContextHandle<TestTypes, MemoryImpl>>;
 
-pub fn consensus_predicate(
-    function: Box<dyn for<'a> Fn(&'a ConsensusTaskTestState) -> bool>,
-    info: &str,
-) -> Predicate<ConsensusTaskTestState> {
-    let wrapped_function = move |e: &ConsensusTaskTestState| PredicateResult::from(function(e));
+type AsyncUpgradeCertCallback =
+    Arc<dyn Fn(Arc<Option<UpgradeCertificate<TestTypes>>>) -> bool + Send + Sync>;
 
-    Predicate {
-        function: Box::new(wrapped_function),
-        info: info.to_string(),
+pub struct UpgradeCertPredicate {
+    check: AsyncUpgradeCertCallback,
+    info: String,
+}
+
+impl std::fmt::Debug for UpgradeCertPredicate {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.info)
     }
 }
 
-pub fn no_decided_upgrade_cert() -> Predicate<ConsensusTaskTestState> {
-    consensus_predicate(
-        Box::new(|state| state.decided_upgrade_cert.is_none()),
-        "expected decided_upgrade_cert to be None",
-    )
+#[async_trait]
+impl Predicate<ConsensusTaskTestState> for UpgradeCertPredicate {
+    async fn evaluate(&self, input: &ConsensusTaskTestState) -> PredicateResult {
+        let upgrade_cert = input.decided_upgrade_cert.clone();
+        PredicateResult::from((self.check)(upgrade_cert.into()))
+    }
+
+    async fn info(&self) -> String {
+        self.info.clone()
+    }
 }
 
-pub fn decided_upgrade_cert() -> Predicate<ConsensusTaskTestState> {
-    consensus_predicate(
-        Box::new(|state| state.decided_upgrade_cert.is_some()),
-        "expected decided_upgrade_cert to be Some(_)",
-    )
+pub fn no_decided_upgrade_cert() -> Box<UpgradeCertPredicate> {
+    let info = "expected decided_upgrade_cert to be None".to_string();
+    let check: AsyncUpgradeCertCallback = Arc::new(move |s| s.is_none());
+    Box::new(UpgradeCertPredicate { info, check })
 }
 
-pub fn is_at_view_number(n: u64) -> Predicate<ConsensusTaskTestState> {
-    consensus_predicate(
-        Box::new(move |state| *state.cur_view == n),
-        format!("expected cur view to be {}", n).as_str(),
-    )
+pub fn decided_upgrade_cert() -> Box<UpgradeCertPredicate> {
+    let info = "expected decided_upgrade_cert to be Some(_)".to_string();
+    let check: AsyncUpgradeCertCallback = Arc::new(move |s| s.is_some());
+    Box::new(UpgradeCertPredicate { info, check })
 }

--- a/crates/testing/src/predicates/event.rs
+++ b/crates/testing/src/predicates/event.rs
@@ -8,24 +8,24 @@ use std::sync::Arc;
 
 use crate::predicates::{Predicate, PredicateResult};
 
-type BooleanCallback<TYPES> = Arc<dyn Fn(Arc<HotShotEvent<TYPES>>) -> bool + Send + Sync>;
+type EventCallback<TYPES> = Arc<dyn Fn(Arc<HotShotEvent<TYPES>>) -> bool + Send + Sync>;
 
-pub struct EventBooleanPredicate<TYPES>
+pub struct EventPredicate<TYPES>
 where
     TYPES: NodeType + Send + Sync,
 {
-    check: BooleanCallback<TYPES>,
+    check: EventCallback<TYPES>,
     info: String,
 }
 
-impl<TYPES: NodeType> std::fmt::Debug for EventBooleanPredicate<TYPES> {
+impl<TYPES: NodeType> std::fmt::Debug for EventPredicate<TYPES> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.info)
     }
 }
 
 #[async_trait]
-impl<TYPES> Predicate<Arc<HotShotEvent<TYPES>>> for EventBooleanPredicate<TYPES>
+impl<TYPES> Predicate<Arc<HotShotEvent<TYPES>>> for EventPredicate<TYPES>
 where
     TYPES: NodeType + Send + Sync + 'static,
 {
@@ -38,106 +38,106 @@ where
     }
 }
 
-pub fn exact<TYPES>(event: HotShotEvent<TYPES>) -> Box<EventBooleanPredicate<TYPES>>
+pub fn exact<TYPES>(event: HotShotEvent<TYPES>) -> Box<EventPredicate<TYPES>>
 where
     TYPES: NodeType,
 {
     let info = format!("{:?}", event);
     let event = Arc::new(event);
 
-    let check: BooleanCallback<TYPES> = Arc::new(move |e: Arc<HotShotEvent<TYPES>>| {
+    let check: EventCallback<TYPES> = Arc::new(move |e: Arc<HotShotEvent<TYPES>>| {
         let event_clone = event.clone();
         *e == *event_clone
     });
 
-    Box::new(EventBooleanPredicate { check, info })
+    Box::new(EventPredicate { check, info })
 }
 
-pub fn leaf_decided<TYPES>() -> Box<EventBooleanPredicate<TYPES>>
+pub fn leaf_decided<TYPES>() -> Box<EventPredicate<TYPES>>
 where
     TYPES: NodeType,
 {
     let info = "LeafDecided".to_string();
-    let check: BooleanCallback<TYPES> =
+    let check: EventCallback<TYPES> =
         Arc::new(move |e: Arc<HotShotEvent<TYPES>>| matches!(e.as_ref(), LeafDecided(_)));
 
-    Box::new(EventBooleanPredicate { check, info })
+    Box::new(EventPredicate { check, info })
 }
 
-pub fn quorum_vote_send<TYPES>() -> Box<EventBooleanPredicate<TYPES>>
+pub fn quorum_vote_send<TYPES>() -> Box<EventPredicate<TYPES>>
 where
     TYPES: NodeType,
 {
     let info = "QuorumVoteSend".to_string();
-    let check: BooleanCallback<TYPES> =
+    let check: EventCallback<TYPES> =
         Arc::new(move |e: Arc<HotShotEvent<TYPES>>| matches!(e.as_ref(), QuorumVoteSend(_)));
 
-    Box::new(EventBooleanPredicate { check, info })
+    Box::new(EventPredicate { check, info })
 }
 
-pub fn view_change<TYPES>() -> Box<EventBooleanPredicate<TYPES>>
+pub fn view_change<TYPES>() -> Box<EventPredicate<TYPES>>
 where
     TYPES: NodeType,
 {
     let info = "ViewChange".to_string();
-    let check: BooleanCallback<TYPES> =
+    let check: EventCallback<TYPES> =
         Arc::new(move |e: Arc<HotShotEvent<TYPES>>| matches!(e.as_ref(), ViewChange(_)));
-    Box::new(EventBooleanPredicate { check, info })
+    Box::new(EventPredicate { check, info })
 }
 
-pub fn upgrade_certificate_formed<TYPES>() -> Box<EventBooleanPredicate<TYPES>>
+pub fn upgrade_certificate_formed<TYPES>() -> Box<EventPredicate<TYPES>>
 where
     TYPES: NodeType,
 {
     let info = "UpgradeCertificateFormed".to_string();
-    let check: BooleanCallback<TYPES> = Arc::new(move |e: Arc<HotShotEvent<TYPES>>| {
+    let check: EventCallback<TYPES> = Arc::new(move |e: Arc<HotShotEvent<TYPES>>| {
         matches!(e.as_ref(), UpgradeCertificateFormed(_))
     });
-    Box::new(EventBooleanPredicate { check, info })
+    Box::new(EventPredicate { check, info })
 }
 
-pub fn quorum_proposal_send_with_upgrade_certificate<TYPES>() -> Box<EventBooleanPredicate<TYPES>>
+pub fn quorum_proposal_send_with_upgrade_certificate<TYPES>() -> Box<EventPredicate<TYPES>>
 where
     TYPES: NodeType,
 {
     let info = "QuorumProposalSend with UpgradeCertificate attached".to_string();
-    let check: BooleanCallback<TYPES> =
+    let check: EventCallback<TYPES> =
         Arc::new(move |e: Arc<HotShotEvent<TYPES>>| match e.as_ref() {
             QuorumProposalSend(proposal, _) => proposal.data.upgrade_certificate.is_some(),
             _ => false,
         });
-    Box::new(EventBooleanPredicate { info, check })
+    Box::new(EventPredicate { info, check })
 }
 
-pub fn quorum_proposal_validated<TYPES>() -> Box<EventBooleanPredicate<TYPES>>
+pub fn quorum_proposal_validated<TYPES>() -> Box<EventPredicate<TYPES>>
 where
     TYPES: NodeType,
 {
     let info = "QuorumProposalValidated".to_string();
-    let check: BooleanCallback<TYPES> = Arc::new(move |e: Arc<HotShotEvent<TYPES>>| {
+    let check: EventCallback<TYPES> = Arc::new(move |e: Arc<HotShotEvent<TYPES>>| {
         matches!(*e.clone(), QuorumProposalValidated(..))
     });
-    Box::new(EventBooleanPredicate { check, info })
+    Box::new(EventPredicate { check, info })
 }
 
-pub fn quorum_proposal_send<TYPES>() -> Box<EventBooleanPredicate<TYPES>>
+pub fn quorum_proposal_send<TYPES>() -> Box<EventPredicate<TYPES>>
 where
     TYPES: NodeType,
 {
     let info = "QuorumProposalSend".to_string();
-    let check: BooleanCallback<TYPES> =
+    let check: EventCallback<TYPES> =
         Arc::new(move |e: Arc<HotShotEvent<TYPES>>| matches!(e.as_ref(), QuorumProposalSend(..)));
-    Box::new(EventBooleanPredicate { check, info })
+    Box::new(EventPredicate { check, info })
 }
 
 pub fn quorum_proposal_send_with_null_block<TYPES>(
     num_storage_nodes: usize,
-) -> Box<EventBooleanPredicate<TYPES>>
+) -> Box<EventPredicate<TYPES>>
 where
     TYPES: NodeType,
 {
     let info = "QuorumProposalSend with null block payload".to_string();
-    let check: BooleanCallback<TYPES> =
+    let check: EventCallback<TYPES> =
         Arc::new(move |e: Arc<HotShotEvent<TYPES>>| match e.as_ref() {
             QuorumProposalSend(proposal, _) => {
                 Some(proposal.data.block_header.payload_commitment())
@@ -145,15 +145,15 @@ where
             }
             _ => false,
         });
-    Box::new(EventBooleanPredicate { check, info })
+    Box::new(EventPredicate { check, info })
 }
 
-pub fn timeout_vote_send<TYPES>() -> Box<EventBooleanPredicate<TYPES>>
+pub fn timeout_vote_send<TYPES>() -> Box<EventPredicate<TYPES>>
 where
     TYPES: NodeType,
 {
     let info = "TimeoutVoteSend".to_string();
-    let check: BooleanCallback<TYPES> =
+    let check: EventCallback<TYPES> =
         Arc::new(move |e: Arc<HotShotEvent<TYPES>>| matches!(e.as_ref(), TimeoutVoteSend(..)));
-    Box::new(EventBooleanPredicate { check, info })
+    Box::new(EventPredicate { check, info })
 }

--- a/crates/testing/src/predicates/mod.rs
+++ b/crates/testing/src/predicates/mod.rs
@@ -1,0 +1,28 @@
+pub mod event;
+pub mod upgrade;
+
+use async_trait::async_trait;
+
+#[derive(Eq, PartialEq, Copy, Clone, Debug)]
+pub enum PredicateResult {
+    Pass,
+
+    Fail,
+
+    Incomplete,
+}
+
+impl From<bool> for PredicateResult {
+    fn from(boolean: bool) -> Self {
+        match boolean {
+            true => PredicateResult::Pass,
+            false => PredicateResult::Fail,
+        }
+    }
+}
+
+#[async_trait]
+pub trait Predicate<INPUT>: std::fmt::Debug {
+    async fn evaluate(&self, input: &INPUT) -> PredicateResult;
+    async fn info(&self) -> String;
+}

--- a/crates/testing/src/predicates/upgrade.rs
+++ b/crates/testing/src/predicates/upgrade.rs
@@ -1,0 +1,49 @@
+use async_trait::async_trait;
+use hotshot::types::SystemContextHandle;
+use hotshot_example_types::node_types::{MemoryImpl, TestTypes};
+use hotshot_task_impls::consensus::ConsensusTaskState;
+use hotshot_types::simple_certificate::UpgradeCertificate;
+use std::sync::Arc;
+
+use crate::predicates::{Predicate, PredicateResult};
+
+type ConsensusTaskTestState =
+    ConsensusTaskState<TestTypes, MemoryImpl, SystemContextHandle<TestTypes, MemoryImpl>>;
+
+type UpgradeCertCallback =
+    Arc<dyn Fn(Arc<Option<UpgradeCertificate<TestTypes>>>) -> bool + Send + Sync>;
+
+pub struct UpgradeCertPredicate {
+    check: UpgradeCertCallback,
+    info: String,
+}
+
+impl std::fmt::Debug for UpgradeCertPredicate {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.info)
+    }
+}
+
+#[async_trait]
+impl Predicate<ConsensusTaskTestState> for UpgradeCertPredicate {
+    async fn evaluate(&self, input: &ConsensusTaskTestState) -> PredicateResult {
+        let upgrade_cert = input.decided_upgrade_cert.clone();
+        PredicateResult::from((self.check)(upgrade_cert.into()))
+    }
+
+    async fn info(&self) -> String {
+        self.info.clone()
+    }
+}
+
+pub fn no_decided_upgrade_cert() -> Box<UpgradeCertPredicate> {
+    let info = "expected decided_upgrade_cert to be None".to_string();
+    let check: UpgradeCertCallback = Arc::new(move |s| s.is_none());
+    Box::new(UpgradeCertPredicate { info, check })
+}
+
+pub fn decided_upgrade_cert() -> Box<UpgradeCertPredicate> {
+    let info = "expected decided_upgrade_cert to be Some(_)".to_string();
+    let check: UpgradeCertCallback = Arc::new(move |s| s.is_some());
+    Box::new(UpgradeCertPredicate { info, check })
+}

--- a/crates/testing/src/script.rs
+++ b/crates/testing/src/script.rs
@@ -12,8 +12,8 @@ pub const RECV_TIMEOUT: Duration = Duration::from_millis(250);
 
 pub struct TestScriptStage<TYPES: NodeType, S: TaskState<Event = Arc<HotShotEvent<TYPES>>>> {
     pub inputs: Vec<HotShotEvent<TYPES>>,
-    pub outputs: Vec<Predicate<Arc<HotShotEvent<TYPES>>>>,
-    pub asserts: Vec<Predicate<S>>,
+    pub outputs: Vec<Box<dyn Predicate<Arc<HotShotEvent<TYPES>>>>>,
+    pub asserts: Vec<Box<dyn Predicate<S>>>,
 }
 
 /// A `TestScript` is a sequence of triples (input sequence, output sequence, assertions).
@@ -43,24 +43,28 @@ where
     panic!("{}", output_missing_error);
 }
 
-pub fn validate_task_state_or_panic<S>(stage_number: usize, state: &S, assert: &mut Predicate<S>) {
+pub async fn validate_task_state_or_panic<S>(
+    stage_number: usize,
+    state: &S,
+    assert: &dyn Predicate<S>,
+) {
     assert!(
-        (assert.function)(state) == PredicateResult::Pass,
+        assert.evaluate(state).await == PredicateResult::Pass,
         "Stage {} | Task state failed to satisfy: {:?}",
         stage_number,
         assert
     );
 }
 
-pub fn validate_output_or_panic<S>(
+pub async fn validate_output_or_panic<S>(
     stage_number: usize,
     output: &S,
-    assert: &mut Predicate<S>,
+    assert: &(dyn Predicate<S> + 'static),
 ) -> PredicateResult
 where
     S: std::fmt::Debug,
 {
-    let result = (assert.function)(output);
+    let result = assert.evaluate(output).await;
 
     match result {
         PredicateResult::Pass => result,
@@ -126,7 +130,14 @@ pub async fn run_test_script<TYPES, S: TaskState<Event = Arc<HotShotEvent<TYPES>
             {
                 tracing::debug!("Test received: {:?}", received_output);
 
-                result = validate_output_or_panic(stage_number, &received_output, assert);
+                result = validate_output_or_panic(
+                    stage_number,
+                    &received_output,
+                    // The first * dereferences &Box<dyn> to Box<dyn>, the second one then dereferences the Box<dyn> to the
+                    // trait object itself and then we're good to go.
+                    &**assert,
+                )
+                .await;
 
                 to_task
                     .broadcast(received_output.clone())
@@ -154,7 +165,7 @@ pub async fn run_test_script<TYPES, S: TaskState<Event = Arc<HotShotEvent<TYPES>
         }
 
         for assert in &mut stage.asserts {
-            validate_task_state_or_panic(stage_number, task.state(), assert);
+            validate_task_state_or_panic(stage_number, task.state(), &**assert).await;
         }
 
         if let Ok(received_output) = from_task.try_recv() {
@@ -169,8 +180,8 @@ pub struct TaskScript<TYPES: NodeType, S> {
 }
 
 pub struct Expectations<TYPES: NodeType, S> {
-    pub output_asserts: Vec<Predicate<Arc<HotShotEvent<TYPES>>>>,
-    pub task_state_asserts: Vec<Predicate<S>>,
+    pub output_asserts: Vec<Box<dyn Predicate<Arc<HotShotEvent<TYPES>>>>>,
+    pub task_state_asserts: Vec<Box<dyn Predicate<S>>>,
 }
 
 pub fn panic_extra_output_in_script<S>(stage_number: usize, script_name: String, output: &S)
@@ -197,14 +208,14 @@ where
     panic!("{}", output_missing_error);
 }
 
-pub fn validate_task_state_or_panic_in_script<S>(
+pub async fn validate_task_state_or_panic_in_script<S>(
     stage_number: usize,
     script_name: String,
     state: &S,
-    assert: &mut Predicate<S>,
+    assert: &dyn Predicate<S>,
 ) {
     assert!(
-        (assert.function)(state) == PredicateResult::Pass,
+        assert.evaluate(state).await == PredicateResult::Pass,
         "Stage {} | Task state in {} failed to satisfy: {:?}",
         stage_number,
         script_name,
@@ -212,14 +223,14 @@ pub fn validate_task_state_or_panic_in_script<S>(
     );
 }
 
-pub fn validate_output_or_panic_in_script<S: std::fmt::Debug>(
+pub async fn validate_output_or_panic_in_script<S: std::fmt::Debug>(
     stage_number: usize,
     script_name: String,
     output: &S,
-    assert: &mut Predicate<S>,
+    assert: &dyn Predicate<S>,
 ) {
     assert!(
-        (assert.function)(output) == PredicateResult::Pass,
+        assert.evaluate(output).await == PredicateResult::Pass,
         "Stage {} | Output in {} failed to satisfy: {:?}.\n\nReceived:\n\n{:?}",
         stage_number,
         script_name,

--- a/crates/testing/tests/tests_1/consensus_task.rs
+++ b/crates/testing/tests/tests_1/consensus_task.rs
@@ -6,8 +6,7 @@ use hotshot_testing::task_helpers::key_pair_for_id;
 use hotshot_testing::test_helpers::permute_input_with_index_order;
 use hotshot_testing::{
     predicates::{
-        exact, is_at_view_number, quorum_proposal_send, quorum_proposal_validated,
-        quorum_vote_send, timeout_vote_send,
+        exact, quorum_proposal_send, quorum_proposal_validated, quorum_vote_send, timeout_vote_send,
     },
     script::{run_test_script, TestScriptStage},
     task_helpers::{build_system_handle, vid_scheme_from_view_number},
@@ -64,7 +63,7 @@ async fn test_consensus_task() {
             quorum_proposal_validated(),
             exact(QuorumVoteSend(votes[0].clone())),
         ],
-        asserts: vec![is_at_view_number(1)],
+        asserts: vec![],
     };
 
     let cert = proposals[1].data.justify_qc.clone();
@@ -82,7 +81,7 @@ async fn test_consensus_task() {
             quorum_proposal_validated(),
             quorum_proposal_send(),
         ],
-        asserts: vec![is_at_view_number(2)],
+        asserts: vec![],
     };
 
     let consensus_state = ConsensusTaskState::<
@@ -195,7 +194,7 @@ async fn test_vote_with_specific_order(input_permutation: Vec<usize>) {
             quorum_proposal_validated(),
             exact(QuorumVoteSend(votes[0].clone())),
         ],
-        asserts: vec![is_at_view_number(1)],
+        asserts: vec![],
     };
 
     let inputs = vec![
@@ -206,17 +205,15 @@ async fn test_vote_with_specific_order(input_permutation: Vec<usize>) {
     ];
     let view_2_inputs = permute_input_with_index_order(inputs, input_permutation);
 
-    let view_2_outputs = vec![
-        exact(ViewChange(ViewNumber::new(2))),
-        quorum_proposal_validated(),
-        exact(QuorumVoteSend(votes[1].clone())),
-    ];
-
     // Use the permuted inputs for view 2 depending on the provided index ordering.
     let view_2 = TestScriptStage {
         inputs: view_2_inputs,
-        outputs: view_2_outputs,
-        asserts: vec![is_at_view_number(2)],
+        outputs: vec![
+            exact(ViewChange(ViewNumber::new(2))),
+            quorum_proposal_validated(),
+            exact(QuorumVoteSend(votes[1].clone())),
+        ],
+        asserts: vec![],
     };
 
     let consensus_state = ConsensusTaskState::<
@@ -307,7 +304,7 @@ async fn test_view_sync_finalize_propose() {
             quorum_proposal_validated(),
             exact(QuorumVoteSend(votes[0].clone())),
         ],
-        asserts: vec![is_at_view_number(1)],
+        asserts: vec![],
     };
 
     // Fail twice here to "trigger" a view sync event. This is accomplished above by advancing the
@@ -316,7 +313,7 @@ async fn test_view_sync_finalize_propose() {
         inputs: vec![Timeout(ViewNumber::new(2)), Timeout(ViewNumber::new(3))],
         outputs: vec![timeout_vote_send(), timeout_vote_send()],
         // Times out, so we now have a delayed view
-        asserts: vec![is_at_view_number(1)],
+        asserts: vec![],
     };
 
     // Handle the view sync finalize cert, get the requisite data, propose.
@@ -359,7 +356,7 @@ async fn test_view_sync_finalize_propose() {
             quorum_proposal_validated(),
             quorum_proposal_send(),
         ],
-        asserts: vec![is_at_view_number(4)],
+        asserts: vec![],
     };
 
     let consensus_state = ConsensusTaskState::<
@@ -430,14 +427,14 @@ async fn test_view_sync_finalize_vote() {
             quorum_proposal_validated(),
             exact(QuorumVoteSend(votes[0].clone())),
         ],
-        asserts: vec![is_at_view_number(1)],
+        asserts: vec![],
     };
 
     let view_2 = TestScriptStage {
         inputs: vec![Timeout(ViewNumber::new(2)), Timeout(ViewNumber::new(3))],
         outputs: vec![timeout_vote_send(), timeout_vote_send()],
         // Times out, so we now have a delayed view
-        asserts: vec![is_at_view_number(1)],
+        asserts: vec![],
     };
 
     // Now we're on the latest view. We want to set the quorum
@@ -532,14 +529,14 @@ async fn test_view_sync_finalize_vote_fail_view_number() {
             quorum_proposal_validated(),
             exact(QuorumVoteSend(votes[0].clone())),
         ],
-        asserts: vec![is_at_view_number(1)],
+        asserts: vec![],
     };
 
     let view_2 = TestScriptStage {
         inputs: vec![Timeout(ViewNumber::new(2)), Timeout(ViewNumber::new(3))],
         outputs: vec![timeout_vote_send(), timeout_vote_send()],
         // Times out, so we now have a delayed view
-        asserts: vec![is_at_view_number(1)],
+        asserts: vec![],
     };
 
     // Now we're on the latest view. We want to set the quorum
@@ -573,7 +570,7 @@ async fn test_view_sync_finalize_vote_fail_view_number() {
         outputs: vec![
             /* No outputs make it through. We never got a valid proposal, so we never vote */
         ],
-        asserts: vec![is_at_view_number(1)],
+        asserts: vec![],
     };
 
     let consensus_state = ConsensusTaskState::<
@@ -628,7 +625,7 @@ async fn test_vid_disperse_storage_failure() {
             quorum_proposal_validated(),
             /* Does not vote */
         ],
-        asserts: vec![is_at_view_number(1)],
+        asserts: vec![],
     };
 
     let consensus_state = ConsensusTaskState::<

--- a/crates/testing/tests/tests_1/consensus_task.rs
+++ b/crates/testing/tests/tests_1/consensus_task.rs
@@ -5,7 +5,7 @@ use hotshot_task_impls::{consensus::ConsensusTaskState, events::HotShotEvent::*}
 use hotshot_testing::task_helpers::key_pair_for_id;
 use hotshot_testing::test_helpers::permute_input_with_index_order;
 use hotshot_testing::{
-    predicates::{
+    predicates::event::{
         exact, quorum_proposal_send, quorum_proposal_validated, quorum_vote_send, timeout_vote_send,
     },
     script::{run_test_script, TestScriptStage},
@@ -103,7 +103,6 @@ async fn test_consensus_vote() {
     use hotshot::tasks::{inject_consensus_polls, task_state::CreateTaskState};
     use hotshot_task_impls::{consensus::ConsensusTaskState, events::HotShotEvent::*};
     use hotshot_testing::{
-        predicates::exact,
         script::{run_test_script, TestScriptStage},
         task_helpers::build_system_handle,
         view_generator::TestViewGenerator,
@@ -378,8 +377,6 @@ async fn test_view_sync_finalize_propose() {
 /// Makes sure that, when a valid ViewSyncFinalize certificate is available, the consensus task
 /// will indeed vote if the cert is valid and matches the correct view number.
 async fn test_view_sync_finalize_vote() {
-    use hotshot_testing::predicates::timeout_vote_send;
-
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
 
@@ -480,8 +477,6 @@ async fn test_view_sync_finalize_vote() {
 /// Makes sure that, when a valid ViewSyncFinalize certificate is available, the consensus task
 /// will NOT vote when the certificate matches a different view number.
 async fn test_view_sync_finalize_vote_fail_view_number() {
-    use hotshot_testing::predicates::timeout_vote_send;
-
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
 

--- a/crates/testing/tests/tests_1/da_task.rs
+++ b/crates/testing/tests/tests_1/da_task.rs
@@ -7,7 +7,7 @@ use hotshot_example_types::{
 use hotshot_task_impls::da::DATaskState;
 use hotshot_task_impls::events::HotShotEvent::*;
 use hotshot_testing::{
-    predicates::exact,
+    predicates::event::exact,
     script::{run_test_script, TestScriptStage},
     task_helpers::build_system_handle,
     view_generator::TestViewGenerator,

--- a/crates/testing/tests/tests_1/proposal_ordering.rs
+++ b/crates/testing/tests/tests_1/proposal_ordering.rs
@@ -2,7 +2,7 @@ use hotshot::{tasks::task_state::CreateTaskState, types::SystemContextHandle};
 use hotshot_example_types::node_types::{MemoryImpl, TestTypes};
 use hotshot_task_impls::{consensus::ConsensusTaskState, events::HotShotEvent::*};
 use hotshot_testing::{
-    predicates::{exact, is_at_view_number, quorum_proposal_send, quorum_proposal_validated},
+    predicates::{exact, quorum_proposal_send, quorum_proposal_validated},
     task_helpers::vid_scheme_from_view_number,
     test_helpers::permute_input_with_index_order,
     view_generator::TestViewGenerator,
@@ -59,7 +59,7 @@ async fn test_ordering_with_specific_order(input_permutation: Vec<usize>) {
             quorum_proposal_validated(),
             exact(QuorumVoteSend(votes[0].clone())),
         ],
-        asserts: vec![is_at_view_number(1)],
+        asserts: vec![],
     };
 
     // Node 2 is the leader up next, so we form the QC for it.
@@ -70,21 +70,18 @@ async fn test_ordering_with_specific_order(input_permutation: Vec<usize>) {
         SendPayloadCommitmentAndMetadata(payload_commitment, (), ViewNumber::new(node_id)),
     ];
 
-    let view_2_outputs = 
-        vec![
-            exact(ViewChange(ViewNumber::new(2))),
-            quorum_proposal_validated(),
-            quorum_proposal_send(),
-        ];
-
     let view_2_inputs = permute_input_with_index_order(inputs, input_permutation);
 
     // This stage transitions from view 1 to view 2.
     let view_2 = TestScriptStage {
         inputs: view_2_inputs,
-        outputs: view_2_outputs,
+        outputs: vec![
+            exact(ViewChange(ViewNumber::new(2))),
+            quorum_proposal_validated(),
+            quorum_proposal_send(),
+        ],
         // We should end on view 2.
-        asserts: vec![is_at_view_number(2)],
+        asserts: vec![],
     };
 
     let script = vec![view_1, view_2];

--- a/crates/testing/tests/tests_1/proposal_ordering.rs
+++ b/crates/testing/tests/tests_1/proposal_ordering.rs
@@ -2,7 +2,7 @@ use hotshot::{tasks::task_state::CreateTaskState, types::SystemContextHandle};
 use hotshot_example_types::node_types::{MemoryImpl, TestTypes};
 use hotshot_task_impls::{consensus::ConsensusTaskState, events::HotShotEvent::*};
 use hotshot_testing::{
-    predicates::{exact, quorum_proposal_send, quorum_proposal_validated},
+    predicates::event::{exact, quorum_proposal_send, quorum_proposal_validated},
     task_helpers::vid_scheme_from_view_number,
     test_helpers::permute_input_with_index_order,
     view_generator::TestViewGenerator,

--- a/crates/testing/tests/tests_1/proposal_ordering.rs
+++ b/crates/testing/tests/tests_1/proposal_ordering.rs
@@ -2,7 +2,9 @@ use hotshot::{tasks::task_state::CreateTaskState, types::SystemContextHandle};
 use hotshot_example_types::node_types::{MemoryImpl, TestTypes};
 use hotshot_task_impls::{consensus::ConsensusTaskState, events::HotShotEvent::*};
 use hotshot_testing::{
-    predicates::event::{exact, quorum_proposal_send, quorum_proposal_validated},
+    predicates::event::{
+        exact, quorum_proposal_send, quorum_proposal_validated,
+    },
     task_helpers::{get_vid_share, vid_scheme_from_view_number},
     test_helpers::permute_input_with_index_order,
     view_generator::TestViewGenerator,
@@ -51,7 +53,7 @@ async fn test_ordering_with_specific_order(input_permutation: Vec<usize>) {
     let view_1 = TestScriptStage {
         inputs: vec![
             QuorumProposalRecv(proposals[0].clone(), leaders[0]),
-            DACertificateRecv(dacs[1].clone()),
+            DACertificateRecv(dacs[0].clone()),
             VIDShareRecv(get_vid_share(&vids[0].0, handle.get_public_key())),
         ],
         outputs: vec![

--- a/crates/testing/tests/tests_1/proposal_ordering.rs
+++ b/crates/testing/tests/tests_1/proposal_ordering.rs
@@ -3,7 +3,7 @@ use hotshot_example_types::node_types::{MemoryImpl, TestTypes};
 use hotshot_task_impls::{consensus::ConsensusTaskState, events::HotShotEvent::*};
 use hotshot_testing::{
     predicates::event::{exact, quorum_proposal_send, quorum_proposal_validated},
-    task_helpers::vid_scheme_from_view_number,
+    task_helpers::{get_vid_share, vid_scheme_from_view_number},
     test_helpers::permute_input_with_index_order,
     view_generator::TestViewGenerator,
 };
@@ -51,7 +51,7 @@ async fn test_ordering_with_specific_order(input_permutation: Vec<usize>) {
     let view_1 = TestScriptStage {
         inputs: vec![
             QuorumProposalRecv(proposals[0].clone(), leaders[0]),
-            DACertificateRecv(dacs[0].clone()),
+            DACertificateRecv(dacs[1].clone()),
             VIDShareRecv(get_vid_share(&vids[0].0, handle.get_public_key())),
         ],
         outputs: vec![

--- a/crates/testing/tests/tests_1/quorum_proposal_task.rs
+++ b/crates/testing/tests/tests_1/quorum_proposal_task.rs
@@ -3,7 +3,7 @@ use hotshot::tasks::task_state::CreateTaskState;
 use hotshot_example_types::node_types::{MemoryImpl, TestTypes};
 use hotshot_task_impls::events::HotShotEvent::*;
 use hotshot_task_impls::quorum_proposal::QuorumProposalTaskState;
-use hotshot_testing::predicates::exact;
+use hotshot_testing::predicates::event::exact;
 use hotshot_testing::task_helpers::vid_scheme_from_view_number;
 use hotshot_testing::{
     script::{run_test_script, TestScriptStage},
@@ -57,9 +57,7 @@ async fn test_quorum_proposal_task_quorum_proposal() {
             QCFormed(either::Left(cert.clone())),
             SendPayloadCommitmentAndMetadata(payload_commitment, (), ViewNumber::new(2)),
         ],
-        outputs: vec![
-            exact(DummyQuorumProposalSend(ViewNumber::new(2))),
-        ],
+        outputs: vec![exact(DummyQuorumProposalSend(ViewNumber::new(2)))],
         asserts: vec![],
     };
 
@@ -112,9 +110,7 @@ async fn test_quorum_proposal_task_qc_timeout() {
             QCFormed(either::Right(cert.clone())),
             SendPayloadCommitmentAndMetadata(payload_commitment, (), ViewNumber::new(2)),
         ],
-        outputs: vec![
-            exact(DummyQuorumProposalSend(ViewNumber::new(2))),
-        ],
+        outputs: vec![exact(DummyQuorumProposalSend(ViewNumber::new(2)))],
         asserts: vec![],
     };
 
@@ -170,9 +166,7 @@ async fn test_quorum_proposal_task_view_sync() {
             ViewSyncFinalizeCertificate2Recv(cert.clone()),
             SendPayloadCommitmentAndMetadata(payload_commitment, (), ViewNumber::new(2)),
         ],
-        outputs: vec![
-            exact(DummyQuorumProposalSend(ViewNumber::new(2))),
-        ],
+        outputs: vec![exact(DummyQuorumProposalSend(ViewNumber::new(2)))],
         asserts: vec![],
     };
 
@@ -188,7 +182,6 @@ async fn test_quorum_proposal_task_view_sync() {
 #[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 async fn test_quorum_proposal_task_with_incomplete_events() {
-
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
 

--- a/crates/testing/tests/tests_1/quorum_vote_task.rs
+++ b/crates/testing/tests/tests_1/quorum_vote_task.rs
@@ -9,7 +9,7 @@ use hotshot_types::{data::ViewNumber, traits::node_implementation::ConsensusTime
 async fn test_quorum_vote_task_success() {
     use hotshot_task_impls::{events::HotShotEvent::*, quorum_vote::QuorumVoteTaskState};
     use hotshot_testing::{
-        predicates::{exact, quorum_proposal_validated,quorum_vote_send},
+        predicates::event::{exact, quorum_proposal_validated, quorum_vote_send},
         script::{run_test_script, TestScriptStage},
         task_helpers::build_system_handle,
         view_generator::TestViewGenerator,
@@ -57,7 +57,7 @@ async fn test_quorum_vote_task_success() {
 async fn test_quorum_vote_task_miss_dependency() {
     use hotshot_task_impls::{events::HotShotEvent::*, quorum_vote::QuorumVoteTaskState};
     use hotshot_testing::{
-        predicates::{exact, quorum_proposal_validated},
+        predicates::event::{exact, quorum_proposal_validated},
         script::{run_test_script, TestScriptStage},
         task_helpers::build_system_handle,
         view_generator::TestViewGenerator,
@@ -125,7 +125,7 @@ async fn test_quorum_vote_task_miss_dependency() {
         QuorumVoteTaskState::<TestTypes, MemoryImpl>::create_from(&handle).await;
 
     run_test_script(
-        vec![ view_no_dac, view_no_vid, view_no_quorum_proposal],
+        vec![view_no_dac, view_no_vid, view_no_quorum_proposal],
         quorum_vote_state,
     )
     .await;

--- a/crates/testing/tests/tests_1/upgrade_task.rs
+++ b/crates/testing/tests/tests_1/upgrade_task.rs
@@ -259,9 +259,9 @@ async fn test_upgrade_and_consensus_task() {
         expectations: vec![
             Expectations {
                 output_asserts: vec![
-                    exact(ViewChange(ViewNumber::new(1))),
-                    quorum_proposal_validated(),
-                    quorum_vote_send(),
+                    exact::<TestTypes>(ViewChange(ViewNumber::new(1))),
+                    quorum_proposal_validated::<TestTypes>(),
+                    quorum_vote_send::<TestTypes>(),
                 ],
                 task_state_asserts: vec![],
             },
@@ -271,13 +271,13 @@ async fn test_upgrade_and_consensus_task() {
             },
             Expectations {
                 output_asserts: vec![
-                    exact(ViewChange(ViewNumber::new(2))),
-                    quorum_proposal_validated(),
+                    exact::<TestTypes>(ViewChange(ViewNumber::new(2))),
+                    quorum_proposal_validated::<TestTypes>(),
                 ],
                 task_state_asserts: vec![],
             },
             Expectations {
-                output_asserts: vec![quorum_proposal_send_with_upgrade_certificate()],
+                output_asserts: vec![quorum_proposal_send_with_upgrade_certificate::<TestTypes>()],
                 task_state_asserts: vec![],
             },
         ],
@@ -291,7 +291,7 @@ async fn test_upgrade_and_consensus_task() {
                 task_state_asserts: vec![],
             },
             Expectations {
-                output_asserts: vec![upgrade_certificate_formed()],
+                output_asserts: vec![upgrade_certificate_formed::<TestTypes>()],
                 task_state_asserts: vec![],
             },
             Expectations {
@@ -495,7 +495,7 @@ async fn test_upgrade_and_consensus_task_blank_blocks() {
         expectations: vec![
             Expectations {
                 output_asserts: vec![
-                    exact(ViewChange(ViewNumber::new(1))),
+                    exact::<TestTypes>(ViewChange(ViewNumber::new(1))),
                     quorum_proposal_validated(),
                     quorum_vote_send(),
                 ],

--- a/crates/testing/tests/tests_1/upgrade_task.rs
+++ b/crates/testing/tests/tests_1/upgrade_task.rs
@@ -9,7 +9,8 @@ use hotshot_task_impls::{
     consensus::ConsensusTaskState, events::HotShotEvent::*, upgrade::UpgradeTaskState,
 };
 use hotshot_testing::{
-    predicates::*,
+    predicates::event::*,
+    predicates::upgrade::*,
     script::{Expectations, TaskScript},
     view_generator::TestViewGenerator,
 };


### PR DESCRIPTION
Closes #<ISSUE_NUMBER>
<!-- See here for keywords in Github -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

### This PR: 
Adds the ability to use async within the testing environment for the purpose of unpacking async structures like RwLocks in a way that avoids deadlocking in the test threads. We are now able to define custom trait implementations with behavior that is able to be unique to the test case. This came as a response to have background async behavior without needing to argue with the borrow checker when trying to take ownership of data that we cannot (or should not) clone.

Specifically, this introduces the `Predicate` trait, which has the following structure:
```rust
#[async_trait]
pub trait Predicate<INPUT>: std::fmt::Debug {
    async fn evaluate(&self, input: &INPUT) -> PredicateResult;
    async fn info(&self) -> String;
}
```

This is very similar to the struct that it replaces, except we can now define this behavior over any callback. We may now define a predicate callback for a given input of any type, exactly as it worked before. An example implementation of this can be seen here:
```rust
type EventCallback<TYPES> = Arc<dyn Fn(Arc<HotShotEvent<TYPES>>) -> bool + Send + Sync>;

pub struct EventPredicate<TYPES>
where
    TYPES: NodeType + Send + Sync,
{
    check: EventCallback<TYPES>,
    info: String,
}

impl<TYPES: NodeType> std::fmt::Debug for EventPredicate<TYPES> {
    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
        write!(f, "{}", self.info)
    }
}

#[async_trait]
impl<TYPES> Predicate<Arc<HotShotEvent<TYPES>>> for EventPredicate<TYPES>
where
    TYPES: NodeType + Send + Sync + 'static,
{
    async fn evaluate(&self, input: &Arc<HotShotEvent<TYPES>>) -> PredicateResult {
        PredicateResult::from((self.check)(input.clone()))
    }

    async fn info(&self) -> String {
        self.info.clone()
    }
}
```

Here, we get a pretty straightforward function, but this gives us an async context to work with, so if the `self.check` method needs to do something async, we now can accomplish this in a way that doesn't require arduous blocking or rewriting of the implementation.

Furthermore, I have upgraded all of the one-liner predicates to automatically build the values that they're looking for. Consider the `exact` predicate:
```rust
pub fn exact<TYPES>(event: HotShotEvent<TYPES>) -> Box<EventBooleanPredicate<TYPES>>
where
    TYPES: NodeType,
{
    let info = format!("{:?}", event);
    let event = Arc::new(event);

    let check: BooleanCallback<TYPES> = Arc::new(move |e: Arc<HotShotEvent<TYPES>>| {
        let event_clone = event.clone();
        *e == *event_clone
    });

    Box::new(EventBooleanPredicate { check, info })
}
```

This predicate is a good example of how you can easily build a callback function for any specific behavior that you'd like to implement. This background function, crucially, may also be an async callback (if you can get the data into it). 

### This PR does not: 
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->

### Key places to review: 
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
