### PR TITLE
Explicitly add feature required by hotshot-types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,6 +86,7 @@ typenum = "1"
 memoize = { version = "0.4", features = ["full"] }
 vbs = "0.1"
 clap = { version = "4", features = ["derive", "env"] }
+url = { version = "2.5.0", features = ["serde"] }
 
 libp2p = { package = "libp2p", version = "0.53", features = [
   "macros",

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -52,7 +52,7 @@ tagged-base64 = { workspace = true }
 vbs = { workspace = true }
 displaydoc = { version = "0.2.3", default-features = false }
 dyn-clone = { git = "https://github.com/dtolnay/dyn-clone", tag = "1.0.17" }
-url = "2.5.0"
+url = { workspace = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }


### PR DESCRIPTION
No linked issue.

### This PR: 
`hotshot-types` requires the `serde` feature on `url`, but this is not explicitly enabled in the crate's `Cargo.toml`. Currently, `just cargo check -p hotshot-types` fails.

This PR moves `url` to the workspace `Cargo.toml`, and enables the `serde` feature explicitly.

### This PR does not: 

### Key places to review: 
