### PR TITLE
[TECH-DEBT] Have `BlockPayload::get_transactions` return an iterator

### DIFF
--- a/crates/example-types/src/block_types.rs
+++ b/crates/example-types/src/block_types.rs
@@ -169,16 +169,6 @@ impl BlockPayload for TestBlockPayload {
         Ok(TestTransaction::encode(self.transactions.clone())?.into_iter())
     }
 
-    fn transaction_commitments(
-        &self,
-        _metadata: &Self::Metadata,
-    ) -> Vec<Commitment<Self::Transaction>> {
-        self.transactions
-            .iter()
-            .map(committable::Committable::commit)
-            .collect()
-    }
-
     fn builder_commitment(&self, _metadata: &Self::Metadata) -> BuilderCommitment {
         let mut digest = sha2::Sha256::new();
         for txn in &self.transactions {
@@ -187,8 +177,11 @@ impl BlockPayload for TestBlockPayload {
         BuilderCommitment::from_raw_digest(digest.finalize())
     }
 
-    fn get_transactions(&self, _metadata: &Self::Metadata) -> &Vec<Self::Transaction> {
-        &self.transactions
+    fn get_transactions<'a>(
+        &'a self,
+        _metadata: &'a Self::Metadata,
+    ) -> impl 'a + Iterator<Item = Self::Transaction> {
+        self.transactions.iter().cloned()
     }
 }
 

--- a/crates/task-impls/src/transactions.rs
+++ b/crates/task-impls/src/transactions.rs
@@ -154,8 +154,7 @@ impl<
         )> = None;
         while task_start_time.elapsed() < self.api.propose_max_round_time()
             && latest_block.as_ref().map_or(true, |(data, _)| {
-                data.block_payload.get_transactions(&data.metadata).len()
-                    < self.api.min_transactions()
+                data.block_payload.num_transactions(&data.metadata) < self.api.min_transactions()
             })
         {
             let mut available_blocks = match self
@@ -212,7 +211,7 @@ impl<
                 }
             };
 
-            let num_txns = block.block_payload.get_transactions(&block.metadata).len();
+            let num_txns = block.block_payload.num_transactions(&block.metadata);
 
             latest_block = Some((block, header_input));
             if num_txns >= self.api.min_transactions() {

--- a/crates/types/src/traits/block_contents.rs
+++ b/crates/types/src/traits/block_contents.rs
@@ -89,13 +89,25 @@ pub trait BlockPayload:
     fn transaction_commitments(
         &self,
         metadata: &Self::Metadata,
-    ) -> Vec<Commitment<Self::Transaction>>;
+    ) -> Vec<Commitment<Self::Transaction>> {
+        self.get_transactions(metadata)
+            .map(|tx| tx.commit())
+            .collect()
+    }
+
+    /// Number of transactions in the block.
+    fn num_transactions(&self, metadata: &Self::Metadata) -> usize {
+        self.get_transactions(metadata).count()
+    }
 
     /// Generate commitment that builders use to sign block options.
     fn builder_commitment(&self, metadata: &Self::Metadata) -> BuilderCommitment;
 
     /// Get the transactions in the payload.
-    fn get_transactions(&self, metadata: &Self::Metadata) -> &Vec<Self::Transaction>;
+    fn get_transactions<'a>(
+        &'a self,
+        metadata: &'a Self::Metadata,
+    ) -> impl 'a + Iterator<Item = Self::Transaction>;
 }
 
 /// extra functions required on block to be usable by hotshot-testing


### PR DESCRIPTION
This means that the payload is no longer required to explicitly store a list of transactions as a field. We also default-impl a couple other trait functions using this iterator.
