### PR TITLE
[Builder] Use correct commitment when querying builder

### DIFF
--- a/crates/task-impls/src/consensus/mod.rs
+++ b/crates/task-impls/src/consensus/mod.rs
@@ -3,14 +3,6 @@ use std::{
     sync::Arc,
 };
 
-use crate::{
-    consensus::{proposal::validate_proposal, view_change::update_view},
-    events::{HotShotEvent, HotShotTaskCompleted},
-    helpers::{broadcast_event, cancel_task},
-    vote_collection::{
-        create_vote_accumulator, AccumulatorInfo, HandleVoteEvent, VoteCollectionTaskState,
-    },
-};
 use async_broadcast::Sender;
 use async_compatibility_layer::art::async_spawn;
 use async_lock::{RwLock, RwLockUpgradableReadGuard};
@@ -52,6 +44,15 @@ use {
         data::{null_block, VidDisperseShare},
         message::GeneralConsensusMessage,
         simple_vote::QuorumData,
+    },
+};
+
+use crate::{
+    consensus::{proposal::validate_proposal, view_change::update_view},
+    events::{HotShotEvent, HotShotTaskCompleted},
+    helpers::{broadcast_event, cancel_task},
+    vote_collection::{
+        create_vote_accumulator, AccumulatorInfo, HandleVoteEvent, VoteCollectionTaskState,
     },
 };
 

--- a/crates/task-impls/src/consensus/proposal.rs
+++ b/crates/task-impls/src/consensus/proposal.rs
@@ -1,12 +1,13 @@
+use core::time::Duration;
+#[cfg(not(feature = "dependency-tasks"))]
+use std::marker::PhantomData;
 use std::sync::Arc;
 
-use crate::{events::HotShotEvent, helpers::broadcast_event};
 use anyhow::{ensure, Context, Result};
 use async_broadcast::Sender;
 use async_compatibility_layer::art::async_sleep;
 use async_lock::{RwLock, RwLockUpgradableReadGuard};
 use committable::Committable;
-use core::time::Duration;
 use hotshot_types::{
     consensus::{CommitmentAndMetadata, Consensus, View},
     data::{Leaf, QuorumProposal, ViewChangeEvidence},
@@ -22,8 +23,7 @@ use hotshot_types::{
 };
 use tracing::{debug, error, warn};
 
-#[cfg(not(feature = "dependency-tasks"))]
-use std::marker::PhantomData;
+use crate::{events::HotShotEvent, helpers::broadcast_event};
 
 /// Validate the state and safety and liveness of a proposal then emit
 /// a `QuorumProposalValidated` event.

--- a/crates/task-impls/src/consensus/view_change.rs
+++ b/crates/task-impls/src/consensus/view_change.rs
@@ -1,14 +1,12 @@
+use core::time::Duration;
 use std::sync::Arc;
 
-use crate::{
-    events::HotShotEvent,
-    helpers::{broadcast_event, cancel_task},
-};
 use anyhow::{ensure, Result};
 use async_broadcast::Sender;
 use async_compatibility_layer::art::{async_sleep, async_spawn};
 use async_lock::{RwLock, RwLockUpgradableReadGuard};
-use core::time::Duration;
+#[cfg(async_executor_impl = "async-std")]
+use async_std::task::JoinHandle;
 use hotshot_types::{
     consensus::Consensus,
     constants::LOOK_AHEAD,
@@ -18,12 +16,14 @@ use hotshot_types::{
         node_implementation::{ConsensusTime, NodeImplementation, NodeType},
     },
 };
-use tracing::{debug, error};
-
-#[cfg(async_executor_impl = "async-std")]
-use async_std::task::JoinHandle;
 #[cfg(async_executor_impl = "tokio")]
 use tokio::task::JoinHandle;
+use tracing::{debug, error};
+
+use crate::{
+    events::HotShotEvent,
+    helpers::{broadcast_event, cancel_task},
+};
 
 /// Update the view if it actually changed, takes a mutable reference to the `cur_view` and the
 /// `timeout_task` which are updated during the operation of the function.

--- a/crates/task-impls/src/quorum_proposal.rs
+++ b/crates/task-impls/src/quorum_proposal.rs
@@ -3,6 +3,8 @@ use std::{collections::HashMap, marker::PhantomData, sync::Arc, time::Duration};
 use async_broadcast::{Receiver, Sender};
 use async_compatibility_layer::art::{async_sleep, async_spawn};
 use async_lock::{RwLock, RwLockUpgradableReadGuard};
+#[cfg(async_executor_impl = "async-std")]
+use async_std::task::JoinHandle;
 use committable::Committable;
 use either::Either;
 use futures::future::FutureExt;
@@ -28,9 +30,6 @@ use hotshot_types::{
     },
     vote::{Certificate, HasViewNumber},
 };
-
-#[cfg(async_executor_impl = "async-std")]
-use async_std::task::JoinHandle;
 #[cfg(async_executor_impl = "tokio")]
 use tokio::task::JoinHandle;
 use tracing::{debug, error, info, instrument, warn};


### PR DESCRIPTION
Closes #0000


### This PR: 
Uses last known `BuilderCommitment` when querying builder for available blocks instead of last *decided* `BuilderCommitment`

### This PR does not: 
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->

### Key places to review: 
`crates/task-impls/src/transactions.rs`

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
