### PR TITLE
[CX_CLEANUP] - Fix build with the `dependency-tasks` feature for the `QuorumProposalRecv` task PR

### DIFF
--- a/crates/hotshot/src/lib.rs
+++ b/crates/hotshot/src/lib.rs
@@ -292,10 +292,11 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> SystemContext<TYPES, I> {
             locked_view: anchored_leaf.get_view_number(),
             high_qc: initializer.high_qc,
             metrics: consensus_metrics.clone(),
-            #[cfg(feature = "dependency-tasks")]
-            decided_upgrade_cert: None,
-            #[cfg(feature = "dependency-tasks")]
-            formed_upgrade_certificate: None,
+            // TODO: Why can't we include these fields when building with `dependency-tasks`?
+            // #[cfg(feature = "dependency-tasks")]
+            // decided_upgrade_cert: None,
+            // #[cfg(feature = "dependency-tasks")]
+            // formed_upgrade_certificate: None,
         };
         let consensus = Arc::new(RwLock::new(consensus));
         let version = Arc::new(RwLock::new(BASE_VERSION));

--- a/crates/task-impls/src/consensus/proposal_helpers.rs
+++ b/crates/task-impls/src/consensus/proposal_helpers.rs
@@ -581,14 +581,14 @@ pub async fn publish_proposal_if_able<TYPES: NodeType>(
     }
 }
 
+/// Task state for handling quorum proposal when building with dependency tasks.
 #[cfg(feature = "dependency-tasks")]
 type TempraryProposalCombinedType<TYPES, I> = QuorumProposalRecvTaskState<TYPES, I>;
 
-/// TODO: doc
+/// Task state for handling quorum proposal when building without dependency tasks.
 #[cfg(not(feature = "dependency-tasks"))]
-type TempraryProposalCombinedType<TYPES, I, A> = ConsensusTaskState<TYPES, I, A>;
+type TempraryProposalCombinedType<TYPES, I> = ConsensusTaskState<TYPES, I>;
 
-// TODO: Fix `clippy::too_many_lines`.
 /// Handle the received quorum proposal.
 ///
 /// Returns the proposal that should be used to set the `cur_proposal` for other tasks.

--- a/justfile
+++ b/justfile
@@ -181,6 +181,11 @@ fmt_lint:
   cargo fmt
   cargo clippy --workspace --examples --bins --tests -- -D warnings
 
+fmt_lint_dependency: 
+  echo Formatting and linting
+  cargo fmt
+  cargo clippy --workspace --examples --bins --tests --features "dependency-tasks" -- -D warnings
+
 careful:
   echo Careful-ing with tokio executor
   cargo careful test --verbose --profile careful --lib --bins --tests --benches --workspace --no-fail-fast -- --test-threads=1 --nocapture


### PR DESCRIPTION
Related issue: #2951. To be merged into #2970 since this PR fixes the build for it.

### This PR: 
* Fixes build _without_ the `dependency-tasks` feature.
  * Adds documentation for `Temporary*` types.
* Fixes build _with_ the `dependency-tasks` feature.
  * Updates fields of `QuorumProposalRecvTaskState`.
  * Removes unused `publish_proposal` and `vote_if_able` functions for the `dependency-tasks` feature.
  * Adds `not(feature = "dependency-tasks")` gate to `publish_proposal` and `vote_if_able` calls in the consensus task.
  * Fixes other lint errors.
* Adds a command to `justfile` to build with `dependency-tasks`.


### This PR does not: 
Change main logic.

### Key places to review: 
* Question added as `TODO` in `crates/hotshot/src/lib.rs`.
* `cancel_tasks` call added to `quorum_proposal_recv.rs`.
* Whether the feature gates are added correctly.

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
