### PR TITLE
[CX_CLEANUP] - Support state update for dependency tasks

### DIFF
--- a/crates/builder-api/src/builder.rs
+++ b/crates/builder-api/src/builder.rs
@@ -133,7 +133,6 @@ pub fn define_api<State, Types: NodeType, Ver: StaticVersionType + 'static>(
 where
     State: 'static + Send + Sync + ReadState,
     <State as ReadState>::State: Send + Sync + BuilderDataSource<Types>,
-    Types: NodeType,
 {
     let mut api = load_api::<State, Error, Ver>(
         options.api_path.as_ref(),
@@ -201,7 +200,6 @@ pub fn submit_api<State, Types: NodeType, Ver: StaticVersionType + 'static>(
 where
     State: 'static + Send + Sync + WriteState,
     <State as ReadState>::State: Send + Sync + AcceptsTxnSubmits<Types>,
-    Types: NodeType,
 {
     let mut api = load_api::<State, Error, Ver>(
         options.api_path.as_ref(),

--- a/crates/task-impls/src/consensus/helpers.rs
+++ b/crates/task-impls/src/consensus/helpers.rs
@@ -33,11 +33,12 @@ use hotshot_types::{
     utils::{Terminator, ViewInner},
     vote::{Certificate, HasViewNumber},
 };
+#[cfg(not(feature = "dependency-tasks"))]
+use hotshot_types::{message::GeneralConsensusMessage, simple_vote::QuorumData};
 #[cfg(async_executor_impl = "tokio")]
 use tokio::task::JoinHandle;
 use tracing::{debug, error, info, warn};
 
-use super::vote_if_able;
 #[cfg(not(feature = "dependency-tasks"))]
 use super::ConsensusTaskState;
 #[cfg(feature = "dependency-tasks")]
@@ -1032,18 +1033,15 @@ pub async fn handle_quorum_proposal_validated<TYPES: NodeType, I: NodeImplementa
         let committee_mem = Arc::clone(&task_state.committee_membership);
         let instance_state = Arc::clone(&task_state.instance_state);
         let handle = async_spawn(async move {
-            vote_if_able::<TYPES, I>(
+            update_state_and_vote_if_able::<TYPES, I>(
                 view,
                 proposal,
                 pub_key,
-                priv_key,
                 consensus,
                 storage,
-                upgrade,
                 quorum_mem,
-                committee_mem,
                 instance_state,
-                event_stream,
+                (priv_key, upgrade, committee_mem, event_stream),
             )
             .await;
         });
@@ -1055,4 +1053,216 @@ pub async fn handle_quorum_proposal_validated<TYPES: NodeType, I: NodeImplementa
     }
 
     Ok(())
+}
+
+/// TEMPORARY TYPE: Dummy type for sending the vote.
+#[cfg(feature = "dependency-tasks")]
+type TemporaryVoteInfo<TYPES> = PhantomData<TYPES>;
+
+/// TEMPORARY TYPE: Private key, latest decided upgrade certificate, committee membership, and
+/// event stream, for sending the vote.
+#[cfg(not(feature = "dependency-tasks"))]
+type TemporaryVoteInfo<TYPES> = (
+    <<TYPES as NodeType>::SignatureKey as SignatureKey>::PrivateKey,
+    Option<UpgradeCertificate<TYPES>>,
+    Arc<<TYPES as NodeType>::Membership>,
+    Sender<Arc<HotShotEvent<TYPES>>>,
+);
+
+#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_lines)]
+#[allow(unused_variables)]
+/// Check if we are able to vote, like whether the proposal is valid,
+/// whether we have DAC and VID share, and if so, vote.
+pub async fn update_state_and_vote_if_able<TYPES: NodeType, I: NodeImplementation<TYPES>>(
+    cur_view: TYPES::Time,
+    proposal: QuorumProposal<TYPES>,
+    public_key: TYPES::SignatureKey,
+    consensus: Arc<RwLock<Consensus<TYPES>>>,
+    storage: Arc<RwLock<I::Storage>>,
+    quorum_membership: Arc<TYPES::Membership>,
+    instance_state: Arc<TYPES::InstanceState>,
+    vote_info: TemporaryVoteInfo<TYPES>,
+) -> bool {
+    #[cfg(not(feature = "dependency-tasks"))]
+    use hotshot_types::simple_vote::QuorumVote;
+
+    if !quorum_membership.has_stake(&public_key) {
+        debug!(
+            "We were not chosen for consensus committee on {:?}",
+            cur_view
+        );
+        return false;
+    }
+
+    let consensus = consensus.upgradable_read().await;
+    // Only vote if you has seen the VID share for this view
+    let Some(vid_shares) = consensus.vid_shares.get(&proposal.view_number) else {
+        debug!(
+            "We have not seen the VID share for this view {:?} yet, so we cannot vote.",
+            proposal.view_number
+        );
+        return false;
+    };
+    let Some(vid_share) = vid_shares.get(&public_key).cloned() else {
+        debug!("we have not seen our VID share yet");
+        return false;
+    };
+
+    #[cfg(not(feature = "dependency-tasks"))]
+    {
+        if let Some(upgrade_cert) = &vote_info.1 {
+            if upgrade_cert.in_interim(cur_view)
+                && Some(proposal.block_header.payload_commitment())
+                    != null_block::commitment(quorum_membership.total_nodes())
+            {
+                info!("Refusing to vote on proposal because it does not have a null commitment, and we are between versions. Expected:\n\n{:?}\n\nActual:{:?}", null_block::commitment(quorum_membership.total_nodes()), Some(proposal.block_header.payload_commitment()));
+                return false;
+            }
+        }
+    }
+
+    // Only vote if you have the DA cert
+    // ED Need to update the view number this is stored under?
+    let Some(cert) = consensus.saved_da_certs.get(&cur_view) else {
+        return false;
+    };
+
+    let view = cert.view_number;
+
+    // TODO: do some of this logic without the vote token check, only do that when voting.
+    let justify_qc = proposal.justify_qc.clone();
+    let parent = consensus
+        .saved_leaves
+        .get(&justify_qc.get_data().leaf_commit)
+        .cloned();
+
+    // Justify qc's leaf commitment is not the same as the parent's leaf commitment, but it should be (in this case)
+    let Some(parent) = parent else {
+        warn!(
+            "Proposal's parent missing from storage with commitment: {:?}, proposal view {:?}",
+            justify_qc.get_data().leaf_commit,
+            proposal.view_number,
+        );
+        return false;
+    };
+    let (Some(parent_state), _) = consensus.get_state_and_delta(parent.get_view_number()) else {
+        warn!("Parent state not found! Consensus internally inconsistent");
+        return false;
+    };
+    let Ok((validated_state, state_delta)) = parent_state
+        .validate_and_apply_header(
+            instance_state.as_ref(),
+            &parent,
+            &proposal.block_header.clone(),
+            vid_share.data.common.clone(),
+        )
+        .await
+    else {
+        warn!("Block header doesn't extend the proposal!");
+        return false;
+    };
+
+    let state = Arc::new(validated_state);
+    let delta = Arc::new(state_delta);
+    let parent_commitment = parent.commit();
+
+    let proposed_leaf = Leaf::from_quorum_proposal(&proposal);
+    if proposed_leaf.get_parent_commitment() != parent_commitment {
+        return false;
+    }
+
+    if let Err(e) = storage
+        .write()
+        .await
+        .update_undecided_state(
+            consensus.saved_leaves.clone(),
+            consensus.validated_state_map.clone(),
+        )
+        .await
+    {
+        warn!("Couldn't store undecided state.  Error: {:?}", e);
+    }
+
+    #[cfg(feature = "dependency-tasks")]
+    {
+        let mut consensus = RwLockUpgradableReadGuard::upgrade(consensus).await;
+        consensus.validated_state_map.insert(
+            view,
+            View {
+                view_inner: ViewInner::Leaf {
+                    leaf: proposed_leaf.commit(),
+                    state: Arc::clone(&state),
+                    delta: Some(Arc::clone(&delta)),
+                },
+            },
+        );
+    }
+
+    #[cfg(not(feature = "dependency-tasks"))]
+    {
+        // Validate the DAC.
+        let message = if cert.is_valid_cert(vote_info.2.as_ref()) {
+            // Validate the block payload commitment for non-genesis DAC.
+            if cert.get_data().payload_commit != proposal.block_header.payload_commitment() {
+                error!(
+                    "Block payload commitment does not equal da cert payload commitment. View = {}",
+                    *view
+                );
+                return false;
+            }
+            if let Ok(vote) = QuorumVote::<TYPES>::create_signed_vote(
+                QuorumData {
+                    leaf_commit: proposed_leaf.commit(),
+                },
+                view,
+                &public_key,
+                &vote_info.0,
+            ) {
+                GeneralConsensusMessage::<TYPES>::Vote(vote)
+            } else {
+                error!("Unable to sign quorum vote!");
+                return false;
+            }
+        } else {
+            error!(
+                "Invalid DAC in proposal! Skipping proposal. {:?} cur view is: {:?}",
+                cert, cur_view
+            );
+            return false;
+        };
+        let mut consensus = RwLockUpgradableReadGuard::upgrade(consensus).await;
+        consensus.validated_state_map.insert(
+            view,
+            View {
+                view_inner: ViewInner::Leaf {
+                    leaf: proposed_leaf.commit(),
+                    state: Arc::clone(&state),
+                    delta: Some(Arc::clone(&delta)),
+                },
+            },
+        );
+
+        if let GeneralConsensusMessage::Vote(vote) = message {
+            debug!(
+                "Sending vote to next quorum leader {:?}",
+                vote.get_view_number() + 1
+            );
+            // Add to the storage that we have received the VID disperse for a specific view
+            if let Err(e) = storage.write().await.append_vid(&vid_share).await {
+                error!(
+                    "Failed to store VID Disperse Proposal with error {:?}, aborting vote",
+                    e
+                );
+                return false;
+            }
+            broadcast_event(Arc::new(HotShotEvent::QuorumVoteSend(vote)), &vote_info.3).await;
+            return true;
+        }
+        debug!(
+            "Received VID share, but couldn't find DAC cert for view {:?}",
+            *proposal.get_view_number(),
+        );
+    }
+    false
 }

--- a/crates/task-impls/src/consensus/mod.rs
+++ b/crates/task-impls/src/consensus/mod.rs
@@ -3,11 +3,11 @@ use std::{collections::BTreeMap, sync::Arc};
 #[cfg(not(feature = "dependency-tasks"))]
 use anyhow::Result;
 use async_broadcast::Sender;
+#[cfg(not(feature = "dependency-tasks"))]
 use async_compatibility_layer::art::async_spawn;
 use async_lock::RwLock;
 #[cfg(async_executor_impl = "async-std")]
 use async_std::task::JoinHandle;
-use committable::Committable;
 use futures::future::join_all;
 use hotshot_task::task::{Task, TaskState};
 #[cfg(not(feature = "dependency-tasks"))]
@@ -16,33 +16,32 @@ use hotshot_types::data::VidDisperseShare;
 use hotshot_types::message::Proposal;
 use hotshot_types::{
     consensus::{CommitmentAndMetadata, Consensus},
-    data::{null_block, Leaf, QuorumProposal, ViewChangeEvidence},
+    data::{QuorumProposal, ViewChangeEvidence},
     event::{Event, EventType},
-    message::GeneralConsensusMessage,
     simple_certificate::{QuorumCertificate, TimeoutCertificate, UpgradeCertificate},
-    simple_vote::{QuorumData, QuorumVote, TimeoutData, TimeoutVote},
+    simple_vote::{QuorumVote, TimeoutData, TimeoutVote},
     traits::{
-        block_contents::BlockHeader,
         election::Membership,
         network::{ConnectedNetwork, ConsensusIntentEvent},
         node_implementation::{NodeImplementation, NodeType},
         signature_key::SignatureKey,
-        storage::Storage,
-        ValidatedState,
     },
-    vid::vid_scheme,
-    vote::{Certificate, HasViewNumber},
+    vote::HasViewNumber,
 };
+#[cfg(not(feature = "dependency-tasks"))]
+use hotshot_types::{traits::storage::Storage, vid::vid_scheme, vote::Certificate};
+#[cfg(not(feature = "dependency-tasks"))]
 use jf_primitives::vid::VidScheme;
 #[cfg(async_executor_impl = "tokio")]
 use tokio::task::JoinHandle;
-use tracing::{debug, error, info, instrument, warn};
+use tracing::{debug, error, instrument, warn};
 use vbs::version::Version;
 
 #[cfg(not(feature = "dependency-tasks"))]
-use self::proposal_helpers::handle_quorum_proposal_validated;
-#[cfg(not(feature = "dependency-tasks"))]
-use crate::consensus::proposal_helpers::{handle_quorum_proposal_recv, publish_proposal_if_able};
+use crate::consensus::helpers::{
+    handle_quorum_proposal_recv, handle_quorum_proposal_validated, publish_proposal_if_able,
+    update_state_and_vote_if_able,
+};
 use crate::{
     consensus::view_change::update_view,
     events::{HotShotEvent, HotShotTaskCompleted},
@@ -53,7 +52,7 @@ use crate::{
 };
 
 /// Helper functions to handle proposal-related functionality.
-pub(crate) mod proposal_helpers;
+pub(crate) mod helpers;
 
 /// Handles view-change related functionality.
 pub(crate) mod view_change;
@@ -144,182 +143,6 @@ pub struct ConsensusTaskState<TYPES: NodeType, I: NodeImplementation<TYPES>> {
     pub storage: Arc<RwLock<I::Storage>>,
 }
 
-#[cfg(not(feature = "dependency-tasks"))]
-#[allow(clippy::too_many_arguments)]
-#[allow(clippy::too_many_lines)]
-/// Check if we are able to vote, like whether the proposal is valid,
-/// whether we have DAC and VID share, and if so, vote.
-async fn vote_if_able<TYPES: NodeType, I: NodeImplementation<TYPES>>(
-    cur_view: TYPES::Time,
-    proposal: QuorumProposal<TYPES>,
-    public_key: TYPES::SignatureKey,
-    private_key: <TYPES::SignatureKey as SignatureKey>::PrivateKey,
-    state: Arc<RwLock<Consensus<TYPES>>>,
-    storage: Arc<RwLock<I::Storage>>,
-    decided_upgrade_cert: Option<UpgradeCertificate<TYPES>>,
-    quorum_membership: Arc<TYPES::Membership>,
-    committee_membership: Arc<TYPES::Membership>,
-    instance_state: Arc<TYPES::InstanceState>,
-    event_stream: Sender<Arc<HotShotEvent<TYPES>>>,
-) -> bool {
-    use async_lock::RwLockUpgradableReadGuard;
-    use hotshot_types::utils::{View, ViewInner};
-
-    if !quorum_membership.has_stake(&public_key) {
-        debug!(
-            "We were not chosen for consensus committee on {:?}",
-            cur_view
-        );
-        return false;
-    }
-
-    let consensus = state.upgradable_read().await;
-    // Only vote if you has seen the VID share for this view
-    let Some(vid_shares) = consensus.vid_shares.get(&proposal.view_number) else {
-        debug!(
-            "We have not seen the VID share for this view {:?} yet, so we cannot vote.",
-            proposal.view_number
-        );
-        return false;
-    };
-    let Some(vid_share) = vid_shares.get(&public_key).cloned() else {
-        debug!("we have not seen our VID share yet");
-        return false;
-    };
-
-    if let Some(upgrade_cert) = &decided_upgrade_cert {
-        if upgrade_cert.in_interim(cur_view)
-            && Some(proposal.block_header.payload_commitment())
-                != null_block::commitment(quorum_membership.total_nodes())
-        {
-            info!("Refusing to vote on proposal because it does not have a null commitment, and we are between versions. Expected:\n\n{:?}\n\nActual:{:?}", null_block::commitment(quorum_membership.total_nodes()), Some(proposal.block_header.payload_commitment()));
-            return false;
-        }
-    }
-
-    // Only vote if you have the DA cert
-    // ED Need to update the view number this is stored under?
-    let Some(cert) = consensus.saved_da_certs.get(&cur_view) else {
-        return false;
-    };
-
-    let view = cert.view_number;
-    // TODO: do some of this logic without the vote token check, only do that when voting.
-    let justify_qc = proposal.justify_qc.clone();
-    let parent = consensus
-        .saved_leaves
-        .get(&justify_qc.get_data().leaf_commit)
-        .cloned();
-
-    // Justify qc's leaf commitment is not the same as the parent's leaf commitment, but it should be (in this case)
-    let Some(parent) = parent else {
-        warn!(
-            "Proposal's parent missing from storage with commitment: {:?}, proposal view {:?}",
-            justify_qc.get_data().leaf_commit,
-            proposal.view_number,
-        );
-        return false;
-    };
-    let (Some(parent_state), _) = consensus.get_state_and_delta(parent.get_view_number()) else {
-        warn!("Parent state not found! Consensus internally inconsistent");
-        return false;
-    };
-    let Ok((validated_state, state_delta)) = parent_state
-        .validate_and_apply_header(
-            instance_state.as_ref(),
-            &parent,
-            &proposal.block_header.clone(),
-            vid_share.data.common.clone(),
-        )
-        .await
-    else {
-        warn!("Block header doesn't extend the proposal!");
-        return false;
-    };
-
-    let state = Arc::new(validated_state);
-    let delta = Arc::new(state_delta);
-    let parent_commitment = parent.commit();
-
-    let proposed_leaf = Leaf::from_quorum_proposal(&proposal);
-    if proposed_leaf.get_parent_commitment() != parent_commitment {
-        return false;
-    }
-
-    if let Err(e) = storage
-        .write()
-        .await
-        .update_undecided_state(
-            consensus.saved_leaves.clone(),
-            consensus.validated_state_map.clone(),
-        )
-        .await
-    {
-        warn!("Couldn't store undecided state.  Error: {:?}", e);
-    }
-    // Validate the DAC.
-    let message = if cert.is_valid_cert(committee_membership.as_ref()) {
-        // Validate the block payload commitment for non-genesis DAC.
-        if cert.get_data().payload_commit != proposal.block_header.payload_commitment() {
-            error!(
-                "Block payload commitment does not equal da cert payload commitment. View = {}",
-                *view
-            );
-            return false;
-        }
-        if let Ok(vote) = QuorumVote::<TYPES>::create_signed_vote(
-            QuorumData {
-                leaf_commit: proposed_leaf.commit(),
-            },
-            view,
-            &public_key,
-            &private_key,
-        ) {
-            GeneralConsensusMessage::<TYPES>::Vote(vote)
-        } else {
-            error!("Unable to sign quorum vote!");
-            return false;
-        }
-    } else {
-        error!(
-            "Invalid DAC in proposal! Skipping proposal. {:?} cur view is: {:?}",
-            cert, cur_view
-        );
-        return false;
-    };
-    let mut consensus = RwLockUpgradableReadGuard::upgrade(consensus).await;
-    consensus.validated_state_map.insert(
-        view,
-        View {
-            view_inner: ViewInner::Leaf {
-                leaf: proposed_leaf.commit(),
-                state: Arc::clone(&state),
-                delta: Some(Arc::clone(&delta)),
-            },
-        },
-    );
-    if let GeneralConsensusMessage::Vote(vote) = message {
-        debug!(
-            "Sending vote to next quorum leader {:?}",
-            vote.get_view_number() + 1
-        );
-        // Add to the storage that we have received the VID disperse for a specific view
-        if let Err(e) = storage.write().await.append_vid(&vid_share).await {
-            error!(
-                "Failed to store VID Disperse Proposal with error {:?}, aborting vote",
-                e
-            );
-            return false;
-        }
-        broadcast_event(Arc::new(HotShotEvent::QuorumVoteSend(vote)), &event_stream).await;
-        return true;
-    }
-    debug!(
-        "Received VID share, but couldn't find DAC cert for view {:?}",
-        *proposal.get_view_number(),
-    );
-    false
-}
 impl<TYPES: NodeType, I: NodeImplementation<TYPES>> ConsensusTaskState<TYPES, I> {
     /// Cancel all tasks the consensus tasks has spawned before the given view
     pub async fn cancel_tasks(&mut self, view: TYPES::Time) {
@@ -331,12 +154,6 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> ConsensusTaskState<TYPES, I>
         }
         self.spawned_tasks = keep;
         join_all(cancel).await;
-    }
-
-    /// Ignores old vote behavior and lets `QuorumVoteTask` take over.
-    #[cfg(feature = "dependency-tasks")]
-    async fn vote_if_able(&mut self, _event_stream: &Sender<Arc<HotShotEvent<TYPES>>>) -> bool {
-        false
     }
 
     /// Validates whether the VID Dispersal Proposal is correctly signed
@@ -443,18 +260,15 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> ConsensusTaskState<TYPES, I>
                         let committee_mem = Arc::clone(&self.committee_membership);
                         let instance_state = Arc::clone(&self.instance_state);
                         let handle = async_spawn(async move {
-                            vote_if_able::<TYPES, I>(
+                            update_state_and_vote_if_able::<TYPES, I>(
                                 view,
                                 proposal,
                                 pub_key,
-                                priv_key,
                                 consensus,
                                 storage,
-                                upgrade,
                                 quorum_mem,
-                                committee_mem,
                                 instance_state,
-                                event_stream,
+                                (priv_key, upgrade, committee_mem, event_stream),
                             )
                             .await;
                         });
@@ -663,18 +477,15 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> ConsensusTaskState<TYPES, I>
                 let committee_mem = Arc::clone(&self.committee_membership);
                 let instance_state = Arc::clone(&self.instance_state);
                 let handle = async_spawn(async move {
-                    vote_if_able::<TYPES, I>(
+                    update_state_and_vote_if_able::<TYPES, I>(
                         view,
                         proposal,
                         pub_key,
-                        priv_key,
                         consensus,
                         storage,
-                        upgrade,
                         quorum_mem,
-                        committee_mem,
                         instance_state,
-                        event_stream,
+                        (priv_key, upgrade, committee_mem, event_stream),
                     )
                     .await;
                 });
@@ -733,18 +544,15 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> ConsensusTaskState<TYPES, I>
                 let committee_mem = Arc::clone(&self.committee_membership);
                 let instance_state = Arc::clone(&self.instance_state);
                 let handle = async_spawn(async move {
-                    vote_if_able::<TYPES, I>(
+                    update_state_and_vote_if_able::<TYPES, I>(
                         view,
                         proposal,
                         pub_key,
-                        priv_key,
                         consensus,
                         storage,
-                        upgrade,
                         quorum_mem,
-                        committee_mem,
                         instance_state,
-                        event_stream,
+                        (priv_key, upgrade, committee_mem, event_stream),
                     )
                     .await;
                 });

--- a/crates/task-impls/src/quorum_proposal.rs
+++ b/crates/task-impls/src/quorum_proposal.rs
@@ -32,7 +32,7 @@ use tokio::task::JoinHandle;
 use tracing::{debug, error, info, instrument, warn};
 
 #[cfg(feature = "dependency-tasks")]
-use crate::consensus::proposal_helpers::handle_quorum_proposal_validated;
+use crate::consensus::helpers::handle_quorum_proposal_validated;
 use crate::{
     events::HotShotEvent,
     helpers::{broadcast_event, cancel_task},

--- a/crates/task-impls/src/quorum_proposal.rs
+++ b/crates/task-impls/src/quorum_proposal.rs
@@ -580,7 +580,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> QuorumProposalTaskState<TYPE
         event: Arc<HotShotEvent<TYPES>>,
     ) {
         info!("Attempting to make dependency task for event {:?}", event);
-        if self.propose_dependencies.get(&view_number).is_some() {
+        if self.propose_dependencies.contains_key(&view_number) {
             debug!("Task already exists");
             return;
         }

--- a/crates/task-impls/src/quorum_proposal_recv.rs
+++ b/crates/task-impls/src/quorum_proposal_recv.rs
@@ -24,7 +24,7 @@ use tokio::task::JoinHandle;
 use tracing::{debug, error, instrument, warn};
 
 use crate::{
-    consensus::proposal_helpers::{get_parent_leaf_and_state, handle_quorum_proposal_recv},
+    consensus::helpers::{get_parent_leaf_and_state, handle_quorum_proposal_recv},
     events::HotShotEvent,
     helpers::{broadcast_event, cancel_task},
 };

--- a/crates/task-impls/src/quorum_vote.rs
+++ b/crates/task-impls/src/quorum_vote.rs
@@ -1,5 +1,9 @@
-use std::{collections::HashMap, sync::Arc};
-
+#[cfg(feature = "dependency-tasks")]
+use crate::consensus::helpers::update_state_and_vote_if_able;
+use crate::{
+    events::HotShotEvent,
+    helpers::{broadcast_event, cancel_task},
+};
 use async_broadcast::{Receiver, Sender};
 use async_lock::RwLock;
 #[cfg(async_executor_impl = "async-std")]
@@ -28,14 +32,12 @@ use hotshot_types::{
     vote::{Certificate, HasViewNumber},
 };
 use jf_primitives::vid::VidScheme;
+#[cfg(feature = "dependency-tasks")]
+use std::marker::PhantomData;
+use std::{collections::HashMap, sync::Arc};
 #[cfg(async_executor_impl = "tokio")]
 use tokio::task::JoinHandle;
 use tracing::{debug, error, instrument, warn};
-
-use crate::{
-    events::HotShotEvent,
-    helpers::{broadcast_event, cancel_task},
-};
 
 /// Vote dependency types.
 #[derive(Debug, PartialEq)]
@@ -51,29 +53,42 @@ enum VoteDependency {
 }
 
 /// Handler for the vote dependency.
-struct VoteDependencyHandle<TYPES: NodeType, S: Storage<TYPES>> {
+#[allow(dead_code)]
+struct VoteDependencyHandle<TYPES: NodeType, I: NodeImplementation<TYPES>> {
     /// Public key.
     pub public_key: TYPES::SignatureKey,
     /// Private Key.
     pub private_key: <TYPES::SignatureKey as SignatureKey>::PrivateKey,
+    /// Reference to consensus. The replica will require a write lock on this.
+    consensus: Arc<RwLock<Consensus<TYPES>>>,
+    /// Immutable instance state
+    instance_state: Arc<TYPES::InstanceState>,
+    /// Membership for Quorum certs/votes.
+    quorum_membership: Arc<TYPES::Membership>,
     /// Reference to the storage.
-    pub storage: Arc<RwLock<S>>,
+    pub storage: Arc<RwLock<I::Storage>>,
     /// View number to vote on.
     view_number: TYPES::Time,
     /// Event sender.
     sender: Sender<Arc<HotShotEvent<TYPES>>>,
 }
-impl<TYPES: NodeType, S: Storage<TYPES> + 'static> HandleDepOutput
-    for VoteDependencyHandle<TYPES, S>
+
+impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static> HandleDepOutput
+    for VoteDependencyHandle<TYPES, I>
 {
     type Output = Vec<Arc<HotShotEvent<TYPES>>>;
+    #[allow(clippy::too_many_lines)]
     async fn handle_dep_result(self, res: Self::Output) {
+        #[allow(unused_variables)]
+        let mut cur_proposal = None;
         let mut payload_commitment = None;
         let mut leaf = None;
         let mut disperse_share = None;
         for event in res {
             match event.as_ref() {
+                #[allow(unused_assignments)]
                 HotShotEvent::QuorumProposalValidated(proposal, parent_leaf) => {
+                    cur_proposal = Some(proposal.clone());
                     let proposal_payload_comm = proposal.block_header.payload_commitment();
                     if let Some(comm) = payload_commitment {
                         if proposal_payload_comm != comm {
@@ -128,6 +143,27 @@ impl<TYPES: NodeType, S: Storage<TYPES> + 'static> HandleDepOutput
             &self.sender,
         )
         .await;
+
+        #[cfg(feature = "dependency-tasks")]
+        {
+            let Some(proposal) = cur_proposal else {
+                error!("No proposal received, but it should be.");
+                return;
+            };
+            // For this vote task, we'll update the state in storage without voting in this function,
+            // then vote later.
+            update_state_and_vote_if_able::<TYPES, I>(
+                self.view_number,
+                proposal,
+                self.public_key.clone(),
+                self.consensus,
+                Arc::clone(&self.storage),
+                self.quorum_membership,
+                self.instance_state,
+                PhantomData,
+            )
+            .await;
+        }
 
         // Create and send the vote.
         let Some(leaf) = leaf else {
@@ -313,9 +349,12 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> QuorumVoteTaskState<TYPES, I
 
         let dependency_task = DependencyTask::new(
             dependency_chain,
-            VoteDependencyHandle {
+            VoteDependencyHandle::<TYPES, I> {
                 public_key: self.public_key.clone(),
                 private_key: self.private_key.clone(),
+                consensus: Arc::clone(&self.consensus),
+                instance_state: Arc::clone(&self.instance_state),
+                quorum_membership: Arc::clone(&self.quorum_membership),
                 storage: Arc::clone(&self.storage),
                 view_number,
                 sender: event_sender.clone(),

--- a/crates/task-impls/src/quorum_vote.rs
+++ b/crates/task-impls/src/quorum_vote.rs
@@ -307,7 +307,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> QuorumVoteTaskState<TYPES, I
         event_sender: &Sender<Arc<HotShotEvent<TYPES>>>,
         event: Option<Arc<HotShotEvent<TYPES>>>,
     ) {
-        if self.vote_dependencies.get(&view_number).is_some() {
+        if self.vote_dependencies.contains_key(&view_number) {
             return;
         }
 

--- a/crates/task/src/dependency.rs
+++ b/crates/task/src/dependency.rs
@@ -33,12 +33,6 @@ pub trait Dependency<T> {
     }
 }
 
-/// Used to combine dependencies to create `AndDependency`s or `OrDependency`s
-trait CombineDependencies<T: Clone + Send + Sync + 'static>:
-    Sized + Dependency<T> + Send + 'static
-{
-}
-
 /// Defines a dependency that completes when all of its deps complete
 pub struct AndDependency<T> {
     /// Dependencies being combined


### PR DESCRIPTION
Closes #3092. Based off and to be merged into https://github.com/EspressoSystems/HotShot/pull/3066, not main.

### This PR: 
* Renames the `vote_if_able` function to `update_state_and_vote_if_able`, and moves it from the main file of the consensus task to the helper file.
* Gates code in `update_state_and_vote_if_able` so that it always updates the state but only votes when building without dependency tasks.
* Calls `update_state_and_vote_if_able` to update the state in the vote task.
* Renames `proposer_helpers.rs` to `helpers` because it now includes a helper function for the vote task as well.

### This PR does not: 
Change consensus logic except adding the state update for the vote task.

### Key places to review: 
* `crates/task-impls/src/consensus/mod.rs`.
* `crates/task-impls/src/quorum_vote.rs`.

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
