### PR TITLE
[CX_CLEANUP] - Add a standalone function to handle `QuorumProposalRecv`

### DIFF
--- a/crates/task-impls/src/consensus/mod.rs
+++ b/crates/task-impls/src/consensus/mod.rs
@@ -5,7 +5,7 @@ use std::{
 
 use crate::{
     consensus::{
-        proposal::{
+        proposal_helpers::{
             publish_proposal_if_able, validate_proposal_safety_and_liveness,
             validate_proposal_view_and_certs,
         },
@@ -61,8 +61,8 @@ use {
     },
 };
 
-/// Handles proposal-related functionality.
-pub(crate) mod proposal;
+/// Helper functions to handler proposal-related functionality.
+pub(crate) mod proposal_helpers;
 
 /// Handles view-change related functionality.
 pub(crate) mod view_change;

--- a/crates/task-impls/src/quorum_proposal.rs
+++ b/crates/task-impls/src/quorum_proposal.rs
@@ -35,7 +35,7 @@ use tokio::task::JoinHandle;
 use tracing::{debug, error, info, instrument, warn};
 
 use crate::{
-    consensus::proposal::validate_proposal_safety_and_liveness,
+    consensus::proposal_helpers::validate_proposal_safety_and_liveness,
     events::HotShotEvent,
     helpers::{broadcast_event, cancel_task, AnyhowTracing},
 };


### PR DESCRIPTION
To be pushed to https://github.com/EspressoSystems/HotShot/pull/2988, which will close #2986.

### This PR: 
* Adds a standalone function to handle the `QuorumProposalRecv` event.
* Renames the `proposal` file to `proposal_helpers` to distinguish it from the `quorum_proposal` file.

### This PR does not: 
* Replace the existing `QuorumProposalRecv` handling code in the consensus, quorum vote, and quorum proposal tasks with this new function.

### Key places to review: 
* `proposal_helpers.rs`.

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
