### PR TITLE
Add The `ProposeNow` and `VoteNow` events.

### DIFF
--- a/crates/task-impls/src/consensus.rs
+++ b/crates/task-impls/src/consensus.rs
@@ -16,7 +16,7 @@ use committable::Committable;
 use futures::future::{join_all, FutureExt};
 use hotshot_task::task::{Task, TaskState};
 use hotshot_types::{
-    consensus::{Consensus, View},
+    consensus::{CommitmentAndMetadata, Consensus, View},
     constants::LOOK_AHEAD,
     data::{null_block, Leaf, QuorumProposal, VidDisperseShare, ViewChangeEvidence},
     event::{Event, EventType, LeafInfo},
@@ -50,13 +50,6 @@ use crate::{
         create_vote_accumulator, AccumulatorInfo, HandleVoteEvent, VoteCollectionTaskState,
     },
 };
-/// Alias for the block payload commitment and the associated metadata.
-pub struct CommitmentAndMetadata<PAYLOAD: BlockPayload> {
-    /// Vid Commitment
-    pub commitment: VidCommitment,
-    /// Metadata for the block payload
-    pub metadata: <PAYLOAD as BlockPayload>::Metadata,
-}
 
 /// Alias for Optional type for Vote Collectors
 type VoteCollectorOption<TYPES, VOTE, CERT> = Option<VoteCollectionTaskState<TYPES, VOTE, CERT>>;

--- a/crates/task-impls/src/events.rs
+++ b/crates/task-impls/src/events.rs
@@ -25,6 +25,7 @@ pub struct HotShotTaskCompleted;
 
 /// All of the possible events that can be passed between Sequecning `HotShot` tasks
 #[derive(Eq, Hash, PartialEq, Debug, Clone)]
+#[allow(clippy::large_enum_variant)]
 pub enum HotShotEvent<TYPES: NodeType> {
     /// Shutdown the task
     Shutdown,

--- a/crates/task-impls/src/events.rs
+++ b/crates/task-impls/src/events.rs
@@ -15,7 +15,7 @@ use hotshot_types::{
 };
 use vbs::version::Version;
 
-use crate::{consensus::CommitmentAndMetadata, view_sync::ViewSyncPhase};
+use crate::view_sync::ViewSyncPhase;
 
 /// Marker that the task completed
 #[derive(Eq, Hash, PartialEq, Debug, Clone)]
@@ -139,14 +139,21 @@ pub enum HotShotEvent<TYPES: NodeType> {
     UpgradeCertificateFormed(UpgradeCertificate<TYPES>),
     /// HotShot was upgraded, with a new network version.
     VersionUpgrade(Version),
-    /// Initiate a proposal right now
+    /// Initiate a proposal right now for a provided view.
     ProposeNow(
-        CommitmentAndMetadata<TYPES>,
+        TYPES::Time,
+        <TYPES::BlockPayload as BlockPayload>::Metadata,
         Option<QuorumProposal<TYPES>>,
         Option<QuorumCertificate<TYPES>>,
         Option<TimeoutCertificate<TYPES>>,
         Option<ViewSyncFinalizeCertificate2<TYPES>>,
     ),
-    // /// Initiate a vote right now
-    // VoteNow(),
+    /// Initiate a vote right now.
+    VoteNow(
+        TYPES::Time,
+        QuorumProposal<TYPES>,
+        Leaf<TYPES>,
+        Proposal<TYPES, VidDisperseShare<TYPES>>,
+        DACertificate<TYPES>,
+    ),
 }

--- a/crates/task-impls/src/events.rs
+++ b/crates/task-impls/src/events.rs
@@ -142,7 +142,7 @@ pub enum HotShotEvent<TYPES: NodeType> {
     /// HotShot was upgraded, with a new network version.
     VersionUpgrade(Version),
     /// Initiate a proposal right now for a provided view.
-    ProposeIfAble(TYPES::Time, ProposalDependencyData<TYPES>),
+    ProposeNow(TYPES::Time, ProposalDependencyData<TYPES>),
     /// Initiate a vote right now for the designated view.
-    VoteIfAble(TYPES::Time, VoteDependencyData<TYPES>),
+    VoteNow(TYPES::Time, VoteDependencyData<TYPES>),
 }

--- a/crates/task-impls/src/events.rs
+++ b/crates/task-impls/src/events.rs
@@ -1,5 +1,6 @@
 use either::Either;
 use hotshot_types::{
+    consensus::ProposalDependencyData,
     data::{DAProposal, Leaf, QuorumProposal, UpgradeProposal, VidDisperse, VidDisperseShare},
     message::Proposal,
     simple_certificate::{
@@ -12,6 +13,7 @@ use hotshot_types::{
     },
     traits::{node_implementation::NodeType, BlockPayload},
     vid::VidCommitment,
+    vote::VoteDependencyData,
 };
 use vbs::version::Version;
 
@@ -140,20 +142,7 @@ pub enum HotShotEvent<TYPES: NodeType> {
     /// HotShot was upgraded, with a new network version.
     VersionUpgrade(Version),
     /// Initiate a proposal right now for a provided view.
-    ProposeNow(
-        TYPES::Time,
-        <TYPES::BlockPayload as BlockPayload>::Metadata,
-        Option<QuorumProposal<TYPES>>,
-        Option<QuorumCertificate<TYPES>>,
-        Option<TimeoutCertificate<TYPES>>,
-        Option<ViewSyncFinalizeCertificate2<TYPES>>,
-    ),
-    /// Initiate a vote right now.
-    VoteNow(
-        TYPES::Time,
-        QuorumProposal<TYPES>,
-        Leaf<TYPES>,
-        Proposal<TYPES, VidDisperseShare<TYPES>>,
-        DACertificate<TYPES>,
-    ),
+    ProposeNow(TYPES::Time, ProposalDependencyData<TYPES>),
+    /// Initiate a vote right now for the designated view.
+    VoteNow(TYPES::Time, VoteDependencyData<TYPES>),
 }

--- a/crates/task-impls/src/events.rs
+++ b/crates/task-impls/src/events.rs
@@ -15,7 +15,7 @@ use hotshot_types::{
 };
 use vbs::version::Version;
 
-use crate::view_sync::ViewSyncPhase;
+use crate::{consensus::CommitmentAndMetadata, view_sync::ViewSyncPhase};
 
 /// Marker that the task completed
 #[derive(Eq, Hash, PartialEq, Debug, Clone)]
@@ -139,4 +139,14 @@ pub enum HotShotEvent<TYPES: NodeType> {
     UpgradeCertificateFormed(UpgradeCertificate<TYPES>),
     /// HotShot was upgraded, with a new network version.
     VersionUpgrade(Version),
+    /// Initiate a proposal right now
+    ProposeNow(
+        CommitmentAndMetadata<TYPES>,
+        Option<QuorumProposal<TYPES>>,
+        Option<QuorumCertificate<TYPES>>,
+        Option<TimeoutCertificate<TYPES>>,
+        Option<ViewSyncFinalizeCertificate2<TYPES>>,
+    ),
+    // /// Initiate a vote right now
+    // VoteNow(),
 }

--- a/crates/task-impls/src/events.rs
+++ b/crates/task-impls/src/events.rs
@@ -142,7 +142,7 @@ pub enum HotShotEvent<TYPES: NodeType> {
     /// HotShot was upgraded, with a new network version.
     VersionUpgrade(Version),
     /// Initiate a proposal right now for a provided view.
-    ProposeNow(TYPES::Time, ProposalDependencyData<TYPES>),
+    ProposeIfAble(TYPES::Time, ProposalDependencyData<TYPES>),
     /// Initiate a vote right now for the designated view.
-    VoteNow(TYPES::Time, VoteDependencyData<TYPES>),
+    VoteIfAble(TYPES::Time, VoteDependencyData<TYPES>),
 }

--- a/crates/task-impls/src/quorum_proposal.rs
+++ b/crates/task-impls/src/quorum_proposal.rs
@@ -274,7 +274,7 @@ impl<TYPES: NodeType> HandleDepOutput for ProposalDependencyHandle<TYPES> {
                 HotShotEvent::ViewSyncFinalizeCertificate2Recv(cert) => {
                     _view_sync_finalize_cert = Some(cert.clone());
                 }
-                HotShotEvent::ProposeIfAble(_, pdd) => {
+                HotShotEvent::ProposeNow(_, pdd) => {
                     commit_and_metadata = Some(pdd.commitment_and_metadata.clone());
                     match &pdd.secondary_proposal_information {
                         hotshot_types::consensus::SecondaryProposalInformation::QuorumProposalAndCertificate(quorum_proposal, quorum_certificate) => {
@@ -420,7 +420,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> QuorumProposalTaskState<TYPE
                         }
                     }
                     ProposalDependency::ProposeNow => {
-                        if let HotShotEvent::ProposeIfAble(view, _) = event {
+                        if let HotShotEvent::ProposeNow(view, _) = event {
                             *view
                         } else {
                             return false;
@@ -485,9 +485,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> QuorumProposalTaskState<TYPE
         );
 
         match event.as_ref() {
-            HotShotEvent::ProposeIfAble(..) => {
-                propose_now_dependency.mark_as_completed(event.clone())
-            }
+            HotShotEvent::ProposeNow(..) => propose_now_dependency.mark_as_completed(event.clone()),
             HotShotEvent::SendPayloadCommitmentAndMetadata(..) => {
                 payload_commitment_dependency.mark_as_completed(event.clone());
             }
@@ -612,7 +610,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> QuorumProposalTaskState<TYPE
         event_sender: Sender<Arc<HotShotEvent<TYPES>>>,
     ) {
         match event.as_ref() {
-            HotShotEvent::ProposeIfAble(view, _) => {
+            HotShotEvent::ProposeNow(view, _) => {
                 self.create_dependency_task_if_new(
                     *view,
                     event_receiver,
@@ -964,7 +962,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> TaskState
                 | HotShotEvent::QCFormed(_)
                 | HotShotEvent::SendPayloadCommitmentAndMetadata(..)
                 | HotShotEvent::ViewSyncFinalizeCertificate2Recv(_)
-                | HotShotEvent::ProposeIfAble(..)
+                | HotShotEvent::ProposeNow(..)
                 | HotShotEvent::Shutdown,
         )
     }

--- a/crates/task-impls/src/quorum_proposal.rs
+++ b/crates/task-impls/src/quorum_proposal.rs
@@ -464,10 +464,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> QuorumProposalTaskState<TYPE
             HotShotEvent::ProposeNow(view, proposal_dependency_data) => {
                 payload_commitment_dependency.mark_as_completed(
                     HotShotEvent::SendPayloadCommitmentAndMetadata(
-                        proposal_dependency_data
-                            .commitment_and_metadata
-                            .commitment
-                            .clone(),
+                        proposal_dependency_data.commitment_and_metadata.commitment,
                         proposal_dependency_data
                             .commitment_and_metadata
                             .metadata

--- a/crates/task-impls/src/quorum_vote.rs
+++ b/crates/task-impls/src/quorum_vote.rs
@@ -112,12 +112,6 @@ impl<TYPES: NodeType, S: Storage<TYPES> + 'static> HandleDepOutput
                     }
                 }
                 HotShotEvent::VoteNow(_, vote_dependency_data) => {
-                    payload_commitment = Some(
-                        vote_dependency_data
-                            .quorum_proposal
-                            .block_header
-                            .payload_commitment(),
-                    );
                     leaf = Some(vote_dependency_data.leaf.clone());
                     disperse_share = Some(vote_dependency_data.disperse_share.clone());
                 }

--- a/crates/task-impls/src/quorum_vote.rs
+++ b/crates/task-impls/src/quorum_vote.rs
@@ -111,7 +111,7 @@ impl<TYPES: NodeType, S: Storage<TYPES> + 'static> HandleDepOutput
                         payload_commitment = Some(vid_payload_commitment);
                     }
                 }
-                HotShotEvent::VoteIfAble(_, vote_dependency_data) => {
+                HotShotEvent::VoteNow(_, vote_dependency_data) => {
                     payload_commitment = Some(
                         vote_dependency_data
                             .quorum_proposal
@@ -245,7 +245,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> QuorumVoteTaskState<TYPES, I
                         }
                     }
                     VoteDependency::VoteNow => {
-                        if let HotShotEvent::VoteIfAble(view, _) = event {
+                        if let HotShotEvent::VoteNow(view, _) = event {
                             *view
                         } else {
                             return false;
@@ -293,7 +293,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> QuorumVoteTaskState<TYPES, I
         // If we have an event provided to us
         if let Some(event) = event {
             // Match on the type of event
-            if let HotShotEvent::VoteIfAble(..) = event.as_ref() {
+            if let HotShotEvent::VoteNow(..) = event.as_ref() {
                 tracing::info!("Completing all events");
                 vote_now_dependency.mark_as_completed(event);
             };
@@ -354,7 +354,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> QuorumVoteTaskState<TYPES, I
         event_sender: Sender<Arc<HotShotEvent<TYPES>>>,
     ) {
         match event.as_ref() {
-            HotShotEvent::VoteIfAble(view, ..) => {
+            HotShotEvent::VoteNow(view, ..) => {
                 self.create_dependency_task_if_new(
                     *view,
                     event_receiver,
@@ -739,7 +739,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> TaskState for QuorumVoteTask
                 | HotShotEvent::ViewChange(_)
                 | HotShotEvent::VIDShareRecv(..)
                 | HotShotEvent::QuorumVoteDependenciesValidated(_)
-                | HotShotEvent::VoteIfAble(..)
+                | HotShotEvent::VoteNow(..)
                 | HotShotEvent::Shutdown,
         )
     }

--- a/crates/testing/tests/tests_1/quorum_proposal_task.rs
+++ b/crates/testing/tests/tests_1/quorum_proposal_task.rs
@@ -84,7 +84,7 @@ async fn test_quorum_proposal_task_quorum_proposal() {
     drop(consensus);
     let cert = proposals[1].data.justify_qc.clone();
 
-    // Run at view 2, the quorum vote task shouldn't care as long as the bookkeeping is correct
+    // Run at view 2, the quorum proposal task shouldn't care as long as the bookkeeping is correct
     let view_2 = TestScriptStage {
         inputs: vec![
             QuorumProposalValidated(proposals[1].data.clone(), leaves[1].clone()),
@@ -256,6 +256,7 @@ async fn test_quorum_proposal_task_propose_now() {
             ),
     };
 
+    // proposal dependency data - timeout cert
     let pdd_timeout = ProposalDependencyData {
         commitment_and_metadata: CommitmentAndMetadata {
             commitment: payload_commitment,
@@ -278,6 +279,7 @@ async fn test_quorum_proposal_task_propose_now() {
             )),
     };
 
+    // proposal dependency data - view sync cert
     let pdd_view_sync = ProposalDependencyData {
         commitment_and_metadata: CommitmentAndMetadata {
             commitment: payload_commitment,
@@ -301,7 +303,6 @@ async fn test_quorum_proposal_task_propose_now() {
             )),
     };
 
-    // Run at view 2, the quorum vote task shouldn't care as long as the bookkeeping is correct
     let view_qp = TestScriptStage {
         inputs: vec![ProposeNow(ViewNumber::new(2), pdd_qp)],
         outputs: vec![quorum_proposal_send()],

--- a/crates/testing/tests/tests_1/quorum_proposal_task.rs
+++ b/crates/testing/tests/tests_1/quorum_proposal_task.rs
@@ -303,19 +303,19 @@ async fn test_quorum_proposal_task_propose_now() {
 
     // Run at view 2, the quorum vote task shouldn't care as long as the bookkeeping is correct
     let view_qp = TestScriptStage {
-        inputs: vec![ProposeIfAble(ViewNumber::new(2), pdd_qp)],
+        inputs: vec![ProposeNow(ViewNumber::new(2), pdd_qp)],
         outputs: vec![quorum_proposal_send()],
         asserts: vec![],
     };
 
     let view_timeout = TestScriptStage {
-        inputs: vec![ProposeIfAble(ViewNumber::new(2), pdd_timeout)],
+        inputs: vec![ProposeNow(ViewNumber::new(2), pdd_timeout)],
         outputs: vec![quorum_proposal_send()],
         asserts: vec![],
     };
 
     let view_view_sync = TestScriptStage {
-        inputs: vec![ProposeIfAble(ViewNumber::new(2), pdd_view_sync)],
+        inputs: vec![ProposeNow(ViewNumber::new(2), pdd_view_sync)],
         outputs: vec![quorum_proposal_send()],
         asserts: vec![],
     };

--- a/crates/testing/tests/tests_1/quorum_vote_task.rs
+++ b/crates/testing/tests/tests_1/quorum_vote_task.rs
@@ -83,9 +83,8 @@ async fn test_quorum_vote_task_vote_now() {
         da_cert: view.da_certificate.clone(),
     };
 
-    // Send the quorum proposal, DAC, and VID disperse data, in which case a dummy vote can be
-    // formed and the view number will be updated.
-    let view_success = TestScriptStage {
+    // Submit an event with just the `VoteNow` event which should successfully send a vote.
+    let view_vote_now = TestScriptStage {
         inputs: vec![VoteNow(view.view_number, vote_dependency_data)],
         outputs: vec![
             exact(QuorumVoteDependenciesValidated(ViewNumber::new(1))),
@@ -97,7 +96,7 @@ async fn test_quorum_vote_task_vote_now() {
     let quorum_vote_state =
         QuorumVoteTaskState::<TestTypes, MemoryImpl>::create_from(&handle).await;
 
-    run_test_script(vec![view_success], quorum_vote_state).await;
+    run_test_script(vec![view_vote_now], quorum_vote_state).await;
 }
 
 #[cfg(test)]

--- a/crates/testing/tests/tests_1/quorum_vote_task.rs
+++ b/crates/testing/tests/tests_1/quorum_vote_task.rs
@@ -86,7 +86,7 @@ async fn test_quorum_vote_task_vote_now() {
     // Send the quorum proposal, DAC, and VID disperse data, in which case a dummy vote can be
     // formed and the view number will be updated.
     let view_success = TestScriptStage {
-        inputs: vec![VoteIfAble(view.view_number, vote_dependency_data)],
+        inputs: vec![VoteNow(view.view_number, vote_dependency_data)],
         outputs: vec![
             exact(QuorumVoteDependenciesValidated(ViewNumber::new(1))),
             quorum_vote_send(),

--- a/crates/types/src/consensus.rs
+++ b/crates/types/src/consensus.rs
@@ -11,16 +11,19 @@ use tracing::error;
 
 pub use crate::utils::{View, ViewInner};
 use crate::{
-    data::{Leaf, VidDisperseShare},
+    data::{Leaf, QuorumProposal, VidDisperseShare},
     error::HotShotError,
     message::Proposal,
-    simple_certificate::{DACertificate, QuorumCertificate},
+    simple_certificate::{
+        DACertificate, QuorumCertificate, TimeoutCertificate, ViewSyncFinalizeCertificate2,
+    },
     traits::{
         metrics::{Counter, Gauge, Histogram, Label, Metrics, NoMetrics},
         node_implementation::NodeType,
-        ValidatedState,
+        BlockPayload, ValidatedState,
     },
     utils::{StateAndDelta, Terminator},
+    vid::VidCommitment,
 };
 
 /// A type alias for `HashMap<Commitment<T>, T>`
@@ -388,4 +391,34 @@ impl<TYPES: NodeType> Consensus<TYPES> {
             .0
             .expect("Decided state not found! Consensus internally inconsistent")
     }
+}
+
+/// Alias for the block payload commitment and the associated metadata. The primary data
+/// needed in order to submit a proposal.
+#[derive(Eq, Hash, PartialEq, Debug, Clone)]
+pub struct CommitmentAndMetadata<PAYLOAD: BlockPayload> {
+    /// Vid Commitment
+    pub commitment: VidCommitment,
+    /// Metadata for the block payload
+    pub metadata: <PAYLOAD as BlockPayload>::Metadata,
+}
+
+/// Helper type to hold the optional secondary information required to propose.
+#[derive(Eq, Hash, PartialEq, Debug, Clone)]
+pub enum SecondaryProposalInformation<TYPES: NodeType> {
+    /// The quorum proposal and certificate needed to propose.
+    QuorumProposalAndCertificate(QuorumProposal<TYPES>, Leaf<TYPES>, QuorumCertificate<TYPES>),
+    /// The timeout certificate which we can propose from.
+    Timeout(TimeoutCertificate<TYPES>),
+    /// The view sync certificate which we can propose from.
+    ViewSync(ViewSyncFinalizeCertificate2<TYPES>),
+}
+
+/// Dependency data required to submit a proposal
+#[derive(Eq, Hash, PartialEq, Debug, Clone)]
+pub struct ProposalDependencyData<TYPES: NodeType> {
+    /// The primary data in a proposal.
+    pub commitment_and_metadata: CommitmentAndMetadata<TYPES::BlockPayload>,
+    /// The secondary data in a proposal
+    pub secondary_proposal_information: SecondaryProposalInformation<TYPES>,
 }

--- a/crates/types/src/consensus.rs
+++ b/crates/types/src/consensus.rs
@@ -405,6 +405,7 @@ pub struct CommitmentAndMetadata<PAYLOAD: BlockPayload> {
 
 /// Helper type to hold the optional secondary information required to propose.
 #[derive(Eq, Hash, PartialEq, Debug, Clone)]
+#[allow(clippy::large_enum_variant)]
 pub enum SecondaryProposalInformation<TYPES: NodeType> {
     /// The quorum proposal and certificate needed to propose.
     QuorumProposalAndCertificate(QuorumProposal<TYPES>, Leaf<TYPES>, QuorumCertificate<TYPES>),

--- a/crates/types/src/consensus.rs
+++ b/crates/types/src/consensus.rs
@@ -405,10 +405,9 @@ pub struct CommitmentAndMetadata<PAYLOAD: BlockPayload> {
 
 /// Helper type to hold the optional secondary information required to propose.
 #[derive(Eq, Hash, PartialEq, Debug, Clone)]
-#[allow(clippy::large_enum_variant)]
 pub enum SecondaryProposalInformation<TYPES: NodeType> {
     /// The quorum proposal and certificate needed to propose.
-    QuorumProposalAndCertificate(QuorumProposal<TYPES>, Leaf<TYPES>, QuorumCertificate<TYPES>),
+    QuorumProposalAndCertificate(QuorumProposal<TYPES>, QuorumCertificate<TYPES>),
     /// The timeout certificate which we can propose from.
     Timeout(TimeoutCertificate<TYPES>),
     /// The view sync certificate which we can propose from.

--- a/crates/types/src/vote.rs
+++ b/crates/types/src/vote.rs
@@ -12,7 +12,9 @@ use ethereum_types::U256;
 use tracing::error;
 
 use crate::{
-    simple_certificate::Threshold,
+    data::{Leaf, QuorumProposal, VidDisperseShare},
+    message::Proposal,
+    simple_certificate::{DACertificate, Threshold},
     simple_vote::Voteable,
     traits::{
         election::Membership,
@@ -180,3 +182,20 @@ impl<TYPES: NodeType, VOTE: Vote<TYPES>, CERT: Certificate<TYPES, Voteable = VOT
 
 /// Mapping of commitments to vote tokens by key.
 type VoteMap2<COMMITMENT, PK, SIG> = HashMap<COMMITMENT, (U256, BTreeMap<PK, (SIG, COMMITMENT)>)>;
+
+/// Payload for the `HotShotEvents::VoteNow` event type. The proposal and leaf are
+/// obtained via a `QuorumProposalValidated` event being processed.
+#[derive(Eq, Hash, PartialEq, Debug, Clone)]
+pub struct VoteDependencyData<TYPES: NodeType> {
+    /// The quorum proposal (not necessarily valid).
+    pub quorum_proposal: QuorumProposal<TYPES>,
+
+    /// The leaf we've obtained from the `QuorumProposalValidated` event.
+    pub leaf: Leaf<TYPES>,
+
+    /// The Vid disperse proposal.
+    pub disperse_proposal: Proposal<TYPES, VidDisperseShare<TYPES>>,
+
+    /// The DA certificate.
+    pub da_cert: DACertificate<TYPES>,
+}

--- a/crates/types/src/vote.rs
+++ b/crates/types/src/vote.rs
@@ -194,7 +194,7 @@ pub struct VoteDependencyData<TYPES: NodeType> {
     pub leaf: Leaf<TYPES>,
 
     /// The Vid disperse proposal.
-    pub disperse_proposal: Proposal<TYPES, VidDisperseShare<TYPES>>,
+    pub disperse_share: Proposal<TYPES, VidDisperseShare<TYPES>>,
 
     /// The DA certificate.
     pub da_cert: DACertificate<TYPES>,


### PR DESCRIPTION
Closes #<ISSUE_NUMBER>
<!-- See here for keywords in Github -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

### This PR: 
Adds the ability to initiate a `ProposeNow` and `VoteNow` event which enables the initiator to be able to submit a proposal with their internal state immediately, without waiting for the appropriate sequence to have taken place. The relevant code for when such an event can happen is within the liveness check in consensus:
```rust
if liveness_check {
    self.current_proposal = Some(proposal.data.clone());
    let new_view = proposal.data.view_number + 1;

    // This is for the case where we form a QC but have not yet seen the previous proposal ourselves
    let should_propose = self.quorum_membership.get_leader(new_view)
        == self.public_key
        && high_qc.view_number
            == self.current_proposal.clone().unwrap().view_number;
    let qc = high_qc.clone();
    if should_propose {
        debug!(
            "Attempting to publish proposal after voting; now in view: {}",
            *new_view
        );
        self.publish_proposal_if_able(qc.view_number + 1, &event_stream)
            .await;
    }
    if self.vote_if_able(&event_stream).await {
        self.current_proposal = None;
    }
}
```
For `QuorumProposal` task, we need the ability to initiate a proposal in this case, but it does not occur within a `QuorumProposalValidated` event, which breaks the dependency tasks for voting and proposing. Instead, we must rely on an additional method for proposing and voting respectively.

The presumption with the liveness check call is that we at least *sometimes* have the ability to propose/vote in this block and would have the data available which would be required to do so. So, by making the new event type, we allow the sender to simply send out whatever data that they have which would make the proposal or vote valid.

So, within the new `QuorumProposalRecv` task (tracking: #2951), we'll be able to do something like this:
```rust
if liveness_check {
    self.current_proposal = Some(proposal.data.clone());
    let new_view = proposal.data.view_number + 1;

    // This is for the case where we form a QC but have not yet seen the previous proposal ourselves
    let should_propose = self.quorum_membership.get_leader(new_view)
        == self.public_key
        && high_qc.view_number
            == self.current_proposal.clone().unwrap().view_number;
    let qc = high_qc.clone();
    if should_propose {
        debug!(
            "Attempting to publish proposal after voting; now in view: {}",
            *new_view
        );
        broadcast_event(
            Arc::new(HotShotEvent::ProposeNow(...)),
            event_stream,
        )
        .await;
    }
    broadcast_event(
            Arc::new(HotShotEvent::VoteNow(...)),
            event_stream,
        )
        .await;
}
```
Which will then get to where it needs to be.

### This PR does not: 
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->

### Key places to review: 
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
