### PR TITLE
[Consensus2] - Init new consensus module

### DIFF
--- a/crates/example-types/src/state_types.rs
+++ b/crates/example-types/src/state_types.rs
@@ -24,7 +24,7 @@ pub struct TestInstanceState {}
 impl InstanceState for TestInstanceState {}
 
 /// Application-specific state delta implementation for testing purposes.
-#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct TestStateDelta {}
 
 impl StateDelta for TestStateDelta {}

--- a/crates/hotshot/src/lib.rs
+++ b/crates/hotshot/src/lib.rs
@@ -58,11 +58,18 @@ use tracing::{debug, instrument, trace};
 use vbs::version::Version;
 
 #[cfg(feature = "dependency-tasks")]
-use crate::tasks::{add_quorum_proposal_recv_task, add_quorum_proposal_task, add_quorum_vote_task};
+use crate::tasks::{
+    add_consensus2_task, add_quorum_proposal_recv_task, add_quorum_proposal_task,
+    add_quorum_vote_task,
+};
+
+#[cfg(not(feature = "dependency-tasks"))]
+use crate::tasks::add_consensus_task;
+
 use crate::{
     tasks::{
-        add_consensus_task, add_da_task, add_network_event_task, add_network_message_task,
-        add_transaction_task, add_upgrade_task, add_view_sync_task,
+        add_da_task, add_network_event_task, add_network_message_task, add_transaction_task,
+        add_upgrade_task, add_view_sync_task,
     },
     traits::NodeImplementation,
     types::{Event, SystemContextHandle},
@@ -635,6 +642,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> SystemContext<TYPES, I> {
             Arc::clone(&handle.get_storage()),
         )
         .await;
+        #[cfg(not(feature = "dependency-tasks"))]
         add_consensus_task(
             Arc::clone(&registry),
             event_tx.clone(),
@@ -695,6 +703,14 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> SystemContext<TYPES, I> {
         .await;
         #[cfg(feature = "dependency-tasks")]
         add_quorum_proposal_recv_task(
+            Arc::clone(&registry),
+            event_tx.clone(),
+            event_rx.activate_cloned(),
+            &handle,
+        )
+        .await;
+        #[cfg(feature = "dependency-tasks")]
+        add_consensus2_task(
             Arc::clone(&registry),
             event_tx.clone(),
             event_rx.activate_cloned(),

--- a/crates/hotshot/src/tasks/mod.rs
+++ b/crates/hotshot/src/tasks/mod.rs
@@ -11,6 +11,7 @@ use async_lock::RwLock;
 use hotshot_task::task::{Task, TaskRegistry};
 use hotshot_task_impls::{
     consensus::ConsensusTaskState,
+    consensus2::Consensus2TaskState,
     da::DATaskState,
     events::HotShotEvent,
     network::{NetworkEventTaskState, NetworkMessageTaskState},
@@ -255,5 +256,17 @@ pub async fn add_quorum_proposal_recv_task<TYPES: NodeType, I: NodeImplementatio
         Arc::clone(&task_reg),
         quorum_proposal_recv_task_state,
     );
+    task_reg.run_task(task).await;
+}
+
+/// Add the Consensus2 task.
+pub async fn add_consensus2_task<TYPES: NodeType, I: NodeImplementation<TYPES>>(
+    task_reg: Arc<TaskRegistry>,
+    tx: Sender<Arc<HotShotEvent<TYPES>>>,
+    rx: Receiver<Arc<HotShotEvent<TYPES>>>,
+    handle: &SystemContextHandle<TYPES, I>,
+) {
+    let consensus2_task_state = Consensus2TaskState::create_from(handle).await;
+    let task = Task::new(tx, rx, Arc::clone(&task_reg), consensus2_task_state);
     task_reg.run_task(task).await;
 }

--- a/crates/hotshot/src/tasks/mod.rs
+++ b/crates/hotshot/src/tasks/mod.rs
@@ -12,7 +12,7 @@ use hotshot_task::task::{Task, TaskRegistry};
 use hotshot_task_impls::{
     consensus::ConsensusTaskState,
     consensus2::Consensus2TaskState,
-    da::DATaskState,
+    da::DaTaskState,
     events::HotShotEvent,
     network::{NetworkEventTaskState, NetworkMessageTaskState},
     quorum_proposal::QuorumProposalTaskState,

--- a/crates/hotshot/src/tasks/task_state.rs
+++ b/crates/hotshot/src/tasks/task_state.rs
@@ -7,7 +7,7 @@ use std::{
 use async_trait::async_trait;
 use hotshot_task_impls::{
     builder::BuilderClient, consensus::ConsensusTaskState, consensus2::Consensus2TaskState,
-    da::DATaskState, quorum_proposal::QuorumProposalTaskState,
+    da::DaTaskState, quorum_proposal::QuorumProposalTaskState,
     quorum_proposal_recv::QuorumProposalRecvTaskState, quorum_vote::QuorumVoteTaskState,
     request::NetworkRequestState, transactions::TransactionTaskState, upgrade::UpgradeTaskState,
     vid::VIDTaskState, view_sync::ViewSyncTaskState,
@@ -311,7 +311,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> CreateTaskState<TYPES, I>
             private_key: handle.private_key().clone(),
             instance_state: handle.hotshot.get_instance_state(),
             quorum_network: Arc::clone(&handle.hotshot.networks.quorum_network),
-            committee_network: Arc::clone(&handle.hotshot.networks.da_network),
+            da_network: Arc::clone(&handle.hotshot.networks.da_network),
             timeout_membership: handle.hotshot.memberships.quorum_membership.clone().into(),
             quorum_membership: handle.hotshot.memberships.quorum_membership.clone().into(),
             committee_membership: handle.hotshot.memberships.da_membership.clone().into(),

--- a/crates/hotshot/src/tasks/task_state.rs
+++ b/crates/hotshot/src/tasks/task_state.rs
@@ -306,11 +306,11 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> CreateTaskState<TYPES, I>
     for Consensus2TaskState<TYPES, I>
 {
     async fn create_from(handle: &SystemContextHandle<TYPES, I>) -> Consensus2TaskState<TYPES, I> {
-        let consensus = handle.hotshot.get_consensus();
+        let consensus = handle.hotshot.consensus();
         Consensus2TaskState {
             public_key: handle.public_key().clone(),
             private_key: handle.private_key().clone(),
-            instance_state: handle.hotshot.get_instance_state(),
+            instance_state: handle.hotshot.instance_state(),
             quorum_network: Arc::clone(&handle.hotshot.networks.quorum_network),
             da_network: Arc::clone(&handle.hotshot.networks.da_network),
             timeout_membership: handle.hotshot.memberships.quorum_membership.clone().into(),
@@ -319,12 +319,12 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> CreateTaskState<TYPES, I>
             vote_collector: None.into(),
             timeout_vote_collector: None.into(),
             storage: Arc::clone(&handle.storage),
-            cur_view: handle.get_cur_view().await,
+            cur_view: handle.cur_view().await,
             output_event_stream: handle.hotshot.external_event_stream.0.clone(),
             timeout_task: None,
             timeout: handle.hotshot.config.next_view_timeout,
             consensus,
-            last_decided_view: handle.get_cur_view().await,
+            last_decided_view: handle.cur_view().await,
             id: handle.hotshot.id,
         }
     }

--- a/crates/task-impls/src/consensus2/handlers.rs
+++ b/crates/task-impls/src/consensus2/handlers.rs
@@ -1,0 +1,253 @@
+use std::{sync::Arc, time::Duration};
+
+use anyhow::{ensure, Context, Result};
+use async_broadcast::Sender;
+use async_compatibility_layer::art::{async_sleep, async_spawn};
+use hotshot_types::{
+    event::{Event, EventType},
+    simple_certificate::{QuorumCertificate, TimeoutCertificate},
+    simple_vote::{QuorumVote, TimeoutData, TimeoutVote},
+    traits::{
+        election::Membership,
+        node_implementation::{ConsensusTime, NodeImplementation, NodeType},
+    },
+    vote::HasViewNumber,
+};
+use tracing::debug;
+
+use crate::{
+    events::{HotShotEvent, HotShotTaskCompleted},
+    helpers::{broadcast_event, cancel_task},
+    vote_collection::{create_vote_accumulator, AccumulatorInfo, HandleVoteEvent},
+};
+
+use super::Consensus2TaskState;
+
+/// Handle a `QuorumVoteRecv` event.
+pub(crate) async fn handle_quorum_vote_recv<TYPES: NodeType, I: NodeImplementation<TYPES>>(
+    vote: &QuorumVote<TYPES>,
+    event: Arc<HotShotEvent<TYPES>>,
+    sender: &Sender<Arc<HotShotEvent<TYPES>>>,
+    task_state: &mut Consensus2TaskState<TYPES, I>,
+) -> Result<()> {
+    // Are we the leader for this view?
+    ensure!(
+        task_state
+            .quorum_membership
+            .get_leader(vote.get_view_number() + 1)
+            == task_state.public_key,
+        format!(
+            "We are not the leader for view {:?}",
+            vote.get_view_number()
+        )
+    );
+
+    let mut collector = task_state.vote_collector.write().await;
+
+    if collector.is_none() || vote.get_view_number() > collector.as_ref().unwrap().view {
+        let info = AccumulatorInfo {
+            public_key: task_state.public_key.clone(),
+            membership: Arc::clone(&task_state.quorum_membership),
+            view: vote.get_view_number(),
+            id: task_state.id,
+        };
+        *collector = create_vote_accumulator::<TYPES, QuorumVote<TYPES>, QuorumCertificate<TYPES>>(
+            &info,
+            vote.clone(),
+            event,
+            sender,
+        )
+        .await;
+    } else {
+        let result = collector
+            .as_mut()
+            .unwrap()
+            .handle_event(Arc::clone(&event), sender)
+            .await;
+
+        if result == Some(HotShotTaskCompleted) {
+            *collector = None;
+        }
+    }
+    Ok(())
+}
+
+/// Handle a `TimeoutVoteRecv` event.
+pub(crate) async fn handle_timeout_vote_recv<TYPES: NodeType, I: NodeImplementation<TYPES>>(
+    vote: &TimeoutVote<TYPES>,
+    event: Arc<HotShotEvent<TYPES>>,
+    sender: &Sender<Arc<HotShotEvent<TYPES>>>,
+    task_state: &mut Consensus2TaskState<TYPES, I>,
+) -> Result<()> {
+    // Are we the leader for this view?
+    ensure!(
+        task_state
+            .timeout_membership
+            .get_leader(vote.get_view_number() + 1)
+            == task_state.public_key,
+        format!(
+            "We are not the leader for view {:?}",
+            vote.get_view_number()
+        )
+    );
+
+    let mut collector = task_state.timeout_vote_collector.write().await;
+
+    if collector.is_none() || vote.get_view_number() > collector.as_ref().unwrap().view {
+        let info = AccumulatorInfo {
+            public_key: task_state.public_key.clone(),
+            membership: Arc::clone(&task_state.quorum_membership),
+            view: vote.get_view_number(),
+            id: task_state.id,
+        };
+        *collector =
+            create_vote_accumulator::<TYPES, TimeoutVote<TYPES>, TimeoutCertificate<TYPES>>(
+                &info,
+                vote.clone(),
+                event,
+                sender,
+            )
+            .await;
+    } else {
+        let result = collector
+            .as_mut()
+            .unwrap()
+            .handle_event(Arc::clone(&event), sender)
+            .await;
+
+        if result == Some(HotShotTaskCompleted) {
+            *collector = None;
+        }
+    }
+    Ok(())
+}
+
+/// Handle a `ViewChange` event.
+pub(crate) async fn handle_view_change<TYPES: NodeType, I: NodeImplementation<TYPES>>(
+    new_view_number: TYPES::Time,
+    sender: &Sender<Arc<HotShotEvent<TYPES>>>,
+    task_state: &mut Consensus2TaskState<TYPES, I>,
+) -> Result<()> {
+    ensure!(
+        new_view_number > task_state.cur_view,
+        "New view is not larger than the current view"
+    );
+
+    let old_view_number = task_state.cur_view;
+    debug!("Updating view from {old_view_number:?} to {new_view_number:?}");
+
+    // Cancel the old timeout task
+    if let Some(timeout_task) = task_state.timeout_task.take() {
+        cancel_task(timeout_task).await;
+    }
+
+    // Move this node to the next view
+    task_state.cur_view = new_view_number;
+
+    // Spawn a timeout task if we did actually update view
+    let timeout = task_state.timeout;
+    task_state.timeout_task = Some(async_spawn({
+        let stream = sender.clone();
+        // Nuance: We timeout on the view + 1 here because that means that we have
+        // not seen evidence to transition to this new view
+        let view_number = new_view_number + 1;
+        async move {
+            async_sleep(Duration::from_millis(timeout)).await;
+            broadcast_event(
+                Arc::new(HotShotEvent::Timeout(TYPES::Time::new(*view_number))),
+                &stream,
+            )
+            .await;
+        }
+    }));
+
+    let consensus = task_state.consensus.read().await;
+    consensus
+        .metrics
+        .current_view
+        .set(usize::try_from(task_state.cur_view.get_u64()).unwrap());
+
+    // Do the comparison before the subtraction to avoid potential overflow, since
+    // `last_decided_view` may be greater than `cur_view` if the node is catching up.
+    if usize::try_from(task_state.cur_view.get_u64()).unwrap()
+        > usize::try_from(task_state.last_decided_view.get_u64()).unwrap()
+    {
+        consensus.metrics.number_of_views_since_last_decide.set(
+            usize::try_from(task_state.cur_view.get_u64()).unwrap()
+                - usize::try_from(task_state.last_decided_view.get_u64()).unwrap(),
+        );
+    }
+
+    broadcast_event(
+        Event {
+            view_number: old_view_number,
+            event: EventType::ViewFinished {
+                view_number: old_view_number,
+            },
+        },
+        &task_state.output_event_stream,
+    )
+    .await;
+    Ok(())
+}
+
+/// Handle a `Timeout` event.
+pub(crate) async fn handle_timeout<TYPES: NodeType, I: NodeImplementation<TYPES>>(
+    view_number: TYPES::Time,
+    sender: &Sender<Arc<HotShotEvent<TYPES>>>,
+    task_state: &mut Consensus2TaskState<TYPES, I>,
+) -> Result<()> {
+    ensure!(
+        task_state.cur_view < view_number,
+        "Timeout event is for an old view"
+    );
+
+    ensure!(
+        task_state
+            .timeout_membership
+            .has_stake(&task_state.public_key),
+        format!("We were not chosen for the consensus committee for view {view_number:?}")
+    );
+
+    let vote = TimeoutVote::create_signed_vote(
+        TimeoutData::<TYPES> { view: view_number },
+        view_number,
+        &task_state.public_key,
+        &task_state.private_key,
+    )
+    .context("Failed to sign TimeoutData")?;
+
+    broadcast_event(Arc::new(HotShotEvent::TimeoutVoteSend(vote)), sender).await;
+    broadcast_event(
+        Event {
+            view_number,
+            event: EventType::ViewTimeout { view_number },
+        },
+        &task_state.output_event_stream,
+    )
+    .await;
+
+    debug!(
+        "We did not receive evidence for view {} in time, sending timeout vote for that view!",
+        *view_number
+    );
+
+    broadcast_event(
+        Event {
+            view_number,
+            event: EventType::ReplicaViewTimeout { view_number },
+        },
+        &task_state.output_event_stream,
+    )
+    .await;
+
+    task_state
+        .consensus
+        .read()
+        .await
+        .metrics
+        .number_of_timeouts
+        .add(1);
+
+    Ok(())
+}

--- a/crates/task-impls/src/consensus2/handlers.rs
+++ b/crates/task-impls/src/consensus2/handlers.rs
@@ -38,7 +38,7 @@ pub(crate) async fn handle_quorum_vote_recv<TYPES: NodeType, I: NodeImplementati
             == task_state.public_key,
         format!(
             "We are not the leader for view {:?}",
-            vote.get_view_number()
+            vote.get_view_number() + 1
         )
     );
 
@@ -87,7 +87,7 @@ pub(crate) async fn handle_timeout_vote_recv<TYPES: NodeType, I: NodeImplementat
             == task_state.public_key,
         format!(
             "We are not the leader for view {:?}",
-            vote.get_view_number()
+            vote.get_view_number() + 1
         )
     );
 

--- a/crates/task-impls/src/consensus2/handlers.rs
+++ b/crates/task-impls/src/consensus2/handlers.rs
@@ -32,23 +32,20 @@ pub(crate) async fn handle_quorum_vote_recv<TYPES: NodeType, I: NodeImplementati
 ) -> Result<()> {
     // Are we the leader for this view?
     ensure!(
-        task_state
-            .quorum_membership
-            .get_leader(vote.get_view_number() + 1)
-            == task_state.public_key,
+        task_state.quorum_membership.leader(vote.view_number() + 1) == task_state.public_key,
         format!(
             "We are not the leader for view {:?}",
-            vote.get_view_number() + 1
+            vote.view_number() + 1
         )
     );
 
     let mut collector = task_state.vote_collector.write().await;
 
-    if collector.is_none() || vote.get_view_number() > collector.as_ref().unwrap().view {
+    if collector.is_none() || vote.view_number() > collector.as_ref().unwrap().view {
         let info = AccumulatorInfo {
             public_key: task_state.public_key.clone(),
             membership: Arc::clone(&task_state.quorum_membership),
-            view: vote.get_view_number(),
+            view: vote.view_number(),
             id: task_state.id,
         };
         *collector = create_vote_accumulator::<TYPES, QuorumVote<TYPES>, QuorumCertificate<TYPES>>(
@@ -81,23 +78,20 @@ pub(crate) async fn handle_timeout_vote_recv<TYPES: NodeType, I: NodeImplementat
 ) -> Result<()> {
     // Are we the leader for this view?
     ensure!(
-        task_state
-            .timeout_membership
-            .get_leader(vote.get_view_number() + 1)
-            == task_state.public_key,
+        task_state.timeout_membership.leader(vote.view_number() + 1) == task_state.public_key,
         format!(
             "We are not the leader for view {:?}",
-            vote.get_view_number() + 1
+            vote.view_number() + 1
         )
     );
 
     let mut collector = task_state.timeout_vote_collector.write().await;
 
-    if collector.is_none() || vote.get_view_number() > collector.as_ref().unwrap().view {
+    if collector.is_none() || vote.view_number() > collector.as_ref().unwrap().view {
         let info = AccumulatorInfo {
             public_key: task_state.public_key.clone(),
             membership: Arc::clone(&task_state.quorum_membership),
-            view: vote.get_view_number(),
+            view: vote.view_number(),
             id: task_state.id,
         };
         *collector =
@@ -165,16 +159,16 @@ pub(crate) async fn handle_view_change<TYPES: NodeType, I: NodeImplementation<TY
     consensus
         .metrics
         .current_view
-        .set(usize::try_from(task_state.cur_view.get_u64()).unwrap());
+        .set(usize::try_from(task_state.cur_view.u64()).unwrap());
 
     // Do the comparison before the subtraction to avoid potential overflow, since
     // `last_decided_view` may be greater than `cur_view` if the node is catching up.
-    if usize::try_from(task_state.cur_view.get_u64()).unwrap()
-        > usize::try_from(task_state.last_decided_view.get_u64()).unwrap()
+    if usize::try_from(task_state.cur_view.u64()).unwrap()
+        > usize::try_from(task_state.last_decided_view.u64()).unwrap()
     {
         consensus.metrics.number_of_views_since_last_decide.set(
-            usize::try_from(task_state.cur_view.get_u64()).unwrap()
-                - usize::try_from(task_state.last_decided_view.get_u64()).unwrap(),
+            usize::try_from(task_state.cur_view.u64()).unwrap()
+                - usize::try_from(task_state.last_decided_view.u64()).unwrap(),
         );
     }
 

--- a/crates/task-impls/src/consensus2/mod.rs
+++ b/crates/task-impls/src/consensus2/mod.rs
@@ -1,0 +1,174 @@
+use async_broadcast::Sender;
+use hotshot_task::task::Task;
+use std::sync::Arc;
+use tracing::instrument;
+
+use async_lock::RwLock;
+use hotshot_task::task::TaskState;
+use hotshot_types::{
+    consensus::Consensus,
+    event::Event,
+    simple_certificate::{QuorumCertificate, TimeoutCertificate},
+    simple_vote::{QuorumVote, TimeoutVote},
+    traits::{
+        node_implementation::{NodeImplementation, NodeType},
+        signature_key::SignatureKey,
+    },
+};
+
+#[cfg(async_executor_impl = "async-std")]
+use async_std::task::JoinHandle;
+#[cfg(async_executor_impl = "tokio")]
+use tokio::task::JoinHandle;
+
+use crate::{events::HotShotEvent, vote_collection::VoteCollectionTaskState};
+
+use self::handlers::{
+    handle_quorum_vote_recv, handle_timeout, handle_timeout_vote_recv, handle_view_change,
+};
+
+/// Alias for Optional type for Vote Collectors
+type VoteCollectorOption<TYPES, VOTE, CERT> = Option<VoteCollectionTaskState<TYPES, VOTE, CERT>>;
+
+/// Event handlers for use in the `handle` method.
+mod handlers;
+
+/// Task state for the Consensus task.
+pub struct Consensus2TaskState<TYPES: NodeType, I: NodeImplementation<TYPES>> {
+    /// Our public key
+    pub public_key: TYPES::SignatureKey,
+
+    /// Our Private Key
+    pub private_key: <TYPES::SignatureKey as SignatureKey>::PrivateKey,
+
+    /// Immutable instance state
+    pub instance_state: Arc<TYPES::InstanceState>,
+
+    /// Network for all nodes
+    pub quorum_network: Arc<I::QuorumNetwork>,
+
+    /// Network for DA committee
+    pub committee_network: Arc<I::CommitteeNetwork>,
+
+    /// Membership for Timeout votes/certs
+    pub timeout_membership: Arc<TYPES::Membership>,
+
+    /// Membership for Quorum Certs/votes
+    pub quorum_membership: Arc<TYPES::Membership>,
+
+    /// Membership for DA committee Votes/certs
+    pub committee_membership: Arc<TYPES::Membership>,
+
+    /// Current Vote collection task, with it's view.
+    pub vote_collector:
+        RwLock<VoteCollectorOption<TYPES, QuorumVote<TYPES>, QuorumCertificate<TYPES>>>,
+
+    /// Current timeout vote collection task with its view
+    pub timeout_vote_collector:
+        RwLock<VoteCollectorOption<TYPES, TimeoutVote<TYPES>, TimeoutCertificate<TYPES>>>,
+
+    /// This node's storage ref
+    pub storage: Arc<RwLock<I::Storage>>,
+
+    /// The view number that this node is currently executing in.
+    pub cur_view: TYPES::Time,
+
+    /// Output events to application
+    pub output_event_stream: async_broadcast::Sender<Event<TYPES>>,
+
+    /// Timeout task handle
+    pub timeout_task: Option<JoinHandle<()>>,
+
+    /// View timeout from config.
+    pub timeout: u64,
+
+    /// A reference to the metrics trait.
+    pub consensus: Arc<RwLock<Consensus<TYPES>>>,
+
+    /// The last decided view
+    pub last_decided_view: TYPES::Time,
+
+    /// The node's id
+    pub id: u64,
+}
+impl<TYPES: NodeType, I: NodeImplementation<TYPES>> Consensus2TaskState<TYPES, I> {
+    /// Handles a consensus event received on the event stream
+    #[instrument(skip_all, fields(id = self.id, cur_view = *self.cur_view, last_decided_view = *self.last_decided_view), name = "Consensus replica task", level = "error")]
+    pub async fn handle(
+        &mut self,
+        event: Arc<HotShotEvent<TYPES>>,
+        sender: Sender<Arc<HotShotEvent<TYPES>>>,
+    ) {
+        match event.as_ref() {
+            HotShotEvent::QuorumVoteRecv(ref vote) => {
+                if let Err(e) =
+                    handle_quorum_vote_recv(vote, Arc::clone(&event), &sender, self).await
+                {
+                    tracing::debug!("Failed to handle QuorumVoteRecv event; error = {e}");
+                }
+            }
+            HotShotEvent::TimeoutVoteRecv(ref vote) => {
+                if let Err(e) =
+                    handle_timeout_vote_recv(vote, Arc::clone(&event), &sender, self).await
+                {
+                    tracing::debug!("Failed to handle TimeoutVoteRecv event; error = {e}");
+                }
+            }
+            HotShotEvent::ViewChange(new_view_number) => {
+                if let Err(e) = handle_view_change(*new_view_number, &sender, self).await {
+                    tracing::trace!("Failed to handle ViewChange event; error = {e}");
+                }
+            }
+            HotShotEvent::Timeout(view_number) => {
+                if let Err(e) = handle_timeout(*view_number, &sender, self).await {
+                    tracing::debug!("Failed to handle Timeout event; error = {e}");
+                }
+            }
+            HotShotEvent::LastDecidedViewUpdated(view_number) => {
+                if *view_number < self.last_decided_view {
+                    tracing::debug!("New decided view is not newer than ours");
+                } else {
+                    self.last_decided_view = *view_number;
+                    if let Err(e) = self
+                        .consensus
+                        .write()
+                        .await
+                        .update_last_decided_view(*view_number)
+                    {
+                        tracing::trace!("{e:?}");
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+impl<TYPES: NodeType, I: NodeImplementation<TYPES>> TaskState for Consensus2TaskState<TYPES, I> {
+    type Event = Arc<HotShotEvent<TYPES>>;
+    type Output = ();
+
+    fn filter(&self, event: &Arc<HotShotEvent<TYPES>>) -> bool {
+        !matches!(
+            event.as_ref(),
+            HotShotEvent::QuorumVoteRecv(_)
+                | HotShotEvent::TimeoutVoteRecv(_)
+                | HotShotEvent::ViewChange(_)
+                | HotShotEvent::Timeout(_)
+                | HotShotEvent::LastDecidedViewUpdated(_)
+                | HotShotEvent::Shutdown
+        )
+    }
+    async fn handle_event(event: Self::Event, task: &mut Task<Self>) -> Option<()>
+    where
+        Self: Sized,
+    {
+        let sender = task.clone_sender();
+        task.state_mut().handle(event, sender).await;
+        None
+    }
+
+    fn should_shutdown(event: &Self::Event) -> bool {
+        matches!(event.as_ref(), HotShotEvent::Shutdown)
+    }
+}

--- a/crates/task-impls/src/consensus2/mod.rs
+++ b/crates/task-impls/src/consensus2/mod.rs
@@ -48,7 +48,7 @@ pub struct Consensus2TaskState<TYPES: NodeType, I: NodeImplementation<TYPES>> {
     pub quorum_network: Arc<I::QuorumNetwork>,
 
     /// Network for DA committee
-    pub committee_network: Arc<I::CommitteeNetwork>,
+    pub da_network: Arc<I::DaNetwork>,
 
     /// Membership for Timeout votes/certs
     pub timeout_membership: Arc<TYPES::Membership>,

--- a/crates/task-impls/src/events.rs
+++ b/crates/task-impls/src/events.rs
@@ -14,7 +14,7 @@ use hotshot_types::{
         ViewSyncPreCommitVote,
     },
     traits::{block_contents::BuilderFee, node_implementation::NodeType, BlockPayload},
-    utils::BuilderCommitment,
+    utils::{BuilderCommitment, View},
     vid::{VidCommitment, VidPrecomputeData},
     vote::VoteDependencyData,
 };
@@ -153,4 +153,11 @@ pub enum HotShotEvent<TYPES: NodeType> {
     ProposeNow(TYPES::Time, ProposalDependencyData<TYPES>),
     /// Initiate a vote right now for the designated view.
     VoteNow(TYPES::Time, VoteDependencyData<TYPES>),
+
+    /* Consensus State Update Events */
+    /// A undecided view has been created and added to the validated state storage.
+    ValidatedStateUpdate(TYPES::Time, View<TYPES>),
+
+    /// A new anchor view has been successfully reached by this node.
+    LastDecidedViewUpdated(TYPES::Time),
 }

--- a/crates/task-impls/src/lib.rs
+++ b/crates/task-impls/src/lib.rs
@@ -4,6 +4,9 @@
 /// the task which implements the main parts of consensus
 pub mod consensus;
 
+/// The task which implements the core state logic of consensus.
+pub mod consensus2;
+
 /// The task which handles the logic for the quorum vote.
 pub mod quorum_vote;
 

--- a/crates/types/src/traits/states.rs
+++ b/crates/types/src/traits/states.rs
@@ -22,7 +22,10 @@ use crate::{
 pub trait InstanceState: Debug + Send + Sync {}
 
 /// Application-specific state delta, which will be used to store a list of merkle tree entries.
-pub trait StateDelta: Debug + Send + Sync + Serialize + for<'a> Deserialize<'a> {}
+pub trait StateDelta:
+    Debug + PartialEq + Eq + Hash + Send + Sync + Serialize + for<'a> Deserialize<'a>
+{
+}
 
 /// Abstraction over the state that blocks modify
 ///

--- a/crates/types/src/utils.rs
+++ b/crates/types/src/utils.rs
@@ -24,7 +24,7 @@ use crate::{
 };
 
 /// A view's state
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, PartialEq, Eq, Hash)]
 #[serde(bound = "")]
 pub enum ViewInner<TYPES: NodeType> {
     /// A pending view with an available block but not leaf proposal yet.
@@ -135,7 +135,7 @@ impl<TYPES: NodeType> Deref for View<TYPES> {
 }
 
 /// This exists so we can perform state transitions mutably
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, Hash)]
 #[serde(bound = "")]
 pub struct View<TYPES: NodeType> {
     /// The view data. Wrapped in a struct so we can mutate


### PR DESCRIPTION
Closes #3172 
<!-- See here for keywords in Github -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

### This PR: 
We need a new separate consensus module that will exist alongside the existing consensus module to achieve our goals of removing the old logic. This will enable us to build the features in isolation without needing to fight against merge conflicts and bug fixes as we stabilize for Cappuccino.

This PR:
- Creates the new `consensus2` module and associated handlers.
- Adds a toggle flag to turn the new consensus2 module on alongside the other dependency tasks.

### This PR does not: 
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->

### Key places to review: 
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
