### PR TITLE
Fix failure to attach view change evidence to proposal

### DIFF
--- a/crates/task-impls/src/consensus/mod.rs
+++ b/crates/task-impls/src/consensus/mod.rs
@@ -637,6 +637,11 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> ConsensusTaskState<TYPES, I>
                 }
 
                 if let Some(cert) = &self.proposal_cert {
+                    if !cert.is_valid_for_view(&view) {
+                        self.proposal_cert = None;
+                        info!("Failed to propose off SendPayloadCommitmentAndMetadata because we had view change evidence, but it was not current.");
+                        return;
+                    }
                     match cert {
                         ViewChangeEvidence::Timeout(tc) => {
                             if self.quorum_membership.get_leader(tc.get_view_number() + 1)


### PR DESCRIPTION
No linked issue.

### This PR: 
Fixes an issue where we were attempting to propose before forming a required timeout certificate under some conditions.

The root cause of this seems to be that we do not clear the stored timeout/viewsync certificate on ViewChange, only on QuorumProposalSend (which may not happen under if we cannot form a QC, for example). Hence, we need to ensure that we do not attempt to propose unless we have a *recent* certificate.

### This PR does not: 
The goal is to quickly fix the issue. This is definitely not the best solution, but I wanted to make a minimal fix that we can be reasonably certain does not introduce any more issues.

### Key places to review: 
