### PR TITLE
Add versioning in the application interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3233,6 +3233,7 @@ dependencies = [
  "time 0.3.36",
  "tokio",
  "tracing",
+ "vbs",
 ]
 
 [[package]]

--- a/crates/example-types/Cargo.toml
+++ b/crates/example-types/Cargo.toml
@@ -17,6 +17,7 @@ async-compatibility-layer = { workspace = true }
 async-trait = { workspace = true }
 anyhow = { workspace = true }
 sha3 = "^0.10"
+vbs = { workspace = true }
 committable = { workspace = true }
 either = { workspace = true }
 futures = { workspace = true }

--- a/crates/example-types/src/node_types.rs
+++ b/crates/example-types/src/node_types.rs
@@ -8,7 +8,7 @@ use hotshot_types::{
     data::ViewNumber,
     message::Message,
     signature_key::{BLSPubKey, BuilderKey},
-    traits::node_implementation::{VersionedNode, NodeType},
+    traits::node_implementation::{NodeType, VersionedNode},
 };
 use serde::{Deserialize, Serialize};
 

--- a/crates/examples/infra/mod.rs
+++ b/crates/examples/infra/mod.rs
@@ -47,6 +47,7 @@ use hotshot_testing::block_builder::{
 };
 use hotshot_types::{
     consensus::ConsensusMetricsValue,
+    constants::ConsensusVersion,
     data::{Leaf, TestableLeaf},
     event::{Event, EventType},
     message::Message,
@@ -325,7 +326,7 @@ fn calculate_num_tx_per_round(
 /// Defines the behavior of a "run" of the network with a given configuration
 #[async_trait]
 pub trait RunDA<
-    TYPES: NodeType<InstanceState = TestInstanceState>,
+    TYPES: NodeType<InstanceState = TestInstanceState, Version = ConsensusVersion>,
     DANET: ConnectedNetwork<Message<TYPES>, TYPES::SignatureKey>,
     QUORUMNET: ConnectedNetwork<Message<TYPES>, TYPES::SignatureKey>,
     NODE: NodeImplementation<
@@ -598,6 +599,7 @@ impl<
             BlockPayload = TestBlockPayload,
             BlockHeader = TestBlockHeader,
             InstanceState = TestInstanceState,
+            Version = ConsensusVersion,
         >,
         NODE: NodeImplementation<
             TYPES,
@@ -684,6 +686,7 @@ impl<
             BlockPayload = TestBlockPayload,
             BlockHeader = TestBlockHeader,
             InstanceState = TestInstanceState,
+            Version = ConsensusVersion,
         >,
         NODE: NodeImplementation<
             TYPES,
@@ -782,6 +785,7 @@ impl<
             BlockPayload = TestBlockPayload,
             BlockHeader = TestBlockHeader,
             InstanceState = TestInstanceState,
+            Version = ConsensusVersion,
         >,
         NODE: NodeImplementation<
             TYPES,
@@ -868,6 +872,7 @@ pub async fn main_entry_point<
         BlockPayload = TestBlockPayload,
         BlockHeader = TestBlockHeader,
         InstanceState = TestInstanceState,
+        Version = ConsensusVersion,
     >,
     DACHANNEL: ConnectedNetwork<Message<TYPES>, TYPES::SignatureKey>,
     QUORUMCHANNEL: ConnectedNetwork<Message<TYPES>, TYPES::SignatureKey>,

--- a/crates/task-impls/src/consensus/mod.rs
+++ b/crates/task-impls/src/consensus/mod.rs
@@ -278,9 +278,8 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> ConsensusTaskState<TYPES, I>
         proposal: QuorumProposal<TYPES>,
         event_stream: Sender<Arc<HotShotEvent<TYPES>>>,
     ) {
-        use crate::consensus::helpers::publish_proposal_from_commitment_and_metadata;
-
         use self::helpers::publish_proposal_from_upgrade_cert;
+        use crate::consensus::helpers::publish_proposal_from_commitment_and_metadata;
 
         let upgrade = self.decided_upgrade_cert.clone();
         let pub_key = self.public_key.clone();

--- a/crates/task-impls/src/quorum_vote.rs
+++ b/crates/task-impls/src/quorum_vote.rs
@@ -1,9 +1,7 @@
 #[cfg(feature = "dependency-tasks")]
-use crate::consensus::helpers::update_state_and_vote_if_able;
-use crate::{
-    events::HotShotEvent,
-    helpers::{broadcast_event, cancel_task},
-};
+use std::marker::PhantomData;
+use std::{collections::HashMap, sync::Arc};
+
 use async_broadcast::{Receiver, Sender};
 use async_lock::RwLock;
 #[cfg(async_executor_impl = "async-std")]
@@ -31,12 +29,16 @@ use hotshot_types::{
     vote::{Certificate, HasViewNumber},
 };
 use jf_primitives::vid::VidScheme;
-#[cfg(feature = "dependency-tasks")]
-use std::marker::PhantomData;
-use std::{collections::HashMap, sync::Arc};
 #[cfg(async_executor_impl = "tokio")]
 use tokio::task::JoinHandle;
 use tracing::{debug, error, instrument, trace, warn};
+
+#[cfg(feature = "dependency-tasks")]
+use crate::consensus::helpers::update_state_and_vote_if_able;
+use crate::{
+    events::HotShotEvent,
+    helpers::{broadcast_event, cancel_task},
+};
 
 /// Vote dependency types.
 #[derive(Debug, PartialEq)]

--- a/crates/testing/src/spinning_task.rs
+++ b/crates/testing/src/spinning_task.rs
@@ -5,6 +5,7 @@ use hotshot::{traits::TestableNodeImplementation, types::EventType, HotShotIniti
 use hotshot_example_types::{state_types::TestInstanceState, storage_types::TestStorage};
 use hotshot_task::task::{Task, TaskState, TestTaskState};
 use hotshot_types::{
+    constants::ConsensusVersion,
     data::Leaf,
     event::Event,
     message::Message,
@@ -44,7 +45,9 @@ pub struct SpinningTask<TYPES: NodeType, I: TestableNodeImplementation<TYPES>> {
     pub(crate) high_qc: QuorumCertificate<TYPES>,
 }
 
-impl<TYPES: NodeType, I: TestableNodeImplementation<TYPES>> TaskState for SpinningTask<TYPES, I> {
+impl<TYPES: NodeType<Version = ConsensusVersion>, I: TestableNodeImplementation<TYPES>> TaskState
+    for SpinningTask<TYPES, I>
+{
     type Event = GlobalTestEvent;
 
     type Output = HotShotTaskCompleted;
@@ -62,7 +65,7 @@ impl<TYPES: NodeType, I: TestableNodeImplementation<TYPES>> TaskState for Spinni
 }
 
 impl<
-        TYPES: NodeType<InstanceState = TestInstanceState>,
+        TYPES: NodeType<InstanceState = TestInstanceState, Version = ConsensusVersion>,
         I: TestableNodeImplementation<TYPES>,
         N: ConnectedNetwork<Message<TYPES>, TYPES::SignatureKey>,
     > TestTaskState for SpinningTask<TYPES, I>

--- a/crates/testing/src/test_runner.rs
+++ b/crates/testing/src/test_runner.rs
@@ -16,7 +16,7 @@ use hotshot_example_types::{state_types::TestInstanceState, storage_types::TestS
 use hotshot_task::task::{Task, TaskRegistry, TestTask};
 use hotshot_types::{
     consensus::ConsensusMetricsValue,
-    constants::EVENT_CHANNEL_SIZE,
+    constants::{ConsensusVersion, EVENT_CHANNEL_SIZE},
     data::Leaf,
     message::Message,
     simple_certificate::QuorumCertificate,
@@ -114,7 +114,7 @@ pub trait TaskErr: std::error::Error + Sync + Send + 'static {}
 impl<T: std::error::Error + Sync + Send + 'static> TaskErr for T {}
 
 impl<
-        TYPES: NodeType<InstanceState = TestInstanceState>,
+        TYPES: NodeType<InstanceState = TestInstanceState, Version = ConsensusVersion>,
         I: TestableNodeImplementation<TYPES>,
         N: ConnectedNetwork<Message<TYPES>, TYPES::SignatureKey>,
     > TestRunner<TYPES, I, N>

--- a/crates/testing/tests/tests_3/memory_network.rs
+++ b/crates/testing/tests/tests_3/memory_network.rs
@@ -13,6 +13,7 @@ use hotshot_example_types::{
     block_types::{TestBlockHeader, TestBlockPayload, TestTransaction},
     state_types::TestValidatedState,
 };
+use hotshot_types::constants::ConsensusVersion;
 use hotshot_types::constants::STATIC_VER_0_1;
 use hotshot_types::message::Message;
 use hotshot_types::signature_key::{BLSPubKey, BuilderKey};
@@ -45,6 +46,7 @@ use tracing::trace;
 pub struct Test;
 
 impl NodeType for Test {
+    type Version = ConsensusVersion;
     type Time = ViewNumber;
     type BlockHeader = TestBlockHeader;
     type BlockPayload = TestBlockPayload;

--- a/crates/types/src/constants.rs
+++ b/crates/types/src/constants.rs
@@ -33,7 +33,16 @@ pub const VERSION_0_1: Version = Version {
 pub const BASE_VERSION: Version = VERSION_0_1;
 
 /// Type for protocol static version 0.1.
-pub type Version01 = StaticVersion<VERSION_MAJ, VERSION_MIN>;
+pub type Version01 = StaticVersion<0, 1>;
+
+/// Type for protocol static version 0.2.
+pub type Version02 = StaticVersion<0, 2>;
+
+/// Type alias for the base version used by consensus.
+pub type ConsensusVersion = Version01;
+
+/// Type alias for the staged version used by consensus.
+pub type ConsensusUpgradeVersion = Version02;
 
 /// Constant for protocol static version 0.1.
 pub const STATIC_VER_0_1: Version01 = StaticVersion {};


### PR DESCRIPTION
Closes #3212 

### This PR: 
This is motivated by a requirement for the sequencer to be able to upgrade the `BlockHeader` and `InstanceState` through a consensus protocol upgrade, to e.g. introduce fees.

To do this, we introduce a `VersionedNode` trait which will be a required bound for the initialization functions in `SystemContext`. Nodes must implement `VersionedNode<BASE_VERSION, UPGRADE_VERSION>` matching the version (at the type-level) that HotShot requires in initialization.

HotShot will propagate the correct `NodeType` implementation to the consensus tasks, and transition between them when the network is upgraded.

### This PR does not:
An alternative implementation would have been to parametrize `NodeType`, i.e.:

    pub trait NodeType<VERSION>
    where
      VERSION: StaticVersionType
    { ... }

In my mind, this is the more correct way to go about this, but the `VERSION` parameter is *extremely* invasive, requiring difficult-to-automate changes in the 600+ places we use `NodeType` in HotShot. I think the current PR provides the same level of type safety in a much smaller change, with a marginal downstream cost.

### Key places to review:
