### PR TITLE
Revert "Remove special treatment of view 1 (#2873)"

### DIFF
--- a/crates/hotshot/src/lib.rs
+++ b/crates/hotshot/src/lib.rs
@@ -286,7 +286,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> SystemContext<TYPES, I> {
         self.internal_event_stream
             .0
             .broadcast_direct(Arc::new(HotShotEvent::QCFormed(either::Left(
-                self.consensus.read().await.high_qc.clone(),
+                QuorumCertificate::genesis(),
             ))))
             .await
             .expect("Genesis Broadcast failed");
@@ -697,13 +697,13 @@ impl<TYPES: NodeType> HotShotInitializer<TYPES> {
         let (validated_state, state_delta) = TYPES::ValidatedState::genesis(&instance_state);
         Ok(Self {
             inner: Leaf::genesis(&instance_state),
+            instance_state,
             validated_state: Some(Arc::new(validated_state)),
             state_delta: Some(Arc::new(state_delta)),
             start_view: TYPES::Time::new(0),
-            high_qc: QuorumCertificate::genesis(&instance_state),
+            high_qc: QuorumCertificate::genesis(),
             undecided_leafs: Vec::new(),
             undecided_state: BTreeMap::new(),
-            instance_state,
         })
     }
 

--- a/crates/testing/src/task_helpers.rs
+++ b/crates/testing/src/task_helpers.rs
@@ -263,7 +263,7 @@ async fn build_quorum_proposal_and_signature(
     let mut proposal = QuorumProposal::<TestTypes> {
         block_header: block_header.clone(),
         view_number: ViewNumber::new(1),
-        justify_qc: QuorumCertificate::genesis(&TestInstanceState {}),
+        justify_qc: QuorumCertificate::genesis(),
         upgrade_certificate: None,
         proposal_certificate: None,
     };

--- a/crates/testing/src/test_runner.rs
+++ b/crates/testing/src/test_runner.rs
@@ -219,7 +219,7 @@ where
             latest_view: None,
             changes,
             last_decided_leaf: Leaf::genesis(&TestInstanceState {}),
-            high_qc: QuorumCertificate::genesis(&TestInstanceState {}),
+            high_qc: QuorumCertificate::genesis(),
         };
         let spinning_task = TestTask::<SpinningTask<TYPES, I>, SpinningTask<TYPES, I>>::new(
             Task::new(tx.clone(), rx.clone(), reg.clone(), spinning_task_state),

--- a/crates/testing/src/view_generator.rs
+++ b/crates/testing/src/view_generator.rs
@@ -85,7 +85,7 @@ impl TestView {
         let quorum_proposal_inner = QuorumProposal::<TestTypes> {
             block_header: block_header.clone(),
             view_number: genesis_view,
-            justify_qc: QuorumCertificate::genesis(&TestInstanceState {}),
+            justify_qc: QuorumCertificate::genesis(),
             upgrade_certificate: None,
             proposal_certificate: None,
         };
@@ -112,6 +112,7 @@ impl TestView {
         leaf.fill_block_payload_unchecked(TestBlockPayload {
             transactions: transactions.clone(),
         });
+        leaf.set_parent_commitment(Leaf::genesis(&TestInstanceState {}).commit());
 
         let signature = <BLSPubKey as SignatureKey>::sign(&private_key, leaf.commit().as_ref())
             .expect("Failed to sign leaf commitment!");

--- a/crates/testing/tests/tests_1/message.rs
+++ b/crates/testing/tests/tests_1/message.rs
@@ -42,6 +42,7 @@ fn version_number_at_start_of_serialization() {
         vote_commitment: data.commit(),
         view_number,
         signatures: None,
+        is_genesis: false,
         _pd: PhantomData,
     };
     let message = Message {

--- a/crates/types/src/simple_certificate.rs
+++ b/crates/types/src/simple_certificate.rs
@@ -7,12 +7,12 @@ use std::{
 };
 
 use anyhow::{ensure, Result};
-use committable::{Commitment, Committable};
+use committable::{Commitment, CommitmentBoundsArkless, Committable};
 use ethereum_types::U256;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    data::serialize_signature2,
+    data::{serialize_signature2, Leaf},
     simple_vote::{
         DAData, QuorumData, TimeoutData, UpgradeProposalData, ViewSyncCommitData,
         ViewSyncFinalizeData, ViewSyncPreCommitData, Voteable,
@@ -72,6 +72,8 @@ pub struct SimpleCertificate<TYPES: NodeType, VOTEABLE: Voteable, THRESHOLD: Thr
     pub view_number: TYPES::Time,
     /// assembled signature for certificate aggregation
     pub signatures: Option<<TYPES::SignatureKey as SignatureKey>::QCType>,
+    /// If this QC is for the genesis block
+    pub is_genesis: bool,
     /// phantom data for `THRESHOLD` and `TYPES`
     pub _pd: PhantomData<(TYPES, THRESHOLD)>,
 }
@@ -89,6 +91,7 @@ impl<TYPES: NodeType, VOTEABLE: Voteable + Committable, THRESHOLD: Threshold<TYP
             .field("vote_commitment", self.vote_commitment)
             .field("view number", self.view_number.commit())
             .var_size_field("signatures", &signature_bytes)
+            .fixed_size_field("is genesis", &[u8::from(self.is_genesis)])
             .finalize()
     }
 }
@@ -110,11 +113,12 @@ impl<TYPES: NodeType, VOTEABLE: Voteable + 'static, THRESHOLD: Threshold<TYPES>>
             vote_commitment,
             view_number: view,
             signatures: Some(sig),
+            is_genesis: false,
             _pd: PhantomData,
         }
     }
     fn is_valid_cert<MEMBERSHIP: Membership<TYPES>>(&self, membership: &MEMBERSHIP) -> bool {
-        if self.view_number == TYPES::Time::genesis() {
+        if self.is_genesis && self.view_number == TYPES::Time::genesis() {
             return true;
         }
         let real_qc_pp = <TYPES::SignatureKey as SignatureKey>::get_public_parameter(
@@ -147,7 +151,30 @@ impl<TYPES: NodeType, VOTEABLE: Voteable + 'static, THRESHOLD: Threshold<TYPES>>
 }
 impl<TYPES: NodeType> Display for QuorumCertificate<TYPES> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "view: {:?}", self.view_number)
+        write!(
+            f,
+            "view: {:?}, is_genesis: {:?}",
+            self.view_number, self.is_genesis
+        )
+    }
+}
+
+impl<TYPES: NodeType> QuorumCertificate<TYPES> {
+    #[must_use]
+    /// Creat the Genisis certificate
+    pub fn genesis() -> Self {
+        let data = QuorumData {
+            leaf_commit: Commitment::<Leaf<TYPES>>::default_commitment_no_preimage(),
+        };
+        let commit = data.commit();
+        Self {
+            data,
+            vote_commitment: commit,
+            view_number: <TYPES::Time as ConsensusTime>::genesis(),
+            signatures: None,
+            is_genesis: true,
+            _pd: PhantomData,
+        }
     }
 }
 


### PR DESCRIPTION
The PR did end up breaking the leaf 0 for the hotshot query service.  I tried to fix forward in: https://github.com/EspressoSystems/HotShot/tree/bf/leaf-0, but it didn't work.

Since the change is not critical for Cappuccino I think it's best to revert.  We confirmed that the query service tests pass with this branch