### PR TITLE
Check Payload Commit before accepting DAVotes

### DIFF
--- a/crates/hotshot/src/tasks/task_state.rs
+++ b/crates/hotshot/src/tasks/task_state.rs
@@ -115,6 +115,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> CreateTaskState<TYPES, I>
             private_key: handle.private_key().clone(),
             id: handle.hotshot.id,
             storage: handle.storage.clone(),
+            proposed_commits: BTreeMap::new(),
         }
     }
 }


### PR DESCRIPTION
No issues
<!-- See here for keywords in Github -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

### This PR: 

Fernando noted during the creation of specs that we don't ever check that DA votes are for the same commitment as the block we proposed.  We technically don't need this as only a bad DA committee would vote for a Fake block.  We'll end up proposing to the quorum with a payload that doesn't match certificate we formed from the fake votes.  We won't get quorum votes, and thus the fake block commitment will never make it on chain.  This hole doesn't open us up to anything besides allowing a bad committee to timeout a view (which it can already do by just not voting at all).  

### This PR does not: 
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->

### Key places to review: 
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
