### PR TITLE
Remove `Default` bound from `InstanceState` trait

### DIFF
--- a/crates/testing/src/block_builder.rs
+++ b/crates/testing/src/block_builder.rs
@@ -37,7 +37,10 @@ use rand::{rngs::SmallRng, Rng, RngCore, SeedableRng};
 use tide_disco::{method::ReadState, App, Url};
 
 #[async_trait]
-pub trait TestBuilderImplementation<TYPES: NodeType> {
+pub trait TestBuilderImplementation<TYPES: NodeType>
+where
+    <TYPES as NodeType>::InstanceState: Default,
+{
     type Config: Default;
 
     async fn start(
@@ -52,6 +55,7 @@ pub struct RandomBuilderImplementation;
 impl<TYPES> TestBuilderImplementation<TYPES> for RandomBuilderImplementation
 where
     TYPES: NodeType<Transaction = TestTransaction>,
+    <TYPES as NodeType>::InstanceState: Default,
 {
     type Config = RandomBuilderConfig;
 
@@ -69,7 +73,10 @@ where
 pub struct SimpleBuilderImplementation;
 
 #[async_trait]
-impl<TYPES: NodeType> TestBuilderImplementation<TYPES> for SimpleBuilderImplementation {
+impl<TYPES: NodeType> TestBuilderImplementation<TYPES> for SimpleBuilderImplementation
+where
+    <TYPES as NodeType>::InstanceState: Default,
+{
     type Config = ();
 
     async fn start(
@@ -140,7 +147,10 @@ where
 
     /// Spawn a task building blocks, configured with given options
     #[allow(clippy::missing_panics_doc)] // ony panics on 16-bit platforms
-    pub fn run(&self, num_storage_nodes: usize, options: RandomBuilderConfig) {
+    pub fn run(&self, num_storage_nodes: usize, options: RandomBuilderConfig)
+    where
+        <TYPES as NodeType>::InstanceState: Default,
+    {
         let blocks = self.blocks.clone();
         let (priv_key, pub_key) = (self.priv_key.clone(), self.pub_key.clone());
         async_spawn(async move {
@@ -262,6 +272,7 @@ impl<TYPES: NodeType> BuilderDataSource<TYPES> for RandomBuilderSource<TYPES> {
 pub fn run_random_builder<TYPES>(url: Url, num_storage_nodes: usize, options: RandomBuilderConfig)
 where
     TYPES: NodeType<Transaction = TestTransaction>,
+    <TYPES as NodeType>::InstanceState: Default,
 {
     let (pub_key, priv_key) = TYPES::BuilderSignatureKey::generated_from_seed_indexed([1; 32], 0);
     let source = RandomBuilderSource::new(pub_key, priv_key);
@@ -307,7 +318,10 @@ impl<TYPES: NodeType> ReadState for SimpleBuilderSource<TYPES> {
 }
 
 #[async_trait]
-impl<TYPES: NodeType> BuilderDataSource<TYPES> for SimpleBuilderSource<TYPES> {
+impl<TYPES: NodeType> BuilderDataSource<TYPES> for SimpleBuilderSource<TYPES>
+where
+    <TYPES as NodeType>::InstanceState: Default,
+{
     async fn get_available_blocks(
         &self,
         _for_parent: &VidCommitment,
@@ -411,7 +425,10 @@ impl<TYPES: NodeType> BuilderDataSource<TYPES> for SimpleBuilderSource<TYPES> {
 }
 
 impl<TYPES: NodeType> SimpleBuilderSource<TYPES> {
-    pub async fn run(self, url: Url) {
+    pub async fn run(self, url: Url)
+    where
+        <TYPES as NodeType>::InstanceState: Default,
+    {
         let builder_api = hotshot_builder_api::builder::define_api::<
             SimpleBuilderSource<TYPES>,
             TYPES,

--- a/crates/types/src/traits/states.rs
+++ b/crates/types/src/traits/states.rs
@@ -18,7 +18,7 @@ use crate::{
 };
 
 /// Instance-level state, which allows us to fetch missing validated state.
-pub trait InstanceState: Debug + Send + Sync + Default {}
+pub trait InstanceState: Debug + Send + Sync {}
 
 /// Application-specific state delta, which will be used to store a list of merkle tree entries.
 pub trait StateDelta: Debug + Send + Sync + Serialize + for<'a> Deserialize<'a> {}


### PR DESCRIPTION
Instead supply bounds in `testing` crate. This avoids modifying the public API and forcing implementation of  `Default`.

Closes #<ISSUE_NUMBER>
<!-- See here for keywords in Github -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

### This PR: 
<!-- Describe what this PR adds to HotSHot -->
<!-- E.g. -->
<!-- * Implements feature 1 -->
<!-- * Implements feature 2 -->
<!-- * Fixes bug 3 -->

### This PR does not: 
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->

### Key places to review: 
  * `crates/testing/src/block_builder.rs`
  * `crates/types/src/traits.states.rs`
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
