### PR TITLE
[CX_CLEANUP] - Remove `ConsensusApi` from the consensus task

### DIFF
--- a/crates/hotshot/src/tasks/mod.rs
+++ b/crates/hotshot/src/tasks/mod.rs
@@ -141,12 +141,8 @@ pub async fn add_network_event_task<
 }
 
 /// Setup polls for the given `consensus_state`
-pub async fn inject_consensus_polls<
-    TYPES: NodeType,
-    I: NodeImplementation<TYPES>,
-    API: ConsensusApi<TYPES, I>,
->(
-    consensus_state: &ConsensusTaskState<TYPES, I, API>,
+pub async fn inject_consensus_polls<TYPES: NodeType, I: NodeImplementation<TYPES>>(
+    consensus_state: &ConsensusTaskState<TYPES, I>,
 ) {
     // Poll (forever) for the latest quorum proposal
     consensus_state

--- a/crates/hotshot/src/tasks/task_state.rs
+++ b/crates/hotshot/src/tasks/task_state.rs
@@ -176,11 +176,9 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, Ver: StaticVersionType>
 
 #[async_trait]
 impl<TYPES: NodeType, I: NodeImplementation<TYPES>> CreateTaskState<TYPES, I>
-    for ConsensusTaskState<TYPES, I, SystemContextHandle<TYPES, I>>
+    for ConsensusTaskState<TYPES, I>
 {
-    async fn create_from(
-        handle: &SystemContextHandle<TYPES, I>,
-    ) -> ConsensusTaskState<TYPES, I, SystemContextHandle<TYPES, I>> {
+    async fn create_from(handle: &SystemContextHandle<TYPES, I>) -> ConsensusTaskState<TYPES, I> {
         let consensus = handle.hotshot.get_consensus();
 
         ConsensusTaskState {
@@ -190,7 +188,6 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> CreateTaskState<TYPES, I>
             round_start_delay: handle.hotshot.config.round_start_delay,
             cur_view: handle.get_cur_view().await,
             payload_commitment_and_metadata: None,
-            api: handle.clone(),
             vote_collector: None.into(),
             timeout_vote_collector: None.into(),
             timeout_task: None,

--- a/crates/task-impls/src/consensus/mod.rs
+++ b/crates/task-impls/src/consensus/mod.rs
@@ -21,7 +21,6 @@ use hotshot_types::{
     simple_vote::{QuorumVote, TimeoutData, TimeoutVote},
     traits::{
         block_contents::BlockHeader,
-        consensus_api::ConsensusApi,
         election::Membership,
         network::{ConnectedNetwork, ConsensusIntentEvent},
         node_implementation::{ConsensusTime, NodeImplementation, NodeType},
@@ -66,11 +65,7 @@ type VoteCollectorOption<TYPES, VOTE, CERT> = Option<VoteCollectionTaskState<TYP
 
 /// The state for the consensus task.  Contains all of the information for the implementation
 /// of consensus
-pub struct ConsensusTaskState<
-    TYPES: NodeType,
-    I: NodeImplementation<TYPES>,
-    A: ConsensusApi<TYPES, I> + 'static,
-> {
+pub struct ConsensusTaskState<TYPES: NodeType, I: NodeImplementation<TYPES>> {
     /// Our public key
     pub public_key: TYPES::SignatureKey,
     /// Our Private Key
@@ -103,9 +98,6 @@ pub struct ConsensusTaskState<
 
     /// Membership for DA committee Votes/certs
     pub committee_membership: Arc<TYPES::Membership>,
-
-    /// Consensus api
-    pub api: A,
 
     /// Current Vote collection task, with it's view.
     pub vote_collector:
@@ -154,9 +146,7 @@ pub struct ConsensusTaskState<
     pub storage: Arc<RwLock<I::Storage>>,
 }
 
-impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 'static>
-    ConsensusTaskState<TYPES, I, A>
-{
+impl<TYPES: NodeType, I: NodeImplementation<TYPES>> ConsensusTaskState<TYPES, I> {
     /// Cancel all tasks the consensus tasks has spawned before the given view
     async fn cancel_tasks(&mut self, view: TYPES::Time) {
         let keep = self.spawned_tasks.split_off(&view);
@@ -1007,9 +997,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
     }
 }
 
-impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 'static> TaskState
-    for ConsensusTaskState<TYPES, I, A>
-{
+impl<TYPES: NodeType, I: NodeImplementation<TYPES>> TaskState for ConsensusTaskState<TYPES, I> {
     type Event = Arc<HotShotEvent<TYPES>>;
     type Output = ();
     fn filter(&self, event: &Arc<HotShotEvent<TYPES>>) -> bool {

--- a/crates/task-impls/src/consensus/proposal_helpers.rs
+++ b/crates/task-impls/src/consensus/proposal_helpers.rs
@@ -17,7 +17,6 @@ use hotshot_types::{
     simple_certificate::UpgradeCertificate,
     traits::{
         block_contents::BlockHeader,
-        consensus_api::ConsensusApi,
         election::Membership,
         network::{ConnectedNetwork, ConsensusIntentEvent},
         node_implementation::{NodeImplementation, NodeType},
@@ -580,15 +579,11 @@ pub async fn publish_proposal_if_able<TYPES: NodeType>(
 ///
 /// Returns the proposal that should be used to set the `cur_proposal` for other tasks.
 #[allow(clippy::too_many_lines)]
-pub async fn handle_quorum_proposal_recv<
-    TYPES: NodeType,
-    I: NodeImplementation<TYPES>,
-    A: ConsensusApi<TYPES, I>,
->(
+pub async fn handle_quorum_proposal_recv<TYPES: NodeType, I: NodeImplementation<TYPES>>(
     proposal: &Proposal<TYPES, QuorumProposal<TYPES>>,
     sender: &TYPES::SignatureKey,
     event_stream: Sender<Arc<HotShotEvent<TYPES>>>,
-    task_state: &mut ConsensusTaskState<TYPES, I, A>,
+    task_state: &mut ConsensusTaskState<TYPES, I>,
 ) -> Result<Option<QuorumProposal<TYPES>>> {
     let sender = sender.clone();
     debug!(

--- a/crates/testing/src/predicates/upgrade.rs
+++ b/crates/testing/src/predicates/upgrade.rs
@@ -1,15 +1,13 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use hotshot::types::SystemContextHandle;
 use hotshot_example_types::node_types::{MemoryImpl, TestTypes};
 use hotshot_task_impls::consensus::ConsensusTaskState;
 use hotshot_types::simple_certificate::UpgradeCertificate;
 
 use crate::predicates::{Predicate, PredicateResult};
 
-type ConsensusTaskTestState =
-    ConsensusTaskState<TestTypes, MemoryImpl, SystemContextHandle<TestTypes, MemoryImpl>>;
+type ConsensusTaskTestState = ConsensusTaskState<TestTypes, MemoryImpl>;
 
 type UpgradeCertCallback =
     Arc<dyn Fn(Arc<Option<UpgradeCertificate<TestTypes>>>) -> bool + Send + Sync>;

--- a/crates/testing/tests/tests_1/consensus_task.rs
+++ b/crates/testing/tests/tests_1/consensus_task.rs
@@ -1,6 +1,5 @@
 use hotshot::{
     tasks::{inject_consensus_polls, task_state::CreateTaskState},
-    types::SystemContextHandle,
 };
 use hotshot_example_types::node_types::{MemoryImpl, TestTypes};
 use hotshot_task_impls::{consensus::ConsensusTaskState, events::HotShotEvent::*};
@@ -102,7 +101,6 @@ async fn test_consensus_task() {
     let consensus_state = ConsensusTaskState::<
         TestTypes,
         MemoryImpl,
-        SystemContextHandle<TestTypes, MemoryImpl>,
     >::create_from(&handle)
     .await;
 
@@ -163,7 +161,6 @@ async fn test_consensus_vote() {
     let consensus_state = ConsensusTaskState::<
         TestTypes,
         MemoryImpl,
-        SystemContextHandle<TestTypes, MemoryImpl>,
     >::create_from(&handle)
     .await;
 
@@ -233,7 +230,6 @@ async fn test_vote_with_specific_order(input_permutation: Vec<usize>) {
     let consensus_state = ConsensusTaskState::<
         TestTypes,
         MemoryImpl,
-        SystemContextHandle<TestTypes, MemoryImpl>,
     >::create_from(&handle)
     .await;
 
@@ -386,7 +382,6 @@ async fn test_view_sync_finalize_propose() {
     let consensus_state = ConsensusTaskState::<
         TestTypes,
         MemoryImpl,
-        SystemContextHandle<TestTypes, MemoryImpl>,
     >::create_from(&handle)
     .await;
 
@@ -486,7 +481,6 @@ async fn test_view_sync_finalize_vote() {
     let consensus_state = ConsensusTaskState::<
         TestTypes,
         MemoryImpl,
-        SystemContextHandle<TestTypes, MemoryImpl>,
     >::create_from(&handle)
     .await;
 
@@ -596,7 +590,6 @@ async fn test_view_sync_finalize_vote_fail_view_number() {
     let consensus_state = ConsensusTaskState::<
         TestTypes,
         MemoryImpl,
-        SystemContextHandle<TestTypes, MemoryImpl>,
     >::create_from(&handle)
     .await;
 
@@ -651,7 +644,6 @@ async fn test_vid_disperse_storage_failure() {
     let consensus_state = ConsensusTaskState::<
         TestTypes,
         MemoryImpl,
-        SystemContextHandle<TestTypes, MemoryImpl>,
     >::create_from(&handle)
     .await;
 

--- a/crates/testing/tests/tests_1/proposal_ordering.rs
+++ b/crates/testing/tests/tests_1/proposal_ordering.rs
@@ -1,4 +1,4 @@
-use hotshot::{tasks::task_state::CreateTaskState, types::SystemContextHandle};
+use hotshot::{tasks::task_state::CreateTaskState};
 use hotshot_example_types::{
     block_types::TestMetadata,
     node_types::{MemoryImpl, TestTypes},
@@ -106,7 +106,6 @@ async fn test_ordering_with_specific_order(input_permutation: Vec<usize>) {
     let consensus_state = ConsensusTaskState::<
         TestTypes,
         MemoryImpl,
-        SystemContextHandle<TestTypes, MemoryImpl>,
     >::create_from(&handle)
     .await;
 

--- a/crates/testing/tests/tests_1/upgrade_task.rs
+++ b/crates/testing/tests/tests_1/upgrade_task.rs
@@ -151,7 +151,6 @@ async fn test_consensus_task_upgrade() {
     let consensus_state = ConsensusTaskState::<
         TestTypes,
         MemoryImpl,
-        SystemContextHandle<TestTypes, MemoryImpl>,
     >::create_from(&handle)
     .await;
 
@@ -225,7 +224,6 @@ async fn test_upgrade_and_consensus_task() {
     let consensus_state = ConsensusTaskState::<
         TestTypes,
         MemoryImpl,
-        SystemContextHandle<TestTypes, MemoryImpl>,
     >::create_from(&handle)
     .await;
     let mut upgrade_state = UpgradeTaskState::<
@@ -417,7 +415,6 @@ async fn test_upgrade_and_consensus_task_blank_blocks() {
     let consensus_state = ConsensusTaskState::<
         TestTypes,
         MemoryImpl,
-        SystemContextHandle<TestTypes, MemoryImpl>,
     >::create_from(&handle)
     .await;
     let mut upgrade_state = UpgradeTaskState::<


### PR DESCRIPTION
Closes #3024.

### This PR: 
* Removes the `api` field and `ConsensusApi` generic from the consensus task state.

### This PR does not: 
* Change any consensus logic.

### Key places to review: 
* `crates/task-impls/src/consensus/mod.rs`.

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
