### PR TITLE
Change `BuilderSignatureKey` bound to `DeserializeOwned`

### DIFF
--- a/crates/types/src/traits/signature_key.rs
+++ b/crates/types/src/traits/signature_key.rs
@@ -7,7 +7,7 @@ use std::{
 use bitvec::prelude::*;
 use ethereum_types::U256;
 use jf_primitives::{errors::PrimitivesError, vid::VidScheme};
-use serde::{Deserialize, Serialize};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use tagged_base64::TaggedBase64;
 
 use super::EncodeBytes;
@@ -154,7 +154,7 @@ pub trait BuilderSignatureKey:
     + Debug
     + Hash
     + Serialize
-    + for<'a> Deserialize<'a>
+    + DeserializeOwned
     + PartialEq
     + Eq
     + PartialOrd


### PR DESCRIPTION
Fixes obscure compilation error.
<!-- See here for keywords in Github -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

### This PR: 
<!-- Describe what this PR adds to HotSHot -->
This fixes compilation error observed in CI `udeps` job here: https://github.com/EspressoSystems/espresso-sequencer/actions/runs/9007591962/job/24747711973
<!-- E.g. -->
<!-- * Implements feature 1 -->
<!-- * Implements feature 2 -->

### This PR does not: 
Should not change behavior in any way.
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->

### Key places to review: 
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->

### How to test this PR: 
Without this change you should encounter a compilation error when running: 
```
just cargo clippy --all-targets
```
With this change you should not encounter the above compilation error.
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
