### PR TITLE
Add `all` predicate

### DIFF
--- a/crates/hotshot/src/traits/election/static_committee.rs
+++ b/crates/hotshot/src/traits/election/static_committee.rs
@@ -1,3 +1,5 @@
+use std::{marker::PhantomData, num::NonZeroU64};
+
 use ethereum_types::U256;
 // use ark_bls12_381::Parameters as Param381;
 use hotshot_types::traits::signature_key::StakeTableEntryType;
@@ -8,7 +10,6 @@ use hotshot_types::{
 };
 #[cfg(feature = "randomized-leader-election")]
 use rand::{rngs::StdRng, Rng};
-use std::{marker::PhantomData, num::NonZeroU64};
 use tracing::debug;
 
 /// Dummy implementation of [`Membership`]

--- a/crates/task-impls/src/consensus/mod.rs
+++ b/crates/task-impls/src/consensus/mod.rs
@@ -1,16 +1,6 @@
 use std::{collections::BTreeMap, sync::Arc};
 
 #[cfg(not(feature = "dependency-tasks"))]
-use crate::consensus::proposal_helpers::{handle_quorum_proposal_recv, publish_proposal_if_able};
-use crate::{
-    consensus::view_change::update_view,
-    events::{HotShotEvent, HotShotTaskCompleted},
-    helpers::{broadcast_event, cancel_task},
-    vote_collection::{
-        create_vote_accumulator, AccumulatorInfo, HandleVoteEvent, VoteCollectionTaskState,
-    },
-};
-#[cfg(not(feature = "dependency-tasks"))]
 use anyhow::Result;
 use async_broadcast::Sender;
 use async_lock::RwLock;
@@ -19,6 +9,8 @@ use async_std::task::JoinHandle;
 use committable::Committable;
 use futures::future::join_all;
 use hotshot_task::task::{Task, TaskState};
+#[cfg(not(feature = "dependency-tasks"))]
+use hotshot_types::data::VidDisperseShare;
 #[cfg(not(feature = "dependency-tasks"))]
 use hotshot_types::message::Proposal;
 use hotshot_types::{
@@ -39,9 +31,6 @@ use hotshot_types::{
     vid::vid_scheme,
     vote::{Certificate, HasViewNumber},
 };
-
-#[cfg(not(feature = "dependency-tasks"))]
-use hotshot_types::data::VidDisperseShare;
 use jf_primitives::vid::VidScheme;
 #[cfg(async_executor_impl = "tokio")]
 use tokio::task::JoinHandle;
@@ -50,6 +39,16 @@ use vbs::version::Version;
 
 #[cfg(not(feature = "dependency-tasks"))]
 use self::proposal_helpers::handle_quorum_proposal_validated;
+#[cfg(not(feature = "dependency-tasks"))]
+use crate::consensus::proposal_helpers::{handle_quorum_proposal_recv, publish_proposal_if_able};
+use crate::{
+    consensus::view_change::update_view,
+    events::{HotShotEvent, HotShotTaskCompleted},
+    helpers::{broadcast_event, cancel_task},
+    vote_collection::{
+        create_vote_accumulator, AccumulatorInfo, HandleVoteEvent, VoteCollectionTaskState,
+    },
+};
 
 /// Helper functions to handle proposal-related functionality.
 pub(crate) mod proposal_helpers;

--- a/crates/task-impls/src/consensus/proposal_helpers.rs
+++ b/crates/task-impls/src/consensus/proposal_helpers.rs
@@ -1,14 +1,3 @@
-#[cfg(not(feature = "dependency-tasks"))]
-use super::ConsensusTaskState;
-#[cfg(feature = "dependency-tasks")]
-use crate::quorum_proposal::QuorumProposalTaskState;
-#[cfg(feature = "dependency-tasks")]
-use crate::quorum_proposal_recv::QuorumProposalRecvTaskState;
-use crate::{
-    consensus::update_view,
-    events::HotShotEvent,
-    helpers::{broadcast_event, AnyhowTracing},
-};
 use core::time::Duration;
 use std::{
     collections::{HashMap, HashSet},
@@ -47,6 +36,18 @@ use hotshot_types::{
 #[cfg(async_executor_impl = "tokio")]
 use tokio::task::JoinHandle;
 use tracing::{debug, error, info, warn};
+
+#[cfg(not(feature = "dependency-tasks"))]
+use super::ConsensusTaskState;
+#[cfg(feature = "dependency-tasks")]
+use crate::quorum_proposal::QuorumProposalTaskState;
+#[cfg(feature = "dependency-tasks")]
+use crate::quorum_proposal_recv::QuorumProposalRecvTaskState;
+use crate::{
+    consensus::update_view,
+    events::HotShotEvent,
+    helpers::{broadcast_event, AnyhowTracing},
+};
 
 /// Validate the state and safety and liveness of a proposal then emit
 /// a `QuorumProposalValidated` event.

--- a/crates/task-impls/src/quorum_proposal.rs
+++ b/crates/task-impls/src/quorum_proposal.rs
@@ -33,7 +33,6 @@ use tracing::{debug, error, info, instrument, warn};
 
 #[cfg(feature = "dependency-tasks")]
 use crate::consensus::proposal_helpers::handle_quorum_proposal_validated;
-
 use crate::{
     events::HotShotEvent,
     helpers::{broadcast_event, cancel_task},

--- a/crates/task-impls/src/quorum_proposal_recv.rs
+++ b/crates/task-impls/src/quorum_proposal_recv.rs
@@ -1,17 +1,12 @@
 #![allow(unused_imports)]
 
-use futures::future::join_all;
 use std::{collections::BTreeMap, sync::Arc};
 
-use crate::{
-    consensus::proposal_helpers::{get_parent_leaf_and_state, handle_quorum_proposal_recv},
-    events::HotShotEvent,
-    helpers::{broadcast_event, cancel_task},
-};
 use async_broadcast::Sender;
 use async_lock::RwLock;
 #[cfg(async_executor_impl = "async-std")]
 use async_std::task::JoinHandle;
+use futures::future::join_all;
 use hotshot_task::task::{Task, TaskState};
 use hotshot_types::{
     consensus::{CommitmentAndMetadata, Consensus},
@@ -27,6 +22,12 @@ use hotshot_types::{
 #[cfg(async_executor_impl = "tokio")]
 use tokio::task::JoinHandle;
 use tracing::{debug, error, instrument, warn};
+
+use crate::{
+    consensus::proposal_helpers::{get_parent_leaf_and_state, handle_quorum_proposal_recv},
+    events::HotShotEvent,
+    helpers::{broadcast_event, cancel_task},
+};
 
 /// The state for the quorum proposal task. Contains all of the information for
 /// handling [`HotShotEvent::QuorumProposalRecv`] events.

--- a/crates/task-impls/src/quorum_vote.rs
+++ b/crates/task-impls/src/quorum_vote.rs
@@ -1,9 +1,5 @@
 use std::{collections::HashMap, sync::Arc};
 
-use crate::{
-    events::HotShotEvent,
-    helpers::{broadcast_event, cancel_task},
-};
 use async_broadcast::{Receiver, Sender};
 use async_lock::RwLock;
 #[cfg(async_executor_impl = "async-std")]
@@ -35,6 +31,11 @@ use jf_primitives::vid::VidScheme;
 #[cfg(async_executor_impl = "tokio")]
 use tokio::task::JoinHandle;
 use tracing::{debug, error, instrument, warn};
+
+use crate::{
+    events::HotShotEvent,
+    helpers::{broadcast_event, cancel_task},
+};
 
 /// Vote dependency types.
 #[derive(Debug, PartialEq)]

--- a/crates/testing/src/predicates/event.rs
+++ b/crates/testing/src/predicates/event.rs
@@ -1,5 +1,6 @@
-use std::sync::Arc;
+use std::{collections::HashSet, sync::Arc};
 
+use async_lock::RwLock;
 use async_trait::async_trait;
 use hotshot_task_impls::events::{HotShotEvent, HotShotEvent::*};
 use hotshot_types::{
@@ -23,6 +24,88 @@ impl<TYPES: NodeType> std::fmt::Debug for EventPredicate<TYPES> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.info)
     }
+}
+
+pub struct TestPredicate<INPUT> {
+    pub function: Arc<RwLock<dyn FnMut(&INPUT) -> PredicateResult + Send + Sync>>,
+    pub info: String,
+}
+
+impl<INPUT> std::fmt::Debug for TestPredicate<INPUT> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.info)
+    }
+}
+
+#[async_trait]
+impl<INPUT> Predicate<INPUT> for TestPredicate<INPUT>
+where
+    INPUT: Send + Sync,
+{
+    async fn evaluate(&self, input: &INPUT) -> PredicateResult {
+        let mut function = self.function.write().await;
+        function(input)
+    }
+
+    async fn info(&self) -> String {
+        self.info.clone()
+    }
+}
+
+pub fn all<TYPES>(events: Vec<HotShotEvent<TYPES>>) -> Box<TestPredicate<Arc<HotShotEvent<TYPES>>>>
+where
+    TYPES: NodeType,
+{
+    let info = format!("{:?}", events);
+    let mut set: HashSet<_> = events.into_iter().collect();
+
+    let function = move |e: &Arc<HotShotEvent<TYPES>>| match set.take(e.as_ref()) {
+        Some(_) => {
+            if set.is_empty() {
+                PredicateResult::Pass
+            } else {
+                PredicateResult::Incomplete
+            }
+        }
+        None => PredicateResult::Fail,
+    };
+
+    Box::new(TestPredicate {
+        function: Arc::new(RwLock::new(function)),
+        info: info,
+    })
+}
+
+pub fn all_predicates<TYPES: NodeType>(
+    predicates: Vec<Box<EventPredicate<TYPES>>>,
+) -> Box<TestPredicate<Arc<HotShotEvent<TYPES>>>> {
+    let info = format!("{:?}", predicates);
+
+    let mut unsatisfied: Vec<_> = predicates.into_iter().map(Arc::new).collect();
+
+    let function = move |e: &Arc<HotShotEvent<TYPES>>| {
+        if !unsatisfied
+            .clone()
+            .into_iter()
+            .map(|pred| (pred.check)(e.clone()))
+            .fold(false, |acc, val| acc || val)
+        {
+            return PredicateResult::Fail;
+        }
+
+        unsatisfied.retain(|pred| !(pred.check)(e.clone()));
+
+        if unsatisfied.is_empty() {
+            PredicateResult::Pass
+        } else {
+            PredicateResult::Incomplete
+        }
+    };
+
+    Box::new(TestPredicate {
+        function: Arc::new(RwLock::new(function)),
+        info: info,
+    })
 }
 
 #[async_trait]

--- a/crates/testing/src/predicates/event.rs
+++ b/crates/testing/src/predicates/event.rs
@@ -26,6 +26,7 @@ impl<TYPES: NodeType> std::fmt::Debug for EventPredicate<TYPES> {
     }
 }
 
+#[allow(clippy::type_complexity)]
 pub struct TestPredicate<INPUT> {
     pub function: Arc<RwLock<dyn FnMut(&INPUT) -> PredicateResult + Send + Sync>>,
     pub info: String,
@@ -72,7 +73,7 @@ where
 
     Box::new(TestPredicate {
         function: Arc::new(RwLock::new(function)),
-        info: info,
+        info,
     })
 }
 
@@ -88,7 +89,7 @@ pub fn all_predicates<TYPES: NodeType>(
             .clone()
             .into_iter()
             .map(|pred| (pred.check)(e.clone()))
-            .fold(false, |acc, val| acc || val)
+            .any(|val| val)
         {
             return PredicateResult::Fail;
         }
@@ -104,7 +105,7 @@ pub fn all_predicates<TYPES: NodeType>(
 
     Box::new(TestPredicate {
         function: Arc::new(RwLock::new(function)),
-        info: info,
+        info,
     })
 }
 

--- a/crates/testing/tests/tests_1/proposal_ordering.rs
+++ b/crates/testing/tests/tests_1/proposal_ordering.rs
@@ -1,17 +1,14 @@
-use hotshot::{tasks::task_state::CreateTaskState};
-
 use std::sync::Arc;
 
-
-use hotshot_example_types::state_types::TestInstanceState;
-
+use hotshot::tasks::task_state::CreateTaskState;
 use hotshot_example_types::{
     block_types::TestMetadata,
     node_types::{MemoryImpl, TestTypes},
+    state_types::TestInstanceState,
 };
 use hotshot_task_impls::{consensus::ConsensusTaskState, events::HotShotEvent::*};
 use hotshot_testing::{
-    predicates::event::{exact, quorum_proposal_send, quorum_proposal_validated},
+    predicates::event::{all_predicates, exact, quorum_proposal_send, quorum_proposal_validated},
     task_helpers::{get_vid_share, vid_scheme_from_view_number},
     test_helpers::permute_input_with_index_order,
     view_generator::TestViewGenerator,
@@ -39,7 +36,6 @@ async fn test_ordering_with_specific_order(input_permutation: Vec<usize>) {
     let handle = build_system_handle(node_id).await.0;
     let quorum_membership = handle.hotshot.memberships.quorum_membership.clone();
     let da_membership = handle.hotshot.memberships.da_membership.clone();
-
 
     let mut vid =
         vid_scheme_from_view_number::<TestTypes>(&quorum_membership, ViewNumber::new(node_id));
@@ -74,8 +70,10 @@ async fn test_ordering_with_specific_order(input_permutation: Vec<usize>) {
         ],
         outputs: vec![
             exact(ViewChange(ViewNumber::new(1))),
-            quorum_proposal_validated(),
-            exact(QuorumVoteSend(votes[0].clone())),
+            all_predicates(vec![
+                quorum_proposal_validated(),
+                exact(QuorumVoteSend(votes[0].clone())),
+            ]),
         ],
         asserts: vec![],
     };
@@ -91,7 +89,11 @@ async fn test_ordering_with_specific_order(input_permutation: Vec<usize>) {
             builder_commitment,
             TestMetadata,
             ViewNumber::new(node_id),
-            null_block::builder_fee(quorum_membership.total_nodes(), Arc::new(TestInstanceState {})).unwrap(),
+            null_block::builder_fee(
+                quorum_membership.total_nodes(),
+                Arc::new(TestInstanceState {}),
+            )
+            .unwrap(),
         ),
     ];
 
@@ -102,8 +104,7 @@ async fn test_ordering_with_specific_order(input_permutation: Vec<usize>) {
         inputs: view_2_inputs,
         outputs: vec![
             exact(ViewChange(ViewNumber::new(2))),
-            quorum_proposal_validated(),
-            quorum_proposal_send(),
+            all_predicates(vec![quorum_proposal_validated(), quorum_proposal_send()]),
         ],
         // We should end on view 2.
         asserts: vec![],
@@ -111,11 +112,7 @@ async fn test_ordering_with_specific_order(input_permutation: Vec<usize>) {
 
     let script = vec![view_1, view_2];
 
-    let consensus_state = ConsensusTaskState::<
-        TestTypes,
-        MemoryImpl,
-    >::create_from(&handle)
-    .await;
+    let consensus_state = ConsensusTaskState::<TestTypes, MemoryImpl>::create_from(&handle).await;
 
     run_test_script(script, consensus_state).await;
 }


### PR DESCRIPTION
No linked issue.

### This PR: 
Adds an `all` predicate, to allow for varying output event orderings in tests.

### This PR does not: 

### Key places to review: 
