### PR TITLE
Add instrument tracing to the network task

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3433,6 +3433,7 @@ dependencies = [
  "bincode",
  "bitvec",
  "blake3",
+ "cdn-proto",
  "committable",
  "custom_debug",
  "derivative",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,6 +134,7 @@ anyhow = "1"
 cdn-client = { git = "https://github.com/EspressoSystems/Push-CDN", tag = "0.2.1" }
 cdn-broker = { git = "https://github.com/EspressoSystems/Push-CDN", tag = "0.2.1" }
 cdn-marshal = { git = "https://github.com/EspressoSystems/Push-CDN", tag = "0.2.1" }
+cdn-proto = { git = "https://github.com/EspressoSystems/Push-CDN", tag = "0.2.1" }
 
 ### Profiles
 ###
@@ -148,7 +149,7 @@ debug = 0
 
 # Generally optimize dependencies a little
 [profile.dev.package."*"]
-opt-level = 1
+opt-level = 0
 strip = true
 debug = 0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -149,7 +149,7 @@ debug = 0
 
 # Generally optimize dependencies a little
 [profile.dev.package."*"]
-opt-level = 0
+opt-level = 1
 strip = true
 debug = 0
 

--- a/crates/task-impls/src/network.rs
+++ b/crates/task-impls/src/network.rs
@@ -101,11 +101,13 @@ impl<TYPES: NodeType> TaskState for NetworkMessageTaskState<TYPES> {
 }
 
 impl<TYPES: NodeType> NetworkMessageTaskState<TYPES> {
+    #[instrument(skip_all, name = "Network message task", level = "trace")]
     /// Handle the message.
     pub async fn handle_messages(&mut self, messages: Vec<Message<TYPES>>) {
         // We will send only one event for a vector of transactions.
         let mut transactions = Vec::new();
         for message in messages {
+            tracing::trace!("Received message from network:\n\n{message:?}");
             let sender = message.sender;
             match message.kind {
                 MessageKind::Consensus(consensus_message) => {

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -28,6 +28,7 @@ either = { workspace = true }
 espresso-systems-common = { workspace = true }
 ethereum-types = { workspace = true }
 futures = { workspace = true }
+cdn-proto = { workspace = true }
 
 generic-array = { workspace = true }
 

--- a/crates/types/src/message.rs
+++ b/crates/types/src/message.rs
@@ -3,9 +3,10 @@
 //! This module contains types used to represent the various types of messages that
 //! `HotShot` nodes can send among themselves.
 
-use std::{fmt::Debug, marker::PhantomData};
+use std::{fmt, fmt::Debug, marker::PhantomData};
 
 use anyhow::{ensure, Result};
+use cdn_proto::mnemonic;
 use committable::Committable;
 use derivative::Derivative;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
@@ -30,7 +31,7 @@ use crate::{
 };
 
 /// Incoming message
-#[derive(Serialize, Deserialize, Clone, Debug, Derivative, PartialEq, Eq, Hash)]
+#[derive(Serialize, Deserialize, Clone, Derivative, PartialEq, Eq, Hash)]
 #[serde(bound(deserialize = "", serialize = ""))]
 pub struct Message<TYPES: NodeType> {
     /// The sender of this message
@@ -38,6 +39,15 @@ pub struct Message<TYPES: NodeType> {
 
     /// The message kind
     pub kind: MessageKind<TYPES>,
+}
+
+impl<TYPES: NodeType> fmt::Debug for Message<TYPES> {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt.debug_struct("Message")
+            .field("sender", &mnemonic(&self.sender))
+            .field("kind", &self.kind)
+            .finish()
+    }
 }
 
 impl<TYPES: NodeType> NetworkMsg for Message<TYPES> {}


### PR DESCRIPTION
No linked issue.

### This PR: 
Adds instrument tracing to the network task, to make it easy to see which messages a node is receiving.

Exporting `RUST_LOG=hotshot_task_impls::network=trace` with now produce logs like:

    2024-04-24T19:23:57.327728Z TRACE hotshot_task_impls::network: Received message from network:

    Message { sender: "modest-bottle-mister--legal-judge-carlo", kind: Data(SubmitTransaction(TestTransaction([0, 0, 0, 0, 0, 0, 0, 0]), ViewNumber(0))) }
        at crates/task-impls/src/network.rs:110
        in hotshot_task_impls::network::Network message task

### This PR does not: 

### Key places to review: 
