### PR TITLE
Revert use of BuilderCommitment in available blocks call

### DIFF
--- a/crates/builder-api/src/data_source.rs
+++ b/crates/builder-api/src/data_source.rs
@@ -2,6 +2,7 @@ use async_trait::async_trait;
 use hotshot_types::{
     traits::{node_implementation::NodeType, signature_key::SignatureKey},
     utils::BuilderCommitment,
+    vid::VidCommitment,
 };
 
 use crate::{
@@ -14,7 +15,7 @@ pub trait BuilderDataSource<TYPES: NodeType> {
     /// To get the list of available blocks
     async fn get_available_blocks(
         &self,
-        for_parent: &BuilderCommitment,
+        for_parent: &VidCommitment,
         sender: TYPES::SignatureKey,
         signature: &<TYPES::SignatureKey as SignatureKey>::PureAssembledSignatureType,
     ) -> Result<Vec<AvailableBlockInfo<TYPES>>, BuildError>;

--- a/crates/task-impls/src/builder.rs
+++ b/crates/task-impls/src/builder.rs
@@ -8,6 +8,7 @@ use hotshot_builder_api::{
 use hotshot_types::{
     traits::{node_implementation::NodeType, signature_key::SignatureKey},
     utils::BuilderCommitment,
+    vid::VidCommitment,
 };
 use serde::{Deserialize, Serialize};
 use snafu::Snafu;
@@ -103,7 +104,7 @@ impl<TYPES: NodeType, Ver: StaticVersionType> BuilderClient<TYPES, Ver> {
     /// - [`BuilderClientError::Api`] if API isn't responding or responds incorrectly
     pub async fn get_available_blocks(
         &self,
-        parent: BuilderCommitment,
+        parent: VidCommitment,
         sender: TYPES::SignatureKey,
         signature: &<<TYPES as NodeType>::SignatureKey as SignatureKey>::PureAssembledSignatureType,
     ) -> Result<Vec<AvailableBlockInfo<TYPES>>, BuilderClientError> {

--- a/crates/testing/src/block_builder.rs
+++ b/crates/testing/src/block_builder.rs
@@ -30,6 +30,7 @@ use hotshot_types::{
         signature_key::BuilderSignatureKey,
     },
     utils::BuilderCommitment,
+    vid::VidCommitment,
 };
 use lru::LruCache;
 use rand::{rngs::SmallRng, Rng, RngCore, SeedableRng};
@@ -199,7 +200,7 @@ impl<TYPES: NodeType> ReadState for RandomBuilderSource<TYPES> {
 impl<TYPES: NodeType> BuilderDataSource<TYPES> for RandomBuilderSource<TYPES> {
     async fn get_available_blocks(
         &self,
-        _for_parent: &BuilderCommitment,
+        _for_parent: &VidCommitment,
         _sender: TYPES::SignatureKey,
         _signature: &<TYPES::SignatureKey as SignatureKey>::PureAssembledSignatureType,
     ) -> Result<Vec<AvailableBlockInfo<TYPES>>, BuildError> {
@@ -305,7 +306,7 @@ impl<TYPES: NodeType> ReadState for SimpleBuilderSource<TYPES> {
 impl<TYPES: NodeType> BuilderDataSource<TYPES> for SimpleBuilderSource<TYPES> {
     async fn get_available_blocks(
         &self,
-        _for_parent: &BuilderCommitment,
+        _for_parent: &VidCommitment,
         _sender: TYPES::SignatureKey,
         _signature: &<TYPES::SignatureKey as SignatureKey>::PureAssembledSignatureType,
     ) -> Result<Vec<AvailableBlockInfo<TYPES>>, BuildError> {

--- a/crates/testing/tests/tests_1/block_builder.rs
+++ b/crates/testing/tests/tests_1/block_builder.rs
@@ -24,7 +24,7 @@ async fn test_random_block_builder() {
 
     use hotshot_builder_api::block_info::AvailableBlockData;
     use hotshot_orchestrator::config::RandomBuilderConfig;
-    use hotshot_types::utils::BuilderCommitment;
+    use hotshot_types::traits::block_contents::vid_commitment;
 
     let port = portpicker::pick_unused_port().expect("Could not find an open port");
     let api_url = Url::parse(format!("http://localhost:{port}").as_str()).unwrap();
@@ -43,7 +43,7 @@ async fn test_random_block_builder() {
     let mut blocks = loop {
         // Test getting blocks
         let blocks = client
-            .get_available_blocks(BuilderCommitment::from_bytes(&vec![]), pub_key, &signature)
+            .get_available_blocks(vid_commitment(&vec![], 1), pub_key, &signature)
             .await
             .expect("Failed to get available blocks");
 

--- a/crates/types/src/traits/block_contents.rs
+++ b/crates/types/src/traits/block_contents.rs
@@ -12,7 +12,7 @@ use std::{
 
 use committable::{Commitment, Committable};
 use jf_primitives::vid::{precomputable::Precomputable, VidScheme};
-use serde::{de::DeserializeOwned, Serialize};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 use super::signature_key::BuilderSignatureKey;
 use crate::{
@@ -146,7 +146,7 @@ pub fn precompute_vid_commitment(
 /// do dispersal for the genesis block. For simplicity and performance, we use 1.
 pub const GENESIS_VID_NUM_STORAGE_NODES: usize = 1;
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 /// Information about builder fee for proposed block
 pub struct BuilderFee<TYPES: NodeType> {
     /// Proposed fee amount


### PR DESCRIPTION
Closes #0000
<!-- See here for keywords in Github -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

### This PR: 
Reverts back to `VidCommitment` as a key for available blocks in builder api.

### This PR does not: 
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->

### Key places to review: 
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
