### PR TITLE
include `view_number` inside api signatures:

### DIFF
--- a/crates/builder-api/api/builder.toml
+++ b/crates/builder-api/api/builder.toml
@@ -47,7 +47,7 @@ Returns
 """
 
 [route.claim_block]
-PATH = ["claimblock/:block_hash/:sender/:signature"]
+PATH = ["claimblock/:block_hash/:parent_hash/:sender/:signature"]
 ":block_hash" = "TaggedBase64"
 ":parent_hash" = "TaggedBase64"
 ":sender" = "TaggedBase64"
@@ -59,7 +59,7 @@ Returns application-specific encoded transactions type
 """
 
 [route.claim_header_input]
-PATH = ["claimheaderinput/:block_hash/:sender/:signature"]
+PATH = ["claimheaderinput/:block_hash/:parent_hash/:sender/:signature"]
 ":block_hash" = "TaggedBase64"
 ":parent_hash" = "TaggedBase64"
 ":sender" = "TaggedBase64"

--- a/crates/builder-api/api/builder.toml
+++ b/crates/builder-api/api/builder.toml
@@ -49,6 +49,7 @@ Returns
 [route.claim_block]
 PATH = ["claimblock/:block_hash/:sender/:signature"]
 ":block_hash" = "TaggedBase64"
+":parent_hash" = "TaggedBase64"
 ":sender" = "TaggedBase64"
 ":signature" = "TaggedBase64"
 DOC = """
@@ -60,6 +61,7 @@ Returns application-specific encoded transactions type
 [route.claim_header_input]
 PATH = ["claimheaderinput/:block_hash/:sender/:signature"]
 ":block_hash" = "TaggedBase64"
+":parent_hash" = "TaggedBase64"
 ":sender" = "TaggedBase64"
 ":signature" = "TaggedBase64"
 DOC = """
@@ -72,4 +74,6 @@ Returns application-specific block header type
 PATH = ["builderaddress"]
 DOC = """
 Get the builder address.
+
+Returns the builder's public key
 """

--- a/crates/builder-api/api/builder.toml
+++ b/crates/builder-api/api/builder.toml
@@ -27,8 +27,9 @@ DESCRIPTION = ""
 FORMAT_VERSION = "0.1.0"
 
 [route.available_blocks]
-PATH = ["availableblocks/:parent_hash/:sender/:signature"]
+PATH = ["availableblocks/:parent_hash/:view_number/:sender/:signature"]
 ":parent_hash" = "TaggedBase64"
+":view_number" = "Integer"
 ":sender" = "TaggedBase64"
 ":signature" = "TaggedBase64"
 DOC = """
@@ -47,9 +48,9 @@ Returns
 """
 
 [route.claim_block]
-PATH = ["claimblock/:block_hash/:parent_hash/:sender/:signature"]
+PATH = ["claimblock/:block_hash/:view_number/:sender/:signature"]
 ":block_hash" = "TaggedBase64"
-":parent_hash" = "TaggedBase64"
+":view_number" = "Integer"
 ":sender" = "TaggedBase64"
 ":signature" = "TaggedBase64"
 DOC = """
@@ -59,9 +60,9 @@ Returns application-specific encoded transactions type
 """
 
 [route.claim_header_input]
-PATH = ["claimheaderinput/:block_hash/:parent_hash/:sender/:signature"]
+PATH = ["claimheaderinput/:block_hash/:view_number/:sender/:signature"]
 ":block_hash" = "TaggedBase64"
-":parent_hash" = "TaggedBase64"
+":view_number" = "Integer"
 ":sender" = "TaggedBase64"
 ":signature" = "TaggedBase64"
 DOC = """

--- a/crates/builder-api/api/submit.toml
+++ b/crates/builder-api/api/submit.toml
@@ -30,4 +30,8 @@ FORMAT_VERSION = "0.1.0"
 [route.submit_txn]
 PATH = ["/submit"]
 METHOD = "POST"
-DOC = "Submit a transaction to builder's private mempool."
+DOC = """
+Submit a transaction to the Builder
+
+Returns transaction hash
+"""

--- a/crates/builder-api/src/builder.rs
+++ b/crates/builder-api/src/builder.rs
@@ -19,7 +19,6 @@ use crate::{
     api::load_api,
     data_source::{AcceptsTxnSubmits, BuilderDataSource},
 };
-use hotshot_types::vid::VidCommitment;
 
 #[derive(Args, Default)]
 pub struct Options {
@@ -145,10 +144,11 @@ where
         .get("available_blocks", |req, state| {
             async move {
                 let hash = req.blob_param("parent_hash")?;
+                let view_number = req.integer_param("view_number")?;
                 let signature = try_extract_param(&req, "signature")?;
                 let sender = try_extract_param(&req, "sender")?;
                 state
-                    .get_available_blocks(&hash, sender, &signature)
+                    .get_available_blocks(&hash, view_number, sender, &signature)
                     .await
                     .context(BlockAvailableSnafu {
                         resource: hash.to_string(),
@@ -159,11 +159,11 @@ where
         .get("claim_block", |req, state| {
             async move {
                 let block_hash: BuilderCommitment = req.blob_param("block_hash")?;
-                let parent_hash: VidCommitment = req.blob_param("parent_hash")?;
+                let view_number = req.integer_param("view_number")?;
                 let signature = try_extract_param(&req, "signature")?;
                 let sender = try_extract_param(&req, "sender")?;
                 state
-                    .claim_block(&block_hash, &parent_hash, sender, &signature)
+                    .claim_block(&block_hash, view_number, sender, &signature)
                     .await
                     .context(BlockClaimSnafu {
                         resource: block_hash.to_string(),
@@ -174,11 +174,11 @@ where
         .get("claim_header_input", |req, state| {
             async move {
                 let block_hash: BuilderCommitment = req.blob_param("block_hash")?;
-                let parent_hash: VidCommitment = req.blob_param("parent_hash")?;
+                let view_number = req.integer_param("view_number")?;
                 let signature = try_extract_param(&req, "signature")?;
                 let sender = try_extract_param(&req, "sender")?;
                 state
-                    .claim_block_header_input(&block_hash, &parent_hash, sender, &signature)
+                    .claim_block_header_input(&block_hash, view_number, sender, &signature)
                     .await
                     .context(BlockClaimSnafu {
                         resource: block_hash.to_string(),

--- a/crates/builder-api/src/builder.rs
+++ b/crates/builder-api/src/builder.rs
@@ -19,6 +19,7 @@ use crate::{
     api::load_api,
     data_source::{AcceptsTxnSubmits, BuilderDataSource},
 };
+use hotshot_types::vid::VidCommitment;
 
 #[derive(Args, Default)]
 pub struct Options {
@@ -157,28 +158,30 @@ where
         })?
         .get("claim_block", |req, state| {
             async move {
-                let hash: BuilderCommitment = req.blob_param("block_hash")?;
+                let block_hash: BuilderCommitment = req.blob_param("block_hash")?;
+                let parent_hash: VidCommitment = req.blob_param("parent_hash")?;
                 let signature = try_extract_param(&req, "signature")?;
                 let sender = try_extract_param(&req, "sender")?;
                 state
-                    .claim_block(&hash, sender, &signature)
+                    .claim_block(&block_hash, &parent_hash, sender, &signature)
                     .await
                     .context(BlockClaimSnafu {
-                        resource: hash.to_string(),
+                        resource: block_hash.to_string(),
                     })
             }
             .boxed()
         })?
         .get("claim_header_input", |req, state| {
             async move {
-                let hash: BuilderCommitment = req.blob_param("block_hash")?;
+                let block_hash: BuilderCommitment = req.blob_param("block_hash")?;
+                let parent_hash: VidCommitment = req.blob_param("parent_hash")?;
                 let signature = try_extract_param(&req, "signature")?;
                 let sender = try_extract_param(&req, "sender")?;
                 state
-                    .claim_block_header_input(&hash, sender, &signature)
+                    .claim_block_header_input(&block_hash, &parent_hash, sender, &signature)
                     .await
                     .context(BlockClaimSnafu {
-                        resource: hash.to_string(),
+                        resource: block_hash.to_string(),
                     })
             }
             .boxed()

--- a/crates/builder-api/src/data_source.rs
+++ b/crates/builder-api/src/data_source.rs
@@ -16,6 +16,7 @@ pub trait BuilderDataSource<TYPES: NodeType> {
     async fn get_available_blocks(
         &self,
         for_parent: &VidCommitment,
+        view_number: u64,
         sender: TYPES::SignatureKey,
         signature: &<TYPES::SignatureKey as SignatureKey>::PureAssembledSignatureType,
     ) -> Result<Vec<AvailableBlockInfo<TYPES>>, BuildError>;
@@ -24,7 +25,7 @@ pub trait BuilderDataSource<TYPES: NodeType> {
     async fn claim_block(
         &self,
         block_hash: &BuilderCommitment,
-        parent_hash: &VidCommitment,
+        view_number: u64,
         sender: TYPES::SignatureKey,
         signature: &<TYPES::SignatureKey as SignatureKey>::PureAssembledSignatureType,
     ) -> Result<AvailableBlockData<TYPES>, BuildError>;
@@ -33,7 +34,7 @@ pub trait BuilderDataSource<TYPES: NodeType> {
     async fn claim_block_header_input(
         &self,
         block_hash: &BuilderCommitment,
-        parent_hash: &VidCommitment,
+        view_number: u64,
         sender: TYPES::SignatureKey,
         signature: &<TYPES::SignatureKey as SignatureKey>::PureAssembledSignatureType,
     ) -> Result<AvailableBlockHeaderInput<TYPES>, BuildError>;

--- a/crates/builder-api/src/data_source.rs
+++ b/crates/builder-api/src/data_source.rs
@@ -1,13 +1,13 @@
+use crate::{
+    block_info::{AvailableBlockData, AvailableBlockHeaderInput, AvailableBlockInfo},
+    builder::BuildError,
+};
 use async_trait::async_trait;
+use committable::Commitment;
 use hotshot_types::{
     traits::{node_implementation::NodeType, signature_key::SignatureKey},
     utils::BuilderCommitment,
     vid::VidCommitment,
-};
-
-use crate::{
-    block_info::{AvailableBlockData, AvailableBlockHeaderInput, AvailableBlockInfo},
-    builder::BuildError,
 };
 
 #[async_trait]
@@ -24,6 +24,7 @@ pub trait BuilderDataSource<TYPES: NodeType> {
     async fn claim_block(
         &self,
         block_hash: &BuilderCommitment,
+        parent_hash: &VidCommitment,
         sender: TYPES::SignatureKey,
         signature: &<TYPES::SignatureKey as SignatureKey>::PureAssembledSignatureType,
     ) -> Result<AvailableBlockData<TYPES>, BuildError>;
@@ -32,6 +33,7 @@ pub trait BuilderDataSource<TYPES: NodeType> {
     async fn claim_block_header_input(
         &self,
         block_hash: &BuilderCommitment,
+        parent_hash: &VidCommitment,
         sender: TYPES::SignatureKey,
         signature: &<TYPES::SignatureKey as SignatureKey>::PureAssembledSignatureType,
     ) -> Result<AvailableBlockHeaderInput<TYPES>, BuildError>;
@@ -45,5 +47,8 @@ pub trait AcceptsTxnSubmits<I>
 where
     I: NodeType,
 {
-    async fn submit_txn(&mut self, txn: <I as NodeType>::Transaction) -> Result<(), BuildError>;
+    async fn submit_txn(
+        &mut self,
+        txn: <I as NodeType>::Transaction,
+    ) -> Result<Commitment<<I as NodeType>::Transaction>, BuildError>;
 }

--- a/crates/task-impls/src/builder.rs
+++ b/crates/task-impls/src/builder.rs
@@ -107,13 +107,14 @@ impl<TYPES: NodeType, Ver: StaticVersionType> BuilderClient<TYPES, Ver> {
     pub async fn get_available_blocks(
         &self,
         parent: VidCommitment,
+        view_number: u64,
         sender: TYPES::SignatureKey,
         signature: &<<TYPES as NodeType>::SignatureKey as SignatureKey>::PureAssembledSignatureType,
     ) -> Result<Vec<AvailableBlockInfo<TYPES>>, BuilderClientError> {
         let encoded_signature: TaggedBase64 = signature.clone().into();
         self.inner
             .get(&format!(
-                "availableblocks/{parent}/{sender}/{encoded_signature}"
+                "availableblocks/{parent}/{view_number}/{sender}/{encoded_signature}"
             ))
             .send()
             .await
@@ -128,14 +129,14 @@ impl<TYPES: NodeType, Ver: StaticVersionType> BuilderClient<TYPES, Ver> {
     pub async fn claim_block(
         &self,
         block_hash: BuilderCommitment,
-        parent_hash: VidCommitment,
+        view_number: u64,
         sender: TYPES::SignatureKey,
         signature: &<<TYPES as NodeType>::SignatureKey as SignatureKey>::PureAssembledSignatureType,
     ) -> Result<AvailableBlockData<TYPES>, BuilderClientError> {
         let encoded_signature: TaggedBase64 = signature.clone().into();
         self.inner
             .get(&format!(
-                "claimblock/{block_hash}/{parent_hash}/{sender}/{encoded_signature}"
+                "claimblock/{block_hash}/{view_number}/{sender}/{encoded_signature}"
             ))
             .send()
             .await
@@ -150,14 +151,14 @@ impl<TYPES: NodeType, Ver: StaticVersionType> BuilderClient<TYPES, Ver> {
     pub async fn claim_block_header_input(
         &self,
         block_hash: BuilderCommitment,
-        parent_hash: VidCommitment,
+        view_number: u64,
         sender: TYPES::SignatureKey,
         signature: &<<TYPES as NodeType>::SignatureKey as SignatureKey>::PureAssembledSignatureType,
     ) -> Result<AvailableBlockHeaderInput<TYPES>, BuilderClientError> {
         let encoded_signature: TaggedBase64 = signature.clone().into();
         self.inner
             .get(&format!(
-                "claimheaderinput/{block_hash}/{parent_hash}/{sender}/{encoded_signature}"
+                "claimheaderinput/{block_hash}/{view_number}/{sender}/{encoded_signature}"
             ))
             .send()
             .await

--- a/crates/task-impls/src/builder.rs
+++ b/crates/task-impls/src/builder.rs
@@ -128,13 +128,14 @@ impl<TYPES: NodeType, Ver: StaticVersionType> BuilderClient<TYPES, Ver> {
     pub async fn claim_block(
         &self,
         block_hash: BuilderCommitment,
+        parent_hash: VidCommitment,
         sender: TYPES::SignatureKey,
         signature: &<<TYPES as NodeType>::SignatureKey as SignatureKey>::PureAssembledSignatureType,
     ) -> Result<AvailableBlockData<TYPES>, BuilderClientError> {
         let encoded_signature: TaggedBase64 = signature.clone().into();
         self.inner
             .get(&format!(
-                "claimblock/{block_hash}/{sender}/{encoded_signature}"
+                "claimblock/{block_hash}/{parent_hash}/{sender}/{encoded_signature}"
             ))
             .send()
             .await
@@ -149,13 +150,14 @@ impl<TYPES: NodeType, Ver: StaticVersionType> BuilderClient<TYPES, Ver> {
     pub async fn claim_block_header_input(
         &self,
         block_hash: BuilderCommitment,
+        parent_hash: VidCommitment,
         sender: TYPES::SignatureKey,
         signature: &<<TYPES as NodeType>::SignatureKey as SignatureKey>::PureAssembledSignatureType,
     ) -> Result<AvailableBlockHeaderInput<TYPES>, BuilderClientError> {
         let encoded_signature: TaggedBase64 = signature.clone().into();
         self.inner
             .get(&format!(
-                "claimheaderinput/{block_hash}/{sender}/{encoded_signature}"
+                "claimheaderinput/{block_hash}/{parent_hash}/{sender}/{encoded_signature}"
             ))
             .send()
             .await

--- a/crates/task-impls/src/transactions.rs
+++ b/crates/task-impls/src/transactions.rs
@@ -341,8 +341,8 @@ impl<
         .context("signing block hash")?;
 
         let (block, header_input) = futures::join! {
-            self.builder_client.claim_block(block_info.block_hash.clone(), self.public_key.clone(), &request_signature),
-            self.builder_client.claim_block_header_input(block_info.block_hash.clone(), self.public_key.clone(), &request_signature)
+            self.builder_client.claim_block(block_info.block_hash.clone(), parent_comm, self.public_key.clone(), &request_signature),
+            self.builder_client.claim_block_header_input(block_info.block_hash.clone(), parent_comm, self.public_key.clone(), &request_signature)
         };
 
         let block_data = block.context("claiming block data")?;

--- a/crates/task-impls/src/transactions.rs
+++ b/crates/task-impls/src/transactions.rs
@@ -214,7 +214,7 @@ impl<
     }
 
     /// Get last known builder commitment from consensus.
-    async fn latest_known_vid_commitment(&self) -> VidCommitment {
+    async fn latest_known_vid_commitment(&self) -> (TYPES::Time, VidCommitment) {
         let consensus = self.consensus.read().await;
 
         let mut prev_view = TYPES::Time::new(self.cur_view.saturating_sub(1));
@@ -235,13 +235,16 @@ impl<
                         ViewInner::Failed => None,
                     })
             {
-                return commitment;
+                return (prev_view, commitment);
             }
             prev_view = prev_view - 1;
         }
 
         // If not found, return commitment for last decided block
-        consensus.get_decided_leaf().get_payload_commitment()
+        (
+            prev_view,
+            consensus.get_decided_leaf().get_payload_commitment(),
+        )
     }
 
     #[instrument(skip_all, fields(id = self.id, view = *self.cur_view), name = "wait_for_block", level = "error")]
@@ -249,7 +252,7 @@ impl<
         let task_start_time = Instant::now();
 
         // Find commitment to the block we want to build upon
-        let parent_comm = self.latest_known_vid_commitment().await;
+        let (view_num, parent_comm) = self.latest_known_vid_commitment().await;
         let parent_comm_sig = match <<TYPES as NodeType>::SignatureKey as SignatureKey>::sign(
             &self.private_key,
             parent_comm.as_ref(),
@@ -266,7 +269,7 @@ impl<
                 self.api
                     .builder_timeout()
                     .saturating_sub(task_start_time.elapsed()),
-                self.get_block_from_builder(parent_comm, &parent_comm_sig),
+                self.get_block_from_builder(parent_comm, view_num, &parent_comm_sig),
             )
             .await
             {
@@ -299,11 +302,17 @@ impl<
     async fn get_block_from_builder(
         &self,
         parent_comm: VidCommitment,
+        view_number: TYPES::Time,
         parent_comm_sig: &<<TYPES as NodeType>::SignatureKey as SignatureKey>::PureAssembledSignatureType,
     ) -> anyhow::Result<BuilderResponses<TYPES>> {
         let available_blocks = self
             .builder_client
-            .get_available_blocks(parent_comm, self.public_key.clone(), parent_comm_sig)
+            .get_available_blocks(
+                parent_comm,
+                view_number.get_u64(),
+                self.public_key.clone(),
+                parent_comm_sig,
+            )
             .await
             .context("getting available blocks")?;
         tracing::debug!("Got available blocks: {available_blocks:?}");
@@ -341,8 +350,8 @@ impl<
         .context("signing block hash")?;
 
         let (block, header_input) = futures::join! {
-            self.builder_client.claim_block(block_info.block_hash.clone(), parent_comm, self.public_key.clone(), &request_signature),
-            self.builder_client.claim_block_header_input(block_info.block_hash.clone(), parent_comm, self.public_key.clone(), &request_signature)
+            self.builder_client.claim_block(block_info.block_hash.clone(), view_number.get_u64(), self.public_key.clone(), &request_signature),
+            self.builder_client.claim_block_header_input(block_info.block_hash.clone(), view_number.get_u64(), self.public_key.clone(), &request_signature)
         };
 
         let block_data = block.context("claiming block data")?;

--- a/crates/testing/src/block_builder.rs
+++ b/crates/testing/src/block_builder.rs
@@ -202,6 +202,7 @@ impl<TYPES: NodeType> BuilderDataSource<TYPES> for RandomBuilderSource<TYPES> {
     async fn get_available_blocks(
         &self,
         _for_parent: &VidCommitment,
+        _view_number: u64,
         _sender: TYPES::SignatureKey,
         _signature: &<TYPES::SignatureKey as SignatureKey>::PureAssembledSignatureType,
     ) -> Result<Vec<AvailableBlockInfo<TYPES>>, BuildError> {
@@ -218,7 +219,7 @@ impl<TYPES: NodeType> BuilderDataSource<TYPES> for RandomBuilderSource<TYPES> {
     async fn claim_block(
         &self,
         block_hash: &BuilderCommitment,
-        _parent_hash: &VidCommitment,
+        _view_number: u64,
         _sender: TYPES::SignatureKey,
         _signature: &<TYPES::SignatureKey as SignatureKey>::PureAssembledSignatureType,
     ) -> Result<AvailableBlockData<TYPES>, BuildError> {
@@ -235,7 +236,7 @@ impl<TYPES: NodeType> BuilderDataSource<TYPES> for RandomBuilderSource<TYPES> {
     async fn claim_block_header_input(
         &self,
         block_hash: &BuilderCommitment,
-        _parent_hash: &VidCommitment,
+        _view_number: u64,
         _sender: TYPES::SignatureKey,
         _signature: &<TYPES::SignatureKey as SignatureKey>::PureAssembledSignatureType,
     ) -> Result<AvailableBlockHeaderInput<TYPES>, BuildError> {
@@ -310,6 +311,7 @@ impl<TYPES: NodeType> BuilderDataSource<TYPES> for SimpleBuilderSource<TYPES> {
     async fn get_available_blocks(
         &self,
         _for_parent: &VidCommitment,
+        _view_number: u64,
         _sender: TYPES::SignatureKey,
         _signature: &<TYPES::SignatureKey as SignatureKey>::PureAssembledSignatureType,
     ) -> Result<Vec<AvailableBlockInfo<TYPES>>, BuildError> {
@@ -365,7 +367,7 @@ impl<TYPES: NodeType> BuilderDataSource<TYPES> for SimpleBuilderSource<TYPES> {
     async fn claim_block(
         &self,
         block_hash: &BuilderCommitment,
-        _parent_hash: &VidCommitment,
+        _view_number: u64,
         _sender: TYPES::SignatureKey,
         _signature: &<TYPES::SignatureKey as SignatureKey>::PureAssembledSignatureType,
     ) -> Result<AvailableBlockData<TYPES>, BuildError> {
@@ -394,7 +396,7 @@ impl<TYPES: NodeType> BuilderDataSource<TYPES> for SimpleBuilderSource<TYPES> {
     async fn claim_block_header_input(
         &self,
         block_hash: &BuilderCommitment,
-        _parent_hash: &VidCommitment,
+        _view_number: u64,
         _sender: TYPES::SignatureKey,
         _signature: &<TYPES::SignatureKey as SignatureKey>::PureAssembledSignatureType,
     ) -> Result<AvailableBlockHeaderInput<TYPES>, BuildError> {

--- a/crates/testing/src/block_builder.rs
+++ b/crates/testing/src/block_builder.rs
@@ -218,6 +218,7 @@ impl<TYPES: NodeType> BuilderDataSource<TYPES> for RandomBuilderSource<TYPES> {
     async fn claim_block(
         &self,
         block_hash: &BuilderCommitment,
+        _parent_hash: &VidCommitment,
         _sender: TYPES::SignatureKey,
         _signature: &<TYPES::SignatureKey as SignatureKey>::PureAssembledSignatureType,
     ) -> Result<AvailableBlockData<TYPES>, BuildError> {
@@ -234,6 +235,7 @@ impl<TYPES: NodeType> BuilderDataSource<TYPES> for RandomBuilderSource<TYPES> {
     async fn claim_block_header_input(
         &self,
         block_hash: &BuilderCommitment,
+        _parent_hash: &VidCommitment,
         _sender: TYPES::SignatureKey,
         _signature: &<TYPES::SignatureKey as SignatureKey>::PureAssembledSignatureType,
     ) -> Result<AvailableBlockHeaderInput<TYPES>, BuildError> {
@@ -363,6 +365,7 @@ impl<TYPES: NodeType> BuilderDataSource<TYPES> for SimpleBuilderSource<TYPES> {
     async fn claim_block(
         &self,
         block_hash: &BuilderCommitment,
+        _parent_hash: &VidCommitment,
         _sender: TYPES::SignatureKey,
         _signature: &<TYPES::SignatureKey as SignatureKey>::PureAssembledSignatureType,
     ) -> Result<AvailableBlockData<TYPES>, BuildError> {
@@ -391,6 +394,7 @@ impl<TYPES: NodeType> BuilderDataSource<TYPES> for SimpleBuilderSource<TYPES> {
     async fn claim_block_header_input(
         &self,
         block_hash: &BuilderCommitment,
+        _parent_hash: &VidCommitment,
         _sender: TYPES::SignatureKey,
         _signature: &<TYPES::SignatureKey as SignatureKey>::PureAssembledSignatureType,
     ) -> Result<AvailableBlockHeaderInput<TYPES>, BuildError> {

--- a/crates/testing/tests/tests_1/block_builder.rs
+++ b/crates/testing/tests/tests_1/block_builder.rs
@@ -49,11 +49,17 @@ async fn test_random_block_builder() {
         <TestTypes as NodeType>::SignatureKey::generated_from_seed_indexed([0_u8; 32], 0);
     let signature = <TestTypes as NodeType>::SignatureKey::sign(&private_key, &[0_u8; 32])
         .expect("Failed to create dummy signature");
+    let dummy_view_number = 0u64;
 
     let mut blocks = loop {
         // Test getting blocks
         let blocks = client
-            .get_available_blocks(vid_commitment(&[], 1), pub_key, &signature)
+            .get_available_blocks(
+                vid_commitment(&[], 1),
+                dummy_view_number,
+                pub_key,
+                &signature,
+            )
             .await
             .expect("Failed to get available blocks");
 
@@ -72,7 +78,7 @@ async fn test_random_block_builder() {
     let _: AvailableBlockData<TestTypes> = client
         .claim_block(
             blocks.pop().unwrap().block_hash,
-            vid_commitment(&[], 1),
+            dummy_view_number,
             pub_key,
             &signature,
         )
@@ -87,7 +93,7 @@ async fn test_random_block_builder() {
     let result = client
         .claim_block(
             commitment_for_non_existent_block,
-            vid_commitment(&[], 1),
+            dummy_view_number,
             pub_key,
             &signature,
         )

--- a/crates/testing/tests/tests_1/block_builder.rs
+++ b/crates/testing/tests/tests_1/block_builder.rs
@@ -70,7 +70,12 @@ async fn test_random_block_builder() {
     };
 
     let _: AvailableBlockData<TestTypes> = client
-        .claim_block(blocks.pop().unwrap().block_hash, pub_key, &signature)
+        .claim_block(
+            blocks.pop().unwrap().block_hash,
+            vid_commitment(&[], 1),
+            pub_key,
+            &signature,
+        )
         .await
         .expect("Failed to claim block");
 
@@ -80,7 +85,12 @@ async fn test_random_block_builder() {
     }
     .builder_commitment(&TestMetadata);
     let result = client
-        .claim_block(commitment_for_non_existent_block, pub_key, &signature)
+        .claim_block(
+            commitment_for_non_existent_block,
+            vid_commitment(&[], 1),
+            pub_key,
+            &signature,
+        )
         .await;
     assert!(matches!(result, Err(BuilderClientError::NotFound)));
 }


### PR DESCRIPTION
Introduces ~`parent_vid_commitment`~ `view_number` in the api request to ensure leader fetches the correct block. 

Closes: #3079 