### PR TITLE
[CX_CLEANUP] - Make `high_qc` and `cur_view` private and add functions to avoid accidental overwrite

### DIFF
--- a/crates/hotshot/src/types/handle.rs
+++ b/crates/hotshot/src/types/handle.rs
@@ -173,7 +173,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static> SystemContextHandl
 
     /// Wrapper to get the view number this node is on.
     pub async fn get_cur_view(&self) -> TYPES::Time {
-        self.hotshot.consensus.read().await.cur_view
+        self.hotshot.consensus.read().await.cur_view()
     }
 
     /// Provides a reference to the underlying storage for this [`SystemContext`], allowing access to

--- a/crates/task-impls/src/consensus/mod.rs
+++ b/crates/task-impls/src/consensus/mod.rs
@@ -515,7 +515,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> ConsensusTaskState<TYPES, I>
                         }
 
                         let mut consensus = self.consensus.write().await;
-                        consensus.high_qc = qc.clone();
+                        consensus.update_high_qc_if_new(qc.clone());
 
                         // cancel poll for votes
                         self.quorum_network
@@ -767,7 +767,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> ConsensusTaskState<TYPES, I>
                     block_view: view,
                 });
                 if self.quorum_membership.get_leader(view) == self.public_key
-                    && self.consensus.read().await.high_qc.get_view_number() + 1 == view
+                    && self.consensus.read().await.high_qc().get_view_number() + 1 == view
                 {
                     if let Err(e) = self.publish_proposal(view, event_stream.clone()).await {
                         warn!("Failed to propose; error = {e:?}");

--- a/crates/task-impls/src/consensus/proposal_helpers.rs
+++ b/crates/task-impls/src/consensus/proposal_helpers.rs
@@ -137,7 +137,7 @@ async fn validate_proposal_safety_and_liveness<TYPES: NodeType>(
             .await;
         }
 
-        format!("Failed safety and liveness check \n High QC is {:?}  Proposal QC is {:?}  Locked view is {:?}", consensus.high_qc, proposal.data.clone(), consensus.locked_view)
+        format!("Failed safety and liveness check \n High QC is {:?}  Proposal QC is {:?}  Locked view is {:?}", consensus.high_qc(), proposal.data.clone(), consensus.locked_view)
     });
 
     // We accept the proposal, notify the application layer
@@ -225,7 +225,7 @@ pub async fn create_and_send_proposal<TYPES: NodeType>(
     let proposal = QuorumProposal {
         block_header,
         view_number: view,
-        justify_qc: consensus.read().await.high_qc.clone(),
+        justify_qc: consensus.read().await.high_qc().clone(),
         proposal_certificate: proposal_cert,
         upgrade_certificate: upgrade_cert,
     };
@@ -345,7 +345,7 @@ pub async fn get_parent_leaf_and_state<TYPES: NodeType>(
     );
 
     let consensus = consensus.read().await;
-    let parent_view_number = &consensus.high_qc.get_view_number();
+    let parent_view_number = &consensus.high_qc().get_view_number();
     let parent_view = consensus.validated_state_map.get(parent_view_number).context(
         format!("Couldn't find parent view in state map, waiting for replica to see proposal; parent_view_number: {}", **parent_view_number)
     )?;
@@ -355,12 +355,12 @@ pub async fn get_parent_leaf_and_state<TYPES: NodeType>(
         format!("Parent of high QC points to a view without a proposal; parent_view_number: {parent_view_number:?}, parent_view {parent_view:?}")
     )?;
 
-    if leaf_commitment != consensus.high_qc.get_data().leaf_commit {
+    if leaf_commitment != consensus.high_qc().get_data().leaf_commit {
         // NOTE: This happens on the genesis block
         debug!(
             "They don't equal: {:?}   {:?}",
             leaf_commitment,
-            consensus.high_qc.get_data().leaf_commit
+            consensus.high_qc().get_data().leaf_commit
         );
     }
 
@@ -683,7 +683,7 @@ pub async fn handle_quorum_proposal_recv<TYPES: NodeType, I: NodeImplementation<
         None => None,
     };
 
-    if justify_qc.get_view_number() > consensus_read.high_qc.view_number {
+    if justify_qc.get_view_number() > consensus_read.high_qc().view_number {
         if let Err(e) = task_state
             .storage
             .write()
@@ -697,10 +697,7 @@ pub async fn handle_quorum_proposal_recv<TYPES: NodeType, I: NodeImplementation<
 
     let mut consensus_write = RwLockUpgradableReadGuard::upgrade(consensus_read).await;
 
-    if justify_qc.get_view_number() > consensus_write.high_qc.view_number {
-        debug!("Updating high QC");
-        consensus_write.high_qc = justify_qc.clone();
-    }
+    consensus_write.update_high_qc_if_new(justify_qc.clone());
 
     // Justify qc's leaf commitment is not the same as the parent's leaf commitment, but it should be (in this case)
     let Some((parent_leaf, parent_state)) = parent else {
@@ -749,7 +746,7 @@ pub async fn handle_quorum_proposal_recv<TYPES: NodeType, I: NodeImplementation<
         {
             let liveness_check = justify_qc.get_view_number() > consensus_write.locked_view;
 
-            let high_qc = consensus_write.high_qc.clone();
+            let high_qc = consensus_write.high_qc().clone();
             let locked_view = consensus_write.locked_view;
 
             drop(consensus_write);
@@ -1041,10 +1038,10 @@ pub async fn handle_quorum_proposal_validated<TYPES: NodeType, I: NodeImplementa
         // This is for the case where we form a QC but have not yet seen the previous proposal ourselves
         let should_propose = task_state.quorum_membership.get_leader(new_view)
             == task_state.public_key
-            && consensus.high_qc.view_number
+            && consensus.high_qc().view_number
                 == task_state.current_proposal.clone().unwrap().view_number;
         // todo get rid of this clone
-        let qc = consensus.high_qc.clone();
+        let qc = consensus.high_qc().clone();
 
         drop(consensus);
         if new_decide_reached {

--- a/crates/task-impls/src/consensus/view_change.rs
+++ b/crates/task-impls/src/consensus/view_change.rs
@@ -133,7 +133,7 @@ pub(crate) async fn update_view<TYPES: NodeType, I: NodeImplementation<TYPES>>(
         );
     }
     let mut consensus = RwLockUpgradableReadGuard::upgrade(consensus).await;
-    consensus.update_view(new_view);
+    consensus.update_view_if_new(new_view);
     tracing::trace!("View updated successfully");
 
     Ok(())

--- a/crates/task-impls/src/quorum_proposal.rs
+++ b/crates/task-impls/src/quorum_proposal.rs
@@ -544,7 +544,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> QuorumProposalTaskState<TYPE
                         }
 
                         let mut consensus = self.consensus.write().await;
-                        consensus.high_qc = qc.clone();
+                        consensus.update_high_qc_if_new(qc.clone());
 
                         // cancel poll for votes
                         self.quorum_network

--- a/crates/task-impls/src/request.rs
+++ b/crates/task-impls/src/request.rs
@@ -266,7 +266,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> DelayedRequester<TYPES, I> {
     async fn cancel_vid(&self, req: &VidRequest<TYPES>) -> bool {
         let view = req.0;
         let state = self.state.read().await;
-        state.vid_shares.contains_key(&view) && state.cur_view > view
+        state.vid_shares.contains_key(&view) && state.cur_view() > view
     }
 
     /// Transform a response into a `HotShotEvent`


### PR DESCRIPTION
Closes #3097.

### This PR: 
* Makes the `high_qc` and `cur_view` fields of the `Consensus` struct private.
* Adds getter and setter for `high_qc`.
* Adds a getter for `cur_view` and updates its setter to only accept a newer view.

### This PR does not: 
* Change where to update the high QC or view number, except for restricting to newer views.

### Key places to review: 
* `crates/types/src/consensus.rs`.

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
