### PR TITLE
Move instance_state out of lock

### DIFF
--- a/crates/hotshot/src/lib.rs
+++ b/crates/hotshot/src/lib.rs
@@ -113,7 +113,6 @@ pub struct Memberships<TYPES: NodeType> {
 }
 
 /// Holds the state needed to participate in `HotShot` consensus
-#[derive(Clone)]
 pub struct SystemContext<TYPES: NodeType, I: NodeImplementation<TYPES>> {
     /// The public key of this node
     public_key: TYPES::SignatureKey,
@@ -131,10 +130,13 @@ pub struct SystemContext<TYPES: NodeType, I: NodeImplementation<TYPES>> {
     pub memberships: Arc<Memberships<TYPES>>,
 
     /// the metrics that the implementor is using.
-    _metrics: Arc<ConsensusMetricsValue>,
+    metrics: Arc<ConsensusMetricsValue>,
 
     /// The hotstuff implementation
     consensus: Arc<RwLock<Consensus<TYPES>>>,
+
+    /// Immutable instance state
+    instance_state: Arc<TYPES::InstanceState>,
 
     /// The network version
     version: Arc<RwLock<Version>>,
@@ -159,6 +161,26 @@ pub struct SystemContext<TYPES: NodeType, I: NodeImplementation<TYPES>> {
     /// Reference to the internal storage for consensus datum.
     pub storage: Arc<RwLock<I::Storage>>,
 }
+impl<TYPES: NodeType, I: NodeImplementation<TYPES>> Clone for SystemContext<TYPES, I> {
+    fn clone(&self) -> Self {
+        Self {
+            public_key: self.public_key.clone(),
+            private_key: self.private_key.clone(),
+            config: self.config.clone(),
+            networks: self.networks.clone(),
+            memberships: self.memberships.clone(),
+            metrics: self.metrics.clone(),
+            consensus: self.consensus.clone(),
+            instance_state: self.instance_state.clone(),
+            version: self.version.clone(),
+            start_view: self.start_view,
+            output_event_stream: self.output_event_stream.clone(),
+            internal_event_stream: self.internal_event_stream.clone(),
+            id: self.id,
+            storage: self.storage.clone(),
+        }
+    }
+}
 
 impl<TYPES: NodeType, I: NodeImplementation<TYPES>> SystemContext<TYPES, I> {
     /// Creates a new [`Arc<SystemContext>`] with the given configuration options.
@@ -180,7 +202,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> SystemContext<TYPES, I> {
     ) -> Result<Arc<Self>, HotShotError<TYPES>> {
         debug!("Creating a new hotshot");
 
-        let consensus_metrics = Arc::new(metrics);
+        let consensusmetrics = Arc::new(metrics);
         let anchored_leaf = initializer.inner;
         let instance_state = initializer.instance_state;
 
@@ -258,7 +280,6 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> SystemContext<TYPES, I> {
         }
 
         let consensus = Consensus {
-            instance_state,
             validated_state_map,
             vid_shares: BTreeMap::new(),
             cur_view: anchored_leaf.get_view_number(),
@@ -270,7 +291,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> SystemContext<TYPES, I> {
             // https://github.com/EspressoSystems/HotShot/issues/560
             locked_view: anchored_leaf.get_view_number(),
             high_qc: initializer.high_qc,
-            metrics: consensus_metrics.clone(),
+            metrics: consensusmetrics.clone(),
         };
         let consensus = Arc::new(RwLock::new(consensus));
         let version = Arc::new(RwLock::new(BASE_VERSION));
@@ -282,6 +303,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> SystemContext<TYPES, I> {
         let inner: Arc<SystemContext<TYPES, I>> = Arc::new(SystemContext {
             id: nonce,
             consensus,
+            instance_state: Arc::new(instance_state),
             public_key,
             private_key,
             config,
@@ -289,7 +311,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> SystemContext<TYPES, I> {
             start_view: initializer.start_view,
             networks: Arc::new(networks),
             memberships: Arc::new(memberships),
-            _metrics: consensus_metrics.clone(),
+            metrics: consensusmetrics.clone(),
             internal_event_stream: (internal_tx, internal_rx.deactivate()),
             output_event_stream: (external_tx, external_rx),
             storage: Arc::new(RwLock::new(storage)),
@@ -382,6 +404,11 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> SystemContext<TYPES, I> {
     #[must_use]
     pub fn get_consensus(&self) -> Arc<RwLock<Consensus<TYPES>>> {
         self.consensus.clone()
+    }
+
+    /// Returns a copy of the instance state
+    pub fn get_instance_state(&self) -> Arc<TYPES::InstanceState> {
+        self.instance_state.clone()
     }
 
     /// Returns a copy of the last decided leaf

--- a/crates/hotshot/src/lib.rs
+++ b/crates/hotshot/src/lib.rs
@@ -202,7 +202,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> SystemContext<TYPES, I> {
     ) -> Result<Arc<Self>, HotShotError<TYPES>> {
         debug!("Creating a new hotshot");
 
-        let consensusmetrics = Arc::new(metrics);
+        let consensus_metrics = Arc::new(metrics);
         let anchored_leaf = initializer.inner;
         let instance_state = initializer.instance_state;
 
@@ -291,7 +291,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> SystemContext<TYPES, I> {
             // https://github.com/EspressoSystems/HotShot/issues/560
             locked_view: anchored_leaf.get_view_number(),
             high_qc: initializer.high_qc,
-            metrics: consensusmetrics.clone(),
+            metrics: consensus_metrics.clone(),
         };
         let consensus = Arc::new(RwLock::new(consensus));
         let version = Arc::new(RwLock::new(BASE_VERSION));
@@ -311,7 +311,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> SystemContext<TYPES, I> {
             start_view: initializer.start_view,
             networks: Arc::new(networks),
             memberships: Arc::new(memberships),
-            metrics: consensusmetrics.clone(),
+            metrics: consensus_metrics.clone(),
             internal_event_stream: (internal_tx, internal_rx.deactivate()),
             output_event_stream: (external_tx, external_rx),
             storage: Arc::new(RwLock::new(storage)),

--- a/crates/hotshot/src/tasks/task_state.rs
+++ b/crates/hotshot/src/tasks/task_state.rs
@@ -185,6 +185,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> CreateTaskState<TYPES, I>
 
         ConsensusTaskState {
             consensus,
+            instance_state: handle.hotshot.get_instance_state(),
             timeout: handle.hotshot.config.next_view_timeout,
             round_start_delay: handle.hotshot.config.round_start_delay,
             cur_view: handle.get_cur_view().await,
@@ -224,6 +225,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> CreateTaskState<TYPES, I>
             public_key: handle.public_key().clone(),
             private_key: handle.private_key().clone(),
             consensus,
+            instance_state: handle.hotshot.get_instance_state(),
             latest_voted_view: handle.get_cur_view().await,
             vote_dependencies: HashMap::new(),
             quorum_network: handle.hotshot.networks.quorum_network.clone(),
@@ -252,6 +254,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> CreateTaskState<TYPES, I>
             committee_network: handle.hotshot.networks.da_network.clone(),
             output_event_stream: handle.hotshot.output_event_stream.0.clone(),
             consensus,
+            instance_state: handle.hotshot.get_instance_state(),
             timeout_membership: handle.hotshot.memberships.quorum_membership.clone().into(),
             quorum_membership: handle.hotshot.memberships.quorum_membership.clone().into(),
             cur_view: handle.get_cur_view().await,

--- a/crates/task-impls/src/consensus/mod.rs
+++ b/crates/task-impls/src/consensus/mod.rs
@@ -77,6 +77,8 @@ pub struct ConsensusTaskState<
     pub private_key: <TYPES::SignatureKey as SignatureKey>::PrivateKey,
     /// Reference to consensus. The replica will require a write lock on this.
     pub consensus: Arc<RwLock<Consensus<TYPES>>>,
+    /// Immutable instance state
+    pub instance_state: Arc<TYPES::InstanceState>,
     /// View timeout from config.
     pub timeout: u64,
     /// Round start delay from config, in milliseconds.
@@ -357,6 +359,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
             self.decided_upgrade_cert.clone(),
             &mut self.payload_commitment_and_metadata,
             &mut self.proposal_cert,
+            self.instance_state.clone(),
         )
         .await?;
 

--- a/crates/task-impls/src/quorum_vote.rs
+++ b/crates/task-impls/src/quorum_vote.rs
@@ -177,6 +177,9 @@ pub struct QuorumVoteTaskState<TYPES: NodeType, I: NodeImplementation<TYPES>> {
     /// Reference to consensus. The replica will require a write lock on this.
     pub consensus: Arc<RwLock<Consensus<TYPES>>>,
 
+    /// Immutable instance state
+    pub instance_state: Arc<TYPES::InstanceState>,
+
     /// Latest view number that has been voted for.
     pub latest_voted_view: TYPES::Time,
 
@@ -465,7 +468,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> QuorumVoteTaskState<TYPES, I
                 // Validate the state.
                 let Ok((validated_state, state_delta)) = parent_state
                     .validate_and_apply_header(
-                        &self.consensus.read().await.instance_state,
+                        self.instance_state.as_ref(),
                         &parent_leaf,
                         &proposal.data.block_header.clone(),
                     )

--- a/crates/types/src/consensus.rs
+++ b/crates/types/src/consensus.rs
@@ -41,9 +41,6 @@ pub type VidShares<TYPES> = BTreeMap<
 /// This will contain the state of all rounds.
 #[derive(custom_debug::Debug)]
 pub struct Consensus<TYPES: NodeType> {
-    /// Immutable instance-level state.
-    pub instance_state: TYPES::InstanceState,
-
     /// The validated states that are currently loaded in memory.
     pub validated_state_map: BTreeMap<TYPES::Time, View<TYPES>>,
 


### PR DESCRIPTION
Moves `instance_state` into it's own arc that gets passed around.  This fixes the issue where we hold a consensus lock while we do catchup in the sequencher.  
