### PR TITLE
Add duplicate keys checking before registration to Orchestrator

### DIFF
--- a/crates/orchestrator/api.toml
+++ b/crates/orchestrator/api.toml
@@ -31,7 +31,7 @@ Get the latest temporary node index only for generating validator's key pair for
 """
 
 
-# GET the latest temporary node index only for generating validator's key pair
+# POST node's public key for duplicate keys checking
 [route.check_dup_key]
 PATH = ["check_dup_key"]
 METHOD = "POST"

--- a/crates/orchestrator/api.toml
+++ b/crates/orchestrator/api.toml
@@ -30,7 +30,18 @@ DOC = """
 Get the latest temporary node index only for generating validator's key pair for testing in hotshot, later the generated key pairs might be bound with other node_index.
 """
 
-# POST the node's node index to generate public key for pubkey collection
+
+# GET the latest temporary node index only for generating validator's key pair
+[route.check_dup_key]
+PATH = ["check_dup_key"]
+METHOD = "POST"
+DOC = """
+Sends a node's public key to the orchestrator to check whether it's duplicate, and get the bool to indicate whether the node can register with its identity.
+Real public key registration is for later `post_and_wait_all_public_keys`.
+Return false if the public key has already been registered.
+"""
+
+# POST the node's node index for pubkey and is_da collection
 [route.post_pubkey]
 PATH = ["pubkey/:node_index/:is_da"]
 METHOD = "POST"

--- a/crates/orchestrator/run-config.toml
+++ b/crates/orchestrator/run-config.toml
@@ -1,4 +1,4 @@
-rounds = 10
+rounds = 100
 transactions_per_round = 10
 transaction_size = 1000
 node_index = 0

--- a/crates/orchestrator/src/client.rs
+++ b/crates/orchestrator/src/client.rs
@@ -342,7 +342,7 @@ impl OrchestratorClient {
         skip(self),
         name = "orchestrator check duplicate keys before identity registration"
     )]
-    pub async fn pass_check_duplicate_keys<K: SignatureKey>(
+    pub async fn pass_check_no_dup_keys<K: SignatureKey>(
         &self,
         my_pub_key: PeerConfig<K>,
     ) -> bool {

--- a/crates/orchestrator/src/config.rs
+++ b/crates/orchestrator/src/config.rs
@@ -300,7 +300,7 @@ impl<K: SignatureKey> NetworkConfig<K> {
         indexed_da: bool,
     ) -> anyhow::Result<(NetworkConfig<K>, NetworkConfigSource)> {
         if !client
-            .pass_check_duplicate_keys::<K>(my_own_validator_config.get_public_config())
+            .pass_check_no_dup_keys::<K>(my_own_validator_config.get_public_config())
             .await
         {
             return Err(anyhow!("Duplicate keys registration is not allowed!"));

--- a/crates/orchestrator/src/lib.rs
+++ b/crates/orchestrator/src/lib.rs
@@ -163,7 +163,7 @@ pub trait OrchestratorApi<KEY: SignatureKey> {
     /// Return false if it's duplicate
     /// # Errors
     /// If we were unable to serve the request
-    fn check_dup_key(&mut self, pubkey: &Vec<u8>) -> Result<bool, ServerError>;
+    fn check_dup_key(&mut self, pubkey: &[u8]) -> Result<bool, ServerError>;
     /// Post an identity to the orchestrator. Takes in optional
     /// arguments so others can identify us on the Libp2p network.
     /// # Errors
@@ -216,14 +216,14 @@ impl<KEY> OrchestratorApi<KEY> for OrchestratorState<KEY>
 where
     KEY: serde::Serialize + Clone + SignatureKey + 'static,
 {
-    fn check_dup_key(&mut self, pubkey: &Vec<u8>) -> Result<bool, ServerError> {
+    fn check_dup_key(&mut self, pubkey: &[u8]) -> Result<bool, ServerError> {
         if self.saved_pub.contains(pubkey) {
             return Err(ServerError {
                 status: tide_disco::StatusCode::BadRequest,
                 message: "The public key has already tried registered".to_string(),
             });
         }
-        self.saved_pub.insert(pubkey.clone());
+        self.saved_pub.insert(pubkey.to_vec());
         Ok(true)
     }
 


### PR DESCRIPTION
<!-- See here for keywords in Github -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

### This PR: 
- Add one api in OrchestratorApi for duplicate keys checking at the very begging when nodes start to post identity
- So that node with same public validator configs ( `my_own_validator_config.get_public_config()` = `public_key`+ `stake_value` + `state_ver_key`) cannot register twice, regardless of their private keys, node index, and p2p config.
- does some nit
<!-- Describe what this PR adds to HotSHot -->
<!-- E.g. -->
<!-- * Implements feature 1 -->
<!-- * Implements feature 2 -->
<!-- * Fixes bug 3 -->

### This PR does not: 
- Restructure orchestrator
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->

### Key places to review: 
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
