### PR TITLE
avoid collect/copy of payload after encode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1136,7 +1136,7 @@ dependencies = [
  "bitflags 2.5.0",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.11.0",
  "lazy_static",
  "lazycell",
  "log",
@@ -6047,9 +6047,9 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.80"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a56dea16b0a29e94408b9aa5e2940a4eedbd128a1ba20e8f7ae60fd3d465af0e"
+checksum = "3d1597b0c024618f09a9c3b8655b7e430397a36d23fdafec26d6965e9eec3eba"
 dependencies = [
  "unicode-ident",
 ]
@@ -6935,9 +6935,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.197"
+version = "1.0.198"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
+checksum = "9846a40c979031340571da2545a4e5b7c4163bdae79b301d5f86d03979451fcc"
 dependencies = [
  "serde_derive",
 ]
@@ -6964,9 +6964,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.197"
+version = "1.0.198"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
+checksum = "e88edab869b01783ba905e7d0153f9fc1a6505a96e4ad3018011eedb838566d9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6984,9 +6984,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.115"
+version = "1.0.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12dc5c46daa8e9fdf4f5e71b6cf9a53f2487da0e86e55808e2d35539666497dd"
+checksum = "3e17db7126d17feb94eb3fad46bf1a96b034e8aacbc2e775fe81505f8b0b2813"
 dependencies = [
  "itoa",
  "ryu",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -483,9 +483,8 @@ dependencies = [
 
 [[package]]
 name = "ark-srs"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f6e9a7036d369a637b2b9f871bc06cefe52a947c98e898dbafab26548f8aa22"
+version = "0.3.1"
+source = "git+https://github.com/EspressoSystems/ark-srs?branch=ma/sync-requests#57a1d3e529b61a8f410b9b0503d5607d8e75be3c"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -1136,7 +1135,7 @@ dependencies = [
  "bitflags 2.5.0",
  "cexpr",
  "clang-sys",
- "itertools 0.11.0",
+ "itertools 0.12.1",
  "lazy_static",
  "lazycell",
  "log",
@@ -3134,7 +3133,7 @@ dependencies = [
 
 [[package]]
 name = "hotshot"
-version = "0.5.40"
+version = "0.5.39"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -3180,7 +3179,7 @@ dependencies = [
 
 [[package]]
 name = "hotshot-builder-api"
-version = "0.1.7"
+version = "0.1.6"
 dependencies = [
  "async-trait",
  "clap",
@@ -3198,7 +3197,7 @@ dependencies = [
 
 [[package]]
 name = "hotshot-example-types"
-version = "0.5.40"
+version = "0.5.39"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -3227,7 +3226,7 @@ dependencies = [
 
 [[package]]
 name = "hotshot-examples"
-version = "0.5.40"
+version = "0.5.39"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -3276,7 +3275,7 @@ dependencies = [
 
 [[package]]
 name = "hotshot-macros"
-version = "0.5.40"
+version = "0.5.39"
 dependencies = [
  "derive_builder",
  "proc-macro2",
@@ -3286,7 +3285,7 @@ dependencies = [
 
 [[package]]
 name = "hotshot-orchestrator"
-version = "0.5.40"
+version = "0.5.39"
 dependencies = [
  "anyhow",
  "async-compatibility-layer",
@@ -3314,7 +3313,7 @@ dependencies = [
 
 [[package]]
 name = "hotshot-stake-table"
-version = "0.5.40"
+version = "0.5.39"
 dependencies = [
  "ark-bn254",
  "ark-ed-on-bn254",
@@ -3333,7 +3332,7 @@ dependencies = [
 
 [[package]]
 name = "hotshot-task"
-version = "0.5.40"
+version = "0.5.39"
 dependencies = [
  "async-broadcast",
  "async-compatibility-layer",
@@ -3345,7 +3344,7 @@ dependencies = [
 
 [[package]]
 name = "hotshot-task-impls"
-version = "0.5.40"
+version = "0.5.39"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -3377,7 +3376,7 @@ dependencies = [
 
 [[package]]
 name = "hotshot-testing"
-version = "0.5.40"
+version = "0.5.39"
 dependencies = [
  "async-broadcast",
  "async-compatibility-layer",
@@ -3466,7 +3465,7 @@ dependencies = [
 
 [[package]]
 name = "hotshot-web-server"
-version = "0.5.40"
+version = "0.5.39"
 dependencies = [
  "async-compatibility-layer",
  "async-lock 2.8.0",
@@ -4588,7 +4587,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-networking"
-version = "0.5.40"
+version = "0.5.39"
 dependencies = [
  "anyhow",
  "async-compatibility-layer",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6047,9 +6047,9 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.81"
+version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d1597b0c024618f09a9c3b8655b7e430397a36d23fdafec26d6965e9eec3eba"
+checksum = "a56dea16b0a29e94408b9aa5e2940a4eedbd128a1ba20e8f7ae60fd3d465af0e"
 dependencies = [
  "unicode-ident",
 ]
@@ -6935,9 +6935,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.198"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9846a40c979031340571da2545a4e5b7c4163bdae79b301d5f86d03979451fcc"
+checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
 dependencies = [
  "serde_derive",
 ]
@@ -6964,9 +6964,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.198"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e88edab869b01783ba905e7d0153f9fc1a6505a96e4ad3018011eedb838566d9"
+checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6984,9 +6984,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.116"
+version = "1.0.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e17db7126d17feb94eb3fad46bf1a96b034e8aacbc2e775fe81505f8b0b2813"
+checksum = "12dc5c46daa8e9fdf4f5e71b6cf9a53f2487da0e86e55808e2d35539666497dd"
 dependencies = [
  "itoa",
  "ryu",

--- a/crates/example-types/src/block_types.rs
+++ b/crates/example-types/src/block_types.rs
@@ -147,7 +147,7 @@ impl BlockPayload for TestBlockPayload {
     }
 
     fn encode(&self) -> Result<Arc<[u8]>, Self::Error> {
-        Ok(TestTransaction::encode(&self.transactions)?)
+        TestTransaction::encode(&self.transactions)
     }
 
     fn builder_commitment(&self, _metadata: &Self::Metadata) -> BuilderCommitment {

--- a/crates/example-types/src/block_types.rs
+++ b/crates/example-types/src/block_types.rs
@@ -107,7 +107,6 @@ impl BlockPayload for TestBlockPayload {
     type Error = BlockError;
     type Transaction = TestTransaction;
     type Metadata = ();
-    type Encode<'a> = <Vec<u8> as IntoIterator>::IntoIter;
 
     fn from_transactions(
         transactions: impl IntoIterator<Item = Self::Transaction>,
@@ -150,7 +149,7 @@ impl BlockPayload for TestBlockPayload {
         (Self::genesis(), ())
     }
 
-    fn encode(&self) -> Result<Self::Encode<'_>, Self::Error> {
+    fn encode(&self) -> Result<impl AsRef<[u8]> + Send, Self::Error> {
         Ok(TestTransaction::encode(self.transactions.clone())?.into_iter())
     }
 

--- a/crates/example-types/src/block_types.rs
+++ b/crates/example-types/src/block_types.rs
@@ -30,7 +30,7 @@ impl TestTransaction {
     ///
     /// # Errors
     /// If the transaction length conversion fails.
-    pub fn encode(transactions: &Vec<Self>) -> Result<Arc<[u8]>, BlockError> {
+    pub fn encode(transactions: &Vec<Self>) -> Result<Arc<Vec<u8>>, BlockError> {
         let mut encoded = Vec::new();
 
         for txn in transactions {
@@ -121,7 +121,7 @@ impl BlockPayload for TestBlockPayload {
         ))
     }
 
-    fn from_bytes(encoded_transactions: Arc<[u8]>, _metadata: &Self::Metadata) -> Self {
+    fn from_bytes(encoded_transactions: Arc<Vec<u8>>, _metadata: &Self::Metadata) -> Self {
         let mut transactions = Vec::new();
         let mut current_index = 0;
         while current_index < encoded_transactions.len() {
@@ -146,7 +146,7 @@ impl BlockPayload for TestBlockPayload {
         (Self::genesis(), ())
     }
 
-    fn encode(&self) -> Result<Arc<[u8]>, Self::Error> {
+    fn encode(&self) -> Result<Arc<Vec<u8>>, Self::Error> {
         TestTransaction::encode(&self.transactions)
     }
 

--- a/crates/example-types/src/block_types.rs
+++ b/crates/example-types/src/block_types.rs
@@ -148,7 +148,7 @@ impl BlockPayload for TestBlockPayload {
 
     fn encode(&self) -> Result<Arc<[u8]>, Self::Error> {
         let encoded = TestTransaction::encode(&self.transactions);
-        encoded.map(|e| Arc::from(e))
+        encoded.map(Arc::from)
     }
 
     fn builder_commitment(&self, _metadata: &Self::Metadata) -> BuilderCommitment {

--- a/crates/example-types/src/block_types.rs
+++ b/crates/example-types/src/block_types.rs
@@ -147,8 +147,7 @@ impl BlockPayload for TestBlockPayload {
     }
 
     fn encode(&self) -> Result<Arc<[u8]>, Self::Error> {
-        let encoded = TestTransaction::encode(&self.transactions);
-        encoded.map(Arc::from)
+        TestTransaction::encode(&self.transactions).map(Arc::from)
     }
 
     fn builder_commitment(&self, _metadata: &Self::Metadata) -> BuilderCommitment {

--- a/crates/example-types/src/block_types.rs
+++ b/crates/example-types/src/block_types.rs
@@ -30,7 +30,7 @@ impl TestTransaction {
     ///
     /// # Errors
     /// If the transaction length conversion fails.
-    pub fn encode(transactions: &Vec<Self>) -> Result<Arc<Vec<u8>>, BlockError> {
+    pub fn encode(transactions: &[Self]) -> Result<Vec<u8>, BlockError> {
         let mut encoded = Vec::new();
 
         for txn in transactions {
@@ -48,7 +48,7 @@ impl TestTransaction {
             encoded.extend(&txn.0);
         }
 
-        Ok(Arc::from(encoded))
+        Ok(encoded)
     }
 }
 
@@ -121,7 +121,7 @@ impl BlockPayload for TestBlockPayload {
         ))
     }
 
-    fn from_bytes(encoded_transactions: Arc<Vec<u8>>, _metadata: &Self::Metadata) -> Self {
+    fn from_bytes(encoded_transactions: &[u8], _metadata: &Self::Metadata) -> Self {
         let mut transactions = Vec::new();
         let mut current_index = 0;
         while current_index < encoded_transactions.len() {
@@ -146,8 +146,9 @@ impl BlockPayload for TestBlockPayload {
         (Self::genesis(), ())
     }
 
-    fn encode(&self) -> Result<Arc<Vec<u8>>, Self::Error> {
-        TestTransaction::encode(&self.transactions)
+    fn encode(&self) -> Result<Arc<[u8]>, Self::Error> {
+        let encoded = TestTransaction::encode(&self.transactions);
+        encoded.map(|e| Arc::from(e))
     }
 
     fn builder_commitment(&self, _metadata: &Self::Metadata) -> BuilderCommitment {

--- a/crates/hotshot/src/lib.rs
+++ b/crates/hotshot/src/lib.rs
@@ -223,10 +223,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> SystemContext<TYPES, I> {
                 }
             };
 
-            saved_payloads.insert(
-                anchored_leaf.get_view_number(),
-                encoded_txns.as_ref().to_vec(),
-            );
+            saved_payloads.insert(anchored_leaf.get_view_number(), encoded_txns.clone());
         }
 
         let consensus = Consensus {

--- a/crates/hotshot/src/lib.rs
+++ b/crates/hotshot/src/lib.rs
@@ -216,16 +216,17 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> SystemContext<TYPES, I> {
             saved_leaves.insert(leaf.commit(), leaf.clone());
         }
         if let Some(payload) = anchored_leaf.get_block_payload() {
-            let encoded_txns: Vec<u8> = match payload.encode() {
-                // TODO (Keyao) [VALIDATED_STATE] - Avoid collect/copy on the encoded transaction bytes.
-                // <https://github.com/EspressoSystems/HotShot/issues/2115>
-                Ok(encoded) => encoded.into_iter().collect(),
+            let encoded_txns = match payload.encode() {
+                Ok(encoded) => encoded,
                 Err(e) => {
                     return Err(HotShotError::BlockError { source: e });
                 }
             };
 
-            saved_payloads.insert(anchored_leaf.get_view_number(), encoded_txns);
+            saved_payloads.insert(
+                anchored_leaf.get_view_number(),
+                encoded_txns.as_ref().to_vec(),
+            );
         }
 
         let consensus = Consensus {

--- a/crates/hotshot/src/lib.rs
+++ b/crates/hotshot/src/lib.rs
@@ -223,7 +223,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> SystemContext<TYPES, I> {
                 }
             };
 
-            saved_payloads.insert(anchored_leaf.get_view_number(), encoded_txns.clone());
+            saved_payloads.insert(anchored_leaf.get_view_number(), Arc::clone(&encoded_txns));
         }
 
         let consensus = Consensus {

--- a/crates/task-impls/src/consensus/mod.rs
+++ b/crates/task-impls/src/consensus/mod.rs
@@ -673,7 +673,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                                     consensus.saved_payloads.get(&leaf.get_view_number())
                                 {
                                     let payload = BlockPayload::from_bytes(
-                                        encoded_txns.clone(),
+                                        encoded_txns,
                                         leaf.get_block_header().metadata(),
                                     );
 

--- a/crates/task-impls/src/consensus/mod.rs
+++ b/crates/task-impls/src/consensus/mod.rs
@@ -673,7 +673,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                                     consensus.saved_payloads.get(&leaf.get_view_number())
                                 {
                                     let payload = BlockPayload::from_bytes(
-                                        encoded_txns.clone().into_iter(),
+                                        encoded_txns.clone(),
                                         leaf.get_block_header().metadata(),
                                     );
 

--- a/crates/task-impls/src/da.rs
+++ b/crates/task-impls/src/da.rs
@@ -132,8 +132,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                     return None;
                 }
 
-                let encoded_transactions_hash =
-                    Sha256::digest(proposal.data.encoded_transactions.as_ref());
+                let encoded_transactions_hash = Sha256::digest(&proposal.data.encoded_transactions);
 
                 // ED Is this the right leader?
                 let view_leader_key = self.da_membership.get_leader(view);
@@ -215,7 +214,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                 // Record the payload we have promised to make available.
                 consensus
                     .saved_payloads
-                    .insert(view, proposal.data.encoded_transactions.clone());
+                    .insert(view, Arc::clone(&proposal.data.encoded_transactions));
             }
             HotShotEvent::DAVoteRecv(ref vote) => {
                 debug!("DA vote recv, Main Task {:?}", vote.get_view_number());
@@ -310,7 +309,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                     .await;
 
                 // quick hash the encoded txns with sha256
-                let encoded_transactions_hash = Sha256::digest(encoded_transactions.as_ref());
+                let encoded_transactions_hash = Sha256::digest(encoded_transactions);
 
                 // sign the encoded transactions as opposed to the VID commitment
                 let Ok(signature) =

--- a/crates/task-impls/src/da.rs
+++ b/crates/task-impls/src/da.rs
@@ -181,7 +181,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                 let txns = proposal.data.encoded_transactions.clone();
                 let num_nodes = self.quorum_membership.total_nodes();
                 let payload_commitment =
-                    spawn_blocking(move || vid_commitment(&txns, num_nodes)).await;
+                    spawn_blocking(move || vid_commitment(txns, num_nodes)).await;
                 #[cfg(async_executor_impl = "tokio")]
                 let payload_commitment = payload_commitment.unwrap();
 

--- a/crates/task-impls/src/da.rs
+++ b/crates/task-impls/src/da.rs
@@ -132,7 +132,8 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                     return None;
                 }
 
-                let encoded_transactions_hash = Sha256::digest(&proposal.data.encoded_transactions);
+                let encoded_transactions_hash =
+                    Sha256::digest(proposal.data.encoded_transactions.as_ref());
 
                 // ED Is this the right leader?
                 let view_leader_key = self.da_membership.get_leader(view);
@@ -181,7 +182,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                 let txns = proposal.data.encoded_transactions.clone();
                 let num_nodes = self.quorum_membership.total_nodes();
                 let payload_commitment =
-                    spawn_blocking(move || vid_commitment(txns, num_nodes)).await;
+                    spawn_blocking(move || vid_commitment(&txns, num_nodes)).await;
                 #[cfg(async_executor_impl = "tokio")]
                 let payload_commitment = payload_commitment.unwrap();
 
@@ -309,7 +310,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                     .await;
 
                 // quick hash the encoded txns with sha256
-                let encoded_transactions_hash = Sha256::digest(encoded_transactions);
+                let encoded_transactions_hash = Sha256::digest(encoded_transactions.as_ref());
 
                 // sign the encoded transactions as opposed to the VID commitment
                 let Ok(signature) =

--- a/crates/task-impls/src/events.rs
+++ b/crates/task-impls/src/events.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use either::Either;
 use hotshot_types::{
     consensus::ProposalDependencyData,
@@ -115,7 +117,7 @@ pub enum HotShotEvent<TYPES: NodeType> {
     ),
     /// Event when the transactions task has sequenced transactions. Contains the encoded transactions, the metadata, and the view number
     BlockRecv(
-        Vec<u8>,
+        Arc<[u8]>,
         <TYPES::BlockPayload as BlockPayload>::Metadata,
         TYPES::Time,
         BuilderFee<TYPES>,

--- a/crates/task-impls/src/events.rs
+++ b/crates/task-impls/src/events.rs
@@ -117,7 +117,7 @@ pub enum HotShotEvent<TYPES: NodeType> {
     ),
     /// Event when the transactions task has sequenced transactions. Contains the encoded transactions, the metadata, and the view number
     BlockRecv(
-        Arc<Vec<u8>>,
+        Arc<[u8]>,
         <TYPES::BlockPayload as BlockPayload>::Metadata,
         TYPES::Time,
         BuilderFee<TYPES>,

--- a/crates/task-impls/src/events.rs
+++ b/crates/task-impls/src/events.rs
@@ -117,7 +117,7 @@ pub enum HotShotEvent<TYPES: NodeType> {
     ),
     /// Event when the transactions task has sequenced transactions. Contains the encoded transactions, the metadata, and the view number
     BlockRecv(
-        Arc<[u8]>,
+        Arc<Vec<u8>>,
         <TYPES::BlockPayload as BlockPayload>::Metadata,
         TYPES::Time,
         BuilderFee<TYPES>,

--- a/crates/task-impls/src/helpers.rs
+++ b/crates/task-impls/src/helpers.rs
@@ -44,13 +44,13 @@ pub async fn broadcast_event<E: Clone + std::fmt::Debug>(event: E, sender: &Send
 /// Panics if the VID calculation fails, this should not happen.
 #[allow(clippy::panic)]
 pub async fn calculate_vid_disperse<TYPES: NodeType>(
-    txns: Vec<u8>,
+    txns: Arc<Vec<u8>>,
     membership: &Arc<TYPES::Membership>,
     view: TYPES::Time,
 ) -> VidDisperse<TYPES> {
     let num_nodes = membership.total_nodes();
     let vid_disperse = spawn_blocking(move || {
-        vid_scheme(num_nodes).disperse(&txns).unwrap_or_else(|err| panic!("VID precompute disperse failure:(num_storage nodes,payload_byte_len)=({num_nodes},{}) error: {err}", txns.len()))
+        vid_scheme(num_nodes).disperse(txns.as_ref()).unwrap_or_else(|err| panic!("VID precompute disperse failure:(num_storage nodes,payload_byte_len)=({num_nodes},{}) error: {err}", txns.len()))
     })
     .await;
     #[cfg(async_executor_impl = "tokio")]

--- a/crates/task-impls/src/helpers.rs
+++ b/crates/task-impls/src/helpers.rs
@@ -44,13 +44,13 @@ pub async fn broadcast_event<E: Clone + std::fmt::Debug>(event: E, sender: &Send
 /// Panics if the VID calculation fails, this should not happen.
 #[allow(clippy::panic)]
 pub async fn calculate_vid_disperse<TYPES: NodeType>(
-    txns: Arc<Vec<u8>>,
+    txns: Arc<[u8]>,
     membership: &Arc<TYPES::Membership>,
     view: TYPES::Time,
 ) -> VidDisperse<TYPES> {
     let num_nodes = membership.total_nodes();
     let vid_disperse = spawn_blocking(move || {
-        vid_scheme(num_nodes).disperse(txns.as_ref()).unwrap_or_else(|err| panic!("VID precompute disperse failure:(num_storage nodes,payload_byte_len)=({num_nodes},{}) error: {err}", txns.len()))
+        vid_scheme(num_nodes).disperse(&txns).unwrap_or_else(|err| panic!("VID precompute disperse failure:(num_storage nodes,payload_byte_len)=({num_nodes},{}) error: {err}", txns.len()))
     })
     .await;
     #[cfg(async_executor_impl = "tokio")]
@@ -66,7 +66,7 @@ pub async fn calculate_vid_disperse<TYPES: NodeType>(
 /// Panics if the VID calculation fails, this should not happen.
 #[allow(clippy::panic)]
 pub async fn calculate_vid_disperse_using_precompute_data<TYPES: NodeType>(
-    txns: Vec<u8>,
+    txns: Arc<[u8]>,
     membership: &Arc<TYPES::Membership>,
     view: TYPES::Time,
     pre_compute_data: VidPrecomputeData,

--- a/crates/task-impls/src/transactions.rs
+++ b/crates/task-impls/src/transactions.rs
@@ -179,7 +179,7 @@ impl<
                     // Broadcast the empty block
                     broadcast_event(
                         Arc::new(HotShotEvent::BlockRecv(
-                            vec![],
+                            vec![].into(),
                             metadata,
                             block_view,
                             builder_fee,

--- a/crates/task-impls/src/transactions.rs
+++ b/crates/task-impls/src/transactions.rs
@@ -134,15 +134,16 @@ impl<
                 {
                     // send the sequenced transactions to VID and DA tasks
                     let encoded_transactions = match block_data.block_payload.encode() {
-                        Ok(encoded) => encoded.into_iter().collect::<Vec<u8>>(),
+                        Ok(encoded) => encoded,
                         Err(e) => {
                             error!("Failed to encode the block payload: {:?}.", e);
                             return None;
                         }
                     };
+
                     broadcast_event(
                         Arc::new(HotShotEvent::BlockRecv(
-                            encoded_transactions,
+                            encoded_transactions.as_ref().to_vec(),
                             block_data.metadata,
                             block_view,
                             BuilderFee {

--- a/crates/task-impls/src/transactions.rs
+++ b/crates/task-impls/src/transactions.rs
@@ -143,7 +143,7 @@ impl<
 
                     broadcast_event(
                         Arc::new(HotShotEvent::BlockRecv(
-                            encoded_transactions.as_ref().to_vec(),
+                            encoded_transactions.clone(),
                             block_data.metadata,
                             block_view,
                             BuilderFee {

--- a/crates/task-impls/src/transactions.rs
+++ b/crates/task-impls/src/transactions.rs
@@ -143,7 +143,7 @@ impl<
 
                     broadcast_event(
                         Arc::new(HotShotEvent::BlockRecv(
-                            encoded_transactions.clone(),
+                            encoded_transactions,
                             block_data.metadata,
                             block_view,
                             BuilderFee {

--- a/crates/task-impls/src/vid.rs
+++ b/crates/task-impls/src/vid.rs
@@ -63,7 +63,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
         match event.as_ref() {
             HotShotEvent::BlockRecv(encoded_transactions, metadata, view_number, fee) => {
                 let payload = <TYPES as NodeType>::BlockPayload::from_bytes(
-                    encoded_transactions.clone().into_iter(),
+                    encoded_transactions.clone(),
                     metadata,
                 );
                 let builder_commitment = payload.builder_commitment(metadata);

--- a/crates/task-impls/src/vid.rs
+++ b/crates/task-impls/src/vid.rs
@@ -62,10 +62,8 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
     ) -> Option<HotShotTaskCompleted> {
         match event.as_ref() {
             HotShotEvent::BlockRecv(encoded_transactions, metadata, view_number, fee) => {
-                let payload = <TYPES as NodeType>::BlockPayload::from_bytes(
-                    encoded_transactions.clone(),
-                    metadata,
-                );
+                let payload =
+                    <TYPES as NodeType>::BlockPayload::from_bytes(encoded_transactions, metadata);
                 let builder_commitment = payload.builder_commitment(metadata);
                 let vid_disperse = calculate_vid_disperse(
                     encoded_transactions.clone(),

--- a/crates/testing/src/block_builder.rs
+++ b/crates/testing/src/block_builder.rs
@@ -453,7 +453,7 @@ impl<TYPES: NodeType> BuilderTask<TYPES> for SimpleBuilderTask<TYPES> {
                         }
                         EventType::DAProposal { proposal, .. } => {
                             let payload = TYPES::BlockPayload::from_bytes(
-                                proposal.data.encoded_transactions,
+                                &proposal.data.encoded_transactions,
                                 &proposal.data.metadata,
                             );
                             let now = Instant::now();

--- a/crates/testing/src/block_builder.rs
+++ b/crates/testing/src/block_builder.rs
@@ -537,7 +537,7 @@ async fn build_block<TYPES: NodeType>(
     let block_size = block_payload
         .encode()
         .expect("failed to encode block")
-        .collect::<Vec<u8>>()
+        .as_ref()
         .len() as u64;
 
     let signature_over_block_info =

--- a/crates/testing/src/block_builder.rs
+++ b/crates/testing/src/block_builder.rs
@@ -531,7 +531,7 @@ async fn build_block<TYPES: NodeType>(
     let commitment = block_payload.builder_commitment(&metadata);
 
     let (vid_commitment, precompute_data) =
-        precompute_vid_commitment(block_payload.encode().unwrap(), num_storage_nodes);
+        precompute_vid_commitment(&block_payload.encode().unwrap(), num_storage_nodes);
 
     // Get block size from the encoded payload
     let block_size = block_payload

--- a/crates/testing/src/block_builder.rs
+++ b/crates/testing/src/block_builder.rs
@@ -530,9 +530,8 @@ async fn build_block<TYPES: NodeType>(
 
     let commitment = block_payload.builder_commitment(&metadata);
 
-    let encoded_payload = block_payload.encode().unwrap().collect();
     let (vid_commitment, precompute_data) =
-        precompute_vid_commitment(&encoded_payload, num_storage_nodes);
+        precompute_vid_commitment(&block_payload.encode().unwrap(), num_storage_nodes);
 
     // Get block size from the encoded payload
     let block_size = block_payload

--- a/crates/testing/src/block_builder.rs
+++ b/crates/testing/src/block_builder.rs
@@ -453,7 +453,7 @@ impl<TYPES: NodeType> BuilderTask<TYPES> for SimpleBuilderTask<TYPES> {
                         }
                         EventType::DAProposal { proposal, .. } => {
                             let payload = TYPES::BlockPayload::from_bytes(
-                                proposal.data.encoded_transactions.into_iter(),
+                                proposal.data.encoded_transactions,
                                 &proposal.data.metadata,
                             );
                             let now = Instant::now();
@@ -531,13 +531,12 @@ async fn build_block<TYPES: NodeType>(
     let commitment = block_payload.builder_commitment(&metadata);
 
     let (vid_commitment, precompute_data) =
-        precompute_vid_commitment(&block_payload.encode().unwrap(), num_storage_nodes);
+        precompute_vid_commitment(block_payload.encode().unwrap(), num_storage_nodes);
 
     // Get block size from the encoded payload
     let block_size = block_payload
         .encode()
         .expect("failed to encode block")
-        .as_ref()
         .len() as u64;
 
     let signature_over_block_info =

--- a/crates/testing/src/task_helpers.rs
+++ b/crates/testing/src/task_helpers.rs
@@ -236,7 +236,7 @@ pub fn vid_payload_commitment(
 ) -> VidCommitment {
     let mut vid = vid_scheme_from_view_number::<TestTypes>(quorum_membership, view_number);
     let encoded_transactions = TestTransaction::encode(&transactions).unwrap();
-    let vid_disperse = vid.disperse(encoded_transactions.as_ref()).unwrap();
+    let vid_disperse = vid.disperse(&encoded_transactions).unwrap();
 
     vid_disperse.commit
 }
@@ -262,7 +262,7 @@ pub fn build_vid_proposal(
 
     let vid_disperse = VidDisperse::from_membership(
         view_number,
-        vid.disperse(encoded_transactions.as_ref()).unwrap(),
+        vid.disperse(&encoded_transactions).unwrap(),
         quorum_membership,
     );
 

--- a/crates/testing/src/task_helpers.rs
+++ b/crates/testing/src/task_helpers.rs
@@ -382,7 +382,7 @@ pub fn da_payload_commitment(
 ) -> VidCommitment {
     let encoded_transactions = TestTransaction::encode(transactions.clone()).unwrap();
 
-    vid_commitment(&encoded_transactions, quorum_membership.total_nodes())
+    vid_commitment(encoded_transactions, quorum_membership.total_nodes())
 }
 
 /// TODO: <https://github.com/EspressoSystems/HotShot/issues/2821>
@@ -421,7 +421,7 @@ pub fn build_da_certificate(
     let encoded_transactions = TestTransaction::encode(transactions.clone()).unwrap();
 
     let da_payload_commitment =
-        vid_commitment(&encoded_transactions, quorum_membership.total_nodes());
+        vid_commitment(encoded_transactions, quorum_membership.total_nodes());
 
     let da_data = DAData {
         payload_commit: da_payload_commitment,

--- a/crates/testing/src/task_helpers.rs
+++ b/crates/testing/src/task_helpers.rs
@@ -208,141 +208,6 @@ pub fn build_assembled_sig<
     real_qc_sig
 }
 
-/// build a quorum proposal and signature
-#[allow(clippy::too_many_lines)]
-async fn build_quorum_proposal_and_signature(
-    handle: &SystemContextHandle<TestTypes, MemoryImpl>,
-    private_key: &<BLSPubKey as SignatureKey>::PrivateKey,
-    public_key: &BLSPubKey,
-    view: u64,
-) -> (
-    QuorumProposal<TestTypes>,
-    <BLSPubKey as SignatureKey>::PureAssembledSignatureType,
-) {
-    // build the genesis view
-    let genesis_consensus = handle.get_consensus();
-    let cur_consensus = genesis_consensus.upgradable_read().await;
-    let mut consensus = RwLockUpgradableReadGuard::upgrade(cur_consensus).await;
-    // parent_view_number should be equal to 0
-    let parent_view_number = &consensus.high_qc.get_view_number();
-    assert_eq!(parent_view_number.get_u64(), 0);
-    let Some(parent_view) = consensus.validated_state_map.get(parent_view_number) else {
-        panic!("Couldn't find high QC parent in state map.");
-    };
-    let Some(leaf_view_0) = parent_view.get_leaf_commitment() else {
-        panic!("Parent of high QC points to a view without a proposal");
-    };
-    let Some(leaf_view_0) = consensus.saved_leaves.get(&leaf_view_0) else {
-        panic!("Failed to find high QC parent.");
-    };
-    let parent_leaf = leaf_view_0.clone();
-
-    // every event input is seen on the event stream in the output.
-    let block = <TestBlockPayload as TestableBlock>::genesis();
-    let payload_commitment = vid_commitment(
-        &block.encode().unwrap(),
-        handle.hotshot.memberships.quorum_membership.total_nodes(),
-    );
-    let mut parent_state = Arc::new(
-        <TestValidatedState as ValidatedState<TestTypes>>::from_header(
-            parent_leaf.get_block_header(),
-        ),
-    );
-    let block_header = TestBlockHeader::new(
-        &*parent_state,
-        &TestInstanceState {},
-        &parent_leaf,
-        payload_commitment,
-        (),
-    )
-    .await;
-    let mut proposal = QuorumProposal::<TestTypes> {
-        block_header: block_header.clone(),
-        view_number: ViewNumber::new(1),
-        justify_qc: QuorumCertificate::genesis(),
-        upgrade_certificate: None,
-        proposal_certificate: None,
-    };
-    // current leaf that can be re-assigned everytime when entering a new view
-    let mut leaf = Leaf::from_quorum_proposal(&proposal);
-
-    let mut signature = <BLSPubKey as SignatureKey>::sign(private_key, leaf.commit().as_ref())
-        .expect("Failed to sign leaf commitment!");
-
-    // Only view 2 is tested, higher views are not tested
-    for cur_view in 2..=view {
-        let (state_new_view, delta_new_view) = parent_state
-            .validate_and_apply_header(&TestInstanceState {}, &parent_leaf, &block_header)
-            .await
-            .unwrap();
-        let state_new_view = Arc::new(state_new_view);
-        // save states for the previous view to pass all the qc checks
-        // In the long term, we want to get rid of this, do not manually update consensus state
-        consensus.validated_state_map.insert(
-            ViewNumber::new(cur_view - 1),
-            View {
-                view_inner: ViewInner::Leaf {
-                    leaf: leaf.commit(),
-                    state: state_new_view.clone(),
-                    delta: Some(Arc::new(delta_new_view)),
-                },
-            },
-        );
-        consensus.saved_leaves.insert(leaf.commit(), leaf.clone());
-        // create a qc by aggregate signatures on the previous view (the data signed is last leaf commitment)
-        let quorum_membership = handle.hotshot.memberships.quorum_membership.clone();
-        let quorum_data = QuorumData {
-            leaf_commit: leaf.commit(),
-        };
-        let created_qc = build_cert::<
-            TestTypes,
-            QuorumData<TestTypes>,
-            QuorumVote<TestTypes>,
-            QuorumCertificate<TestTypes>,
-        >(
-            quorum_data,
-            &quorum_membership,
-            ViewNumber::new(cur_view - 1),
-            public_key,
-            private_key,
-        );
-        // create a new leaf for the current view
-        let proposal_new_view = QuorumProposal::<TestTypes> {
-            block_header: block_header.clone(),
-            view_number: ViewNumber::new(cur_view),
-            justify_qc: created_qc,
-            upgrade_certificate: None,
-            proposal_certificate: None,
-        };
-        let leaf_new_view = Leaf::from_quorum_proposal(&proposal_new_view);
-        let signature_new_view =
-            <BLSPubKey as SignatureKey>::sign(private_key, leaf_new_view.commit().as_ref())
-                .expect("Failed to sign leaf commitment!");
-        proposal = proposal_new_view;
-        signature = signature_new_view;
-        leaf = leaf_new_view;
-        parent_state = state_new_view;
-    }
-
-    (proposal, signature)
-}
-
-/// create a quorum proposal
-pub async fn build_quorum_proposal(
-    handle: &SystemContextHandle<TestTypes, MemoryImpl>,
-    private_key: &<BLSPubKey as SignatureKey>::PrivateKey,
-    view: u64,
-) -> Proposal<TestTypes, QuorumProposal<TestTypes>> {
-    let public_key = &BLSPubKey::from_private(private_key);
-    let (proposal, signature) =
-        build_quorum_proposal_and_signature(handle, private_key, public_key, view).await;
-    Proposal {
-        data: proposal,
-        signature,
-        _pd: PhantomData,
-    }
-}
-
 /// get the keypair for a node id
 #[must_use]
 pub fn key_pair_for_id(node_id: u64) -> (<BLSPubKey as SignatureKey>::PrivateKey, BLSPubKey) {
@@ -370,7 +235,7 @@ pub fn vid_payload_commitment(
     transactions: Vec<TestTransaction>,
 ) -> VidCommitment {
     let mut vid = vid_scheme_from_view_number::<TestTypes>(quorum_membership, view_number);
-    let encoded_transactions = TestTransaction::encode(transactions.clone()).unwrap();
+    let encoded_transactions = TestTransaction::encode(&transactions).unwrap();
     let vid_disperse = vid.disperse(encoded_transactions).unwrap();
 
     vid_disperse.commit
@@ -380,7 +245,7 @@ pub fn da_payload_commitment(
     quorum_membership: &<TestTypes as NodeType>::Membership,
     transactions: Vec<TestTransaction>,
 ) -> VidCommitment {
-    let encoded_transactions = TestTransaction::encode(transactions.clone()).unwrap();
+    let encoded_transactions = TestTransaction::encode(&transactions).unwrap();
 
     vid_commitment(encoded_transactions, quorum_membership.total_nodes())
 }
@@ -393,7 +258,7 @@ pub fn build_vid_proposal(
     private_key: &<BLSPubKey as SignatureKey>::PrivateKey,
 ) -> Vec<Proposal<TestTypes, VidDisperseShare<TestTypes>>> {
     let mut vid = vid_scheme_from_view_number::<TestTypes>(quorum_membership, view_number);
-    let encoded_transactions = TestTransaction::encode(transactions.clone()).unwrap();
+    let encoded_transactions = TestTransaction::encode(&transactions).unwrap();
 
     let vid_disperse = VidDisperse::from_membership(
         view_number,
@@ -418,7 +283,7 @@ pub fn build_da_certificate(
     public_key: &<TestTypes as NodeType>::SignatureKey,
     private_key: &<BLSPubKey as SignatureKey>::PrivateKey,
 ) -> DACertificate<TestTypes> {
-    let encoded_transactions = TestTransaction::encode(transactions.clone()).unwrap();
+    let encoded_transactions = TestTransaction::encode(&transactions).unwrap();
 
     let da_payload_commitment =
         vid_commitment(encoded_transactions, quorum_membership.total_nodes());

--- a/crates/testing/src/task_helpers.rs
+++ b/crates/testing/src/task_helpers.rs
@@ -236,7 +236,7 @@ pub fn vid_payload_commitment(
 ) -> VidCommitment {
     let mut vid = vid_scheme_from_view_number::<TestTypes>(quorum_membership, view_number);
     let encoded_transactions = TestTransaction::encode(&transactions).unwrap();
-    let vid_disperse = vid.disperse(encoded_transactions).unwrap();
+    let vid_disperse = vid.disperse(encoded_transactions.as_ref()).unwrap();
 
     vid_disperse.commit
 }
@@ -247,7 +247,7 @@ pub fn da_payload_commitment(
 ) -> VidCommitment {
     let encoded_transactions = TestTransaction::encode(&transactions).unwrap();
 
-    vid_commitment(encoded_transactions, quorum_membership.total_nodes())
+    vid_commitment(&encoded_transactions, quorum_membership.total_nodes())
 }
 
 /// TODO: <https://github.com/EspressoSystems/HotShot/issues/2821>
@@ -262,7 +262,7 @@ pub fn build_vid_proposal(
 
     let vid_disperse = VidDisperse::from_membership(
         view_number,
-        vid.disperse(encoded_transactions).unwrap(),
+        vid.disperse(encoded_transactions.as_ref()).unwrap(),
         quorum_membership,
     );
 
@@ -286,7 +286,7 @@ pub fn build_da_certificate(
     let encoded_transactions = TestTransaction::encode(&transactions).unwrap();
 
     let da_payload_commitment =
-        vid_commitment(encoded_transactions, quorum_membership.total_nodes());
+        vid_commitment(&encoded_transactions, quorum_membership.total_nodes());
 
     let da_data = DAData {
         payload_commit: da_payload_commitment,

--- a/crates/testing/src/task_helpers.rs
+++ b/crates/testing/src/task_helpers.rs
@@ -208,6 +208,141 @@ pub fn build_assembled_sig<
     real_qc_sig
 }
 
+/// build a quorum proposal and signature
+#[allow(clippy::too_many_lines)]
+async fn build_quorum_proposal_and_signature(
+    handle: &SystemContextHandle<TestTypes, MemoryImpl>,
+    private_key: &<BLSPubKey as SignatureKey>::PrivateKey,
+    public_key: &BLSPubKey,
+    view: u64,
+) -> (
+    QuorumProposal<TestTypes>,
+    <BLSPubKey as SignatureKey>::PureAssembledSignatureType,
+) {
+    // build the genesis view
+    let genesis_consensus = handle.get_consensus();
+    let cur_consensus = genesis_consensus.upgradable_read().await;
+    let mut consensus = RwLockUpgradableReadGuard::upgrade(cur_consensus).await;
+    // parent_view_number should be equal to 0
+    let parent_view_number = &consensus.high_qc.get_view_number();
+    assert_eq!(parent_view_number.get_u64(), 0);
+    let Some(parent_view) = consensus.validated_state_map.get(parent_view_number) else {
+        panic!("Couldn't find high QC parent in state map.");
+    };
+    let Some(leaf_view_0) = parent_view.get_leaf_commitment() else {
+        panic!("Parent of high QC points to a view without a proposal");
+    };
+    let Some(leaf_view_0) = consensus.saved_leaves.get(&leaf_view_0) else {
+        panic!("Failed to find high QC parent.");
+    };
+    let parent_leaf = leaf_view_0.clone();
+
+    // every event input is seen on the event stream in the output.
+    let block = <TestBlockPayload as TestableBlock>::genesis();
+    let payload_commitment = vid_commitment(
+        &block.encode().unwrap(),
+        handle.hotshot.memberships.quorum_membership.total_nodes(),
+    );
+    let mut parent_state = Arc::new(
+        <TestValidatedState as ValidatedState<TestTypes>>::from_header(
+            parent_leaf.get_block_header(),
+        ),
+    );
+    let block_header = TestBlockHeader::new(
+        &*parent_state,
+        &TestInstanceState {},
+        &parent_leaf,
+        payload_commitment,
+        (),
+    )
+    .await;
+    let mut proposal = QuorumProposal::<TestTypes> {
+        block_header: block_header.clone(),
+        view_number: ViewNumber::new(1),
+        justify_qc: QuorumCertificate::genesis(),
+        upgrade_certificate: None,
+        proposal_certificate: None,
+    };
+    // current leaf that can be re-assigned everytime when entering a new view
+    let mut leaf = Leaf::from_quorum_proposal(&proposal);
+
+    let mut signature = <BLSPubKey as SignatureKey>::sign(private_key, leaf.commit().as_ref())
+        .expect("Failed to sign leaf commitment!");
+
+    // Only view 2 is tested, higher views are not tested
+    for cur_view in 2..=view {
+        let (state_new_view, delta_new_view) = parent_state
+            .validate_and_apply_header(&TestInstanceState {}, &parent_leaf, &block_header)
+            .await
+            .unwrap();
+        let state_new_view = Arc::new(state_new_view);
+        // save states for the previous view to pass all the qc checks
+        // In the long term, we want to get rid of this, do not manually update consensus state
+        consensus.validated_state_map.insert(
+            ViewNumber::new(cur_view - 1),
+            View {
+                view_inner: ViewInner::Leaf {
+                    leaf: leaf.commit(),
+                    state: state_new_view.clone(),
+                    delta: Some(Arc::new(delta_new_view)),
+                },
+            },
+        );
+        consensus.saved_leaves.insert(leaf.commit(), leaf.clone());
+        // create a qc by aggregate signatures on the previous view (the data signed is last leaf commitment)
+        let quorum_membership = handle.hotshot.memberships.quorum_membership.clone();
+        let quorum_data = QuorumData {
+            leaf_commit: leaf.commit(),
+        };
+        let created_qc = build_cert::<
+            TestTypes,
+            QuorumData<TestTypes>,
+            QuorumVote<TestTypes>,
+            QuorumCertificate<TestTypes>,
+        >(
+            quorum_data,
+            &quorum_membership,
+            ViewNumber::new(cur_view - 1),
+            public_key,
+            private_key,
+        );
+        // create a new leaf for the current view
+        let proposal_new_view = QuorumProposal::<TestTypes> {
+            block_header: block_header.clone(),
+            view_number: ViewNumber::new(cur_view),
+            justify_qc: created_qc,
+            upgrade_certificate: None,
+            proposal_certificate: None,
+        };
+        let leaf_new_view = Leaf::from_quorum_proposal(&proposal_new_view);
+        let signature_new_view =
+            <BLSPubKey as SignatureKey>::sign(private_key, leaf_new_view.commit().as_ref())
+                .expect("Failed to sign leaf commitment!");
+        proposal = proposal_new_view;
+        signature = signature_new_view;
+        leaf = leaf_new_view;
+        parent_state = state_new_view;
+    }
+
+    (proposal, signature)
+}
+
+/// create a quorum proposal
+pub async fn build_quorum_proposal(
+    handle: &SystemContextHandle<TestTypes, MemoryImpl>,
+    private_key: &<BLSPubKey as SignatureKey>::PrivateKey,
+    view: u64,
+) -> Proposal<TestTypes, QuorumProposal<TestTypes>> {
+    let public_key = &BLSPubKey::from_private(private_key);
+    let (proposal, signature) =
+        build_quorum_proposal_and_signature(handle, private_key, public_key, view).await;
+    Proposal {
+        data: proposal,
+        signature,
+        _pd: PhantomData,
+    }
+}
+
 /// get the keypair for a node id
 #[must_use]
 pub fn key_pair_for_id(node_id: u64) -> (<BLSPubKey as SignatureKey>::PrivateKey, BLSPubKey) {

--- a/crates/testing/src/view_generator.rs
+++ b/crates/testing/src/view_generator.rs
@@ -298,7 +298,7 @@ impl TestView {
             _pd: PhantomData,
         };
 
-        let encoded_transactions = TestTransaction::encode(&transactions).unwrap();
+        let encoded_transactions = TestTransaction::encode(transactions).unwrap();
         let encoded_transactions_hash = Sha256::digest(&encoded_transactions);
         let block_payload_signature =
             <TestTypes as NodeType>::SignatureKey::sign(&private_key, &encoded_transactions_hash)

--- a/crates/testing/src/view_generator.rs
+++ b/crates/testing/src/view_generator.rs
@@ -1,4 +1,4 @@
-use std::{cmp::max, marker::PhantomData};
+use std::{cmp::max, marker::PhantomData, sync::Arc};
 
 use committable::Committable;
 use hotshot::types::{BLSPubKey, SignatureKey, SystemContextHandle};
@@ -96,8 +96,8 @@ impl TestView {
             proposal_certificate: None,
         };
 
-        let encoded_transactions = TestTransaction::encode(&transactions).unwrap();
-        let encoded_transactions_hash = Sha256::digest(encoded_transactions.as_ref());
+        let encoded_transactions = Arc::from(TestTransaction::encode(&transactions).unwrap());
+        let encoded_transactions_hash = Sha256::digest(&encoded_transactions);
         let block_payload_signature =
             <TestTypes as NodeType>::SignatureKey::sign(&private_key, &encoded_transactions_hash)
                 .expect("Failed to sign block payload");
@@ -298,8 +298,8 @@ impl TestView {
             _pd: PhantomData,
         };
 
-        let encoded_transactions = TestTransaction::encode(transactions).unwrap();
-        let encoded_transactions_hash = Sha256::digest(encoded_transactions.as_ref());
+        let encoded_transactions = Arc::from(TestTransaction::encode(transactions).unwrap());
+        let encoded_transactions_hash = Sha256::digest(&encoded_transactions);
         let block_payload_signature =
             <TestTypes as NodeType>::SignatureKey::sign(&private_key, &encoded_transactions_hash)
                 .expect("Failed to sign block payload");

--- a/crates/testing/src/view_generator.rs
+++ b/crates/testing/src/view_generator.rs
@@ -96,7 +96,7 @@ impl TestView {
             proposal_certificate: None,
         };
 
-        let encoded_transactions = TestTransaction::encode(transactions.clone()).unwrap();
+        let encoded_transactions = TestTransaction::encode(&transactions).unwrap();
         let encoded_transactions_hash = Sha256::digest(&encoded_transactions);
         let block_payload_signature =
             <TestTypes as NodeType>::SignatureKey::sign(&private_key, &encoded_transactions_hash)
@@ -298,7 +298,7 @@ impl TestView {
             _pd: PhantomData,
         };
 
-        let encoded_transactions = TestTransaction::encode(transactions.clone()).unwrap();
+        let encoded_transactions = TestTransaction::encode(&transactions).unwrap();
         let encoded_transactions_hash = Sha256::digest(&encoded_transactions);
         let block_payload_signature =
             <TestTypes as NodeType>::SignatureKey::sign(&private_key, &encoded_transactions_hash)

--- a/crates/testing/src/view_generator.rs
+++ b/crates/testing/src/view_generator.rs
@@ -97,7 +97,7 @@ impl TestView {
         };
 
         let encoded_transactions = TestTransaction::encode(&transactions).unwrap();
-        let encoded_transactions_hash = Sha256::digest(&encoded_transactions);
+        let encoded_transactions_hash = Sha256::digest(encoded_transactions.as_ref());
         let block_payload_signature =
             <TestTypes as NodeType>::SignatureKey::sign(&private_key, &encoded_transactions_hash)
                 .expect("Failed to sign block payload");
@@ -299,7 +299,7 @@ impl TestView {
         };
 
         let encoded_transactions = TestTransaction::encode(transactions).unwrap();
-        let encoded_transactions_hash = Sha256::digest(&encoded_transactions);
+        let encoded_transactions_hash = Sha256::digest(encoded_transactions.as_ref());
         let block_payload_signature =
             <TestTypes as NodeType>::SignatureKey::sign(&private_key, &encoded_transactions_hash)
                 .expect("Failed to sign block payload");

--- a/crates/testing/tests/tests_1/block_builder.rs
+++ b/crates/testing/tests/tests_1/block_builder.rs
@@ -52,7 +52,7 @@ async fn test_random_block_builder() {
     let mut blocks = loop {
         // Test getting blocks
         let blocks = client
-            .get_available_blocks(vid_commitment(&vec![], 1), pub_key, &signature)
+            .get_available_blocks(vid_commitment(&[], 1), pub_key, &signature)
             .await
             .expect("Failed to get available blocks");
 

--- a/crates/testing/tests/tests_1/da_task.rs
+++ b/crates/testing/tests/tests_1/da_task.rs
@@ -30,9 +30,9 @@ async fn test_da_task() {
     // Make some empty encoded transactions, we just care about having a commitment handy for the
     // later calls. We need the VID commitment to be able to propose later.
     let transactions = vec![TestTransaction(vec![0])];
-    let encoded_transactions = TestTransaction::encode(transactions.clone()).unwrap();
+    let encoded_transactions = TestTransaction::encode(&transactions).unwrap();
     let payload_commit = vid_commitment(
-        &encoded_transactions,
+        encoded_transactions.clone(),
         handle.hotshot.memberships.quorum_membership.total_nodes(),
     );
 
@@ -68,7 +68,7 @@ async fn test_da_task() {
             ViewChange(ViewNumber::new(1)),
             ViewChange(ViewNumber::new(2)),
             BlockRecv(
-                encoded_transactions.clone(),
+                encoded_transactions,
                 (),
                 ViewNumber::new(2),
                 null_block::builder_fee(quorum_membership.total_nodes()).unwrap(),
@@ -109,9 +109,9 @@ async fn test_da_task_storage_failure() {
     // Make some empty encoded transactions, we just care about having a commitment handy for the
     // later calls. We need the VID commitment to be able to propose later.
     let transactions = vec![TestTransaction(vec![0])];
-    let encoded_transactions = TestTransaction::encode(transactions.clone()).unwrap();
+    let encoded_transactions = TestTransaction::encode(&transactions).unwrap();
     let payload_commit = vid_commitment(
-        &encoded_transactions,
+        encoded_transactions.clone(),
         handle.hotshot.memberships.quorum_membership.total_nodes(),
     );
 

--- a/crates/testing/tests/tests_1/da_task.rs
+++ b/crates/testing/tests/tests_1/da_task.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use hotshot::{tasks::task_state::CreateTaskState, types::SystemContextHandle};
 use hotshot_example_types::{
     block_types::TestTransaction,
@@ -30,7 +32,7 @@ async fn test_da_task() {
     // Make some empty encoded transactions, we just care about having a commitment handy for the
     // later calls. We need the VID commitment to be able to propose later.
     let transactions = vec![TestTransaction(vec![0])];
-    let encoded_transactions = TestTransaction::encode(&transactions).unwrap();
+    let encoded_transactions = Arc::from(TestTransaction::encode(&transactions).unwrap());
     let payload_commit = vid_commitment(
         &encoded_transactions,
         handle.hotshot.memberships.quorum_membership.total_nodes(),
@@ -109,7 +111,7 @@ async fn test_da_task_storage_failure() {
     // Make some empty encoded transactions, we just care about having a commitment handy for the
     // later calls. We need the VID commitment to be able to propose later.
     let transactions = vec![TestTransaction(vec![0])];
-    let encoded_transactions = TestTransaction::encode(&transactions).unwrap();
+    let encoded_transactions = Arc::from(TestTransaction::encode(&transactions).unwrap());
     let payload_commit = vid_commitment(
         &encoded_transactions,
         handle.hotshot.memberships.quorum_membership.total_nodes(),
@@ -147,7 +149,7 @@ async fn test_da_task_storage_failure() {
             ViewChange(ViewNumber::new(1)),
             ViewChange(ViewNumber::new(2)),
             BlockRecv(
-                encoded_transactions.clone(),
+                encoded_transactions,
                 (),
                 ViewNumber::new(2),
                 null_block::builder_fee(quorum_membership.total_nodes()).unwrap(),

--- a/crates/testing/tests/tests_1/da_task.rs
+++ b/crates/testing/tests/tests_1/da_task.rs
@@ -32,7 +32,7 @@ async fn test_da_task() {
     let transactions = vec![TestTransaction(vec![0])];
     let encoded_transactions = TestTransaction::encode(&transactions).unwrap();
     let payload_commit = vid_commitment(
-        encoded_transactions.clone(),
+        &encoded_transactions,
         handle.hotshot.memberships.quorum_membership.total_nodes(),
     );
 
@@ -111,7 +111,7 @@ async fn test_da_task_storage_failure() {
     let transactions = vec![TestTransaction(vec![0])];
     let encoded_transactions = TestTransaction::encode(&transactions).unwrap();
     let payload_commit = vid_commitment(
-        encoded_transactions.clone(),
+        &encoded_transactions,
         handle.hotshot.memberships.quorum_membership.total_nodes(),
     );
 

--- a/crates/testing/tests/tests_1/vid_task.rs
+++ b/crates/testing/tests/tests_1/vid_task.rs
@@ -38,7 +38,7 @@ async fn test_vid_task() {
     let transactions = vec![TestTransaction(vec![0])];
     let (payload, metadata) = TestBlockPayload::from_transactions(transactions.clone()).unwrap();
     let builder_commitment = payload.builder_commitment(&metadata);
-    let encoded_transactions = TestTransaction::encode(transactions.clone()).unwrap();
+    let encoded_transactions = TestTransaction::encode(&transactions).unwrap();
     let vid_disperse = vid.disperse(&encoded_transactions).unwrap();
     let payload_commitment = vid_disperse.commit;
 

--- a/crates/testing/tests/tests_1/vid_task.rs
+++ b/crates/testing/tests/tests_1/vid_task.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, marker::PhantomData};
+use std::{collections::HashMap, marker::PhantomData, sync::Arc};
 
 use hotshot::types::SignatureKey;
 use hotshot_example_types::{
@@ -38,8 +38,8 @@ async fn test_vid_task() {
     let transactions = vec![TestTransaction(vec![0])];
     let (payload, metadata) = TestBlockPayload::from_transactions(transactions.clone()).unwrap();
     let builder_commitment = payload.builder_commitment(&metadata);
-    let encoded_transactions = TestTransaction::encode(&transactions).unwrap();
-    let vid_disperse = vid.disperse(encoded_transactions.as_ref()).unwrap();
+    let encoded_transactions = Arc::from(TestTransaction::encode(&transactions).unwrap());
+    let vid_disperse = vid.disperse(&encoded_transactions).unwrap();
     let payload_commitment = vid_disperse.commit;
 
     let signature = <TestTypes as NodeType>::SignatureKey::sign(
@@ -83,7 +83,7 @@ async fn test_vid_task() {
     input.push(HotShotEvent::ViewChange(ViewNumber::new(1)));
     input.push(HotShotEvent::ViewChange(ViewNumber::new(2)));
     input.push(HotShotEvent::BlockRecv(
-        encoded_transactions.clone(),
+        encoded_transactions,
         (),
         ViewNumber::new(2),
         null_block::builder_fee(quorum_membership.total_nodes()).unwrap(),

--- a/crates/testing/tests/tests_1/vid_task.rs
+++ b/crates/testing/tests/tests_1/vid_task.rs
@@ -39,7 +39,7 @@ async fn test_vid_task() {
     let (payload, metadata) = TestBlockPayload::from_transactions(transactions.clone()).unwrap();
     let builder_commitment = payload.builder_commitment(&metadata);
     let encoded_transactions = TestTransaction::encode(&transactions).unwrap();
-    let vid_disperse = vid.disperse(&encoded_transactions).unwrap();
+    let vid_disperse = vid.disperse(encoded_transactions.as_ref()).unwrap();
     let payload_commitment = vid_disperse.commit;
 
     let signature = <TestTypes as NodeType>::SignatureKey::sign(

--- a/crates/types/src/consensus.rs
+++ b/crates/types/src/consensus.rs
@@ -68,7 +68,7 @@ pub struct Consensus<TYPES: NodeType> {
     /// Saved payloads.
     ///
     /// Encoded transactions for every view if we got a payload for that view.
-    pub saved_payloads: BTreeMap<TYPES::Time, Vec<u8>>,
+    pub saved_payloads: BTreeMap<TYPES::Time, Arc<[u8]>>,
 
     /// The `locked_qc` view number
     pub locked_view: TYPES::Time,

--- a/crates/types/src/consensus.rs
+++ b/crates/types/src/consensus.rs
@@ -68,7 +68,7 @@ pub struct Consensus<TYPES: NodeType> {
     /// Saved payloads.
     ///
     /// Encoded transactions for every view if we got a payload for that view.
-    pub saved_payloads: BTreeMap<TYPES::Time, Arc<[u8]>>,
+    pub saved_payloads: BTreeMap<TYPES::Time, Arc<Vec<u8>>>,
 
     /// The `locked_qc` view number
     pub locked_view: TYPES::Time,

--- a/crates/types/src/consensus.rs
+++ b/crates/types/src/consensus.rs
@@ -68,7 +68,7 @@ pub struct Consensus<TYPES: NodeType> {
     /// Saved payloads.
     ///
     /// Encoded transactions for every view if we got a payload for that view.
-    pub saved_payloads: BTreeMap<TYPES::Time, Arc<Vec<u8>>>,
+    pub saved_payloads: BTreeMap<TYPES::Time, Arc<[u8]>>,
 
     /// The `locked_qc` view number
     pub locked_view: TYPES::Time,

--- a/crates/types/src/data.rs
+++ b/crates/types/src/data.rs
@@ -503,14 +503,13 @@ impl<TYPES: NodeType> Leaf<TYPES> {
     /// or if the transactions are of invalid length
     pub fn fill_block_payload(
         &mut self,
-        block_payload: TYPES::BlockPayload,
+        block_payload: &TYPES::BlockPayload,
         num_storage_nodes: usize,
     ) -> Result<(), BlockError> {
-        let encoded_txns = match block_payload.encode() {
-            Ok(encoded) => encoded,
-            Err(_) => return Err(BlockError::InvalidTransactionLength),
+        let Ok(encoded_txns) = block_payload.encode() else {
+            return Err(BlockError::InvalidTransactionLength);
         };
-        let commitment = vid_commitment(&encoded_txns, num_storage_nodes);
+        let commitment = vid_commitment(encoded_txns, num_storage_nodes);
         if commitment != self.block_header.payload_commitment() {
             return Err(BlockError::InconsistentPayloadCommitment);
         }

--- a/crates/types/src/data.rs
+++ b/crates/types/src/data.rs
@@ -115,7 +115,7 @@ impl std::ops::Sub<u64> for ViewNumber {
 #[derive(custom_debug::Debug, Serialize, Deserialize, Clone, Eq, PartialEq, Hash)]
 pub struct DAProposal<TYPES: NodeType> {
     /// Encoded transactions in the block to be applied.
-    pub encoded_transactions: Arc<Vec<u8>>,
+    pub encoded_transactions: Arc<[u8]>,
     /// Metadata of the block to be applied.
     pub metadata: <TYPES::BlockPayload as BlockPayload>::Metadata,
     /// View this proposal applies to

--- a/crates/types/src/data.rs
+++ b/crates/types/src/data.rs
@@ -115,7 +115,7 @@ impl std::ops::Sub<u64> for ViewNumber {
 #[derive(custom_debug::Debug, Serialize, Deserialize, Clone, Eq, PartialEq, Hash)]
 pub struct DAProposal<TYPES: NodeType> {
     /// Encoded transactions in the block to be applied.
-    pub encoded_transactions: Arc<[u8]>,
+    pub encoded_transactions: Arc<Vec<u8>>,
     /// Metadata of the block to be applied.
     pub metadata: <TYPES::BlockPayload as BlockPayload>::Metadata,
     /// View this proposal applies to
@@ -443,7 +443,7 @@ impl<TYPES: NodeType> Leaf<TYPES> {
         let builder_commitment = payload.builder_commitment(&metadata);
         let payload_bytes = payload.encode().expect("unable to encode genesis payload");
 
-        let payload_commitment = vid_commitment(payload_bytes, GENESIS_VID_NUM_STORAGE_NODES);
+        let payload_commitment = vid_commitment(&payload_bytes, GENESIS_VID_NUM_STORAGE_NODES);
         let block_header = TYPES::BlockHeader::genesis(
             instance_state,
             payload_commitment,
@@ -509,7 +509,7 @@ impl<TYPES: NodeType> Leaf<TYPES> {
         let Ok(encoded_txns) = block_payload.encode() else {
             return Err(BlockError::InvalidTransactionLength);
         };
-        let commitment = vid_commitment(encoded_txns, num_storage_nodes);
+        let commitment = vid_commitment(&encoded_txns, num_storage_nodes);
         if commitment != self.block_header.payload_commitment() {
             return Err(BlockError::InconsistentPayloadCommitment);
         }

--- a/crates/types/src/data.rs
+++ b/crates/types/src/data.rs
@@ -456,7 +456,7 @@ impl<TYPES: NodeType> Leaf<TYPES> {
             parent_commitment: fake_commitment(),
             upgrade_certificate: None,
             block_header: block_header.clone(),
-            block_payload: Some(payload.clone()),
+            block_payload: Some(payload),
         }
     }
 
@@ -503,7 +503,7 @@ impl<TYPES: NodeType> Leaf<TYPES> {
     /// or if the transactions are of invalid length
     pub fn fill_block_payload(
         &mut self,
-        block_payload: &TYPES::BlockPayload,
+        block_payload: TYPES::BlockPayload,
         num_storage_nodes: usize,
     ) -> Result<(), BlockError> {
         let Ok(encoded_txns) = block_payload.encode() else {
@@ -513,7 +513,7 @@ impl<TYPES: NodeType> Leaf<TYPES> {
         if commitment != self.block_header.payload_commitment() {
             return Err(BlockError::InconsistentPayloadCommitment);
         }
-        self.block_payload = Some(block_payload.clone());
+        self.block_payload = Some(block_payload);
         Ok(())
     }
 

--- a/crates/types/src/data.rs
+++ b/crates/types/src/data.rs
@@ -8,6 +8,7 @@ use std::{
     fmt::{Debug, Display},
     hash::Hash,
     marker::PhantomData,
+    sync::Arc,
 };
 
 use anyhow::{ensure, Result};
@@ -114,7 +115,7 @@ impl std::ops::Sub<u64> for ViewNumber {
 #[derive(custom_debug::Debug, Serialize, Deserialize, Clone, Eq, PartialEq, Hash)]
 pub struct DAProposal<TYPES: NodeType> {
     /// Encoded transactions in the block to be applied.
-    pub encoded_transactions: Vec<u8>,
+    pub encoded_transactions: Arc<[u8]>,
     /// Metadata of the block to be applied.
     pub metadata: <TYPES::BlockPayload as BlockPayload>::Metadata,
     /// View this proposal applies to
@@ -442,14 +443,13 @@ impl<TYPES: NodeType> Leaf<TYPES> {
         let builder_commitment = payload.builder_commitment(&metadata);
         let payload_bytes = payload.encode().expect("unable to encode genesis payload");
 
-        let payload_commitment = vid_commitment(&payload_bytes, GENESIS_VID_NUM_STORAGE_NODES);
+        let payload_commitment = vid_commitment(payload_bytes, GENESIS_VID_NUM_STORAGE_NODES);
         let block_header = TYPES::BlockHeader::genesis(
             instance_state,
             payload_commitment,
             builder_commitment,
             metadata,
         );
-
         Self {
             view_number: TYPES::Time::genesis(),
             justify_qc: QuorumCertificate::<TYPES>::genesis(),

--- a/crates/types/src/traits/block_contents.rs
+++ b/crates/types/src/traits/block_contents.rs
@@ -117,7 +117,8 @@ pub fn vid_commitment(
     encoded_transactions: impl AsRef<[u8]>,
     num_storage_nodes: usize,
 ) -> <VidSchemeType as VidScheme>::Commit {
-    vid_scheme(num_storage_nodes).commit_only(encoded_transactions).unwrap_or_else(|err| panic!("VidScheme::commit_only failure:\n\t(num_storage_nodes)=({num_storage_nodes}\n\t{err}"))
+    let encoded_tx_len = encoded_transactions.as_ref().len();
+    vid_scheme(num_storage_nodes).commit_only(encoded_transactions).unwrap_or_else(|err| panic!("VidScheme::commit_only failure:(num_storage_nodes,payload_byte_len)=({num_storage_nodes},{encoded_tx_len}) error: {err}"))
 }
 
 /// Compute the VID payload commitment along with precompute data reducing time in VID Disperse
@@ -126,13 +127,14 @@ pub fn vid_commitment(
 #[must_use]
 #[allow(clippy::panic)]
 pub fn precompute_vid_commitment(
-    encoded_transactions: &Vec<u8>,
+    encoded_transactions: impl AsRef<[u8]>,
     num_storage_nodes: usize,
 ) -> (
     <VidSchemeType as VidScheme>::Commit,
     <VidSchemeType as Precomputable>::PrecomputeData,
 ) {
-    vid_scheme(num_storage_nodes).commit_only_precompute(encoded_transactions).unwrap_or_else(|err| panic!("VidScheme::commit_only failure:\n\t(num_storage_nodes)=({num_storage_nodes}\n\t{err}"))
+    let encoded_tx_len = encoded_transactions.as_ref().len();
+    vid_scheme(num_storage_nodes).commit_only_precompute(encoded_transactions).unwrap_or_else(|err| panic!("VidScheme::commit_only failure:(num_storage_nodes,payload_byte_len)=({num_storage_nodes},{encoded_tx_len}) error: {err}"))
 }
 
 /// The number of storage nodes to use when computing the genesis VID commitment.

--- a/crates/types/src/traits/block_contents.rs
+++ b/crates/types/src/traits/block_contents.rs
@@ -59,7 +59,7 @@ pub trait BlockPayload:
 
     /// Build a payload with the encoded transaction bytes, metadata,
     /// and the associated number of VID storage nodes
-    fn from_bytes(encoded_transactions: Arc<[u8]>, metadata: &Self::Metadata) -> Self;
+    fn from_bytes(encoded_transactions: Arc<Vec<u8>>, metadata: &Self::Metadata) -> Self;
 
     /// Build the genesis payload and metadata.
     fn genesis() -> (Self, Self::Metadata);
@@ -68,7 +68,7 @@ pub trait BlockPayload:
     ///
     /// # Errors
     /// If the transaction length conversion fails.
-    fn encode(&self) -> Result<Arc<[u8]>, Self::Error>;
+    fn encode(&self) -> Result<Arc<Vec<u8>>, Self::Error>;
 
     /// List of transaction commitments.
     fn transaction_commitments(
@@ -111,11 +111,11 @@ pub trait TestableBlock: BlockPayload + Debug {
 #[must_use]
 #[allow(clippy::panic)]
 pub fn vid_commitment(
-    encoded_transactions: Arc<[u8]>,
+    encoded_transactions: &Arc<Vec<u8>>,
     num_storage_nodes: usize,
 ) -> <VidSchemeType as VidScheme>::Commit {
-    let encoded_tx_len = encoded_transactions.as_ref().len();
-    vid_scheme(num_storage_nodes).commit_only(encoded_transactions).unwrap_or_else(|err| panic!("VidScheme::commit_only failure:(num_storage_nodes,payload_byte_len)=({num_storage_nodes},{encoded_tx_len}) error: {err}"))
+    let encoded_tx_len = encoded_transactions.len();
+    vid_scheme(num_storage_nodes).commit_only(encoded_transactions.as_ref()).unwrap_or_else(|err| panic!("VidScheme::commit_only failure:(num_storage_nodes,payload_byte_len)=({num_storage_nodes},{encoded_tx_len}) error: {err}"))
 }
 
 /// Compute the VID payload commitment along with precompute data reducing time in VID Disperse
@@ -124,14 +124,14 @@ pub fn vid_commitment(
 #[must_use]
 #[allow(clippy::panic)]
 pub fn precompute_vid_commitment(
-    encoded_transactions: Arc<[u8]>,
+    encoded_transactions: &Arc<Vec<u8>>,
     num_storage_nodes: usize,
 ) -> (
     <VidSchemeType as VidScheme>::Commit,
     <VidSchemeType as Precomputable>::PrecomputeData,
 ) {
-    let encoded_tx_len = encoded_transactions.as_ref().len();
-    vid_scheme(num_storage_nodes).commit_only_precompute(encoded_transactions).unwrap_or_else(|err| panic!("VidScheme::commit_only failure:(num_storage_nodes,payload_byte_len)=({num_storage_nodes},{encoded_tx_len}) error: {err}"))
+    let encoded_tx_len = encoded_transactions.len();
+    vid_scheme(num_storage_nodes).commit_only_precompute(encoded_transactions.as_ref()).unwrap_or_else(|err| panic!("VidScheme::commit_only failure:(num_storage_nodes,payload_byte_len)=({num_storage_nodes},{encoded_tx_len}) error: {err}"))
 }
 
 /// The number of storage nodes to use when computing the genesis VID commitment.

--- a/crates/types/src/traits/block_contents.rs
+++ b/crates/types/src/traits/block_contents.rs
@@ -59,7 +59,7 @@ pub trait BlockPayload:
 
     /// Build a payload with the encoded transaction bytes, metadata,
     /// and the associated number of VID storage nodes
-    fn from_bytes(encoded_transactions: Arc<Vec<u8>>, metadata: &Self::Metadata) -> Self;
+    fn from_bytes(encoded_transactions: &[u8], metadata: &Self::Metadata) -> Self;
 
     /// Build the genesis payload and metadata.
     fn genesis() -> (Self, Self::Metadata);
@@ -68,7 +68,7 @@ pub trait BlockPayload:
     ///
     /// # Errors
     /// If the transaction length conversion fails.
-    fn encode(&self) -> Result<Arc<Vec<u8>>, Self::Error>;
+    fn encode(&self) -> Result<Arc<[u8]>, Self::Error>;
 
     /// List of transaction commitments.
     fn transaction_commitments(
@@ -111,11 +111,11 @@ pub trait TestableBlock: BlockPayload + Debug {
 #[must_use]
 #[allow(clippy::panic)]
 pub fn vid_commitment(
-    encoded_transactions: &Arc<Vec<u8>>,
+    encoded_transactions: &[u8],
     num_storage_nodes: usize,
 ) -> <VidSchemeType as VidScheme>::Commit {
     let encoded_tx_len = encoded_transactions.len();
-    vid_scheme(num_storage_nodes).commit_only(encoded_transactions.as_ref()).unwrap_or_else(|err| panic!("VidScheme::commit_only failure:(num_storage_nodes,payload_byte_len)=({num_storage_nodes},{encoded_tx_len}) error: {err}"))
+    vid_scheme(num_storage_nodes).commit_only(encoded_transactions).unwrap_or_else(|err| panic!("VidScheme::commit_only failure:(num_storage_nodes,payload_byte_len)=({num_storage_nodes},{encoded_tx_len}) error: {err}"))
 }
 
 /// Compute the VID payload commitment along with precompute data reducing time in VID Disperse
@@ -124,14 +124,14 @@ pub fn vid_commitment(
 #[must_use]
 #[allow(clippy::panic)]
 pub fn precompute_vid_commitment(
-    encoded_transactions: &Arc<Vec<u8>>,
+    encoded_transactions: &[u8],
     num_storage_nodes: usize,
 ) -> (
     <VidSchemeType as VidScheme>::Commit,
     <VidSchemeType as Precomputable>::PrecomputeData,
 ) {
     let encoded_tx_len = encoded_transactions.len();
-    vid_scheme(num_storage_nodes).commit_only_precompute(encoded_transactions.as_ref()).unwrap_or_else(|err| panic!("VidScheme::commit_only failure:(num_storage_nodes,payload_byte_len)=({num_storage_nodes},{encoded_tx_len}) error: {err}"))
+    vid_scheme(num_storage_nodes).commit_only_precompute(encoded_transactions).unwrap_or_else(|err| panic!("VidScheme::commit_only failure:(num_storage_nodes,payload_byte_len)=({num_storage_nodes},{encoded_tx_len}) error: {err}"))
 }
 
 /// The number of storage nodes to use when computing the genesis VID commitment.

--- a/crates/types/src/traits/block_contents.rs
+++ b/crates/types/src/traits/block_contents.rs
@@ -8,6 +8,7 @@ use std::{
     fmt::{Debug, Display},
     future::Future,
     hash::Hash,
+    sync::Arc,
 };
 
 use committable::{Commitment, Committable};
@@ -58,11 +59,7 @@ pub trait BlockPayload:
 
     /// Build a payload with the encoded transaction bytes, metadata,
     /// and the associated number of VID storage nodes
-    ///
-    /// `I` may be, but not necessarily is, the `Encode` type directly from `fn encode`.
-    fn from_bytes<I>(encoded_transactions: I, metadata: &Self::Metadata) -> Self
-    where
-        I: Iterator<Item = u8>;
+    fn from_bytes(encoded_transactions: Arc<[u8]>, metadata: &Self::Metadata) -> Self;
 
     /// Build the genesis payload and metadata.
     fn genesis() -> (Self, Self::Metadata);
@@ -71,7 +68,7 @@ pub trait BlockPayload:
     ///
     /// # Errors
     /// If the transaction length conversion fails.
-    fn encode(&self) -> Result<impl AsRef<[u8]> + Send, Self::Error>;
+    fn encode(&self) -> Result<Arc<[u8]>, Self::Error>;
 
     /// List of transaction commitments.
     fn transaction_commitments(
@@ -114,7 +111,7 @@ pub trait TestableBlock: BlockPayload + Debug {
 #[must_use]
 #[allow(clippy::panic)]
 pub fn vid_commitment(
-    encoded_transactions: impl AsRef<[u8]>,
+    encoded_transactions: Arc<[u8]>,
     num_storage_nodes: usize,
 ) -> <VidSchemeType as VidScheme>::Commit {
     let encoded_tx_len = encoded_transactions.as_ref().len();
@@ -127,7 +124,7 @@ pub fn vid_commitment(
 #[must_use]
 #[allow(clippy::panic)]
 pub fn precompute_vid_commitment(
-    encoded_transactions: impl AsRef<[u8]>,
+    encoded_transactions: Arc<[u8]>,
     num_storage_nodes: usize,
 ) -> (
     <VidSchemeType as VidScheme>::Commit,


### PR DESCRIPTION
Closes: EspressoSystems/jellyfish#417 and #2115
<!-- See here for keywords in Github -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

### This PR: 
Addresses the issue of collect/copy of the encoded payload like here:
https://github.com/EspressoSystems/HotShot/blob/15c776d32001ce88edf2a87f3c520301da22a582/crates/hotshot/src/lib.rs#L217-L226
This is done by changing the output type of `BlockPayload::encode` to `Result<Arc<[u8]>, Self::Error>` and thereby avoiding collect/copy when using it in fx `vid_commitment`.

<!-- Describe what this PR adds to HotSHot -->
<!-- E.g. -->
<!-- * Implements feature 1 -->
<!-- * Implements feature 2 -->
<!-- * Fixes bug 3 -->

**NB: This has implications for components downstream (espresso-sequencer, hotshot-query-service, hotshot-builder-core) using this trait interface.**

### This PR does not: 
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->

### Key places to review: 
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
