### PR TITLE
Fix linting due to version update

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 version = "0.5.43"                                        # same as `hotshot`, but workspace subcrate can also release its own version
 authors = ["Espresso Systems <hello@espressosys.com>"]
 edition = "2021"
-rust-version = "1.65.0"
+rust-version = "1.76.0"
 homepage = "https://github.com/EspressoSystems/HotShot"
 documentation = "https://hotshot.docs.espressosys.com"
 repository = "https://github.com/EspressoSystems/HotShot"

--- a/crates/builder-api/src/builder.rs
+++ b/crates/builder-api/src/builder.rs
@@ -129,7 +129,6 @@ pub fn define_api<State, Types: NodeType, Ver: StaticVersionType + 'static>(
 where
     State: 'static + Send + Sync + ReadState,
     <State as ReadState>::State: Send + Sync + BuilderDataSource<Types>,
-    Types: NodeType,
 {
     let mut api = load_api::<State, Error, Ver>(
         options.api_path.as_ref(),

--- a/crates/builder-api/src/builder.rs
+++ b/crates/builder-api/src/builder.rs
@@ -199,7 +199,6 @@ pub fn submit_api<State, Types: NodeType, Ver: StaticVersionType + 'static>(
 ) -> Result<Api<State, Error, Ver>, ApiError>
 where
     State: 'static + Send + Sync + AcceptsTxnSubmits<Types>,
-    Types: NodeType,
 {
     let mut api = load_api::<State, Error, Ver>(
         options.api_path.as_ref(),

--- a/crates/examples/Cargo.toml
+++ b/crates/examples/Cargo.toml
@@ -5,7 +5,7 @@ edition = { workspace = true }
 name = "hotshot-examples"
 readme = "README.md"
 version = { workspace = true }
-rust-version = "1.65.0"
+rust-version = "1.70.0"
 
 [features]
 default = ["docs", "doc-images", "hotshot-testing"]

--- a/crates/examples/Cargo.toml
+++ b/crates/examples/Cargo.toml
@@ -5,7 +5,7 @@ edition = { workspace = true }
 name = "hotshot-examples"
 readme = "README.md"
 version = { workspace = true }
-rust-version = "1.70.0"
+rust-version = { workspace = true }
 
 [features]
 default = ["docs", "doc-images", "hotshot-testing"]

--- a/crates/hotshot-stake-table/src/mt_based.rs
+++ b/crates/hotshot-stake-table/src/mt_based.rs
@@ -45,7 +45,7 @@ impl<K: Key> StakeTableScheme for StakeTable<K> {
         amount: Self::Amount,
         (): Self::Aux,
     ) -> Result<(), StakeTableError> {
-        if self.mapping.get(&new_key).is_some() {
+        if self.mapping.contains_key(&new_key) {
             Err(StakeTableError::ExistingKey)
         } else {
             let pos = self.mapping.len();

--- a/crates/hotshot-stake-table/src/vec_based.rs
+++ b/crates/hotshot-stake-table/src/vec_based.rs
@@ -103,7 +103,7 @@ where
         amount: Self::Amount,
         aux: Self::Aux,
     ) -> Result<(), StakeTableError> {
-        if self.bls_mapping.get(&new_key).is_some() {
+        if self.bls_mapping.contains_key(&new_key) {
             Err(StakeTableError::ExistingKey)
         } else {
             let pos = self.bls_mapping.len();

--- a/crates/libp2p-networking/tests/common/mod.rs
+++ b/crates/libp2p-networking/tests/common/mod.rs
@@ -91,7 +91,7 @@ where
 /// - Initialize network nodes
 /// - Kill network nodes
 /// - A test assertion fails
-pub async fn test_bed<S: 'static + Send + Default + Debug + Clone, F, FutF, G: Clone, FutG>(
+pub async fn test_bed<S: 'static + Send + Default + Debug + Clone, F, FutF, G, FutG>(
     run_test: F,
     client_handler: G,
     num_nodes: usize,
@@ -101,7 +101,7 @@ pub async fn test_bed<S: 'static + Send + Default + Debug + Clone, F, FutF, G: C
     FutF: Future<Output = ()>,
     FutG: Future<Output = Result<(), NetworkNodeHandleError>> + 'static + Send + Sync,
     F: FnOnce(Vec<HandleWithState<S>>, Duration) -> FutF,
-    G: Fn(NetworkEvent, HandleWithState<S>) -> FutG + 'static + Send + Sync,
+    G: Fn(NetworkEvent, HandleWithState<S>) -> FutG + 'static + Send + Sync + Clone,
 {
     setup_logging();
     setup_backtrace();

--- a/crates/orchestrator/src/lib.rs
+++ b/crates/orchestrator/src/lib.rs
@@ -497,13 +497,12 @@ where
 }
 
 /// Sets up all API routes
-fn define_api<KEY: SignatureKey, State, VER: StaticVersionType>(
-) -> Result<Api<State, ServerError, VER>, ApiError>
+fn define_api<KEY, State, VER>() -> Result<Api<State, ServerError, VER>, ApiError>
 where
     State: 'static + Send + Sync + ReadState + WriteState,
     <State as ReadState>::State: Send + Sync + OrchestratorApi<KEY>,
-    KEY: serde::Serialize,
-    VER: 'static,
+    KEY: serde::Serialize + SignatureKey,
+    VER: StaticVersionType + 'static,
 {
     let api_toml = toml::from_str::<toml::Value>(include_str!(concat!(
         env!("CARGO_MANIFEST_DIR"),

--- a/crates/task-impls/src/harness.rs
+++ b/crates/task-impls/src/harness.rs
@@ -44,14 +44,13 @@ impl<TYPES: NodeType> TaskState for TestHarnessState<TYPES> {
 /// Panics if any state the test expects is not set. Panicking causes a test failure
 #[allow(clippy::implicit_hasher)]
 #[allow(clippy::panic)]
-pub async fn run_harness<TYPES, S: TaskState<Event = Arc<HotShotEvent<TYPES>>>>(
+pub async fn run_harness<TYPES, S: TaskState<Event = Arc<HotShotEvent<TYPES>>> + Send + 'static>(
     input: Vec<HotShotEvent<TYPES>>,
     expected_output: HashMap<HotShotEvent<TYPES>, usize>,
     state: S,
     allow_extra_output: bool,
 ) where
     TYPES: NodeType,
-    S: Send + 'static,
 {
     let registry = Arc::new(TaskRegistry::default());
     let mut tasks = vec![];

--- a/crates/task-impls/src/quorum_proposal.rs
+++ b/crates/task-impls/src/quorum_proposal.rs
@@ -447,7 +447,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> QuorumProposalTaskState<TYPE
         }
 
         debug!("Attempting to make dependency task for view {view_number:?} and event {event:?}");
-        if self.propose_dependencies.get(&view_number).is_some() {
+        if self.propose_dependencies.contains_key(&view_number) {
             debug!("Task already exists");
             return;
         }

--- a/crates/task-impls/src/quorum_vote.rs
+++ b/crates/task-impls/src/quorum_vote.rs
@@ -271,7 +271,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> QuorumVoteTaskState<TYPES, I
         event_sender: &Sender<Arc<HotShotEvent<TYPES>>>,
         event: Option<Arc<HotShotEvent<TYPES>>>,
     ) {
-        if self.vote_dependencies.get(&view_number).is_some() {
+        if self.vote_dependencies.contains_key(&view_number) {
             return;
         }
 

--- a/crates/task/src/dependency.rs
+++ b/crates/task/src/dependency.rs
@@ -33,12 +33,6 @@ pub trait Dependency<T> {
     }
 }
 
-/// Used to combine dependencies to create `AndDependency`s or `OrDependency`s
-trait CombineDependencies<T: Clone + Send + Sync + 'static>:
-    Sized + Dependency<T> + Send + 'static
-{
-}
-
 /// Defines a dependency that completes when all of its deps complete
 pub struct AndDependency<T> {
     /// Dependencies being combined

--- a/crates/testing/src/script.rs
+++ b/crates/testing/src/script.rs
@@ -89,12 +89,14 @@ where
 /// Note: the task is not spawned with an async thread; instead, the harness just calls `handle_event`.
 /// This has a few implications, e.g. shutting down tasks doesn't really make sense,
 /// and event ordering is deterministic.
-pub async fn run_test_script<TYPES, S: TaskState<Event = Arc<HotShotEvent<TYPES>>>>(
+pub async fn run_test_script<
+    TYPES,
+    S: TaskState<Event = Arc<HotShotEvent<TYPES>>> + Send + 'static,
+>(
     mut script: TestScript<TYPES, S>,
     state: S,
 ) where
     TYPES: NodeType,
-    S: Send + 'static,
 {
     let registry = Arc::new(TaskRegistry::default());
 

--- a/crates/testing/src/test_builder.rs
+++ b/crates/testing/src/test_builder.rs
@@ -1,6 +1,6 @@
 use std::{num::NonZeroUsize, sync::Arc, time::Duration};
 
-use hotshot::traits::{NetworkReliability, NodeImplementation, TestableNodeImplementation};
+use hotshot::traits::{NetworkReliability, TestableNodeImplementation};
 use hotshot_example_types::{state_types::TestInstanceState, storage_types::TestStorage};
 use hotshot_orchestrator::config::ValidatorConfigFile;
 use hotshot_types::{
@@ -233,10 +233,7 @@ impl TestDescription {
     >(
         self,
         node_id: u64,
-    ) -> TestLauncher<TYPES, I>
-    where
-        I: NodeImplementation<TYPES>,
-    {
+    ) -> TestLauncher<TYPES, I> {
         let TestDescription {
             num_nodes_with_stake,
             num_bootstrap_nodes,

--- a/crates/testing/src/txn_task.rs
+++ b/crates/testing/src/txn_task.rs
@@ -30,7 +30,7 @@ pub struct TxnTask<TYPES: NodeType, I: TestableNodeImplementation<TYPES>> {
     pub next_node_idx: Option<usize>,
     /// time to wait between txns
     pub duration: Duration,
-    ///
+    /// Receiver for the shutdown signal from the testing harness
     pub shutdown_chan: Receiver<GlobalTestEvent>,
 }
 

--- a/crates/web_server/src/lib.rs
+++ b/crates/web_server/src/lib.rs
@@ -873,14 +873,13 @@ pub struct Options {
 /// Transport versioning (generic params here) only changes when the web-CDN itself changes.
 /// When transport versioning changes, the application itself must update its version.
 #[allow(clippy::too_many_lines)]
-fn define_api<State, KEY, NetworkVersion: StaticVersionType>(
+fn define_api<State, KEY, NetworkVersion: StaticVersionType + 'static>(
     options: &Options,
 ) -> Result<Api<State, Error, NetworkVersion>, ApiError>
 where
     State: 'static + Send + Sync + ReadState + WriteState,
     <State as ReadState>::State: Send + Sync + WebServerDataSource<KEY>,
     KEY: SignatureKey,
-    NetworkVersion: 'static,
 {
     let mut api = match &options.api_path {
         Some(path) => Api::<State, Error, NetworkVersion>::from_file(path)?,


### PR DESCRIPTION
Cherry-pick from https://github.com/EspressoSystems/HotShot/pull/3066/commits/c295e43409b1c0532fffa77bc570618c95f00e5b to fix the linting errors due to `rustc` version update.