### PR TITLE
Make Header::new fallible

### DIFF
--- a/crates/example-types/src/block_types.rs
+++ b/crates/example-types/src/block_types.rs
@@ -193,6 +193,8 @@ pub struct TestBlockHeader {
 impl<TYPES: NodeType<BlockHeader = Self, BlockPayload = TestBlockPayload>> BlockHeader<TYPES>
     for TestBlockHeader
 {
+    type Error = std::convert::Infallible;
+
     async fn new(
         _parent_state: &TYPES::ValidatedState,
         _instance_state: &<TYPES::ValidatedState as ValidatedState<TYPES>>::Instance,
@@ -201,7 +203,7 @@ impl<TYPES: NodeType<BlockHeader = Self, BlockPayload = TestBlockPayload>> Block
         builder_commitment: BuilderCommitment,
         _metadata: <TYPES::BlockPayload as BlockPayload>::Metadata,
         _builder_fee: BuilderFee<TYPES>,
-    ) -> Self {
+    ) -> Result<Self, Self::Error> {
         let parent = parent_leaf.get_block_header();
 
         let mut timestamp = OffsetDateTime::now_utc().unix_timestamp() as u64;
@@ -210,12 +212,12 @@ impl<TYPES: NodeType<BlockHeader = Self, BlockPayload = TestBlockPayload>> Block
             timestamp = parent.timestamp;
         }
 
-        Self {
+        Ok(Self {
             block_number: parent.block_number + 1,
             payload_commitment,
             builder_commitment,
             timestamp,
-        }
+        })
     }
 
     fn genesis(

--- a/crates/task-impls/src/consensus/proposal_helpers.rs
+++ b/crates/task-impls/src/consensus/proposal_helpers.rs
@@ -211,7 +211,7 @@ pub async fn create_and_send_proposal<TYPES: NodeType>(
     round_start_delay: u64,
     instance_state: Arc<TYPES::InstanceState>,
 ) {
-    let block_header = TYPES::BlockHeader::new(
+    let block_header = match TYPES::BlockHeader::new(
         state.as_ref(),
         instance_state.as_ref(),
         &parent_leaf,
@@ -220,7 +220,14 @@ pub async fn create_and_send_proposal<TYPES: NodeType>(
         commitment_and_metadata.metadata,
         commitment_and_metadata.fee,
     )
-    .await;
+    .await
+    {
+        Ok(header) => header,
+        Err(err) => {
+            error!(%err, "Failed to construct block header");
+            return;
+        }
+    };
 
     let proposal = QuorumProposal {
         block_header,

--- a/crates/types/src/traits/block_contents.rs
+++ b/crates/types/src/traits/block_contents.rs
@@ -167,6 +167,9 @@ pub struct BuilderFee<TYPES: NodeType> {
 pub trait BlockHeader<TYPES: NodeType>:
     Serialize + Clone + Debug + Hash + PartialEq + Eq + Send + Sync + DeserializeOwned + Committable
 {
+    /// Error type for this type of block header
+    type Error: Error + Debug + Send + Sync;
+
     /// Build a header with the parent validate state, instance-level state, parent leaf, payload
     /// commitment, and metadata.
     fn new(
@@ -177,7 +180,7 @@ pub trait BlockHeader<TYPES: NodeType>:
         builder_commitment: BuilderCommitment,
         metadata: <TYPES::BlockPayload as BlockPayload>::Metadata,
         builder_fee: BuilderFee<TYPES>,
-    ) -> impl Future<Output = Self> + Send;
+    ) -> impl Future<Output = Result<Self, Self::Error>> + Send;
 
     /// Build the genesis header, payload, and metadata.
     fn genesis(


### PR DESCRIPTION
Closes #3019 


### This PR: 
Adds an associated type `Error` to `BlockHeader` trait and makes `BlockHeader::new` return a result.

### This PR does not: 


### Key places to review: 
Everything

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
