### PR TITLE
Fix Tests in bf/vid-common

### DIFF
--- a/crates/task-impls/src/consensus/mod.rs
+++ b/crates/task-impls/src/consensus/mod.rs
@@ -35,7 +35,6 @@ use hotshot_types::{traits::storage::Storage, vote::Certificate};
 use jf_primitives::vid::VidScheme;
 #[cfg(async_executor_impl = "tokio")]
 use tokio::task::JoinHandle;
-#[cfg(not(feature = "dependency-tasks"))]
 use tracing::{debug, error, instrument, warn};
 use vbs::version::Version;
 
@@ -805,6 +804,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> ConsensusTaskState<TYPES, I>
                     };
                 }
             }
+            #[cfg(not(feature = "dependency-tasks"))]
             HotShotEvent::QuorumVoteSend(vote) => {
                 let Some(proposal) = self.current_proposal.clone() else {
                     return;

--- a/crates/testing/tests/tests_1/quorum_proposal_task.rs
+++ b/crates/testing/tests/tests_1/quorum_proposal_task.rs
@@ -1,5 +1,6 @@
-use hotshot::tasks::task_state::CreateTaskState;
+use hotshot::{tasks::task_state::CreateTaskState, types::SystemContextHandle};
 use hotshot_example_types::{
+    block_types::TestMetadata,
     node_types::{MemoryImpl, TestTypes},
     state_types::TestInstanceState,
 };
@@ -7,12 +8,18 @@ use hotshot_task_impls::{events::HotShotEvent::*, quorum_proposal::QuorumProposa
 use hotshot_testing::{
     predicates::event::quorum_proposal_send,
     script::{run_test_script, TestScriptStage},
+    task_helpers::{build_cert, key_pair_for_id},
     task_helpers::{build_system_handle, vid_scheme_from_view_number},
     view_generator::TestViewGenerator,
 };
 use hotshot_types::{
-    data::{ViewChangeEvidence, ViewNumber},
+    consensus::{CommitmentAndMetadata, ProposalDependencyData},
+    data::null_block,
+    data::{VidDisperseShare, ViewChangeEvidence, ViewNumber},
+    message::Proposal,
+    simple_certificate::{TimeoutCertificate, ViewSyncFinalizeCertificate2},
     simple_vote::ViewSyncFinalizeData,
+    simple_vote::{TimeoutData, TimeoutVote, ViewSyncFinalizeVote},
     traits::{
         election::Membership,
         node_implementation::{ConsensusTime, NodeType},
@@ -34,6 +41,26 @@ fn make_payload_commitment(
     vid.commit_only(&encoded_transactions).unwrap()
 }
 
+async fn insert_vid_shares_for_view(
+    view: <TestTypes as NodeType>::Time,
+    handle: &SystemContextHandle<TestTypes, MemoryImpl>,
+    vid: (
+        Vec<Proposal<TestTypes, VidDisperseShare<TestTypes>>>,
+        <TestTypes as NodeType>::SignatureKey,
+    ),
+) {
+    let consensus = handle.get_consensus();
+    let mut consensus = consensus.write().await;
+
+    // `create_and_send_proposal` depends on the `vid_shares` obtaining a vid dispersal.
+    // to avoid needing to spin up the vote task, we can just insert it in here.
+    consensus
+        .vid_shares
+        .entry(view)
+        .or_default()
+        .insert(vid.1.clone(), vid.0[0].clone());
+}
+
 #[cfg(feature = "dependency-tasks")]
 #[cfg(test)]
 #[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
@@ -45,22 +72,27 @@ async fn test_quorum_proposal_task_quorum_proposal_view_1() {
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
 
-    let handle = build_system_handle(1).await.0;
+    let node_id = 1;
+    let handle = build_system_handle(node_id).await.0;
     let quorum_membership = handle.hotshot.memberships.quorum_membership.clone();
     let da_membership = handle.hotshot.memberships.da_membership.clone();
 
-    let payload_commitment = make_payload_commitment(&quorum_membership, ViewNumber::new(1));
+    let payload_commitment = make_payload_commitment(&quorum_membership, ViewNumber::new(node_id));
 
     let mut generator = TestViewGenerator::generate(quorum_membership.clone(), da_membership);
 
     let mut proposals = Vec::new();
     let mut leaders = Vec::new();
     let mut leaves = Vec::new();
+    let mut vids = Vec::new();
     for view in (&mut generator).take(2) {
         proposals.push(view.quorum_proposal.clone());
         leaders.push(view.leader_public_key);
         leaves.push(view.leaf.clone());
+        vids.push(view.vid_proposal.clone());
     }
+
+    insert_vid_shares_for_view(ViewNumber::new(node_id), &handle, vids[0].clone()).await;
 
     let cert = proposals[0].data.justify_qc.clone();
     let builder_commitment = BuilderCommitment::from_raw_digest(sha2::Sha256::new().finalize());
@@ -114,11 +146,15 @@ async fn test_quorum_proposal_task_quorum_proposal_view_gt_1() {
     let mut proposals = Vec::new();
     let mut leaders = Vec::new();
     let mut leaves = Vec::new();
+    let mut vids = Vec::new();
     for view in (&mut generator).take(3) {
         proposals.push(view.quorum_proposal.clone());
         leaders.push(view.leader_public_key);
         leaves.push(view.leaf.clone());
+        vids.push(view.vid_proposal.clone());
     }
+
+    insert_vid_shares_for_view(ViewNumber::new(node_id), &handle, vids[2].clone()).await;
     let consensus = handle.get_consensus();
     let mut consensus = consensus.write().await;
 
@@ -175,7 +211,7 @@ async fn test_quorum_proposal_task_quorum_proposal_view_gt_1() {
     run_test_script(script, quorum_proposal_task_state).await;
 }
 
-#[ignore]
+#[cfg(feature = "dependency-tasks")]
 #[cfg(test)]
 #[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
@@ -185,20 +221,23 @@ async fn test_quorum_proposal_task_qc_timeout() {
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
 
-    let handle = build_system_handle(2).await.0;
+    let node_id = 2;
+    let handle = build_system_handle(node_id).await.0;
     let quorum_membership = handle.hotshot.memberships.quorum_membership.clone();
     let da_membership = handle.hotshot.memberships.da_membership.clone();
 
-    let payload_commitment = make_payload_commitment(&quorum_membership, ViewNumber::new(2));
+    let payload_commitment = make_payload_commitment(&quorum_membership, ViewNumber::new(node_id));
     let builder_commitment = BuilderCommitment::from_raw_digest(sha2::Sha256::new().finalize());
 
     let mut generator = TestViewGenerator::generate(quorum_membership.clone(), da_membership);
 
     let mut proposals = Vec::new();
     let mut leaders = Vec::new();
+    let mut vids = Vec::new();
     for view in (&mut generator).take(1) {
         proposals.push(view.quorum_proposal.clone());
         leaders.push(view.leader_public_key);
+        vids.push(view.vid_proposal.clone());
     }
     let timeout_data = TimeoutData {
         view: ViewNumber::new(1),
@@ -207,8 +246,10 @@ async fn test_quorum_proposal_task_qc_timeout() {
     for view in (&mut generator).take(1) {
         proposals.push(view.quorum_proposal.clone());
         leaders.push(view.leader_public_key);
+        vids.push(view.vid_proposal.clone());
     }
 
+    insert_vid_shares_for_view(ViewNumber::new(node_id), &handle, vids[1].clone()).await;
     // Get the proposal cert out for the view sync input
     let cert = match proposals[1].data.proposal_certificate.clone().unwrap() {
         ViewChangeEvidence::Timeout(tc) => tc,
@@ -239,7 +280,7 @@ async fn test_quorum_proposal_task_qc_timeout() {
     run_test_script(script, quorum_proposal_task_state).await;
 }
 
-#[ignore]
+#[cfg(feature = "dependency-tasks")]
 #[cfg(test)]
 #[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
@@ -252,32 +293,37 @@ async fn test_quorum_proposal_task_view_sync() {
 
     // We need to propose as the leader for view 2, otherwise we get caught up with the special
     // case in the genesis view.
-    let handle = build_system_handle(2).await.0;
+    let node_id = 2;
+    let handle = build_system_handle(node_id).await.0;
     let quorum_membership = handle.hotshot.memberships.quorum_membership.clone();
     let da_membership = handle.hotshot.memberships.da_membership.clone();
 
-    let payload_commitment = make_payload_commitment(&quorum_membership, ViewNumber::new(2));
+    let payload_commitment = make_payload_commitment(&quorum_membership, ViewNumber::new(node_id));
     let builder_commitment = BuilderCommitment::from_raw_digest(sha2::Sha256::new().finalize());
 
     let mut generator = TestViewGenerator::generate(quorum_membership.clone(), da_membership);
 
     let mut proposals = Vec::new();
     let mut leaders = Vec::new();
+    let mut vids = Vec::new();
     for view in (&mut generator).take(1) {
         proposals.push(view.quorum_proposal.clone());
         leaders.push(view.leader_public_key);
+        vids.push(view.vid_proposal.clone());
     }
 
     let view_sync_finalize_data = ViewSyncFinalizeData {
         relay: 2,
-        round: ViewNumber::new(2),
+        round: ViewNumber::new(node_id),
     };
     generator.add_view_sync_finalize(view_sync_finalize_data);
     for view in (&mut generator).take(1) {
         proposals.push(view.quorum_proposal.clone());
         leaders.push(view.leader_public_key);
+        vids.push(view.vid_proposal.clone());
     }
 
+    insert_vid_shares_for_view(ViewNumber::new(node_id), &handle, vids[1].clone()).await;
     // Get the proposal cert out for the view sync input
     let cert = match proposals[1].data.proposal_certificate.clone().unwrap() {
         ViewChangeEvidence::ViewSync(vsc) => vsc,
@@ -308,41 +354,37 @@ async fn test_quorum_proposal_task_view_sync() {
     run_test_script(script, quorum_proposal_task_state).await;
 }
 
-#[ignore]
+#[cfg(feature = "dependency-tasks")]
 #[cfg(test)]
 #[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 async fn test_quorum_proposal_task_propose_now() {
-    use hotshot_example_types::block_types::TestMetadata;
-    use hotshot_testing::task_helpers::{build_cert, key_pair_for_id};
-    use hotshot_types::{
-        consensus::{CommitmentAndMetadata, ProposalDependencyData},
-        data::null_block,
-        simple_certificate::{TimeoutCertificate, ViewSyncFinalizeCertificate2},
-        simple_vote::{TimeoutData, TimeoutVote, ViewSyncFinalizeVote},
-    };
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
 
-    let handle = build_system_handle(2).await.0;
-    let (private_key, public_key) = key_pair_for_id(2);
+    let node_id = 2;
+    let handle = build_system_handle(node_id).await.0;
     let quorum_membership = handle.hotshot.memberships.quorum_membership.clone();
     let da_membership = handle.hotshot.memberships.da_membership.clone();
 
-    let payload_commitment = make_payload_commitment(&quorum_membership, ViewNumber::new(2));
+    let payload_commitment = make_payload_commitment(&quorum_membership, ViewNumber::new(node_id));
 
     let mut generator = TestViewGenerator::generate(quorum_membership.clone(), da_membership);
 
     let mut proposals = Vec::new();
     let mut leaders = Vec::new();
+    let mut vids = Vec::new();
     for view in (&mut generator).take(1) {
         proposals.push(view.quorum_proposal.clone());
         leaders.push(view.leader_public_key);
+        vids.push(view.vid_proposal.clone());
     }
     for view in (&mut generator).take(1) {
         proposals.push(view.quorum_proposal.clone());
         leaders.push(view.leader_public_key);
+        vids.push(view.vid_proposal.clone());
     }
+
     let builder_commitment = BuilderCommitment::from_raw_digest(sha2::Sha256::new().finalize());
     // proposal dependency data - quorum proposal and cert
     let pdd_qp = ProposalDependencyData {
@@ -361,6 +403,53 @@ async fn test_quorum_proposal_task_propose_now() {
             ),
     };
 
+    let view_qp = TestScriptStage {
+        inputs: vec![ProposeNow(ViewNumber::new(node_id), pdd_qp)],
+        outputs: vec![quorum_proposal_send()],
+        asserts: vec![],
+    };
+
+    let quorum_proposal_task_state =
+        QuorumProposalTaskState::<TestTypes, MemoryImpl>::create_from(&handle).await;
+    insert_vid_shares_for_view(ViewNumber::new(node_id), &handle, vids[1].clone()).await;
+
+    let script = vec![view_qp];
+    run_test_script(script, quorum_proposal_task_state).await;
+}
+
+#[cfg(feature = "dependency-tasks")]
+#[cfg(test)]
+#[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
+#[cfg_attr(async_executor_impl = "async-std", async_std::test)]
+async fn test_quorum_proposal_task_propose_now_timeout() {
+    async_compatibility_layer::logging::setup_logging();
+    async_compatibility_layer::logging::setup_backtrace();
+
+    let node_id = 2;
+    let handle = build_system_handle(node_id).await.0;
+    let (private_key, public_key) = key_pair_for_id(node_id);
+    let quorum_membership = handle.hotshot.memberships.quorum_membership.clone();
+    let da_membership = handle.hotshot.memberships.da_membership.clone();
+
+    let payload_commitment = make_payload_commitment(&quorum_membership, ViewNumber::new(node_id));
+
+    let mut generator = TestViewGenerator::generate(quorum_membership.clone(), da_membership);
+
+    let mut proposals = Vec::new();
+    let mut leaders = Vec::new();
+    let mut vids = Vec::new();
+    for view in (&mut generator).take(1) {
+        proposals.push(view.quorum_proposal.clone());
+        leaders.push(view.leader_public_key);
+        vids.push(view.vid_proposal.clone());
+    }
+    for view in (&mut generator).take(1) {
+        proposals.push(view.quorum_proposal.clone());
+        leaders.push(view.leader_public_key);
+        vids.push(view.vid_proposal.clone());
+    }
+
+    let builder_commitment = BuilderCommitment::from_raw_digest(sha2::Sha256::new().finalize());
     // proposal dependency data - timeout cert
     let pdd_timeout = ProposalDependencyData {
         commitment_and_metadata: CommitmentAndMetadata {
@@ -388,6 +477,53 @@ async fn test_quorum_proposal_task_propose_now() {
             )),
     };
 
+    let view_timeout = TestScriptStage {
+        inputs: vec![ProposeNow(ViewNumber::new(node_id), pdd_timeout)],
+        outputs: vec![quorum_proposal_send()],
+        asserts: vec![],
+    };
+
+    let quorum_proposal_task_state =
+        QuorumProposalTaskState::<TestTypes, MemoryImpl>::create_from(&handle).await;
+    insert_vid_shares_for_view(ViewNumber::new(node_id), &handle, vids[1].clone()).await;
+
+    let script = vec![view_timeout];
+    run_test_script(script, quorum_proposal_task_state).await;
+}
+#[cfg(feature = "dependency-tasks")]
+#[cfg(test)]
+#[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
+#[cfg_attr(async_executor_impl = "async-std", async_std::test)]
+async fn test_quorum_proposal_task_propose_now_view_sync() {
+    async_compatibility_layer::logging::setup_logging();
+    async_compatibility_layer::logging::setup_backtrace();
+
+    let node_id = 2;
+    let handle = build_system_handle(node_id).await.0;
+    let (private_key, public_key) = key_pair_for_id(node_id);
+    let quorum_membership = handle.hotshot.memberships.quorum_membership.clone();
+    let da_membership = handle.hotshot.memberships.da_membership.clone();
+
+    let payload_commitment = make_payload_commitment(&quorum_membership, ViewNumber::new(node_id));
+
+    let mut generator = TestViewGenerator::generate(quorum_membership.clone(), da_membership);
+
+    let mut proposals = Vec::new();
+    let mut leaders = Vec::new();
+    let mut vids = Vec::new();
+    for view in (&mut generator).take(1) {
+        proposals.push(view.quorum_proposal.clone());
+        leaders.push(view.leader_public_key);
+        vids.push(view.vid_proposal.clone());
+    }
+    for view in (&mut generator).take(1) {
+        proposals.push(view.quorum_proposal.clone());
+        leaders.push(view.leader_public_key);
+        vids.push(view.vid_proposal.clone());
+    }
+
+    let builder_commitment = BuilderCommitment::from_raw_digest(sha2::Sha256::new().finalize());
+
     // proposal dependency data - view sync cert
     let pdd_view_sync = ProposalDependencyData {
         commitment_and_metadata: CommitmentAndMetadata {
@@ -410,40 +546,27 @@ async fn test_quorum_proposal_task_propose_now() {
                     round: ViewNumber::new(1),
                 },
                 &quorum_membership,
-                ViewNumber::new(2),
+                ViewNumber::new(node_id),
                 &public_key,
                 &private_key,
             )),
     };
 
-    let view_qp = TestScriptStage {
-        inputs: vec![ProposeNow(ViewNumber::new(2), pdd_qp)],
-        outputs: vec![quorum_proposal_send()],
-        asserts: vec![],
-    };
-
-    let view_timeout = TestScriptStage {
-        inputs: vec![ProposeNow(ViewNumber::new(2), pdd_timeout)],
-        outputs: vec![quorum_proposal_send()],
-        asserts: vec![],
-    };
-
     let view_view_sync = TestScriptStage {
-        inputs: vec![ProposeNow(ViewNumber::new(2), pdd_view_sync)],
+        inputs: vec![ProposeNow(ViewNumber::new(node_id), pdd_view_sync)],
         outputs: vec![quorum_proposal_send()],
         asserts: vec![],
     };
 
-    for stage in vec![view_qp, view_timeout, view_view_sync] {
-        let quorum_proposal_task_state =
-            QuorumProposalTaskState::<TestTypes, MemoryImpl>::create_from(&handle).await;
+    let quorum_proposal_task_state =
+        QuorumProposalTaskState::<TestTypes, MemoryImpl>::create_from(&handle).await;
+    insert_vid_shares_for_view(ViewNumber::new(node_id), &handle, vids[1].clone()).await;
 
-        let script = vec![stage];
-        run_test_script(script, quorum_proposal_task_state).await;
-    }
+    let script = vec![view_view_sync];
+    run_test_script(script, quorum_proposal_task_state).await;
 }
 
-#[ignore]
+#[cfg(feature = "dependency-tasks")]
 #[cfg(test)]
 #[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]

--- a/crates/testing/tests/tests_1/quorum_proposal_task.rs
+++ b/crates/testing/tests/tests_1/quorum_proposal_task.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "dependency-tasks")]
+
 use hotshot::{tasks::task_state::CreateTaskState, types::SystemContextHandle};
 use hotshot_example_types::{
     block_types::TestMetadata,
@@ -58,7 +60,7 @@ async fn insert_vid_shares_for_view(
         .vid_shares
         .entry(view)
         .or_default()
-        .insert(vid.1.clone(), vid.0[0].clone());
+        .insert(vid.1, vid.0[0].clone());
 }
 
 #[cfg(feature = "dependency-tasks")]

--- a/crates/testing/tests/tests_1/quorum_proposal_task.rs
+++ b/crates/testing/tests/tests_1/quorum_proposal_task.rs
@@ -63,7 +63,6 @@ async fn insert_vid_shares_for_view(
         .insert(vid.1, vid.0[0].clone());
 }
 
-#[cfg(feature = "dependency-tasks")]
 #[cfg(test)]
 #[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
@@ -122,7 +121,6 @@ async fn test_quorum_proposal_task_quorum_proposal_view_1() {
     run_test_script(script, quorum_proposal_task_state).await;
 }
 
-#[cfg(feature = "dependency-tasks")]
 #[cfg(test)]
 #[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
@@ -213,7 +211,6 @@ async fn test_quorum_proposal_task_quorum_proposal_view_gt_1() {
     run_test_script(script, quorum_proposal_task_state).await;
 }
 
-#[cfg(feature = "dependency-tasks")]
 #[cfg(test)]
 #[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
@@ -282,7 +279,6 @@ async fn test_quorum_proposal_task_qc_timeout() {
     run_test_script(script, quorum_proposal_task_state).await;
 }
 
-#[cfg(feature = "dependency-tasks")]
 #[cfg(test)]
 #[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
@@ -356,7 +352,6 @@ async fn test_quorum_proposal_task_view_sync() {
     run_test_script(script, quorum_proposal_task_state).await;
 }
 
-#[cfg(feature = "dependency-tasks")]
 #[cfg(test)]
 #[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
@@ -419,7 +414,6 @@ async fn test_quorum_proposal_task_propose_now() {
     run_test_script(script, quorum_proposal_task_state).await;
 }
 
-#[cfg(feature = "dependency-tasks")]
 #[cfg(test)]
 #[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
@@ -492,7 +486,6 @@ async fn test_quorum_proposal_task_propose_now_timeout() {
     let script = vec![view_timeout];
     run_test_script(script, quorum_proposal_task_state).await;
 }
-#[cfg(feature = "dependency-tasks")]
 #[cfg(test)]
 #[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
@@ -568,7 +561,6 @@ async fn test_quorum_proposal_task_propose_now_view_sync() {
     run_test_script(script, quorum_proposal_task_state).await;
 }
 
-#[cfg(feature = "dependency-tasks")]
 #[cfg(test)]
 #[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]


### PR DESCRIPTION
Closes #<ISSUE_NUMBER>
<!-- See here for keywords in Github -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

### This PR: 
Fixes the QuorumProposal task tests within the branch `bf/vid-common`. These tasks now require the vid shares table to be updated, which does not happen in the existing QuorumProposal task logic, resulting in the system failing to send the proposal.

Setting this field was a trip, so I split the test into individual tests to make the state more isolated. 

### This PR does not: 
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->
This PR does not fix the race condition that may cause this to fail in the network tests. This will be done in #3052.

### Key places to review: 
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
