### PR TITLE
Add configurable start threshold for orchestrator

### DIFF
--- a/crates/orchestrator/run-config.toml
+++ b/crates/orchestrator/run-config.toml
@@ -42,6 +42,10 @@ cdn_marshal_address = "127.0.0.1:9000"
 [config]
 num_nodes_with_stake = 10
 num_nodes_without_stake = 0
+start_threshold = [
+    8,
+    10,
+]
 staked_committee_nodes = 10
 non_staked_committee_nodes = 0
 fixed_leader_for_gpuvid = 0

--- a/crates/orchestrator/src/config.rs
+++ b/crates/orchestrator/src/config.rs
@@ -573,6 +573,9 @@ fn default_builder_url() -> Url {
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(bound(deserialize = ""))]
 pub struct HotShotConfigFile<KEY: SignatureKey> {
+    /// The proportion of nodes required before the orchestrator issues the ready signal,
+    /// expressed as (numerator, denominator)
+    pub start_threshold: (u64, u64),
     /// Total number of staked nodes in the network
     pub num_nodes_with_stake: NonZeroUsize,
     /// Total number of non-staked nodes in the network
@@ -680,6 +683,7 @@ impl<KEY: SignatureKey, E: ElectionConfig> From<HotShotConfigFile<KEY>> for HotS
     fn from(val: HotShotConfigFile<KEY>) -> Self {
         HotShotConfig {
             execution_type: ExecutionType::Continuous,
+            start_threshold: val.start_threshold,
             num_nodes_with_stake: val.num_nodes_with_stake,
             num_nodes_without_stake: val.num_nodes_without_stake,
             known_da_nodes: val.known_da_nodes,
@@ -753,6 +757,7 @@ impl<KEY: SignatureKey> Default for HotShotConfigFile<KEY> {
 
         Self {
             num_nodes_with_stake: NonZeroUsize::new(10).unwrap(),
+            start_threshold: (8, 10),
             num_nodes_without_stake: 0,
             my_own_validator_config: ValidatorConfig::default(),
             known_nodes_with_stake: gen_known_nodes_with_stake,

--- a/crates/orchestrator/src/lib.rs
+++ b/crates/orchestrator/src/lib.rs
@@ -334,7 +334,11 @@ where
     fn post_ready(&mut self) -> Result<(), ServerError> {
         self.nodes_connected += 1;
         println!("Nodes connected: {}", self.nodes_connected);
-        if self.nodes_connected >= (self.config.config.num_nodes_with_stake.get() as u64) {
+        // i.e. nodes_connected >= num_nodes_with_stake * (start_threshold.0 / start_threshold.1)
+        if self.nodes_connected * self.config.config.start_threshold.1
+            >= (self.config.config.num_nodes_with_stake.get() as u64)
+                * self.config.config.start_threshold.0
+        {
             self.start = true;
         }
         Ok(())

--- a/crates/task-impls/src/consensus/mod.rs
+++ b/crates/task-impls/src/consensus/mod.rs
@@ -36,6 +36,7 @@ use tokio::task::JoinHandle;
 use tracing::{debug, error, info, instrument, warn};
 use vbs::version::Version;
 
+use self::proposal_helpers::handle_quorum_proposal_validated;
 use crate::{
     consensus::{
         proposal_helpers::{handle_quorum_proposal_recv, publish_proposal_if_able},
@@ -47,8 +48,6 @@ use crate::{
         create_vote_accumulator, AccumulatorInfo, HandleVoteEvent, VoteCollectionTaskState,
     },
 };
-
-use self::proposal_helpers::handle_quorum_proposal_validated;
 
 /// Helper functions to handler proposal-related functionality.
 pub(crate) mod proposal_helpers;

--- a/crates/testing/src/test_builder.rs
+++ b/crates/testing/src/test_builder.rs
@@ -293,6 +293,7 @@ impl TestDescription {
         let config = HotShotConfig {
             // TODO this doesn't exist anymore
             execution_type: ExecutionType::Incremental,
+            start_threshold: (1, 1),
             num_nodes_with_stake: NonZeroUsize::new(num_nodes_with_stake).unwrap(),
             // Currently making this zero for simplicity
             known_da_nodes,

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -160,6 +160,9 @@ impl<KEY: SignatureKey> Default for PeerConfig<KEY> {
 pub struct HotShotConfig<KEY: SignatureKey, ELECTIONCONFIG: ElectionConfig> {
     /// Whether to run one view or continuous views
     pub execution_type: ExecutionType,
+    /// The proportion of nodes required before the orchestrator issues the ready signal,
+    /// expressed as (numerator, denominator)
+    pub start_threshold: (u64, u64),
     /// Total number of nodes in the network
     // Earlier it was total_nodes
     pub num_nodes_with_stake: NonZeroUsize,


### PR DESCRIPTION
No linked issue.

### This PR: 
Adds a configurable start threshold for the orchestrator

### This PR does not: 

### Key places to review: 
