### PR TITLE
Sanitize Consensus State Variables and Updates

### DIFF
--- a/crates/task-impls/src/consensus/mod.rs
+++ b/crates/task-impls/src/consensus/mod.rs
@@ -499,7 +499,9 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> ConsensusTaskState<TYPES, I>
                     }
 
                     let mut consensus = self.consensus.write().await;
-                    consensus.update_high_qc_if_new(qc.clone());
+                    if let Err(e) = consensus.update_high_qc(qc.clone()) {
+                        tracing::trace!("{e:?}");
+                    }
 
                     drop(consensus);
                     debug!(
@@ -536,8 +538,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> ConsensusTaskState<TYPES, I>
                 self.consensus
                     .write()
                     .await
-                    .saved_da_certs
-                    .insert(view, cert.clone());
+                    .update_saved_da_certs(view, cert.clone());
                 let Some(proposal) = self.current_proposal.clone() else {
                     return;
                 };
@@ -574,10 +575,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> ConsensusTaskState<TYPES, I>
                 self.consensus
                     .write()
                     .await
-                    .vid_shares
-                    .entry(view)
-                    .or_default()
-                    .insert(disperse.data.recipient_key.clone(), disperse.clone());
+                    .update_vid_shares(view, disperse.clone());
                 if disperse.data.recipient_key != self.public_key {
                     return;
                 }

--- a/crates/task-impls/src/consensus/view_change.rs
+++ b/crates/task-impls/src/consensus/view_change.rs
@@ -99,7 +99,9 @@ pub(crate) async fn update_view<TYPES: NodeType>(
         );
     }
     let mut consensus = RwLockUpgradableReadGuard::upgrade(consensus).await;
-    consensus.update_view_if_new(new_view);
+    if let Err(e) = consensus.update_view(new_view) {
+        tracing::trace!("{e:?}");
+    }
     tracing::trace!("View updated successfully");
 
     Ok(())

--- a/crates/task-impls/src/da.rs
+++ b/crates/task-impls/src/da.rs
@@ -199,9 +199,14 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                 // Ensure this view is in the view map for garbage collection, but do not overwrite if
                 // there is already a view there: the replica task may have inserted a `Leaf` view which
                 // contains strictly more information.
-                consensus.validated_state_map.entry(view).or_insert(View {
-                    view_inner: ViewInner::DA { payload_commitment },
-                });
+                if !consensus.validated_state_map().contains_key(&view) {
+                    consensus.update_validated_state_map(
+                        view,
+                        View {
+                            view_inner: ViewInner::DA { payload_commitment },
+                        },
+                    );
+                }
 
                 // Record the payload we have promised to make available.
                 consensus

--- a/crates/task-impls/src/quorum_proposal.rs
+++ b/crates/task-impls/src/quorum_proposal.rs
@@ -535,7 +535,9 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> QuorumProposalTaskState<TYPE
                         }
 
                         let mut consensus = self.consensus.write().await;
-                        consensus.update_high_qc_if_new(qc.clone());
+                        if let Err(e) = consensus.update_high_qc(qc.clone()) {
+                            tracing::trace!("{e:?}");
+                        }
 
                         // We need to drop our handle here to make the borrow checker happy.
                         drop(consensus);

--- a/crates/task-impls/src/quorum_proposal_recv.rs
+++ b/crates/task-impls/src/quorum_proposal_recv.rs
@@ -138,7 +138,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> QuorumProposalRecvTaskState<
                     let view = current_proposal.get_view_number();
                     self.cancel_tasks(proposal.data.get_view_number()).await;
                     let consensus = self.consensus.read().await;
-                    let Some(vid_shares) = consensus.vid_shares.get(&view) else {
+                    let Some(vid_shares) = consensus.vid_shares().get(&view) else {
                         debug!(
                                 "We have not seen the VID share for this view {:?} yet, so we cannot vote.",
                                 view
@@ -150,7 +150,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> QuorumProposalRecvTaskState<
                         return;
                     };
                     let Some(da_cert) = consensus
-                        .saved_da_certs
+                        .saved_da_certs()
                         .get(&current_proposal.get_view_number())
                     else {
                         debug!(

--- a/crates/task-impls/src/quorum_vote.rs
+++ b/crates/task-impls/src/quorum_vote.rs
@@ -432,8 +432,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> QuorumVoteTaskState<TYPES, I
                 self.consensus
                     .write()
                     .await
-                    .saved_da_certs
-                    .insert(view, cert.clone());
+                    .update_saved_da_certs(view, cert.clone());
 
                 broadcast_event(
                     Arc::new(HotShotEvent::DACertificateValidated(cert.clone())),
@@ -489,10 +488,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> QuorumVoteTaskState<TYPES, I
                 self.consensus
                     .write()
                     .await
-                    .vid_shares
-                    .entry(view)
-                    .or_default()
-                    .insert(disperse.data.recipient_key.clone(), disperse.clone());
+                    .update_vid_shares(view, disperse.clone());
 
                 if disperse.data.recipient_key != self.public_key {
                     debug!("Got a Valid VID share but it's not for our key");

--- a/crates/task-impls/src/request.rs
+++ b/crates/task-impls/src/request.rs
@@ -134,7 +134,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, Ver: StaticVersionType + 'st
     /// Creates the srequest structures for all types that are needed.
     async fn build_requests(&self, view: TYPES::Time, _: Ver) -> Vec<RequestKind<TYPES>> {
         let mut reqs = Vec::new();
-        if !self.state.read().await.vid_shares.contains_key(&view) {
+        if !self.state.read().await.vid_shares().contains_key(&view) {
             reqs.push(RequestKind::VID(view, self.public_key.clone()));
         }
         // TODO request other things
@@ -266,7 +266,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> DelayedRequester<TYPES, I> {
     async fn cancel_vid(&self, req: &VidRequest<TYPES>) -> bool {
         let view = req.0;
         let state = self.state.read().await;
-        state.vid_shares.contains_key(&view) && state.cur_view() > view
+        state.vid_shares().contains_key(&view) && state.cur_view() > view
     }
 
     /// Transform a response into a `HotShotEvent`

--- a/crates/task-impls/src/transactions.rs
+++ b/crates/task-impls/src/transactions.rs
@@ -224,13 +224,13 @@ impl<
         while prev_view != TYPES::Time::genesis() {
             if let Some(commitment) =
                 consensus
-                    .validated_state_map
+                    .validated_state_map()
                     .get(&prev_view)
                     .and_then(|view| match view.view_inner {
                         // For a view for which we have a Leaf stored
                         ViewInner::DA { payload_commitment } => Some(payload_commitment),
                         ViewInner::Leaf { leaf, .. } => consensus
-                            .saved_leaves
+                            .saved_leaves()
                             .get(&leaf)
                             .map(Leaf::get_payload_commitment),
                         ViewInner::Failed => None,

--- a/crates/task-impls/src/vid.rs
+++ b/crates/task-impls/src/vid.rs
@@ -75,14 +75,8 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                 let shares = VidDisperseShare::from_vid_disperse(vid_disperse.clone());
                 let mut consensus = self.consensus.write().await;
                 for share in shares {
-                    let s = share.clone();
-                    let key: <TYPES as NodeType>::SignatureKey = s.recipient_key;
-                    if let Some(prop) = share.to_proposal(&self.private_key) {
-                        consensus
-                            .vid_shares
-                            .entry(*view_number)
-                            .or_default()
-                            .insert(key, prop);
+                    if let Some(disperse) = share.to_proposal(&self.private_key) {
+                        consensus.update_vid_shares(*view_number, disperse);
                     }
                 }
 

--- a/crates/testing/tests/tests_1/quorum_proposal_task.rs
+++ b/crates/testing/tests/tests_1/quorum_proposal_task.rs
@@ -56,11 +56,7 @@ async fn insert_vid_shares_for_view(
 
     // `create_and_send_proposal` depends on the `vid_shares` obtaining a vid dispersal.
     // to avoid needing to spin up the vote task, we can just insert it in here.
-    consensus
-        .vid_shares
-        .entry(view)
-        .or_default()
-        .insert(vid.1, vid.0[0].clone());
+    consensus.update_vid_shares(view, vid.0[0].clone());
 }
 
 #[cfg(test)]
@@ -164,7 +160,7 @@ async fn test_quorum_proposal_task_quorum_proposal_view_gt_1() {
 
     // First, insert a parent view whose leaf commitment will be returned in the lower function
     // call.
-    consensus.validated_state_map.insert(
+    consensus.update_validated_state_map(
         ViewNumber::new(2),
         View {
             view_inner: ViewInner::Leaf {
@@ -177,9 +173,7 @@ async fn test_quorum_proposal_task_quorum_proposal_view_gt_1() {
 
     // Match an entry into the saved leaves for the parent commitment, returning the generated leaf
     // for this call.
-    consensus
-        .saved_leaves
-        .insert(leaves[1].get_parent_commitment(), leaves[1].clone());
+    consensus.update_saved_leaves(leaves[1].clone());
 
     // Release the write lock before proceeding with the test
     drop(consensus);

--- a/crates/types/src/consensus.rs
+++ b/crates/types/src/consensus.rs
@@ -327,6 +327,8 @@ impl<TYPES: NodeType> Consensus<TYPES> {
     }
 
     /// Update the current view.
+    /// # Errors
+    /// Can return an error when the new view_number is not higher than the existing view number.
     pub fn update_view(&mut self, view_number: TYPES::Time) -> Result<()> {
         ensure!(view_number > self.cur_view);
         self.cur_view = view_number;
@@ -344,6 +346,8 @@ impl<TYPES: NodeType> Consensus<TYPES> {
     }
 
     /// Update the high QC if given a newer one.
+    /// # Errors
+    /// Can return an error when the provided high_qc is not newer than the existing entry.
     pub fn update_high_qc(&mut self, high_qc: QuorumCertificate<TYPES>) -> Result<()> {
         ensure!(high_qc.view_number > self.high_qc.view_number);
         debug!("Updating high QC");

--- a/crates/types/src/consensus.rs
+++ b/crates/types/src/consensus.rs
@@ -5,7 +5,8 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use committable::Commitment;
+use anyhow::{ensure, Result};
+use committable::{Commitment, Committable};
 use displaydoc::Display;
 use tracing::{debug, error};
 
@@ -43,14 +44,14 @@ pub type VidShares<TYPES> = BTreeMap<
 #[derive(custom_debug::Debug)]
 pub struct Consensus<TYPES: NodeType> {
     /// The validated states that are currently loaded in memory.
-    pub validated_state_map: BTreeMap<TYPES::Time, View<TYPES>>,
+    validated_state_map: BTreeMap<TYPES::Time, View<TYPES>>,
 
     /// All the VID shares we've received for current and future views.
-    pub vid_shares: VidShares<TYPES>,
+    vid_shares: VidShares<TYPES>,
 
     /// All the DA certs we've received for current and future views.
     /// view -> DA cert
-    pub saved_da_certs: HashMap<TYPES::Time, DACertificate<TYPES>>,
+    saved_da_certs: HashMap<TYPES::Time, DACertificate<TYPES>>,
 
     /// View number that is currently on.
     cur_view: TYPES::Time,
@@ -64,7 +65,7 @@ pub struct Consensus<TYPES: NodeType> {
     /// Map of leaf hash -> leaf
     /// - contains undecided leaves
     /// - includes the MOST RECENT decided leaf
-    pub saved_leaves: CommitmentMap<Leaf<TYPES>>,
+    saved_leaves: CommitmentMap<Leaf<TYPES>>,
 
     /// Saved payloads.
     ///
@@ -300,24 +301,72 @@ impl<TYPES: NodeType> Consensus<TYPES> {
         self.cur_view
     }
 
-    /// Update the current view.
-    pub fn update_view_if_new(&mut self, view_number: TYPES::Time) {
-        if view_number > self.cur_view {
-            self.cur_view = view_number;
-        }
-    }
-
     /// Get the high QC.
     pub fn high_qc(&self) -> &QuorumCertificate<TYPES> {
         &self.high_qc
     }
 
+    /// Get the validated state map.
+    pub fn validated_state_map(&self) -> &BTreeMap<TYPES::Time, View<TYPES>> {
+        &self.validated_state_map
+    }
+
+    /// Get the saved leaves.
+    pub fn saved_leaves(&self) -> &CommitmentMap<Leaf<TYPES>> {
+        &self.saved_leaves
+    }
+
+    /// Get the vid shares.
+    pub fn vid_shares(&self) -> &VidShares<TYPES> {
+        &self.vid_shares
+    }
+
+    /// Get the saved DA certs.
+    pub fn saved_da_certs(&self) -> &HashMap<TYPES::Time, DACertificate<TYPES>> {
+        &self.saved_da_certs
+    }
+
+    /// Update the current view.
+    pub fn update_view(&mut self, view_number: TYPES::Time) -> Result<()> {
+        ensure!(view_number > self.cur_view);
+        self.cur_view = view_number;
+        Ok(())
+    }
+
+    /// Update the validated state map with a new view_number/view combo.
+    pub fn update_validated_state_map(&mut self, view_number: TYPES::Time, view: View<TYPES>) {
+        self.validated_state_map.insert(view_number, view);
+    }
+
+    /// Update the saved leaves with a new leaf.
+    pub fn update_saved_leaves(&mut self, leaf: Leaf<TYPES>) {
+        self.saved_leaves.insert(leaf.commit(), leaf);
+    }
+
     /// Update the high QC if given a newer one.
-    pub fn update_high_qc_if_new(&mut self, high_qc: QuorumCertificate<TYPES>) {
-        if high_qc.view_number > self.high_qc.view_number {
-            debug!("Updating high QC");
-            self.high_qc = high_qc;
-        }
+    pub fn update_high_qc(&mut self, high_qc: QuorumCertificate<TYPES>) -> Result<()> {
+        ensure!(high_qc.view_number > self.high_qc.view_number);
+        debug!("Updating high QC");
+        self.high_qc = high_qc;
+
+        Ok(())
+    }
+
+    /// Add a new entry to the vid_shares map.
+    pub fn update_vid_shares(
+        &mut self,
+        view_number: TYPES::Time,
+        disperse: Proposal<TYPES, VidDisperseShare<TYPES>>,
+    ) {
+        self.vid_shares
+            .entry(view_number)
+            .or_default()
+            .insert(disperse.data.recipient_key.clone(), disperse);
+    }
+
+    /// Add a new entry to the da_certs map.
+    pub fn update_saved_da_certs(&mut self, view_number: TYPES::Time, cert: DACertificate<TYPES>) {
+        self.saved_da_certs.insert(view_number, cert);
     }
 
     /// gather information from the parent chain of leaves


### PR DESCRIPTION
Closes #<ISSUE_NUMBER>
<!-- See here for keywords in Github -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

### This PR: 
The dependency tasks and, to a lesser extent, the current consensus functionality suffer from severe race conditions when updating state. This PR is the first in a multi-part effort to address this problem by sanitizing state updates behind methods.

To characterize the issue, consider the flow for the proposal task. Upon receiving a `QuorumProposalValidated` event, the system may be in a state in which it can propose. However, sometimes the event can arrive before the leaves are updated, leading to a race condition, causing the proposal to fail even when all the requisite information *would* have been there.

This changeset does *not* solve such an issue, but it begins making problems like this easier to track down.

### This PR does not: 
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->

### Key places to review: 
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
