### PR TITLE
Move `QuorumProposalValidated` to its own function

### DIFF
--- a/crates/task-impls/src/consensus/mod.rs
+++ b/crates/task-impls/src/consensus/mod.rs
@@ -1,21 +1,17 @@
-use std::{
-    collections::{BTreeMap, HashMap, HashSet},
-    sync::Arc,
-};
+use std::{collections::BTreeMap, sync::Arc};
 
 use anyhow::Result;
 use async_broadcast::Sender;
-use async_lock::{RwLock, RwLockUpgradableReadGuard};
+use async_lock::RwLock;
 #[cfg(async_executor_impl = "async-std")]
 use async_std::task::JoinHandle;
-use chrono::Utc;
 use committable::Committable;
 use futures::future::join_all;
 use hotshot_task::task::{Task, TaskState};
 use hotshot_types::{
     consensus::{CommitmentAndMetadata, Consensus},
     data::{Leaf, QuorumProposal, ViewChangeEvidence},
-    event::{Event, EventType, LeafInfo},
+    event::{Event, EventType},
     message::Proposal,
     simple_certificate::{QuorumCertificate, TimeoutCertificate, UpgradeCertificate},
     simple_vote::{QuorumVote, TimeoutData, TimeoutVote},
@@ -23,12 +19,10 @@ use hotshot_types::{
         block_contents::BlockHeader,
         election::Membership,
         network::{ConnectedNetwork, ConsensusIntentEvent},
-        node_implementation::{ConsensusTime, NodeImplementation, NodeType},
+        node_implementation::{NodeImplementation, NodeType},
         signature_key::SignatureKey,
         storage::Storage,
-        BlockPayload,
     },
-    utils::Terminator,
     vote::{Certificate, HasViewNumber},
 };
 #[cfg(not(feature = "dependency-tasks"))]
@@ -53,6 +47,8 @@ use crate::{
         create_vote_accumulator, AccumulatorInfo, HandleVoteEvent, VoteCollectionTaskState,
     },
 };
+
+use self::proposal_helpers::handle_quorum_proposal_validated;
 
 /// Helper functions to handler proposal-related functionality.
 pub(crate) mod proposal_helpers;
@@ -385,186 +381,11 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> ConsensusTaskState<TYPES, I>
                 }
             }
             HotShotEvent::QuorumProposalValidated(proposal, _) => {
-                let consensus = self.consensus.upgradable_read().await;
-                let view = proposal.get_view_number();
-                self.current_proposal = Some(proposal.clone());
-                let mut new_anchor_view = consensus.last_decided_view;
-                let mut new_locked_view = consensus.locked_view;
-                let mut last_view_number_visited = view;
-                let mut new_commit_reached: bool = false;
-                let mut new_decide_reached = false;
-                let mut new_decide_qc = None;
-                let mut leaf_views = Vec::new();
-                let mut leafs_decided = Vec::new();
-                let mut included_txns = HashSet::new();
-                let old_anchor_view = consensus.last_decided_view;
-                let parent_view = proposal.justify_qc.get_view_number();
-                let mut current_chain_length = 0usize;
-                if parent_view + 1 == view {
-                    current_chain_length += 1;
-                    if let Err(e) = consensus.visit_leaf_ancestors(
-                        parent_view,
-                        Terminator::Exclusive(old_anchor_view),
-                        true,
-                        |leaf, state, delta| {
-                            if !new_decide_reached {
-                                if last_view_number_visited == leaf.get_view_number() + 1 {
-                                    last_view_number_visited = leaf.get_view_number();
-                                    current_chain_length += 1;
-                                    if current_chain_length == 2 {
-                                        new_locked_view = leaf.get_view_number();
-                                        new_commit_reached = true;
-                                        // The next leaf in the chain, if there is one, is decided, so this
-                                        // leaf's justify_qc would become the QC for the decided chain.
-                                        new_decide_qc = Some(leaf.get_justify_qc().clone());
-                                    } else if current_chain_length == 3 {
-                                        new_anchor_view = leaf.get_view_number();
-                                        new_decide_reached = true;
-                                    }
-                                } else {
-                                    // nothing more to do here... we don't have a new chain extension
-                                    return false;
-                                }
-                            }
-                            // starting from the first iteration with a three chain, e.g. right after the else if case nested in the if case above
-                            if new_decide_reached {
-                                let mut leaf = leaf.clone();
-                                if leaf.get_view_number() == new_anchor_view {
-                                    consensus
-                                        .metrics
-                                        .last_synced_block_height
-                                        .set(usize::try_from(leaf.get_height()).unwrap_or(0));
-                                }
-                                if let Some(cert) = leaf.get_upgrade_certificate() {
-                                  if cert.data.decide_by < view {
-                                    warn!("Failed to decide an upgrade certificate in time. Ignoring.");
-                                  } else {
-                                    info!("Updating consensus state with decided upgrade certificate: {:?}", cert);
-                                    self.decided_upgrade_cert = Some(cert.clone());
-                                  }
-                                }
-                                // If the block payload is available for this leaf, include it in
-                                // the leaf chain that we send to the client.
-                                if let Some(encoded_txns) =
-                                    consensus.saved_payloads.get(&leaf.get_view_number())
-                                {
-                                    let payload = BlockPayload::from_bytes(
-                                        encoded_txns,
-                                        leaf.get_block_header().metadata(),
-                                    );
-
-                                    leaf.fill_block_payload_unchecked(payload);
-                                }
-
-                                // Get the VID share at the leaf's view number, corresponding to our key
-                                // (if one exists)
-                                let vid_share = consensus
-                                        .vid_shares
-                                        .get(&leaf.get_view_number())
-                                        .unwrap_or(&HashMap::new())
-                                        .get(&self.public_key).cloned().map(|prop| prop.data);
-
-                                // Add our data into a new `LeafInfo`
-                                leaf_views.push(LeafInfo::new(leaf.clone(), Arc::clone(&state), delta.clone(), vid_share));
-                                leafs_decided.push(leaf.clone());
-                                if let Some(ref payload) = leaf.get_block_payload() {
-                                    for txn in payload
-                                        .transaction_commitments(leaf.get_block_header().metadata())
-                                    {
-                                        included_txns.insert(txn);
-                                    }
-                                }
-                            }
-                            true
-                        },
-                    ) {
-                        error!("view publish error {e}");
-                    }
+                if let Err(e) =
+                    handle_quorum_proposal_validated(proposal, event_stream.clone(), self).await
+                {
+                    warn!(?e, "Failed to handle QuorumProposalValidated event");
                 }
-
-                let included_txns_set: HashSet<_> = if new_decide_reached {
-                    included_txns
-                } else {
-                    HashSet::new()
-                };
-
-                let mut consensus = RwLockUpgradableReadGuard::upgrade(consensus).await;
-                if new_commit_reached {
-                    consensus.locked_view = new_locked_view;
-                }
-                #[allow(clippy::cast_precision_loss)]
-                if new_decide_reached {
-                    broadcast_event(
-                        Arc::new(HotShotEvent::LeafDecided(leafs_decided)),
-                        &event_stream,
-                    )
-                    .await;
-                    let decide_sent = broadcast_event(
-                        Event {
-                            view_number: consensus.last_decided_view,
-                            event: EventType::Decide {
-                                leaf_chain: Arc::new(leaf_views),
-                                qc: Arc::new(new_decide_qc.unwrap()),
-                                block_size: Some(included_txns_set.len().try_into().unwrap()),
-                            },
-                        },
-                        &self.output_event_stream,
-                    );
-                    let old_anchor_view = consensus.last_decided_view;
-                    consensus.collect_garbage(old_anchor_view, new_anchor_view);
-                    consensus.last_decided_view = new_anchor_view;
-                    consensus
-                        .metrics
-                        .last_decided_time
-                        .set(Utc::now().timestamp().try_into().unwrap());
-                    consensus.metrics.invalid_qc.set(0);
-                    consensus
-                        .metrics
-                        .last_decided_view
-                        .set(usize::try_from(consensus.last_decided_view.get_u64()).unwrap());
-                    let cur_number_of_views_per_decide_event =
-                        *self.cur_view - consensus.last_decided_view.get_u64();
-                    consensus
-                        .metrics
-                        .number_of_views_per_decide_event
-                        .add_point(cur_number_of_views_per_decide_event as f64);
-
-                    debug!("Sending Decide for view {:?}", consensus.last_decided_view);
-                    debug!("Decided txns len {:?}", included_txns_set.len());
-                    decide_sent.await;
-                    debug!("decide send succeeded");
-                }
-
-                let new_view = self.current_proposal.clone().unwrap().view_number + 1;
-                // In future we can use the mempool model where we fetch the proposal if we don't have it, instead of having to wait for it here
-                // This is for the case where we form a QC but have not yet seen the previous proposal ourselves
-                let should_propose = self.quorum_membership.get_leader(new_view) == self.public_key
-                    && consensus.high_qc.view_number
-                        == self.current_proposal.clone().unwrap().view_number;
-                // todo get rid of this clone
-                let qc = consensus.high_qc.clone();
-
-                drop(consensus);
-                if new_decide_reached {
-                    self.cancel_tasks(new_anchor_view).await;
-                }
-                if should_propose {
-                    debug!(
-                        "Attempting to publish proposal after voting; now in view: {}",
-                        *new_view
-                    );
-                    if let Err(e) = self
-                        .publish_proposal(qc.view_number + 1, event_stream.clone())
-                        .await
-                    {
-                        warn!("Failed to propose; error = {e:?}");
-                    };
-                }
-
-                if !self.vote_if_able(&event_stream).await {
-                    return;
-                }
-                self.current_proposal = None;
             }
             HotShotEvent::QuorumVoteRecv(ref vote) => {
                 debug!("Received quorum vote: {:?}", vote.get_view_number());

--- a/crates/task-impls/src/consensus/mod.rs
+++ b/crates/task-impls/src/consensus/mod.rs
@@ -377,14 +377,14 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> ConsensusTaskState<TYPES, I>
                         }
                     }
                     Ok(None) => {}
-                    Err(e) => warn!(?e, "Failed to propose"),
+                    Err(e) => warn!("Failed to propose {e:#}"),
                 }
             }
             HotShotEvent::QuorumProposalValidated(proposal, _) => {
                 if let Err(e) =
                     handle_quorum_proposal_validated(proposal, event_stream.clone(), self).await
                 {
-                    debug!(?e, "Failed to handle QuorumProposalValidated event");
+                    info!("Failed to handle QuorumProposalValidated event {e:#}");
                 }
             }
             HotShotEvent::QuorumVoteRecv(ref vote) => {
@@ -669,7 +669,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> ConsensusTaskState<TYPES, I>
                 )
                 .await
                 {
-                    tracing::trace!("Failed to update view; error = {e:?}");
+                    tracing::trace!("Failed to update view; error = {e}");
                     return;
                 }
 

--- a/crates/task-impls/src/consensus/mod.rs
+++ b/crates/task-impls/src/consensus/mod.rs
@@ -384,7 +384,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> ConsensusTaskState<TYPES, I>
                 if let Err(e) =
                     handle_quorum_proposal_validated(proposal, event_stream.clone(), self).await
                 {
-                    warn!(?e, "Failed to handle QuorumProposalValidated event");
+                    debug!(?e, "Failed to handle QuorumProposalValidated event");
                 }
             }
             HotShotEvent::QuorumVoteRecv(ref vote) => {

--- a/crates/types/src/consensus.rs
+++ b/crates/types/src/consensus.rs
@@ -256,7 +256,7 @@ impl<TYPES: NodeType> Consensus<TYPES> {
         self.cur_view = view_number;
     }
 
-    /// gather information from the parent chain of leafs
+    /// gather information from the parent chain of leaves
     /// # Errors
     /// If the leaf or its ancestors are not found in storage
     pub fn visit_leaf_ancestors<F>(


### PR DESCRIPTION
Closes #<ISSUE_NUMBER>
<!-- See here for keywords in Github -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

### This PR: 
While making the `QuorumProposalRecv` task, I noticed that I need to be able to gate the proposal behavior within the `QuorumProposalValidated` event. To do this without duplicating the functionality or making the PR extremely massive I have opted to push the change here so that way it's easier to review.

### This PR does not: 
No functionality is changed, it is copied verbatim.

### Key places to review: 
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
