### PR TITLE
Demote update_view log

### DIFF
--- a/crates/task-impls/src/consensus/mod.rs
+++ b/crates/task-impls/src/consensus/mod.rs
@@ -438,7 +438,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                 )
                 .await
                 {
-                    warn!("Failed to update view; error = {e:?}");
+                    tracing::trace!("Failed to update view; error = {e:?}");
                 }
 
                 let consensus = self.consensus.upgradable_read().await;
@@ -1066,7 +1066,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                 )
                 .await
                 {
-                    warn!("Failed to update view; error = {e:?}");
+                    tracing::trace!("Failed to update view; error = {e:?}");
                     return;
                 }
 


### PR DESCRIPTION
### This PR: 
Demotes the log produced by the call to `update_view` in consensus to `trace`, down from `warn`.

### This PR does not: 

### Key places to review: 
Should it be any higher?

Note that this is a relatively large log that happens at least once every view, because we call `update_view` twice each view (and the second call will always fail). 

But I don't think it produces any useful information. View changes are logged on seeing a `ViewChange` event, and almost all (if not all) errors from `update_view` are expected anyway.
