### PR TITLE
Update the CDN (again)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1340,7 +1340,7 @@ checksum = "d32a725bc159af97c3e629873bb9f88fb8cf8a4867175f76dc987815ea07c83b"
 [[package]]
 name = "cdn-broker"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/Push-CDN?tag=0.3.2#c41604361b634830b5ba874e06b997993055c25c"
+source = "git+https://github.com/EspressoSystems/Push-CDN?tag=0.3.5#6a2578e15c80558753d647d7d32407a0df0e4235"
 dependencies = [
  "async-std",
  "cdn-proto",
@@ -1364,7 +1364,7 @@ dependencies = [
 [[package]]
 name = "cdn-client"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/Push-CDN?tag=0.3.2#c41604361b634830b5ba874e06b997993055c25c"
+source = "git+https://github.com/EspressoSystems/Push-CDN?tag=0.3.5#6a2578e15c80558753d647d7d32407a0df0e4235"
 dependencies = [
  "async-std",
  "cdn-proto",
@@ -1379,7 +1379,7 @@ dependencies = [
 [[package]]
 name = "cdn-marshal"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/Push-CDN?tag=0.3.2#c41604361b634830b5ba874e06b997993055c25c"
+source = "git+https://github.com/EspressoSystems/Push-CDN?tag=0.3.5#6a2578e15c80558753d647d7d32407a0df0e4235"
 dependencies = [
  "async-std",
  "cdn-proto",
@@ -1393,7 +1393,7 @@ dependencies = [
 [[package]]
 name = "cdn-proto"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/Push-CDN?tag=0.3.2#c41604361b634830b5ba874e06b997993055c25c"
+source = "git+https://github.com/EspressoSystems/Push-CDN?tag=0.3.5#6a2578e15c80558753d647d7d32407a0df0e4235"
 dependencies = [
  "anyhow",
  "ark-serialize",
@@ -1405,7 +1405,7 @@ dependencies = [
  "kanal",
  "lazy_static",
  "mnemonic",
- "mockall",
+ "num_enum",
  "pem",
  "prometheus",
  "quinn",
@@ -2282,12 +2282,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
-name = "downcast"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
-
-[[package]]
 name = "downcast-rs"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2609,12 +2603,6 @@ checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
-
-[[package]]
-name = "fragile"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
 name = "funty"
@@ -3175,6 +3163,7 @@ dependencies = [
  "libp2p-identity",
  "libp2p-networking",
  "lru 0.12.3",
+ "num_enum",
  "portpicker",
  "rand 0.8.5",
  "serde",
@@ -5215,33 +5204,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2b8f3a258db515d5e91a904ce4ae3f73e091149b90cadbdb93d210bee07f63b"
 
 [[package]]
-name = "mockall"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43766c2b5203b10de348ffe19f7e54564b64f3d6018ff7648d1e2d6d3a0f0a48"
-dependencies = [
- "cfg-if",
- "downcast",
- "fragile",
- "lazy_static",
- "mockall_derive",
- "predicates",
- "predicates-tree",
-]
-
-[[package]]
-name = "mockall_derive"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af7cbce79ec385a1d4f54baa90a76401eb15d9cab93685f62e7e9f942aa00ae2"
-dependencies = [
- "cfg-if",
- "proc-macro2",
- "quote",
- "syn 2.0.61",
-]
-
-[[package]]
 name = "multiaddr"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5535,6 +5497,27 @@ checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
  "hermit-abi",
  "libc",
+]
+
+[[package]]
+name = "num_enum"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02339744ee7253741199f897151b38e72257d13802d4ee837285cc2990a90845"
+dependencies = [
+ "num_enum_derive",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "681030a937600a36906c185595136d26abfebb4aa9c65701cefcaf8578bb982b"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -5949,32 +5932,6 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
-
-[[package]]
-name = "predicates"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b87bfd4605926cdfefc1c3b5f8fe560e3feca9d5552cf68c466d3d8236c7e8"
-dependencies = [
- "anstyle",
- "predicates-core",
-]
-
-[[package]]
-name = "predicates-core"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b794032607612e7abeb4db69adb4e33590fa6cf1149e95fd7cb00e634b92f174"
-
-[[package]]
-name = "predicates-tree"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368ba315fb8c5052ab692e68a0eefec6ec57b23a36959c14496f0b0df2c0cecf"
-dependencies = [
- "predicates-core",
- "termtree",
-]
 
 [[package]]
 name = "prettyplease"
@@ -7920,12 +7877,6 @@ dependencies = [
  "rustix 0.38.33",
  "windows-sys 0.52.0",
 ]
-
-[[package]]
-name = "termtree"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "thiserror"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,10 +131,10 @@ anyhow = "1"
 
 
 # Push CDN imports
-cdn-client = { git = "https://github.com/EspressoSystems/Push-CDN", tag = "0.3.2" }
-cdn-broker = { git = "https://github.com/EspressoSystems/Push-CDN", tag = "0.3.2" }
-cdn-marshal = { git = "https://github.com/EspressoSystems/Push-CDN", tag = "0.3.2" }
-cdn-proto = { git = "https://github.com/EspressoSystems/Push-CDN", tag = "0.3.2" }
+cdn-client = { git = "https://github.com/EspressoSystems/Push-CDN", tag = "0.3.5" }
+cdn-broker = { git = "https://github.com/EspressoSystems/Push-CDN", tag = "0.3.5" }
+cdn-marshal = { git = "https://github.com/EspressoSystems/Push-CDN", tag = "0.3.5" }
+cdn-proto = { git = "https://github.com/EspressoSystems/Push-CDN", tag = "0.3.5" }
 
 ### Profiles
 ###

--- a/crates/hotshot/Cargo.toml
+++ b/crates/hotshot/Cargo.toml
@@ -57,6 +57,7 @@ jf-primitives.workspace = true
 hotshot-orchestrator = { path = "../orchestrator" }
 blake3.workspace = true
 sha2 = { workspace = true }
+num_enum = "0.7"
 
 [target.'cfg(all(async_executor_impl = "tokio"))'.dependencies]
 tokio = { workspace = true }


### PR DESCRIPTION
No linked issue.

This CDN update lets us specify which topics are valid at the application level. A subscription to an invalid topic will have their connection closed.