### PR TITLE
Add builder public key to fee info

### DIFF
--- a/crates/task-impls/src/transactions.rs
+++ b/crates/task-impls/src/transactions.rs
@@ -151,6 +151,7 @@ impl<
                             block_view,
                             BuilderFee {
                                 fee_amount: blocks_initial_info.offered_fee,
+                                fee_account: block_data.sender,
                                 fee_signature: block_header.fee_signature,
                             },
                         )),

--- a/crates/types/src/data.rs
+++ b/crates/types/src/data.rs
@@ -740,7 +740,7 @@ pub mod null_block {
         /// Arbitrary fee amount, this block doesn't actually come from a builder
         const FEE_AMOUNT: u64 = 0;
 
-        let (_, priv_key) =
+        let (pub_key, priv_key) =
             <TYPES::BuilderSignatureKey as BuilderSignatureKey>::generated_from_seed_indexed(
                 [0_u8; 32], 0,
             );
@@ -756,6 +756,7 @@ pub mod null_block {
         ) {
             Ok(sig) => Some(BuilderFee {
                 fee_amount: FEE_AMOUNT,
+                fee_account: pub_key,
                 fee_signature: sig,
             }),
             Err(_) => None,

--- a/crates/types/src/traits/block_contents.rs
+++ b/crates/types/src/traits/block_contents.rs
@@ -161,7 +161,9 @@ pub const GENESIS_VID_NUM_STORAGE_NODES: usize = 1;
 pub struct BuilderFee<TYPES: NodeType> {
     /// Proposed fee amount
     pub fee_amount: u64,
-    /// Signature over fee amount
+    /// Account authorizing the fee.
+    pub fee_account: TYPES::BuilderSignatureKey,
+    /// Signature over fee amount by `fee_account`.
     pub fee_signature: <TYPES::BuilderSignatureKey as BuilderSignatureKey>::BuilderSignature,
 }
 


### PR DESCRIPTION
### This PR: 

Adds the builder public key used to sign the block to the `BuilderFee` info. This makes validation easier in the sequencer, because instead of recovering the address from the signature (and possibly getting a garbage address if somehow the message differs from the one that was signed), we just verify the signature using the provided address.

### This PR does not: 

### Key places to review: 

All the changes are important but should be pretty straightforward.