### PR TITLE
Update  the CDN

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1314,6 +1314,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "capnpc"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c75ba30e0f08582d53c2f3710cf4bb65ff562614b1ba86906d7391adffe189ec"
+dependencies = [
+ "capnp",
+]
+
+[[package]]
 name = "cbor4ii"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1331,7 +1340,7 @@ checksum = "d32a725bc159af97c3e629873bb9f88fb8cf8a4867175f76dc987815ea07c83b"
 [[package]]
 name = "cdn-broker"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/Push-CDN?tag=0.3#bde96dbc21f4c9fde116606cb580db0ab759f44f"
+source = "git+https://github.com/EspressoSystems/Push-CDN?tag=0.3.2#c41604361b634830b5ba874e06b997993055c25c"
 dependencies = [
  "async-std",
  "cdn-proto",
@@ -1355,7 +1364,7 @@ dependencies = [
 [[package]]
 name = "cdn-client"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/Push-CDN?tag=0.3#bde96dbc21f4c9fde116606cb580db0ab759f44f"
+source = "git+https://github.com/EspressoSystems/Push-CDN?tag=0.3.2#c41604361b634830b5ba874e06b997993055c25c"
 dependencies = [
  "async-std",
  "cdn-proto",
@@ -1370,7 +1379,7 @@ dependencies = [
 [[package]]
 name = "cdn-marshal"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/Push-CDN?tag=0.3#bde96dbc21f4c9fde116606cb580db0ab759f44f"
+source = "git+https://github.com/EspressoSystems/Push-CDN?tag=0.3.2#c41604361b634830b5ba874e06b997993055c25c"
 dependencies = [
  "async-std",
  "cdn-proto",
@@ -1384,12 +1393,13 @@ dependencies = [
 [[package]]
 name = "cdn-proto"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/Push-CDN?tag=0.3#bde96dbc21f4c9fde116606cb580db0ab759f44f"
+source = "git+https://github.com/EspressoSystems/Push-CDN?tag=0.3.2#c41604361b634830b5ba874e06b997993055c25c"
 dependencies = [
  "anyhow",
  "ark-serialize",
  "async-trait",
  "capnp",
+ "capnpc",
  "derivative",
  "jf-primitives 0.4.0-pre.0",
  "kanal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,10 +131,10 @@ anyhow = "1"
 
 
 # Push CDN imports
-cdn-client = { git = "https://github.com/EspressoSystems/Push-CDN", tag = "0.3" }
-cdn-broker = { git = "https://github.com/EspressoSystems/Push-CDN", tag = "0.3" }
-cdn-marshal = { git = "https://github.com/EspressoSystems/Push-CDN", tag = "0.3" }
-cdn-proto = { git = "https://github.com/EspressoSystems/Push-CDN", tag = "0.3" }
+cdn-client = { git = "https://github.com/EspressoSystems/Push-CDN", tag = "0.3.2" }
+cdn-broker = { git = "https://github.com/EspressoSystems/Push-CDN", tag = "0.3.2" }
+cdn-marshal = { git = "https://github.com/EspressoSystems/Push-CDN", tag = "0.3.2" }
+cdn-proto = { git = "https://github.com/EspressoSystems/Push-CDN", tag = "0.3.2" }
 
 ### Profiles
 ###

--- a/crates/examples/infra/mod.rs
+++ b/crates/examples/infra/mod.rs
@@ -20,7 +20,7 @@ use futures::StreamExt;
 use hotshot::{
     traits::{
         implementations::{
-            derive_libp2p_peer_id, CombinedNetworks, Libp2pNetwork, PushCdnNetwork, Topics,
+            derive_libp2p_peer_id, CombinedNetworks, Libp2pNetwork, PushCdnNetwork, Topic,
             WrappedSignatureKey,
         },
         BlockPayload, NodeImplementation,
@@ -631,9 +631,9 @@ where
         };
 
         // See if we should be DA, subscribe to the DA topic if so
-        let mut topics = vec![Topics::Global];
+        let mut topics = vec![Topic::Global];
         if config.config.my_own_validator_config.is_da {
-            topics.push(Topics::DA);
+            topics.push(Topic::DA);
         }
 
         // Create the network and await the initial connection
@@ -642,7 +642,7 @@ where
                 .cdn_marshal_address
                 .clone()
                 .expect("`cdn_marshal_address` needs to be supplied for a push CDN run"),
-            topics.into_iter().map(|t| t as u8).collect(),
+            topics,
             keypair,
         )
         .expect("failed to create network");

--- a/crates/examples/infra/mod.rs
+++ b/crates/examples/infra/mod.rs
@@ -13,14 +13,14 @@ use async_compatibility_layer::{
     logging::{setup_backtrace, setup_logging},
 };
 use async_trait::async_trait;
-use cdn_broker::reexports::{crypto::signature::KeyPair, message::Topic};
+use cdn_broker::reexports::crypto::signature::KeyPair;
 use chrono::Utc;
 use clap::{value_parser, Arg, Command, Parser};
 use futures::StreamExt;
 use hotshot::{
     traits::{
         implementations::{
-            derive_libp2p_peer_id, CombinedNetworks, Libp2pNetwork, PushCdnNetwork,
+            derive_libp2p_peer_id, CombinedNetworks, Libp2pNetwork, PushCdnNetwork, Topics,
             WrappedSignatureKey,
         },
         BlockPayload, NodeImplementation,
@@ -631,9 +631,9 @@ where
         };
 
         // See if we should be DA, subscribe to the DA topic if so
-        let mut topics = vec![Topic::Global];
+        let mut topics = vec![Topics::Global];
         if config.config.my_own_validator_config.is_da {
-            topics.push(Topic::DA);
+            topics.push(Topics::DA);
         }
 
         // Create the network and await the initial connection
@@ -642,7 +642,7 @@ where
                 .cdn_marshal_address
                 .clone()
                 .expect("`cdn_marshal_address` needs to be supplied for a push CDN run"),
-            topics.iter().map(ToString::to_string).collect(),
+            topics.into_iter().map(|t| t as u8).collect(),
             keypair,
         )
         .expect("failed to create network");

--- a/crates/hotshot/src/traits.rs
+++ b/crates/hotshot/src/traits.rs
@@ -17,7 +17,7 @@ pub mod implementations {
         },
         memory_network::{MasterMap, MemoryNetwork},
         push_cdn_network::{
-            KeyPair, ProductionDef, PushCdnNetwork, TestingDef, WrappedSignatureKey,
+            KeyPair, ProductionDef, PushCdnNetwork, TestingDef, Topics, WrappedSignatureKey,
         },
         NetworkingMetricsValue,
     };

--- a/crates/hotshot/src/traits.rs
+++ b/crates/hotshot/src/traits.rs
@@ -17,7 +17,7 @@ pub mod implementations {
         },
         memory_network::{MasterMap, MemoryNetwork},
         push_cdn_network::{
-            KeyPair, ProductionDef, PushCdnNetwork, TestingDef, Topics, WrappedSignatureKey,
+            KeyPair, ProductionDef, PushCdnNetwork, TestingDef, Topic, WrappedSignatureKey,
         },
         NetworkingMetricsValue,
     };


### PR DESCRIPTION
Does not close a linked issue.

This update changes `topics` so that they are specified application-side instead of CDN-side. This way we can add/remove as we see fit by just changing the enum.