### PR TITLE
Maybe fix CDN tests

### DIFF
--- a/crates/task-impls/src/consensus/mod.rs
+++ b/crates/task-impls/src/consensus/mod.rs
@@ -249,6 +249,9 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> ConsensusTaskState<TYPES, I>
         let Some(proposal) = self.current_proposal.clone() else {
             return;
         };
+        if proposal.get_view_number() != view {
+            return;
+        }
         let upgrade = self.decided_upgrade_cert.clone();
         let pub_key = self.public_key.clone();
         let priv_key = self.private_key.clone();

--- a/crates/task-impls/src/consensus/mod.rs
+++ b/crates/task-impls/src/consensus/mod.rs
@@ -498,6 +498,12 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> ConsensusTaskState<TYPES, I>
                 if disperse.data.recipient_key != self.public_key {
                     return;
                 }
+                let Some(proposal) = self.current_proposal.clone() else {
+                    return;
+                };
+                if proposal.get_view_number() != view {
+                    return;
+                }
                 self.spawn_vote_task(view, event_stream.clone());
             }
             HotShotEvent::ViewChange(new_view) => {

--- a/crates/testing/tests/tests_5/combined_network.rs
+++ b/crates/testing/tests/tests_5/combined_network.rs
@@ -172,7 +172,7 @@ async fn test_combined_network_half_dc() {
         // allow more time to pass in CI
         completion_task_description: CompletionTaskDescription::TimeBasedCompletionTaskBuilder(
             TimeBasedCompletionTaskDescription {
-                duration: Duration::from_secs(120),
+                duration: Duration::from_secs(220),
             },
         ),
         ..TestDescription::default_multiple_rounds()


### PR DESCRIPTION
Closes #<ISSUE_NUMBER>

Should fix the bad state causing unwrap to panic, and IconsistentBlocks error from popping up. 

### This PR: 

This PR checks that we actually have a proposal for the same view before trying to vote after we get our VID share.  Without this check if we got a VID share for one before or any view after the current proposal we have then we might store the state from the current proposal in our maps for the view of the VID share.  In other words there is a condition where we store state for the wrong view when the VID share view doesn't match the current proposals view.

### This PR does not: 
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->

### Key places to review: 
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
