### PR TITLE
Conditional DA

### DIFF
--- a/crates/examples/infra/mod.rs
+++ b/crates/examples/infra/mod.rs
@@ -296,7 +296,7 @@ pub fn load_config_from_file<TYPES: NodeType>(
     // but its type is too complex to load so we'll generate it from seed now.
     // Also this function is only used for orchestrator initialization now, so this value doesn't matter
     config.config.my_own_validator_config =
-        ValidatorConfig::generated_from_seed_indexed(config.seed, config.node_index, 1);
+        ValidatorConfig::generated_from_seed_indexed(config.seed, config.node_index, 1, true);
     // initialize it with size for better assignment of peers' config
     config.config.known_nodes_with_stake =
         vec![PeerConfig::default(); config.config.num_nodes_with_stake.get() as usize];
@@ -403,7 +403,8 @@ pub trait RunDA<
         });
 
         let committee_election_config = TYPES::Membership::default_election_config(
-            config.config.da_staked_committee_size.try_into().unwrap(),
+            // Use the number of _actual_ DA nodes connected for the committee size
+            config.config.known_da_nodes.len() as u64,
             config.config.num_nodes_without_stake as u64,
         );
         let networks_bundle = Networks {
@@ -751,9 +752,9 @@ where
             private_key: key.private_key,
         };
 
-        // See if we should be DA
+        // See if we should be DA, subscribe to the DA topic if so
         let mut topics = vec![Topic::Global];
-        if config.node_index < config.config.da_staked_committee_size as u64 {
+        if config.config.my_own_validator_config.is_da {
             topics.push(Topic::DA);
         }
 
@@ -767,6 +768,9 @@ where
             keypair,
         )
         .expect("failed to create network");
+
+        // Wait for the network to be ready
+        network.wait_for_ready().await;
 
         PushCdnDaRun {
             config,
@@ -1018,6 +1022,8 @@ pub async fn main_entry_point<
     // We assume one node will not call this twice to generate two validator_config-s with same identity.
     let my_own_validator_config = NetworkConfig::<TYPES::SignatureKey, TYPES::ElectionConfigType>::generate_init_validator_config(
         &orchestrator_client,
+        // This is false for now, we only use it to generate the keypair
+        false
     ).await;
 
     // Derives our Libp2p private key from our private key, and then returns the public key of that key
@@ -1038,6 +1044,7 @@ pub async fn main_entry_point<
             my_own_validator_config,
             args.advertise_address,
             Some(libp2p_public_key),
+            true,
         )
         .await
         .expect("failed to get config");

--- a/crates/examples/infra/mod.rs
+++ b/crates/examples/infra/mod.rs
@@ -1044,6 +1044,7 @@ pub async fn main_entry_point<
             my_own_validator_config,
             args.advertise_address,
             Some(libp2p_public_key),
+            // If `indexed_da` is true: use the node index to determine if we are a DA node.
             true,
         )
         .await

--- a/crates/hotshot/src/traits/networking/libp2p_network.rs
+++ b/crates/hotshot/src/traits/networking/libp2p_network.rs
@@ -401,12 +401,12 @@ impl<M: NetworkMsg, K: SignatureKey> Libp2pNetwork<M, K> {
         let mut da_keys = BTreeSet::new();
 
         // Make a node DA if it is under the staked committee size
-        for (_, node) in config.config.known_da_nodes.into_iter().enumerate() {
+        for node in config.config.known_da_nodes {
             da_keys.insert(K::get_public_key(&node.stake_table_entry));
         }
 
         // Insert all known nodes into the set of all keys
-        for (_, node) in config.config.known_nodes_with_stake.into_iter().enumerate() {
+        for node in config.config.known_nodes_with_stake {
             all_keys.insert(K::get_public_key(&node.stake_table_entry));
         }
 

--- a/crates/hotshot/src/traits/networking/libp2p_network.rs
+++ b/crates/hotshot/src/traits/networking/libp2p_network.rs
@@ -401,10 +401,12 @@ impl<M: NetworkMsg, K: SignatureKey> Libp2pNetwork<M, K> {
         let mut da_keys = BTreeSet::new();
 
         // Make a node DA if it is under the staked committee size
-        for (i, node) in config.config.known_nodes_with_stake.into_iter().enumerate() {
-            if i < config.config.da_staked_committee_size {
-                da_keys.insert(K::get_public_key(&node.stake_table_entry));
-            }
+        for (_, node) in config.config.known_da_nodes.into_iter().enumerate() {
+            da_keys.insert(K::get_public_key(&node.stake_table_entry));
+        }
+
+        // Insert all known nodes into the set of all keys
+        for (_, node) in config.config.known_nodes_with_stake.into_iter().enumerate() {
             all_keys.insert(K::get_public_key(&node.stake_table_entry));
         }
 

--- a/crates/orchestrator/api.toml
+++ b/crates/orchestrator/api.toml
@@ -32,11 +32,13 @@ Get the latest temporary node index only for generating validator's key pair for
 
 # POST the node's node index to generate public key for pubkey collection
 [route.post_pubkey]
-PATH = ["pubkey/:node_index"]
+PATH = ["pubkey/:node_index/:is_da"]
 METHOD = "POST"
 ":node_index" = "Integer"
+":is_da" = "Boolean"
 DOC = """
-Post a node's node_index so that its public key could be posted and collected by the orchestrator.
+Post a node's node_index so that its public key could be posted and collected by the orchestrator. 
+Supply whether or not we are DA.
 """
 
 # GET whether or not the config with all peers' public keys / configs are ready

--- a/crates/orchestrator/src/client.rs
+++ b/crates/orchestrator/src/client.rs
@@ -298,11 +298,12 @@ impl OrchestratorClient {
         &self,
         node_index: u64,
         my_pub_key: PeerConfig<K>,
+        is_da: bool,
     ) -> NetworkConfig<K, E> {
         // send my public key
         let _send_pubkey_ready_f: Result<(), ClientError> = self
             .client
-            .post(&format!("api/pubkey/{node_index}"))
+            .post(&format!("api/pubkey/{node_index}/{is_da}"))
             .body_binary(&PeerConfig::<K>::to_bytes(&my_pub_key))
             .unwrap()
             .send()

--- a/crates/orchestrator/src/config.rs
+++ b/crates/orchestrator/src/config.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::HashSet,
     env, fs,
     net::SocketAddr,
     num::NonZeroUsize,
@@ -281,11 +282,14 @@ impl<K: SignatureKey, E: ElectionConfig> NetworkConfig<K, E> {
     }
 
     /// Get a temporary node index for generating a validator config
-    pub async fn generate_init_validator_config(client: &OrchestratorClient) -> ValidatorConfig<K> {
+    pub async fn generate_init_validator_config(
+        client: &OrchestratorClient,
+        is_da: bool,
+    ) -> ValidatorConfig<K> {
         // This cur_node_index is only used for key pair generation, it's not bound with the node,
         // lather the node with the generated key pair will get a new node_index from orchestrator.
         let cur_node_index = client.get_node_index_for_init_validator_config().await;
-        ValidatorConfig::generated_from_seed_indexed([0u8; 32], cur_node_index.into(), 1)
+        ValidatorConfig::generated_from_seed_indexed([0u8; 32], cur_node_index.into(), 1, is_da)
     }
 
     /// Asynchronously retrieves a `NetworkConfig` from an orchestrator.
@@ -299,6 +303,8 @@ impl<K: SignatureKey, E: ElectionConfig> NetworkConfig<K, E> {
         my_own_validator_config: ValidatorConfig<K>,
         libp2p_address: Option<SocketAddr>,
         libp2p_public_key: Option<PeerId>,
+        // If true, we will use the node index to determine if we are a DA node
+        indexed_da: bool,
     ) -> anyhow::Result<(NetworkConfig<K, E>, NetworkConfigSource)> {
         let (mut run_config, source) =
             Self::from_file_or_orchestrator(client, file, libp2p_address, libp2p_public_key)
@@ -308,11 +314,17 @@ impl<K: SignatureKey, E: ElectionConfig> NetworkConfig<K, E> {
         // Assign my_own_validator_config to the run_config if not loading from file
         match source {
             NetworkConfigSource::Orchestrator => {
-                run_config.config.my_own_validator_config = my_own_validator_config;
+                run_config.config.my_own_validator_config = my_own_validator_config.clone();
             }
             NetworkConfigSource::File => {
                 // do nothing, my_own_validator_config has already been loaded from file
             }
+        }
+
+        // If we've chosen to be DA based on the index, do so
+        if indexed_da {
+            run_config.config.my_own_validator_config.is_da =
+                run_config.node_index < run_config.config.da_staked_committee_size as u64;
         }
 
         // one more round of orchestrator here to get peer's public key/config
@@ -323,9 +335,11 @@ impl<K: SignatureKey, E: ElectionConfig> NetworkConfig<K, E> {
                     .config
                     .my_own_validator_config
                     .get_public_config(),
+                run_config.config.my_own_validator_config.is_da,
             )
             .await;
         run_config.config.known_nodes_with_stake = updated_config.config.known_nodes_with_stake;
+        run_config.config.known_da_nodes = updated_config.config.known_da_nodes;
 
         info!("Retrieved config; our node index is {node_index}.");
         Ok((run_config, source))
@@ -570,6 +584,9 @@ pub struct HotShotConfigFile<KEY: SignatureKey> {
     /// The known nodes' public key and stake value
     pub known_nodes_with_stake: Vec<PeerConfig<KEY>>,
     #[serde(skip)]
+    /// The known DA nodes' public key and stake values
+    pub known_da_nodes: HashSet<PeerConfig<KEY>>,
+    #[serde(skip)]
     /// The known non-staking nodes'
     pub known_nodes_without_stake: Vec<KEY>,
     /// Number of staking committee nodes
@@ -615,6 +632,8 @@ pub struct ValidatorConfigFile {
     pub node_id: u64,
     // The validator's stake, commented for now
     // pub stake_value: u64,
+    /// Whether or not we are DA
+    pub is_da: bool,
 }
 
 impl ValidatorConfigFile {
@@ -663,6 +682,7 @@ impl<KEY: SignatureKey, E: ElectionConfig> From<HotShotConfigFile<KEY>> for HotS
             execution_type: ExecutionType::Continuous,
             num_nodes_with_stake: val.num_nodes_with_stake,
             num_nodes_without_stake: val.num_nodes_without_stake,
+            known_da_nodes: val.known_da_nodes,
             max_transactions: val.max_transactions,
             min_transactions: val.min_transactions,
             known_nodes_with_stake: val.known_nodes_with_stake,
@@ -697,7 +717,7 @@ pub const ORCHESTRATOR_DEFAULT_START_DELAY_SECONDS: u64 = 60;
 impl<K: SignatureKey> From<ValidatorConfigFile> for ValidatorConfig<K> {
     fn from(val: ValidatorConfigFile) -> Self {
         // here stake_value is set to 1, since we don't input stake_value from ValidatorConfigFile for now
-        ValidatorConfig::generated_from_seed_indexed(val.seed, val.node_id, 1)
+        ValidatorConfig::generated_from_seed_indexed(val.seed, val.node_id, 1, val.is_da)
     }
 }
 impl<KEY: SignatureKey, E: ElectionConfig> From<ValidatorConfigFile> for HotShotConfig<KEY, E> {
@@ -710,20 +730,34 @@ impl<KEY: SignatureKey, E: ElectionConfig> From<ValidatorConfigFile> for HotShot
 
 impl<KEY: SignatureKey> Default for HotShotConfigFile<KEY> {
     fn default() -> Self {
+        let staked_committee_nodes: usize = 5;
+
+        // Aggregate the DA nodes
+        let mut known_da_nodes = HashSet::new();
+
         let gen_known_nodes_with_stake = (0..10)
             .map(|node_id| {
-                let cur_validator_config: ValidatorConfig<KEY> =
-                    ValidatorConfig::generated_from_seed_indexed([0u8; 32], node_id, 1);
+                let mut cur_validator_config: ValidatorConfig<KEY> =
+                    ValidatorConfig::generated_from_seed_indexed([0u8; 32], node_id, 1, false);
+
+                // Add to DA nodes based on index
+                if node_id < staked_committee_nodes as u64 {
+                    known_da_nodes.insert(cur_validator_config.get_public_config());
+                    cur_validator_config.is_da = true;
+                }
+
                 cur_validator_config.get_public_config()
             })
             .collect();
+
         Self {
             num_nodes_with_stake: NonZeroUsize::new(10).unwrap(),
             num_nodes_without_stake: 0,
             my_own_validator_config: ValidatorConfig::default(),
             known_nodes_with_stake: gen_known_nodes_with_stake,
             known_nodes_without_stake: vec![],
-            staked_committee_nodes: 5,
+            staked_committee_nodes,
+            known_da_nodes,
             non_staked_committee_nodes: 0,
             fixed_leader_for_gpuvid: 0,
             max_transactions: NonZeroUsize::new(100).unwrap(),

--- a/crates/orchestrator/src/config.rs
+++ b/crates/orchestrator/src/config.rs
@@ -730,6 +730,7 @@ impl<KEY: SignatureKey, E: ElectionConfig> From<ValidatorConfigFile> for HotShot
 
 impl<KEY: SignatureKey> Default for HotShotConfigFile<KEY> {
     fn default() -> Self {
+        // The default number of nodes is 5
         let staked_committee_nodes: usize = 5;
 
         // Aggregate the DA nodes

--- a/crates/testing/src/spinning_task.rs
+++ b/crates/testing/src/spinning_task.rs
@@ -137,7 +137,11 @@ where
                                         // We assign node's public key and stake value rather than read from config file since it's a test
                                         let validator_config =
                                             ValidatorConfig::generated_from_seed_indexed(
-                                                [0u8; 32], node_id, 1,
+                                                [0u8; 32],
+                                                node_id,
+                                                1,
+                                                // For tests, make the node DA based on its index
+                                                node_id < config.da_staked_committee_size as u64,
                                             );
                                         TestRunner::add_node_with_config(
                                             node_id,

--- a/crates/testing/src/task_helpers.rs
+++ b/crates/testing/src/task_helpers.rs
@@ -70,7 +70,8 @@ pub async fn build_system_handle(
 
     let committee_election_config = config.election_config.clone().unwrap_or_else(|| {
         <TestTypes as NodeType>::Membership::default_election_config(
-            config.num_nodes_with_stake.get() as u64,
+            // Use the _actual_ number of known DA nodes instead of the expected number of DA nodes
+            config.known_da_nodes.len() as u64,
             config.num_nodes_without_stake as u64,
         )
     });

--- a/crates/testing/src/test_runner.rs
+++ b/crates/testing/src/test_runner.rs
@@ -359,7 +359,8 @@ where
                 da_membership: <TYPES as NodeType>::Membership::create_election(
                     known_nodes_with_stake.clone(),
                     committee_election_config(
-                        config.da_staked_committee_size as u64,
+                        // Use the _actual_ number of DA nodes instead of expected
+                        config.known_da_nodes.len() as u64,
                         config.num_nodes_without_stake as u64,
                     ),
                     config.fixed_leader_for_gpuvid,
@@ -391,9 +392,13 @@ where
             } else {
                 let initializer =
                     HotShotInitializer::<TYPES>::from_genesis(TestInstanceState {}).unwrap();
+
+                // See whether or not we should be DA
+                let is_da = node_id < config.da_staked_committee_size as u64;
+
                 // We assign node's public key and stake value rather than read from config file since it's a test
                 let validator_config =
-                    ValidatorConfig::generated_from_seed_indexed([0u8; 32], node_id, 1);
+                    ValidatorConfig::generated_from_seed_indexed([0u8; 32], node_id, 1, is_da);
                 let hotshot = Self::add_node_with_config(
                     node_id,
                     networks.clone(),


### PR DESCRIPTION
No linked issue.

### This PR: 
<!-- Describe what this PR adds to HotSHot -->
<!-- E.g. -->
<!-- * Implements feature 1 -->
<!-- * Implements feature 2 -->
<!-- * Fixes bug 3 -->
- Changes the orchestrator to supply whether or not nodes are DA
- Changes certificate signatures to require a threshold based on the  number of DA nodes connected instead of the expected value
- Changes [PushCDN/Libp2p] networks to not subscribe to DA if they are not
- Changes Libp2p to use the `da_keys` specified therein instead of by node index
- Edits some configs to support this

### This PR does not: 
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->
- Automatically make the sequencer do this upstream

### Key places to review: 
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->

The certificate signature threshold change for correctness

