### PR TITLE
Remove special casing for view 1 (again)

### DIFF
--- a/crates/hotshot/src/lib.rs
+++ b/crates/hotshot/src/lib.rs
@@ -286,7 +286,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> SystemContext<TYPES, I> {
         self.internal_event_stream
             .0
             .broadcast_direct(Arc::new(HotShotEvent::QCFormed(either::Left(
-                QuorumCertificate::genesis(),
+                self.consensus.read().await.high_qc.clone(),
             ))))
             .await
             .expect("Genesis Broadcast failed");
@@ -697,13 +697,13 @@ impl<TYPES: NodeType> HotShotInitializer<TYPES> {
         let (validated_state, state_delta) = TYPES::ValidatedState::genesis(&instance_state);
         Ok(Self {
             inner: Leaf::genesis(&instance_state),
-            instance_state,
             validated_state: Some(Arc::new(validated_state)),
             state_delta: Some(Arc::new(state_delta)),
             start_view: TYPES::Time::new(0),
-            high_qc: QuorumCertificate::genesis(),
+            high_qc: QuorumCertificate::genesis(&instance_state),
             undecided_leafs: Vec::new(),
             undecided_state: BTreeMap::new(),
+            instance_state,
         })
     }
 

--- a/crates/task-impls/src/consensus.rs
+++ b/crates/task-impls/src/consensus.rs
@@ -89,11 +89,13 @@ pub(crate) async fn validate_proposal<TYPES: NodeType>(
 
     let state = Arc::new(validated_state);
     let delta = Arc::new(state_delta);
-    let parent_commitment = parent_leaf.commit();
     let view = proposal.data.get_view_number();
 
-    let mut proposed_leaf = Leaf::from_quorum_proposal(&proposal.data);
-    proposed_leaf.set_parent_commitment(parent_commitment);
+    let proposed_leaf = Leaf::from_quorum_proposal(&proposal.data);
+    ensure!(
+        proposed_leaf.get_parent_commitment() == parent_leaf.commit(),
+        "Proposed leaf does not extend the parent leaf."
+    );
 
     // Validate the proposal's signature. This should also catch if the leaf_commitment does not equal our calculated parent commitment
     //
@@ -237,8 +239,10 @@ async fn create_and_send_proposal<TYPES: NodeType>(
         upgrade_certificate: upgrade_cert,
     };
 
-    let mut proposed_leaf = Leaf::from_quorum_proposal(&proposal);
-    proposed_leaf.set_parent_commitment(parent_leaf.commit());
+    let proposed_leaf = Leaf::from_quorum_proposal(&proposal);
+    if proposed_leaf.get_parent_commitment() != parent_leaf.commit() {
+        return;
+    }
 
     let Ok(signature) = TYPES::SignatureKey::sign(&private_key, proposed_leaf.commit().as_ref())
     else {
@@ -407,14 +411,10 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                 let view = cert.view_number;
                 // TODO: do some of this logic without the vote token check, only do that when voting.
                 let justify_qc = proposal.justify_qc.clone();
-                let parent = if justify_qc.is_genesis {
-                    Some(Leaf::genesis(&consensus.instance_state))
-                } else {
-                    consensus
-                        .saved_leaves
-                        .get(&justify_qc.get_data().leaf_commit)
-                        .cloned()
-                };
+                let parent = consensus
+                    .saved_leaves
+                    .get(&justify_qc.get_data().leaf_commit)
+                    .cloned();
 
                 // Justify qc's leaf commitment is not the same as the parent's leaf commitment, but it should be (in this case)
                 let Some(parent) = parent else {
@@ -427,15 +427,15 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                 };
                 let parent_commitment = parent.commit();
 
-                let mut proposed_leaf = Leaf::from_quorum_proposal(proposal);
-                proposed_leaf.set_parent_commitment(parent_commitment);
+                let proposed_leaf = Leaf::from_quorum_proposal(proposal);
+                if proposed_leaf.get_parent_commitment() != parent_commitment {
+                    return false;
+                }
 
                 // Validate the DAC.
                 let message = if cert.is_valid_cert(self.committee_membership.as_ref()) {
                     // Validate the block payload commitment for non-genesis DAC.
-                    if !cert.is_genesis
-                        && cert.get_data().payload_commit
-                            != proposal.block_header.payload_commitment()
+                    if cert.get_data().payload_commit != proposal.block_header.payload_commitment()
                     {
                         error!("Block payload commitment does not equal da cert payload commitment. View = {}", *view);
                         return false;
@@ -720,48 +720,22 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                 let consensus = self.consensus.upgradable_read().await;
 
                 // Get the parent leaf and state.
-                let parent = if justify_qc.is_genesis {
-                    // Send the `Decide` event for the genesis block if the justify QC is genesis.
-                    let leaf = Leaf::genesis(&consensus.instance_state);
-                    let (validated_state, state_delta) =
-                        TYPES::ValidatedState::genesis(&consensus.instance_state);
-                    let state = Arc::new(validated_state);
-                    broadcast_event(
-                        Event {
-                            view_number: TYPES::Time::genesis(),
-                            event: EventType::Decide {
-                                leaf_chain: Arc::new(vec![LeafInfo::new(
-                                    leaf.clone(),
-                                    state.clone(),
-                                    Some(Arc::new(state_delta)),
-                                    None,
-                                )]),
-                                qc: Arc::new(justify_qc.clone()),
-                                block_size: None,
-                            },
-                        },
-                        &self.output_event_stream,
-                    )
-                    .await;
-                    Some((leaf, state))
-                } else {
-                    match consensus
-                        .saved_leaves
-                        .get(&justify_qc.get_data().leaf_commit)
-                        .cloned()
-                    {
-                        Some(leaf) => {
-                            if let (Some(state), _) =
-                                consensus.get_state_and_delta(leaf.get_view_number())
-                            {
-                                Some((leaf, state.clone()))
-                            } else {
-                                error!("Parent state not found! Consensus internally inconsistent");
-                                return;
-                            }
+                let parent = match consensus
+                    .saved_leaves
+                    .get(&justify_qc.get_data().leaf_commit)
+                    .cloned()
+                {
+                    Some(leaf) => {
+                        if let (Some(state), _) =
+                            consensus.get_state_and_delta(leaf.get_view_number())
+                        {
+                            Some((leaf, state.clone()))
+                        } else {
+                            error!("Parent state not found! Consensus internally inconsistent");
+                            return;
                         }
-                        None => None,
                     }
+                    None => None,
                 };
 
                 if justify_qc.get_view_number() > consensus.high_qc.view_number {
@@ -790,7 +764,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                         "Proposal's parent missing from storage with commitment: {:?}",
                         justify_qc.get_data().leaf_commit
                     );
-                    let leaf = Leaf::from_quorum_proposal(&proposal.data);
+                    let proposed_leaf = Leaf::from_quorum_proposal(&proposal.data);
 
                     let state = Arc::new(
                         <TYPES::ValidatedState as ValidatedState<TYPES>>::from_header(
@@ -802,13 +776,15 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                         view,
                         View {
                             view_inner: ViewInner::Leaf {
-                                leaf: leaf.commit(),
+                                leaf: proposed_leaf.commit(),
                                 state,
                                 delta: None,
                             },
                         },
                     );
-                    consensus.saved_leaves.insert(leaf.commit(), leaf.clone());
+                    consensus
+                        .saved_leaves
+                        .insert(proposed_leaf.commit(), proposed_leaf.clone());
 
                     if let Err(e) = self
                         .storage
@@ -1606,6 +1582,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                 .as_ref()
                 .filter(|cert| cert.is_valid_for_view(&view))
                 .cloned();
+
             let pub_key = self.public_key.clone();
             let priv_key = self.private_key.clone();
             let consensus = self.consensus.clone();

--- a/crates/task-impls/src/quorum_vote.rs
+++ b/crates/task-impls/src/quorum_vote.rs
@@ -13,7 +13,7 @@ use hotshot_task::{
 use hotshot_types::{
     consensus::Consensus,
     data::Leaf,
-    event::{Event, EventType, LeafInfo},
+    event::{Event, EventType},
     message::GeneralConsensusMessage,
     simple_vote::{QuorumData, QuorumVote},
     traits::{
@@ -82,14 +82,16 @@ impl<TYPES: NodeType, S: Storage<TYPES> + 'static> HandleDepOutput
                         payload_commitment = Some(proposal_payload_comm);
                     }
                     let parent_commitment = parent_leaf.commit();
-                    let mut proposed_leaf = Leaf::from_quorum_proposal(proposal);
-                    proposed_leaf.set_parent_commitment(parent_commitment);
+                    let proposed_leaf = Leaf::from_quorum_proposal(proposal);
+                    if proposed_leaf.get_parent_commitment() != parent_commitment {
+                        return;
+                    }
                     leaf = Some(proposed_leaf);
                 }
                 HotShotEvent::DACertificateValidated(cert) => {
                     let cert_payload_comm = cert.get_data().payload_commit;
                     if let Some(comm) = payload_commitment {
-                        if !cert.is_genesis && cert_payload_comm != comm {
+                        if cert_payload_comm != comm {
                             error!("DAC has inconsistent payload commitment with quorum proposal or VID.");
                             return;
                         }
@@ -332,31 +334,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> QuorumVoteTaskState<TYPES, I
 
                 let consensus = self.consensus.upgradable_read().await;
                 // Get the parent leaf and state.
-                let parent = if justify_qc.is_genesis {
-                    // Send the `Decide` event for the genesis block if the justify QC is genesis.
-                    let leaf = Leaf::genesis(&consensus.instance_state);
-                    let (validated_state, state_delta) =
-                        TYPES::ValidatedState::genesis(&consensus.instance_state);
-                    let state = Arc::new(validated_state);
-                    broadcast_event(
-                        Event {
-                            view_number: TYPES::Time::genesis(),
-                            event: EventType::Decide {
-                                leaf_chain: Arc::new(vec![LeafInfo::new(
-                                    leaf.clone(),
-                                    state.clone(),
-                                    Some(Arc::new(state_delta)),
-                                    None,
-                                )]),
-                                qc: Arc::new(justify_qc.clone()),
-                                block_size: None,
-                            },
-                        },
-                        &self.output_event_stream,
-                    )
-                    .await;
-                    Some((leaf, state))
-                } else {
+                let parent = {
                     match consensus
                         .saved_leaves
                         .get(&justify_qc.get_data().leaf_commit)
@@ -455,8 +433,10 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> QuorumVoteTaskState<TYPES, I
                 let delta = Arc::new(state_delta);
                 let parent_commitment = parent_leaf.commit();
                 let view = proposal.data.get_view_number();
-                let mut proposed_leaf = Leaf::from_quorum_proposal(&proposal.data);
-                proposed_leaf.set_parent_commitment(parent_commitment);
+                let proposed_leaf = Leaf::from_quorum_proposal(&proposal.data);
+                if proposed_leaf.get_parent_commitment() != parent_commitment {
+                    return;
+                }
 
                 // Validate the signature. This should also catch if `leaf_commitment`` does not
                 // equal our calculated parent commitment.

--- a/crates/testing/src/task_helpers.rs
+++ b/crates/testing/src/task_helpers.rs
@@ -263,7 +263,7 @@ async fn build_quorum_proposal_and_signature(
     let mut proposal = QuorumProposal::<TestTypes> {
         block_header: block_header.clone(),
         view_number: ViewNumber::new(1),
-        justify_qc: QuorumCertificate::genesis(),
+        justify_qc: QuorumCertificate::genesis(&TestInstanceState {}),
         upgrade_certificate: None,
         proposal_certificate: None,
     };

--- a/crates/testing/src/test_runner.rs
+++ b/crates/testing/src/test_runner.rs
@@ -219,7 +219,7 @@ where
             latest_view: None,
             changes,
             last_decided_leaf: Leaf::genesis(&TestInstanceState {}),
-            high_qc: QuorumCertificate::genesis(),
+            high_qc: QuorumCertificate::genesis(&TestInstanceState {}),
         };
         let spinning_task = TestTask::<SpinningTask<TYPES, I>, SpinningTask<TYPES, I>>::new(
             Task::new(tx.clone(), rx.clone(), reg.clone(), spinning_task_state),

--- a/crates/testing/src/view_generator.rs
+++ b/crates/testing/src/view_generator.rs
@@ -85,7 +85,7 @@ impl TestView {
         let quorum_proposal_inner = QuorumProposal::<TestTypes> {
             block_header: block_header.clone(),
             view_number: genesis_view,
-            justify_qc: QuorumCertificate::genesis(),
+            justify_qc: QuorumCertificate::genesis(&TestInstanceState {}),
             upgrade_certificate: None,
             proposal_certificate: None,
         };
@@ -112,7 +112,6 @@ impl TestView {
         leaf.fill_block_payload_unchecked(TestBlockPayload {
             transactions: transactions.clone(),
         });
-        leaf.set_parent_commitment(Leaf::genesis(&TestInstanceState {}).commit());
 
         let signature = <BLSPubKey as SignatureKey>::sign(&private_key, leaf.commit().as_ref())
             .expect("Failed to sign leaf commitment!");

--- a/crates/testing/tests/tests_1/message.rs
+++ b/crates/testing/tests/tests_1/message.rs
@@ -42,7 +42,6 @@ fn version_number_at_start_of_serialization() {
         vote_commitment: data.commit(),
         view_number,
         signatures: None,
-        is_genesis: false,
         _pd: PhantomData,
     };
     let message = Message {

--- a/crates/types/src/data.rs
+++ b/crates/types/src/data.rs
@@ -13,7 +13,7 @@ use std::{
 use anyhow::{ensure, Result};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use bincode::Options;
-use committable::{Commitment, Committable, RawCommitmentBuilder};
+use committable::{Commitment, CommitmentBoundsArkless, Committable, RawCommitmentBuilder};
 use derivative::Derivative;
 use jf_primitives::vid::VidDisperse as JfVidDisperse;
 use rand::Rng;
@@ -26,7 +26,7 @@ use crate::{
     simple_certificate::{
         QuorumCertificate, TimeoutCertificate, UpgradeCertificate, ViewSyncFinalizeCertificate2,
     },
-    simple_vote::UpgradeProposalData,
+    simple_vote::{QuorumData, UpgradeProposalData},
     traits::{
         block_contents::{
             vid_commitment, BlockHeader, TestableBlock, GENESIS_VID_NUM_STORAGE_NODES,
@@ -429,6 +429,24 @@ impl<TYPES: NodeType> Display for Leaf<TYPES> {
     }
 }
 
+impl<TYPES: NodeType> QuorumCertificate<TYPES> {
+    #[must_use]
+    /// Creat the Genesis certificate
+    pub fn genesis(instance_state: &TYPES::InstanceState) -> Self {
+        let data = QuorumData {
+            leaf_commit: Leaf::genesis(instance_state).commit(),
+        };
+        let commit = data.commit();
+        Self {
+            data,
+            vote_commitment: commit,
+            view_number: <TYPES::Time as ConsensusTime>::genesis(),
+            signatures: None,
+            _pd: PhantomData,
+        }
+    }
+}
+
 impl<TYPES: NodeType> Leaf<TYPES> {
     /// Create a new leaf from its components.
     ///
@@ -446,10 +464,23 @@ impl<TYPES: NodeType> Leaf<TYPES> {
         let payload_commitment = vid_commitment(&payload_bytes, GENESIS_VID_NUM_STORAGE_NODES);
         let block_header =
             TYPES::BlockHeader::genesis(instance_state, payload_commitment, metadata);
+
+        let null_quorum_data = QuorumData {
+            leaf_commit: Commitment::<Leaf<TYPES>>::default_commitment_no_preimage(),
+        };
+
+        let justify_qc = QuorumCertificate {
+            data: null_quorum_data.clone(),
+            vote_commitment: null_quorum_data.commit(),
+            view_number: <TYPES::Time as ConsensusTime>::genesis(),
+            signatures: None,
+            _pd: PhantomData,
+        };
+
         Self {
             view_number: TYPES::Time::genesis(),
-            justify_qc: QuorumCertificate::<TYPES>::genesis(),
-            parent_commitment: fake_commitment(),
+            justify_qc,
+            parent_commitment: null_quorum_data.leaf_commit,
             upgrade_certificate: None,
             block_header: block_header.clone(),
             block_payload: Some(payload),
@@ -478,11 +509,7 @@ impl<TYPES: NodeType> Leaf<TYPES> {
     pub fn get_parent_commitment(&self) -> Commitment<Self> {
         self.parent_commitment
     }
-    /// Commitment to this leaf's parent.
-    pub fn set_parent_commitment(&mut self, commitment: Commitment<Self>) {
-        self.parent_commitment = commitment;
-    }
-    /// Get a reference to the block header contained in this leaf.
+    /// The block header contained in this leaf.
     pub fn get_block_header(&self) -> &<TYPES as NodeType>::BlockHeader {
         &self.block_header
     }
@@ -548,9 +575,10 @@ impl<TYPES: NodeType> Leaf<TYPES> {
             self.get_upgrade_certificate(),
             parent.get_upgrade_certificate(),
         ) {
-            // If the parent didn't have a certificate, but we see one now, it just means that we have begun an upgrade. Again, this is always fine.
-            // But, if we have no upgrade certificate on either is the most common case, and is always fine.
-            (Some(_) | None, None) => {}
+            // Easiest cases are:
+            //   - no upgrade certificate on either: this is the most common case, and is always fine.
+            //   - if the parent didn't have a certificate, but we see one now, it just means that we have begun an upgrade: again, this is always fine.
+            (None | Some(_), None) => {}
             // If we no longer see a cert, we have to make sure that we either:
             //    - no longer care because we have passed new_version_first_view, or
             //    - no longer care because we have passed `decide_by` without deciding the certificate.


### PR DESCRIPTION
No linked issue.

### This PR: 
Adds back #2873 (reverted by #2952).

The only change over #2873 is that we now broadcast a leaf decide event on startup, which seems to be required by `hotshot-query-service`.

### This PR does not: 

### Key places to review: 
