### PR TITLE
[CLEANUP] - Remove `get_` from all getters

### DIFF
--- a/crates/builder-api/src/builder.rs
+++ b/crates/builder-api/src/builder.rs
@@ -143,7 +143,7 @@ where
                 let signature = try_extract_param(&req, "signature")?;
                 let sender = try_extract_param(&req, "sender")?;
                 state
-                    .get_available_blocks(&hash, view_number, sender, &signature)
+                    .available_blocks(&hash, view_number, sender, &signature)
                     .await
                     .context(BlockAvailableSnafu {
                         resource: hash.to_string(),
@@ -182,13 +182,7 @@ where
             .boxed()
         })?
         .get("builder_address", |_req, state| {
-            async move {
-                state
-                    .get_builder_address()
-                    .await
-                    .context(BuilderAddressSnafu)
-            }
-            .boxed()
+            async move { state.builder_address().await.context(BuilderAddressSnafu) }.boxed()
         })?;
     Ok(api)
 }

--- a/crates/builder-api/src/data_source.rs
+++ b/crates/builder-api/src/data_source.rs
@@ -14,7 +14,7 @@ use crate::{
 #[async_trait]
 pub trait BuilderDataSource<TYPES: NodeType> {
     /// To get the list of available blocks
-    async fn get_available_blocks(
+    async fn available_blocks(
         &self,
         for_parent: &VidCommitment,
         view_number: u64,
@@ -41,7 +41,7 @@ pub trait BuilderDataSource<TYPES: NodeType> {
     ) -> Result<AvailableBlockHeaderInput<TYPES>, BuildError>;
 
     /// To get the builder address
-    async fn get_builder_address(&self) -> Result<TYPES::BuilderSignatureKey, BuildError>;
+    async fn builder_address(&self) -> Result<TYPES::BuilderSignatureKey, BuildError>;
 }
 
 #[async_trait]

--- a/crates/example-types/src/block_types.rs
+++ b/crates/example-types/src/block_types.rs
@@ -169,7 +169,7 @@ impl BlockPayload for TestBlockPayload {
         BuilderCommitment::from_raw_digest(digest.finalize())
     }
 
-    fn get_transactions<'a>(
+    fn transactions<'a>(
         &'a self,
         _metadata: &'a Self::Metadata,
     ) -> impl 'a + Iterator<Item = Self::Transaction> {
@@ -205,7 +205,7 @@ impl<TYPES: NodeType<BlockHeader = Self, BlockPayload = TestBlockPayload>> Block
         _builder_fee: BuilderFee<TYPES>,
         _vid_common: VidCommon,
     ) -> Result<Self, Self::Error> {
-        let parent = parent_leaf.get_block_header();
+        let parent = parent_leaf.block_header();
 
         let mut timestamp = OffsetDateTime::now_utc().unix_timestamp() as u64;
         if timestamp < parent.timestamp {

--- a/crates/examples/infra/mod.rs
+++ b/crates/examples/infra/mod.rs
@@ -912,7 +912,7 @@ pub async fn main_entry_point<
     // It returns the complete config which also includes peer's public key and public config.
     // This function will be taken solely by sequencer right after OrchestratorClient::new,
     // which means the previous `generate_validator_config_when_init` will not be taken by sequencer, it's only for key pair generation for testing in hotshot.
-    let (mut run_config, source) = NetworkConfig::<TYPES::SignatureKey>::complete_config(
+    let (mut run_config, source) = NetworkConfig::<TYPES::SignatureKey>::get_complete_config(
         &orchestrator_client,
         my_own_validator_config,
         args.advertise_address,

--- a/crates/examples/infra/mod.rs
+++ b/crates/examples/infra/mod.rs
@@ -355,15 +355,15 @@ pub trait RunDa<
         let initializer = hotshot::HotShotInitializer::<TYPES>::from_genesis(TestInstanceState {})
             .expect("Couldn't generate genesis block");
 
-        let config = self.get_config();
+        let config = self.config();
 
         // Get KeyPair for certificate Aggregation
         let pk = config.config.my_own_validator_config.public_key.clone();
         let sk = config.config.my_own_validator_config.private_key.clone();
         let known_nodes_with_stake = config.config.known_nodes_with_stake.clone();
 
-        let da_network = self.get_da_channel();
-        let quorum_network = self.get_quorum_channel();
+        let da_network = self.da_channel();
+        let quorum_network = self.quorum_channel();
 
         let networks_bundle = Networks {
             quorum_network: quorum_network.clone().into(),
@@ -423,7 +423,7 @@ pub trait RunDa<
             node_index,
             start_delay_seconds,
             ..
-        } = self.get_config();
+        } = self.config();
 
         let mut total_transactions_committed = 0;
         let mut total_transactions_sent = 0;
@@ -438,7 +438,7 @@ pub trait RunDa<
         info!("Starting HotShot example!");
         let start = Instant::now();
 
-        let mut event_stream = context.get_event_stream();
+        let mut event_stream = context.event_stream();
         let mut anchor_view: TYPES::Time = <TYPES::Time as ConsensusTime>::genesis();
         let mut num_successful_commits = 0;
 
@@ -464,12 +464,12 @@ pub trait RunDa<
                             // this might be a obob
                             if let Some(leaf_info) = leaf_chain.first() {
                                 let leaf = &leaf_info.leaf;
-                                info!("Decide event for leaf: {}", *leaf.get_view_number());
+                                info!("Decide event for leaf: {}", *leaf.view_number());
 
                                 // iterate all the decided transactions to calculate latency
-                                if let Some(block_payload) = &leaf.get_block_payload() {
-                                    for tx in block_payload
-                                        .get_transactions(leaf.get_block_header().metadata())
+                                if let Some(block_payload) = &leaf.block_payload() {
+                                    for tx in
+                                        block_payload.transactions(leaf.block_header().metadata())
                                     {
                                         let restored_timestamp_vec =
                                             tx.0[tx.0.len() - 8..].to_vec();
@@ -486,9 +486,9 @@ pub trait RunDa<
                                     }
                                 }
 
-                                let new_anchor = leaf.get_view_number();
+                                let new_anchor = leaf.view_number();
                                 if new_anchor >= anchor_view {
-                                    anchor_view = leaf.get_view_number();
+                                    anchor_view = leaf.view_number();
                                 }
 
                                 // send transactions
@@ -532,9 +532,9 @@ pub trait RunDa<
                 }
             }
         }
-        let consensus_lock = context.hotshot.get_consensus();
+        let consensus_lock = context.hotshot.consensus();
         let consensus = consensus_lock.read().await;
-        let total_num_views = usize::try_from(consensus.locked_view().get_u64()).unwrap();
+        let total_num_views = usize::try_from(consensus.locked_view().u64()).unwrap();
         // `failed_num_views` could include uncommitted views
         let failed_num_views = total_num_views - num_successful_commits;
         // When posting to the orchestrator, note that the total number of views also include un-finalized views.
@@ -570,13 +570,13 @@ pub trait RunDa<
     }
 
     /// Returns the da network for this run
-    fn get_da_channel(&self) -> DANET;
+    fn da_channel(&self) -> DANET;
 
     /// Returns the quorum network for this run
-    fn get_quorum_channel(&self) -> QUORUMNET;
+    fn quorum_channel(&self) -> QUORUMNET;
 
     /// Returns the config for this run
-    fn get_config(&self) -> NetworkConfig<TYPES::SignatureKey>;
+    fn config(&self) -> NetworkConfig<TYPES::SignatureKey>;
 }
 
 // Push CDN
@@ -652,15 +652,15 @@ where
         }
     }
 
-    fn get_da_channel(&self) -> PushCdnNetwork<TYPES> {
+    fn da_channel(&self) -> PushCdnNetwork<TYPES> {
         self.da_channel.clone()
     }
 
-    fn get_quorum_channel(&self) -> PushCdnNetwork<TYPES> {
+    fn quorum_channel(&self) -> PushCdnNetwork<TYPES> {
         self.quorum_channel.clone()
     }
 
-    fn get_config(&self) -> NetworkConfig<TYPES::SignatureKey> {
+    fn config(&self) -> NetworkConfig<TYPES::SignatureKey> {
         self.config.clone()
     }
 }
@@ -750,15 +750,15 @@ where
         }
     }
 
-    fn get_da_channel(&self) -> Libp2pNetwork<Message<TYPES>, TYPES::SignatureKey> {
+    fn da_channel(&self) -> Libp2pNetwork<Message<TYPES>, TYPES::SignatureKey> {
         self.da_channel.clone()
     }
 
-    fn get_quorum_channel(&self) -> Libp2pNetwork<Message<TYPES>, TYPES::SignatureKey> {
+    fn quorum_channel(&self) -> Libp2pNetwork<Message<TYPES>, TYPES::SignatureKey> {
         self.quorum_channel.clone()
     }
 
-    fn get_config(&self) -> NetworkConfig<TYPES::SignatureKey> {
+    fn config(&self) -> NetworkConfig<TYPES::SignatureKey> {
         self.config.clone()
     }
 }
@@ -846,15 +846,15 @@ where
         }
     }
 
-    fn get_da_channel(&self) -> CombinedNetworks<TYPES> {
+    fn da_channel(&self) -> CombinedNetworks<TYPES> {
         self.da_channel.clone()
     }
 
-    fn get_quorum_channel(&self) -> CombinedNetworks<TYPES> {
+    fn quorum_channel(&self) -> CombinedNetworks<TYPES> {
         self.quorum_channel.clone()
     }
 
-    fn get_config(&self) -> NetworkConfig<TYPES::SignatureKey> {
+    fn config(&self) -> NetworkConfig<TYPES::SignatureKey> {
         self.config.clone()
     }
 }
@@ -912,7 +912,7 @@ pub async fn main_entry_point<
     // It returns the complete config which also includes peer's public key and public config.
     // This function will be taken solely by sequencer right after OrchestratorClient::new,
     // which means the previous `generate_validator_config_when_init` will not be taken by sequencer, it's only for key pair generation for testing in hotshot.
-    let (mut run_config, source) = NetworkConfig::<TYPES::SignatureKey>::get_complete_config(
+    let (mut run_config, source) = NetworkConfig::<TYPES::SignatureKey>::complete_config(
         &orchestrator_client,
         my_own_validator_config,
         args.advertise_address,
@@ -954,7 +954,7 @@ pub async fn main_entry_point<
     let hotshot = run.initialize_state_and_hotshot().await;
 
     if let Some(task) = builder_task {
-        task.start(Box::new(hotshot.get_event_stream()));
+        task.start(Box::new(hotshot.event_stream()));
     }
 
     // pre-generate transactions

--- a/crates/examples/push-cdn/whitelist-adapter.rs
+++ b/crates/examples/push-cdn/whitelist-adapter.rs
@@ -53,7 +53,7 @@ async fn main() -> Result<()> {
     // Attempt to get the config from the orchestrator.
     // Loops internally until the config is received.
     let config: NetworkConfig<<TestTypes as NodeType>::SignatureKey> =
-        orchestrator_client.config_after_collection().await;
+        orchestrator_client.get_config_after_collection().await;
 
     tracing::info!("Received config from orchestrator");
 

--- a/crates/examples/push-cdn/whitelist-adapter.rs
+++ b/crates/examples/push-cdn/whitelist-adapter.rs
@@ -53,7 +53,7 @@ async fn main() -> Result<()> {
     // Attempt to get the config from the orchestrator.
     // Loops internally until the config is received.
     let config: NetworkConfig<<TestTypes as NodeType>::SignatureKey> =
-        orchestrator_client.get_config_after_collection().await;
+        orchestrator_client.config_after_collection().await;
 
     tracing::info!("Received config from orchestrator");
 

--- a/crates/hotshot-qc/src/bit_vector_old.rs
+++ b/crates/hotshot-qc/src/bit_vector_old.rs
@@ -33,7 +33,7 @@ pub struct StakeTableEntry<V> {
 }
 
 impl<V> StakeTableEntryType for StakeTableEntry<V> {
-    fn get_stake(&self) -> U256 {
+    fn stake(&self) -> U256 {
         self.stake_amount
     }
 }

--- a/crates/hotshot-stake-table/src/mt_based/internal.rs
+++ b/crates/hotshot-stake-table/src/mt_based/internal.rs
@@ -103,7 +103,7 @@ impl<K: Key> MerkleProof<K> {
     }
 
     /// Returns the public key of the associated stake table entry, if there's any.
-    pub fn get_key(&self) -> Option<&K> {
+    pub fn key(&self) -> Option<&K> {
         match self.path.first() {
             Some(MerklePathEntry::Leaf { key, value: _ }) => Some(key),
             _ => None,
@@ -111,7 +111,7 @@ impl<K: Key> MerkleProof<K> {
     }
 
     /// Returns the stake amount of the associated stake table entry, if there's any.
-    pub fn get_value(&self) -> Option<&U256> {
+    pub fn value(&self) -> Option<&U256> {
         match self.path.first() {
             Some(MerklePathEntry::Leaf { key: _, value }) => Some(value),
             _ => None,
@@ -119,7 +119,7 @@ impl<K: Key> MerkleProof<K> {
     }
 
     /// Returns the associated stake table entry, if there's any.
-    pub fn get_key_value(&self) -> Option<(&K, &U256)> {
+    pub fn key_value(&self) -> Option<(&K, &U256)> {
         match self.path.first() {
             Some(MerklePathEntry::Leaf { key, value }) => Some((key, value)),
             _ => None,
@@ -317,7 +317,7 @@ impl<K: Key> PersistentMerkleNode<K> {
     /// Imagine that the keys in this subtree is sorted, returns the first key such that
     /// the prefix sum of withholding stakes is greater or equal the given `stake_number`.
     /// Useful for key sampling weighted by withholding stakes
-    pub fn get_key_by_stake(&self, mut stake_number: U256) -> Option<(&K, &U256)> {
+    pub fn key_by_stake(&self, mut stake_number: U256) -> Option<(&K, &U256)> {
         if stake_number >= self.total_stakes() {
             None
         } else {
@@ -334,7 +334,7 @@ impl<K: Key> PersistentMerkleNode<K> {
                         stake_number -= children[ptr].total_stakes();
                         ptr += 1;
                     }
-                    children[ptr].get_key_by_stake(stake_number)
+                    children[ptr].key_by_stake(stake_number)
                 }
                 PersistentMerkleNode::Leaf {
                     comm: _,
@@ -663,14 +663,14 @@ mod tests {
                 roots[i + 1].simple_lookup(height, &path[i]).unwrap()
             );
         }
-        // test get_key_by_stake
+        // test key_by_stake
         keys.iter().enumerate().for_each(|(i, key)| {
             assert_eq!(
                 key,
                 roots
                     .last()
                     .unwrap()
-                    .get_key_by_stake(U256::from(i as u64 * 100 + i as u64 + 1))
+                    .key_by_stake(U256::from(i as u64 * 100 + i as u64 + 1))
                     .unwrap()
                     .0
             );
@@ -680,8 +680,8 @@ mod tests {
         for i in 0..10 {
             let proof = roots.last().unwrap().lookup(height, &path[i]).unwrap();
             assert_eq!(height, proof.tree_height());
-            assert_eq!(&keys[i], proof.get_key().unwrap());
-            assert_eq!(&U256::from(100), proof.get_value().unwrap());
+            assert_eq!(&keys[i], proof.key().unwrap());
+            assert_eq!(&U256::from(100), proof.value().unwrap());
             assert_eq!(
                 roots.last().unwrap().commitment(),
                 proof.compute_root().unwrap()

--- a/crates/hotshot-stake-table/src/vec_based.rs
+++ b/crates/hotshot-stake-table/src/vec_based.rs
@@ -144,7 +144,7 @@ where
     }
 
     fn len(&self, version: SnapshotVersion) -> Result<usize, StakeTableError> {
-        Ok(self.get_version(&version)?.bls_keys.len())
+        Ok(self.version(&version)?.bls_keys.len())
     }
 
     fn contains_key(&self, key: &Self::Key) -> bool {
@@ -156,7 +156,7 @@ where
         version: SnapshotVersion,
         key: &Self::Key,
     ) -> Result<Self::Amount, StakeTableError> {
-        let table = self.get_version(&version)?;
+        let table = self.version(&version)?;
         let pos = self.lookup_pos(key)?;
         if pos >= table.bls_keys.len() {
             Err(StakeTableError::KeyNotFound)
@@ -179,7 +179,7 @@ where
         version: SnapshotVersion,
         key: &Self::Key,
     ) -> Result<(Self::Amount, Self::Aux, Self::LookupProof), StakeTableError> {
-        let table = self.get_version(&version)?;
+        let table = self.version(&version)?;
         let pos = self.lookup_pos(key)?;
         if pos >= table.bls_keys.len() {
             Err(StakeTableError::KeyNotFound)
@@ -228,7 +228,7 @@ where
     }
 
     fn try_iter(&self, version: SnapshotVersion) -> Result<Self::IntoIter, StakeTableError> {
-        let table = self.get_version(&version)?;
+        let table = self.version(&version)?;
         let owned = (0..table.bls_keys.len())
             .map(|i| {
                 (
@@ -354,7 +354,7 @@ where
     }
 
     /// returns the snapshot version
-    fn get_version(
+    fn version(
         &self,
         version: &SnapshotVersion,
     ) -> Result<&StakeTableSnapshot<K1, K2>, StakeTableError> {

--- a/crates/hotshot/src/lib.rs
+++ b/crates/hotshot/src/lib.rs
@@ -145,10 +145,7 @@ pub struct SystemContext<TYPES: NodeType, I: NodeImplementation<TYPES>> {
     start_view: TYPES::Time,
 
     /// Access to the output event stream.
-    #[deprecated(
-        note = "please use the `event_stream` method on `SystemContextHandle` instead. This field will be made private in a future release of HotShot"
-    )]
-    pub output_event_stream: (Sender<Event<TYPES>>, InactiveReceiver<Event<TYPES>>),
+    output_event_stream: (Sender<Event<TYPES>>, InactiveReceiver<Event<TYPES>>),
 
     /// External event stream for communication with the application.
     pub(crate) external_event_stream: (Sender<Event<TYPES>>, InactiveReceiver<Event<TYPES>>),

--- a/crates/hotshot/src/tasks/mod.rs
+++ b/crates/hotshot/src/tasks/mod.rs
@@ -67,7 +67,7 @@ pub async fn add_response_task<TYPES: NodeType, I: NodeImplementation<TYPES>>(
     handle: &SystemContextHandle<TYPES, I>,
 ) {
     let state = NetworkResponseState::<TYPES>::new(
-        handle.hotshot.get_consensus(),
+        handle.hotshot.consensus(),
         rx,
         handle.hotshot.memberships.quorum_membership.clone().into(),
         handle.public_key().clone(),

--- a/crates/hotshot/src/traits/networking/combined_network.rs
+++ b/crates/hotshot/src/traits/networking/combined_network.rs
@@ -169,7 +169,7 @@ impl<TYPES: NodeType> CombinedNetworks<TYPES> {
             self.delayed_tasks
                 .write()
                 .await
-                .entry(message.kind.get_view_number().get_u64())
+                .entry(message.kind.view_number().u64())
                 .or_default()
                 .push(async_spawn(async move {
                     async_sleep(duration).await;

--- a/crates/hotshot/src/traits/networking/libp2p_network.rs
+++ b/crates/hotshot/src/traits/networking/libp2p_network.rs
@@ -403,12 +403,12 @@ impl<M: NetworkMsg, K: SignatureKey> Libp2pNetwork<M, K> {
 
         // Make a node DA if it is under the staked committee size
         for node in config.config.known_da_nodes {
-            da_keys.insert(K::get_public_key(&node.stake_table_entry));
+            da_keys.insert(K::public_key(&node.stake_table_entry));
         }
 
         // Insert all known nodes into the set of all keys
         for node in config.config.known_nodes_with_stake {
-            all_keys.insert(K::get_public_key(&node.stake_table_entry));
+            all_keys.insert(K::public_key(&node.stake_table_entry));
         }
 
         Ok(Libp2pNetwork::new(
@@ -1119,7 +1119,7 @@ impl<M: NetworkMsg, K: SignatureKey + 'static> ConnectedNetwork<M, K> for Libp2p
         TYPES: NodeType<SignatureKey = K> + 'a,
     {
         let future_view = <TYPES as NodeType>::Time::new(view) + LOOK_AHEAD;
-        let future_leader = membership.get_leader(future_view);
+        let future_leader = membership.leader(future_view);
 
         let _ = self
             .queue_node_lookup(ViewNumber::new(*future_view), future_leader)

--- a/crates/hotshot/src/types/handle.rs
+++ b/crates/hotshot/src/types/handle.rs
@@ -47,7 +47,7 @@ pub struct SystemContextHandle<TYPES: NodeType, I: NodeImplementation<TYPES>> {
 
 impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static> SystemContextHandle<TYPES, I> {
     /// obtains a stream to expose to the user
-    pub fn get_event_stream(&self) -> impl Stream<Item = Event<TYPES>> {
+    pub fn event_stream(&self) -> impl Stream<Item = Event<TYPES>> {
         self.output_event_stream.1.activate_cloned()
     }
 
@@ -56,7 +56,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static> SystemContextHandl
     /// - make the stream generic and in nodetypes or nodeimpelmentation
     /// - type wrapper
     #[must_use]
-    pub fn get_event_stream_known_impl(&self) -> Receiver<Event<TYPES>> {
+    pub fn event_stream_known_impl(&self) -> Receiver<Event<TYPES>> {
         self.output_event_stream.1.activate_cloned()
     }
 
@@ -66,7 +66,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static> SystemContextHandl
     /// - type wrapper
     /// NOTE: this is only used for sanity checks in our tests
     #[must_use]
-    pub fn get_internal_event_stream_known_impl(&self) -> Receiver<Arc<HotShotEvent<TYPES>>> {
+    pub fn internal_event_stream_known_impl(&self) -> Receiver<Arc<HotShotEvent<TYPES>>> {
         self.internal_event_stream.1.activate_cloned()
     }
 
@@ -74,8 +74,8 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static> SystemContextHandl
     ///
     /// # Panics
     /// If the internal consensus is in an inconsistent state.
-    pub async fn get_decided_state(&self) -> Arc<TYPES::ValidatedState> {
-        self.hotshot.get_decided_state().await
+    pub async fn decided_state(&self) -> Arc<TYPES::ValidatedState> {
+        self.hotshot.decided_state().await
     }
 
     /// Get the validated state from a given `view`.
@@ -83,18 +83,18 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static> SystemContextHandl
     /// Returns the requested state, if the [`SystemContext`] is tracking this view. Consensus
     /// tracks views that have not yet been decided but could be in the future. This function may
     /// return [`None`] if the requested view has already been decided (but see
-    /// [`get_decided_state`](Self::get_decided_state)) or if there is no path for the requested
+    /// [`decided_state`](Self::decided_state)) or if there is no path for the requested
     /// view to ever be decided.
-    pub async fn get_state(&self, view: TYPES::Time) -> Option<Arc<TYPES::ValidatedState>> {
-        self.hotshot.get_state(view).await
+    pub async fn state(&self, view: TYPES::Time) -> Option<Arc<TYPES::ValidatedState>> {
+        self.hotshot.state(view).await
     }
 
     /// Get the last decided leaf of the [`SystemContext`] instance.
     ///
     /// # Panics
     /// If the internal consensus is in an inconsistent state.
-    pub async fn get_decided_leaf(&self) -> Leaf<TYPES> {
-        self.hotshot.get_decided_leaf().await
+    pub async fn decided_leaf(&self) -> Leaf<TYPES> {
+        self.hotshot.decided_leaf().await
     }
 
     /// Tries to get the most recent decided leaf, returning instantly
@@ -103,8 +103,8 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static> SystemContextHandl
     /// # Panics
     /// Panics if internal consensus is in an inconsistent state.
     #[must_use]
-    pub fn try_get_decided_leaf(&self) -> Option<Leaf<TYPES>> {
-        self.hotshot.try_get_decided_leaf()
+    pub fn try_decided_leaf(&self) -> Option<Leaf<TYPES>> {
+        self.hotshot.try_decided_leaf()
     }
 
     /// Submits a transaction to the backing [`SystemContext`] instance.
@@ -124,8 +124,8 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static> SystemContextHandl
 
     /// Get the underlying consensus state for this [`SystemContext`]
     #[must_use]
-    pub fn get_consensus(&self) -> Arc<RwLock<Consensus<TYPES>>> {
-        self.hotshot.get_consensus()
+    pub fn consensus(&self) -> Arc<RwLock<Consensus<TYPES>>> {
+        self.hotshot.consensus()
     }
 
     /// Block the underlying quorum (and DA) networking interfaces until node is
@@ -158,36 +158,36 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static> SystemContextHandl
 
     /// return the timeout for a view of the underlying `SystemContext`
     #[must_use]
-    pub fn get_next_view_timeout(&self) -> u64 {
-        self.hotshot.get_next_view_timeout()
+    pub fn next_view_timeout(&self) -> u64 {
+        self.hotshot.next_view_timeout()
     }
 
-    /// Wrapper for `HotShotConsensusApi`'s `get_leader` function
+    /// Wrapper for `HotShotConsensusApi`'s `leader` function
     #[allow(clippy::unused_async)] // async for API compatibility reasons
-    pub async fn get_leader(&self, view_number: TYPES::Time) -> TYPES::SignatureKey {
+    pub async fn leader(&self, view_number: TYPES::Time) -> TYPES::SignatureKey {
         self.hotshot
             .memberships
             .quorum_membership
-            .get_leader(view_number)
+            .leader(view_number)
     }
 
     // Below is for testing only:
     /// Wrapper to get this node's public key
     #[cfg(feature = "hotshot-testing")]
     #[must_use]
-    pub fn get_public_key(&self) -> TYPES::SignatureKey {
+    pub fn public_key(&self) -> TYPES::SignatureKey {
         self.hotshot.public_key.clone()
     }
 
     /// Wrapper to get the view number this node is on.
-    pub async fn get_cur_view(&self) -> TYPES::Time {
+    pub async fn cur_view(&self) -> TYPES::Time {
         self.hotshot.consensus.read().await.cur_view()
     }
 
     /// Provides a reference to the underlying storage for this [`SystemContext`], allowing access to
     /// historical data
     #[must_use]
-    pub fn get_storage(&self) -> Arc<RwLock<I::Storage>> {
+    pub fn storage(&self) -> Arc<RwLock<I::Storage>> {
         Arc::clone(&self.storage)
     }
 }

--- a/crates/libp2p-networking/src/network/node.rs
+++ b/crates/libp2p-networking/src/network/node.rs
@@ -355,7 +355,7 @@ impl NetworkNode {
         let record = Record::new(query.key.clone(), query.value.clone());
         match self.swarm.behaviour_mut().dht.put_record(
             record,
-            libp2p::kad::Quorum::N(self.dht_handler.get_replication_factor()),
+            libp2p::kad::Quorum::N(self.dht_handler.replication_factor()),
         ) {
             Err(e) => {
                 // failed try again later
@@ -433,7 +433,7 @@ impl NetworkNode {
                         notify,
                         retry_count,
                     } => {
-                        self.dht_handler.get_record(
+                        self.dht_handler.record(
                             key,
                             notify,
                             NonZeroUsize::new(NUM_REPLICATED_TO_TRUST).unwrap(),

--- a/crates/libp2p-networking/src/network/node/handle.rs
+++ b/crates/libp2p-networking/src/network/node/handle.rs
@@ -242,7 +242,7 @@ impl NetworkNodeHandle {
     ) -> Result<PeerId, NetworkNodeHandleError> {
         // get record (from DHT)
         let pid = self
-            .get_record_timeout::<PeerId, VER>(&key, dht_timeout, bind_version)
+            .record_timeout::<PeerId, VER>(&key, dht_timeout, bind_version)
             .await?;
 
         // pid lookup for routing
@@ -279,7 +279,7 @@ impl NetworkNodeHandle {
     /// - Will return [`NetworkNodeHandleError::DHTError`] when encountering an error putting to DHT
     /// - Will return [`NetworkNodeHandleError::SerializationError`] when unable to serialize the key
     /// - Will return [`NetworkNodeHandleError::DeserializationError`] when unable to deserialize the returned value
-    pub async fn get_record<V: for<'a> Deserialize<'a>, VER: StaticVersionType>(
+    pub async fn record<V: for<'a> Deserialize<'a>, VER: StaticVersionType>(
         &self,
         key: &impl Serialize,
         retry_count: u8,
@@ -305,13 +305,13 @@ impl NetworkNodeHandle {
     /// - Will return [`NetworkNodeHandleError::TimeoutError`] when times out
     /// - Will return [`NetworkNodeHandleError::SerializationError`] when unable to serialize the key
     /// - Will return [`NetworkNodeHandleError::DeserializationError`] when unable to deserialize the returned value
-    pub async fn get_record_timeout<V: for<'a> Deserialize<'a>, VER: StaticVersionType>(
+    pub async fn record_timeout<V: for<'a> Deserialize<'a>, VER: StaticVersionType>(
         &self,
         key: &impl Serialize,
         timeout: Duration,
         bind_version: VER,
     ) -> Result<V, NetworkNodeHandleError> {
-        let result = async_timeout(timeout, self.get_record(key, 3, bind_version)).await;
+        let result = async_timeout(timeout, self.record(key, 3, bind_version)).await;
         match result {
             Err(e) => Err(e).context(TimeoutSnafu),
             Ok(r) => r,

--- a/crates/libp2p-networking/tests/counter.rs
+++ b/crates/libp2p-networking/tests/counter.rs
@@ -55,7 +55,7 @@ pub enum CounterMessage {
 /// chooses one
 /// # Panics
 /// panics if handles is of length 0
-fn get_random_handle<S: Debug + Default + Send + Clone>(
+fn random_handle<S: Debug + Default + Send + Clone>(
     handles: &[HandleWithState<S>],
     rng: &mut dyn rand::RngCore,
 ) -> HandleWithState<S> {
@@ -208,7 +208,7 @@ async fn run_gossip_round(
     timeout_duration: Duration,
 ) -> Result<(), TestError<CounterState>> {
     let mut rng = rand::thread_rng();
-    let msg_handle = get_random_handle(handles, &mut rng);
+    let msg_handle = random_handle(handles, &mut rng);
     msg_handle.state.modify(|s| *s = new_state).await;
 
     let mut futs = Vec::new();
@@ -351,7 +351,7 @@ async fn run_dht_rounds(
     let mut rng = rand::thread_rng();
     for i in 0..num_rounds {
         debug!("begin round {}", i);
-        let msg_handle = get_random_handle(handles, &mut rng);
+        let msg_handle = random_handle(handles, &mut rng);
         let mut key = vec![0; DHT_KV_PADDING];
         let inc_val = u8::try_from(starting_val + i).unwrap();
         key.push(inc_val);
@@ -369,7 +369,7 @@ async fn run_dht_rounds(
         for handle in handles {
             let result: Result<Vec<u8>, NetworkNodeHandleError> = handle
                 .handle
-                .get_record_timeout(&key, timeout, STATIC_VER_0_1)
+                .record_timeout(&key, timeout, STATIC_VER_0_1)
                 .await;
             match result {
                 Err(e) => {
@@ -416,7 +416,7 @@ async fn run_request_response_increment_all(
     timeout: Duration,
 ) {
     let mut rng = rand::thread_rng();
-    let requestee_handle = get_random_handle(handles, &mut rng);
+    let requestee_handle = random_handle(handles, &mut rng);
     requestee_handle.state.modify(|s| *s += 1).await;
     info!("RR REQUESTEE IS {:?}", requestee_handle.handle.peer_id());
     let mut futs = Vec::new();

--- a/crates/orchestrator/api.toml
+++ b/crates/orchestrator/api.toml
@@ -23,8 +23,8 @@ received from the 'identity' endpoint
 """
 
 # POST the latest temporary node index only for generating validator's key pair
-[route.get_tmp_node_index]
-PATH = ["get_tmp_node_index"]
+[route.tmp_node_index]
+PATH = ["tmp_node_index"]
 METHOD = "POST"
 DOC = """
 Get the latest temporary node index only for generating validator's key pair for testing in hotshot, later the generated key pairs might be bound with other node_index.
@@ -66,7 +66,7 @@ Post whether the node with node_index is ready to start the run
 """
 
 # GET whether or not to start the run
-[route.get_start]
+[route.start]
 PATH = ["start"]
 DOC = """
 Get whether the node should start the run, returns a boolean

--- a/crates/orchestrator/api.toml
+++ b/crates/orchestrator/api.toml
@@ -23,8 +23,8 @@ received from the 'identity' endpoint
 """
 
 # POST the latest temporary node index only for generating validator's key pair
-[route.tmp_node_index]
-PATH = ["tmp_node_index"]
+[route.get_tmp_node_index]
+PATH = ["get_tmp_node_index"]
 METHOD = "POST"
 DOC = """
 Get the latest temporary node index only for generating validator's key pair for testing in hotshot, later the generated key pairs might be bound with other node_index.
@@ -66,7 +66,7 @@ Post whether the node with node_index is ready to start the run
 """
 
 # GET whether or not to start the run
-[route.start]
+[route.get_start]
 PATH = ["start"]
 DOC = """
 Get whether the node should start the run, returns a boolean

--- a/crates/orchestrator/src/client.rs
+++ b/crates/orchestrator/src/client.rs
@@ -393,7 +393,7 @@ impl OrchestratorClient {
             .await;
 
         let wait_for_all_nodes_ready_f = |client: Client<ClientError, OrchestratorVersion>| {
-            async move { client.get("api/get_start").send().await }.boxed()
+            async move { client.get("api/start").send().await }.boxed()
         };
         self.wait_for_fn_from_orchestrator(wait_for_all_nodes_ready_f)
             .await

--- a/crates/orchestrator/src/client.rs
+++ b/crates/orchestrator/src/client.rs
@@ -228,7 +228,7 @@ impl OrchestratorClient {
             }
             .boxed()
         };
-        let node_index = self.get_wait_for_fn_from_orchestrator(identity).await;
+        let node_index = self.wait_for_fn_from_orchestrator(identity).await;
 
         // get the corresponding config
         let f = |client: Client<ClientError, OrchestratorVersion>| {
@@ -242,7 +242,7 @@ impl OrchestratorClient {
             .boxed()
         };
 
-        let mut config = self.get_wait_for_fn_from_orchestrator(f).await;
+        let mut config = self.wait_for_fn_from_orchestrator(f).await;
         config.node_index = From::<u16>::from(node_index);
 
         Ok(config)
@@ -257,7 +257,7 @@ impl OrchestratorClient {
         let cur_node_index = |client: Client<ClientError, OrchestratorVersion>| {
             async move {
                 let cur_node_index: Result<u16, ClientError> = client
-                    .post("api/tmp_node_index")
+                    .post("api/get_tmp_node_index")
                     .send()
                     .await
                     .inspect_err(|err| tracing::error!("{err}"));
@@ -266,7 +266,7 @@ impl OrchestratorClient {
             }
             .boxed()
         };
-        self.get_wait_for_fn_from_orchestrator(cur_node_index).await
+        self.wait_for_fn_from_orchestrator(cur_node_index).await
     }
 
     /// Requests the configuration from the orchestrator with the stipulation that
@@ -293,7 +293,7 @@ impl OrchestratorClient {
         };
 
         // Loop until successful
-        self.get_wait_for_fn_from_orchestrator(get_config_after_collection)
+        self.wait_for_fn_from_orchestrator(get_config_after_collection)
             .await
     }
 
@@ -359,7 +359,7 @@ impl OrchestratorClient {
             }
             .boxed()
         };
-        self.get_wait_for_fn_from_orchestrator::<_, _, ()>(wait_for_all_nodes_pub_key)
+        self.wait_for_fn_from_orchestrator::<_, _, ()>(wait_for_all_nodes_pub_key)
             .await;
 
         let mut network_config = self.get_config_after_collection().await;
@@ -389,13 +389,13 @@ impl OrchestratorClient {
             }
             .boxed()
         };
-        self.get_wait_for_fn_from_orchestrator::<_, _, ()>(send_ready_f)
+        self.wait_for_fn_from_orchestrator::<_, _, ()>(send_ready_f)
             .await;
 
         let wait_for_all_nodes_ready_f = |client: Client<ClientError, OrchestratorVersion>| {
-            async move { client.get("api/start").send().await }.boxed()
+            async move { client.get("api/get_start").send().await }.boxed()
         };
-        self.get_wait_for_fn_from_orchestrator(wait_for_all_nodes_ready_f)
+        self.wait_for_fn_from_orchestrator(wait_for_all_nodes_ready_f)
             .await
     }
 
@@ -417,7 +417,7 @@ impl OrchestratorClient {
     /// Generic function that waits for the orchestrator to return a non-error
     /// Returns whatever type the given function returns
     #[instrument(skip_all, name = "waiting for orchestrator")]
-    async fn get_wait_for_fn_from_orchestrator<F, Fut, GEN>(&self, f: F) -> GEN
+    async fn wait_for_fn_from_orchestrator<F, Fut, GEN>(&self, f: F) -> GEN
     where
         F: Fn(Client<ClientError, OrchestratorVersion>) -> Fut,
         Fut: Future<Output = Result<GEN, ClientError>>,

--- a/crates/orchestrator/src/config.rs
+++ b/crates/orchestrator/src/config.rs
@@ -256,7 +256,7 @@ impl<K: SignatureKey> NetworkConfig<K> {
                     error!("{e}, falling back to orchestrator");
 
                     let config = client
-                        .config_without_peer(libp2p_address, libp2p_public_key)
+                        .get_config_without_peer(libp2p_address, libp2p_public_key)
                         .await?;
 
                     // save to file if we fell back
@@ -273,7 +273,7 @@ impl<K: SignatureKey> NetworkConfig<K> {
             // otherwise just get from orchestrator
             Ok((
                 client
-                    .config_without_peer(libp2p_address, libp2p_public_key)
+                    .get_config_without_peer(libp2p_address, libp2p_public_key)
                     .await?,
                 NetworkConfigSource::Orchestrator,
             ))
@@ -287,7 +287,7 @@ impl<K: SignatureKey> NetworkConfig<K> {
     ) -> ValidatorConfig<K> {
         // This cur_node_index is only used for key pair generation, it's not bound with the node,
         // lather the node with the generated key pair will get a new node_index from orchestrator.
-        let cur_node_index = client.node_index_for_init_validator_config().await;
+        let cur_node_index = client.get_node_index_for_init_validator_config().await;
         ValidatorConfig::generated_from_seed_indexed([0u8; 32], cur_node_index.into(), 1, is_da)
     }
 

--- a/crates/orchestrator/src/config.rs
+++ b/crates/orchestrator/src/config.rs
@@ -296,7 +296,7 @@ impl<K: SignatureKey> NetworkConfig<K> {
     ///
     /// # Errors
     /// If we are unable to get the configuration from the orchestrator
-    pub async fn complete_config(
+    pub async fn get_complete_config(
         client: &OrchestratorClient,
         my_own_validator_config: ValidatorConfig<K>,
         libp2p_address: Option<SocketAddr>,

--- a/crates/orchestrator/src/config.rs
+++ b/crates/orchestrator/src/config.rs
@@ -256,7 +256,7 @@ impl<K: SignatureKey> NetworkConfig<K> {
                     error!("{e}, falling back to orchestrator");
 
                     let config = client
-                        .get_config_without_peer(libp2p_address, libp2p_public_key)
+                        .config_without_peer(libp2p_address, libp2p_public_key)
                         .await?;
 
                     // save to file if we fell back
@@ -273,7 +273,7 @@ impl<K: SignatureKey> NetworkConfig<K> {
             // otherwise just get from orchestrator
             Ok((
                 client
-                    .get_config_without_peer(libp2p_address, libp2p_public_key)
+                    .config_without_peer(libp2p_address, libp2p_public_key)
                     .await?,
                 NetworkConfigSource::Orchestrator,
             ))
@@ -287,7 +287,7 @@ impl<K: SignatureKey> NetworkConfig<K> {
     ) -> ValidatorConfig<K> {
         // This cur_node_index is only used for key pair generation, it's not bound with the node,
         // lather the node with the generated key pair will get a new node_index from orchestrator.
-        let cur_node_index = client.get_node_index_for_init_validator_config().await;
+        let cur_node_index = client.node_index_for_init_validator_config().await;
         ValidatorConfig::generated_from_seed_indexed([0u8; 32], cur_node_index.into(), 1, is_da)
     }
 
@@ -296,7 +296,7 @@ impl<K: SignatureKey> NetworkConfig<K> {
     ///
     /// # Errors
     /// If we are unable to get the configuration from the orchestrator
-    pub async fn get_complete_config(
+    pub async fn complete_config(
         client: &OrchestratorClient,
         my_own_validator_config: ValidatorConfig<K>,
         libp2p_address: Option<SocketAddr>,
@@ -716,11 +716,11 @@ impl<KEY: SignatureKey> Default for HotShotConfigFile<KEY> {
 
                 // Add to DA nodes based on index
                 if node_id < staked_da_nodes as u64 {
-                    known_da_nodes.push(cur_validator_config.get_public_config());
+                    known_da_nodes.push(cur_validator_config.public_config());
                     cur_validator_config.is_da = true;
                 }
 
-                cur_validator_config.get_public_config()
+                cur_validator_config.public_config()
             })
             .collect();
 

--- a/crates/orchestrator/src/lib.rs
+++ b/crates/orchestrator/src/lib.rs
@@ -262,17 +262,17 @@ where
 
     // Assumes one node do not get twice
     fn get_tmp_node_index(&mut self) -> Result<u16, ServerError> {
-        let get_tmp_node_index = self.tmp_latest_index;
+        let tmp_node_index = self.tmp_latest_index;
         self.tmp_latest_index += 1;
 
-        if usize::from(get_tmp_node_index) >= self.config.config.num_nodes_with_stake.get() {
+        if usize::from(tmp_node_index) >= self.config.config.num_nodes_with_stake.get() {
             return Err(ServerError {
                 status: tide_disco::StatusCode::BadRequest,
                 message: "Node index getter for key pair generation has reached capacity"
                     .to_string(),
             });
         }
-        Ok(get_tmp_node_index)
+        Ok(tmp_node_index)
     }
 
     #[allow(clippy::cast_possible_truncation)]
@@ -582,7 +582,7 @@ where
             .boxed()
         },
     )?
-    .get("start", |_req, state| {
+    .get("get_start", |_req, state| {
         async move { state.get_start() }.boxed()
     })?
     .post("post_results", |req, state| {

--- a/crates/task-impls/src/builder.rs
+++ b/crates/task-impls/src/builder.rs
@@ -104,7 +104,7 @@ impl<TYPES: NodeType, Ver: StaticVersionType> BuilderClient<TYPES, Ver> {
     /// # Errors
     /// - [`BuilderClientError::NotFound`] if blocks aren't available for this parent
     /// - [`BuilderClientError::Api`] if API isn't responding or responds incorrectly
-    pub async fn get_available_blocks(
+    pub async fn available_blocks(
         &self,
         parent: VidCommitment,
         view_number: u64,

--- a/crates/task-impls/src/consensus/helpers.rs
+++ b/crates/task-impls/src/consensus/helpers.rs
@@ -65,11 +65,11 @@ async fn validate_proposal_safety_and_liveness<TYPES: NodeType>(
     sender: TYPES::SignatureKey,
     event_sender: Sender<Event<TYPES>>,
 ) -> Result<()> {
-    let view = proposal.data.get_view_number();
+    let view = proposal.data.view_number();
 
     let proposed_leaf = Leaf::from_quorum_proposal(&proposal.data);
     ensure!(
-        proposed_leaf.get_parent_commitment() == parent_leaf.commit(),
+        proposed_leaf.parent_commitment() == parent_leaf.commit(),
         "Proposed leaf does not extend the parent leaf."
     );
 
@@ -96,18 +96,18 @@ async fn validate_proposal_safety_and_liveness<TYPES: NodeType>(
 
     // Liveness check.
     let read_consensus = consensus.read().await;
-    let liveness_check = justify_qc.get_view_number() > read_consensus.locked_view();
+    let liveness_check = justify_qc.view_number() > read_consensus.locked_view();
 
     // Safety check.
     // Check if proposal extends from the locked leaf.
     let outcome = read_consensus.visit_leaf_ancestors(
-        justify_qc.get_view_number(),
+        justify_qc.view_number(),
         Terminator::Inclusive(read_consensus.locked_view()),
         false,
         |leaf, _, _| {
             // if leaf view no == locked view no then we're done, report success by
             // returning true
-            leaf.get_view_number() != read_consensus.locked_view()
+            leaf.view_number() != read_consensus.locked_view()
         },
     );
     let safety_check = outcome.is_ok();
@@ -208,7 +208,7 @@ pub async fn create_and_send_proposal<TYPES: NodeType>(
     };
 
     let proposed_leaf = Leaf::from_quorum_proposal(&proposal);
-    if proposed_leaf.get_parent_commitment() != parent_leaf.commit() {
+    if proposed_leaf.parent_commitment() != parent_leaf.commit() {
         return;
     }
 
@@ -226,7 +226,7 @@ pub async fn create_and_send_proposal<TYPES: NodeType>(
     };
     debug!(
         "Sending null proposal for view {:?}",
-        proposed_leaf.get_view_number(),
+        proposed_leaf.view_number(),
     );
     if let Err(e) = consensus.write().await.update_last_proposed_view(view) {
         tracing::trace!("{e:?}");
@@ -253,21 +253,21 @@ pub fn validate_proposal_view_and_certs<TYPES: NodeType>(
     quorum_membership: &Arc<TYPES::Membership>,
     timeout_membership: &Arc<TYPES::Membership>,
 ) -> Result<()> {
-    let view = proposal.data.get_view_number();
+    let view = proposal.data.view_number();
     ensure!(
         view >= cur_view,
         "Proposal is from an older view {:?}",
         proposal.data.clone()
     );
 
-    let view_leader_key = quorum_membership.get_leader(view);
+    let view_leader_key = quorum_membership.leader(view);
     ensure!(
         view_leader_key == *sender,
         "Leader key does not match key in proposal"
     );
 
     // Verify a timeout certificate OR a view sync certificate exists and is valid.
-    if proposal.data.justify_qc.get_view_number() != view - 1 {
+    if proposal.data.justify_qc.view_number() != view - 1 {
         let received_proposal_cert =
             proposal.data.proposal_certificate.clone().context(format!(
                 "Quorum proposal for view {} needed a timeout or view sync certificate, but did not have one",
@@ -277,7 +277,7 @@ pub fn validate_proposal_view_and_certs<TYPES: NodeType>(
         match received_proposal_cert {
             ViewChangeEvidence::Timeout(timeout_cert) => {
                 ensure!(
-                    timeout_cert.get_data().view == view - 1,
+                    timeout_cert.date().view == view - 1,
                     "Timeout certificate for view {} was not for the immediately preceding view",
                     *view
                 );
@@ -312,7 +312,7 @@ pub fn validate_proposal_view_and_certs<TYPES: NodeType>(
 }
 
 /// Gets the parent leaf and state from the parent of a proposal, returning an [`anyhow::Error`] if not.
-pub(crate) async fn get_parent_leaf_and_state<TYPES: NodeType>(
+pub(crate) async fn parent_leaf_and_state<TYPES: NodeType>(
     cur_view: TYPES::Time,
     view: TYPES::Time,
     quorum_membership: Arc<TYPES::Membership>,
@@ -320,27 +320,27 @@ pub(crate) async fn get_parent_leaf_and_state<TYPES: NodeType>(
     consensus: Arc<RwLock<Consensus<TYPES>>>,
 ) -> Result<(Leaf<TYPES>, Arc<<TYPES as NodeType>::ValidatedState>)> {
     ensure!(
-        quorum_membership.get_leader(view) == public_key,
+        quorum_membership.leader(view) == public_key,
         "Somehow we formed a QC but are not the leader for the next view {view:?}",
     );
 
     let consensus = consensus.read().await;
-    let parent_view_number = &consensus.high_qc().get_view_number();
+    let parent_view_number = &consensus.high_qc().view_number();
     let parent_view = consensus.validated_state_map().get(parent_view_number).context(
         format!("Couldn't find parent view in state map, waiting for replica to see proposal; parent_view_number: {}", **parent_view_number)
     )?;
 
     // Leaf hash in view inner does not match high qc hash - Why?
-    let (leaf_commitment, state) = parent_view.get_leaf_and_state().context(
+    let (leaf_commitment, state) = parent_view.leaf_and_state().context(
         format!("Parent of high QC points to a view without a proposal; parent_view_number: {parent_view_number:?}, parent_view {parent_view:?}")
     )?;
 
-    if leaf_commitment != consensus.high_qc().get_data().leaf_commit {
+    if leaf_commitment != consensus.high_qc().date().leaf_commit {
         // NOTE: This happens on the genesis block
         debug!(
             "They don't equal: {:?}   {:?}",
             leaf_commitment,
-            consensus.high_qc().get_data().leaf_commit
+            consensus.high_qc().date().leaf_commit
         );
     }
 
@@ -349,7 +349,7 @@ pub(crate) async fn get_parent_leaf_and_state<TYPES: NodeType>(
         .get(&leaf_commitment)
         .context("Failed to find high QC of parent")?;
 
-    let reached_decided = leaf.get_view_number() == consensus.last_decided_view();
+    let reached_decided = leaf.view_number() == consensus.last_decided_view();
     let parent_leaf = leaf.clone();
     let original_parent_hash = parent_leaf.commit();
     let mut next_parent_hash = original_parent_hash;
@@ -358,10 +358,10 @@ pub(crate) async fn get_parent_leaf_and_state<TYPES: NodeType>(
     if !reached_decided {
         debug!("We have not reached decide from view {:?}", cur_view);
         while let Some(next_parent_leaf) = consensus.saved_leaves().get(&next_parent_hash) {
-            if next_parent_leaf.get_view_number() <= consensus.last_decided_view() {
+            if next_parent_leaf.view_number() <= consensus.last_decided_view() {
                 break;
             }
-            next_parent_hash = next_parent_leaf.get_parent_commitment();
+            next_parent_hash = next_parent_leaf.parent_commitment();
         }
         // TODO do some sort of sanity check on the view number that it matches decided
     }
@@ -385,7 +385,7 @@ pub(crate) async fn publish_proposal_from_upgrade_cert<TYPES: NodeType>(
     delay: u64,
     instance_state: Arc<TYPES::InstanceState>,
 ) -> Result<JoinHandle<()>> {
-    let (parent_leaf, state) = get_parent_leaf_and_state(
+    let (parent_leaf, state) = parent_leaf_and_state(
         cur_view,
         view,
         Arc::clone(&quorum_membership),
@@ -453,7 +453,7 @@ pub async fn publish_proposal_from_commitment_and_metadata<TYPES: NodeType>(
     proposal_cert: Option<ViewChangeEvidence<TYPES>>,
     instance_state: Arc<TYPES::InstanceState>,
 ) -> Result<JoinHandle<()>> {
-    let (parent_leaf, state) = get_parent_leaf_and_state(
+    let (parent_leaf, state) = parent_leaf_and_state(
         cur_view,
         view,
         quorum_membership,
@@ -470,7 +470,7 @@ pub async fn publish_proposal_from_commitment_and_metadata<TYPES: NodeType>(
     // Note: once we reach a point of potentially propose with our formed upgrade certificate, we will ALWAYS drop it. If we cannot immediately use it for whatever reason, we choose to discard it.
     // It is possible that multiple nodes form separate upgrade certificates for the some upgrade if we are not careful about voting. But this shouldn't bother us: the first leader to propose is the one whose certificate will be used. And if that fails to reach a decide for whatever reason, we may lose our own certificate, but something will likely have gone wrong there anyway.
     let mut proposal_upgrade_certificate = parent_leaf
-        .get_upgrade_certificate()
+        .upgrade_certificate()
         .or(formed_upgrade_certificate);
 
     if !proposal_upgrade_certificate
@@ -604,8 +604,8 @@ pub async fn handle_quorum_proposal_recv<TYPES: NodeType, I: NodeImplementation<
     )
     .context("Failed to validate proposal view and attached certs")?;
 
-    let view = proposal.data.get_view_number();
-    let view_leader_key = task_state.quorum_membership.get_leader(view);
+    let view = proposal.data.view_number();
+    let view_leader_key = task_state.quorum_membership.leader(view);
     let justify_qc = proposal.data.justify_qc.clone();
 
     if !justify_qc.is_valid_cert(task_state.quorum_membership.as_ref()) {
@@ -634,11 +634,11 @@ pub async fn handle_quorum_proposal_recv<TYPES: NodeType, I: NodeImplementation<
     // Get the parent leaf and state.
     let parent = match consensus_read
         .saved_leaves()
-        .get(&justify_qc.get_data().leaf_commit)
+        .get(&justify_qc.date().leaf_commit)
         .cloned()
     {
         Some(leaf) => {
-            if let (Some(state), _) = consensus_read.get_state_and_delta(leaf.get_view_number()) {
+            if let (Some(state), _) = consensus_read.state_and_delta(leaf.view_number()) {
                 Some((leaf, Arc::clone(&state)))
             } else {
                 bail!("Parent state not found! Consensus internally inconsistent");
@@ -647,7 +647,7 @@ pub async fn handle_quorum_proposal_recv<TYPES: NodeType, I: NodeImplementation<
         None => None,
     };
 
-    if justify_qc.get_view_number() > consensus_read.high_qc().view_number {
+    if justify_qc.view_number() > consensus_read.high_qc().view_number {
         if let Err(e) = task_state
             .storage
             .write()
@@ -669,7 +669,7 @@ pub async fn handle_quorum_proposal_recv<TYPES: NodeType, I: NodeImplementation<
     let Some((parent_leaf, _parent_state)) = parent else {
         warn!(
             "Proposal's parent missing from storage with commitment: {:?}",
-            justify_qc.get_data().leaf_commit
+            justify_qc.date().leaf_commit
         );
         let leaf = Leaf::from_quorum_proposal(&proposal.data);
 
@@ -709,7 +709,7 @@ pub async fn handle_quorum_proposal_recv<TYPES: NodeType, I: NodeImplementation<
         // still vote if the liveness check succeeds.
         #[cfg(not(feature = "dependency-tasks"))]
         {
-            let liveness_check = justify_qc.get_view_number() > consensus_write.locked_view();
+            let liveness_check = justify_qc.view_number() > consensus_write.locked_view();
 
             let high_qc = consensus_write.high_qc().clone();
             let locked_view = consensus_write.locked_view();
@@ -722,7 +722,7 @@ pub async fn handle_quorum_proposal_recv<TYPES: NodeType, I: NodeImplementation<
                 let new_view = proposal.data.view_number + 1;
 
                 // This is for the case where we form a QC but have not yet seen the previous proposal ourselves
-                let should_propose = task_state.quorum_membership.get_leader(new_view)
+                let should_propose = task_state.quorum_membership.leader(new_view)
                     == task_state.public_key
                     && high_qc.view_number == current_proposal.clone().unwrap().view_number;
 
@@ -768,7 +768,7 @@ pub async fn handle_quorum_proposal_recv<TYPES: NodeType, I: NodeImplementation<
 
     task_state
         .spawned_tasks
-        .entry(proposal.data.get_view_number())
+        .entry(proposal.data.view_number())
         .or_default()
         .push(async_spawn(
             validate_proposal_safety_and_liveness(
@@ -803,7 +803,7 @@ pub async fn handle_quorum_proposal_validated<TYPES: NodeType, I: NodeImplementa
     task_state: &mut TemporaryProposalValidatedCombinedType<TYPES, I>,
 ) -> Result<()> {
     let consensus = task_state.consensus.read().await;
-    let view = proposal.get_view_number();
+    let view = proposal.view_number();
     #[cfg(not(feature = "dependency-tasks"))]
     {
         task_state.current_proposal = Some(proposal.clone());
@@ -822,7 +822,7 @@ pub async fn handle_quorum_proposal_validated<TYPES: NodeType, I: NodeImplementa
     let mut leafs_decided = Vec::new();
     let mut included_txns = HashSet::new();
     let old_anchor_view = consensus.last_decided_view();
-    let parent_view = proposal.justify_qc.get_view_number();
+    let parent_view = proposal.justify_qc.view_number();
     let mut current_chain_length = 0usize;
     if parent_view + 1 == view {
         current_chain_length += 1;
@@ -832,17 +832,17 @@ pub async fn handle_quorum_proposal_validated<TYPES: NodeType, I: NodeImplementa
             true,
             |leaf, state, delta| {
                 if !new_decide_reached {
-                    if last_view_number_visited == leaf.get_view_number() + 1 {
-                        last_view_number_visited = leaf.get_view_number();
+                    if last_view_number_visited == leaf.view_number() + 1 {
+                        last_view_number_visited = leaf.view_number();
                         current_chain_length += 1;
                         if current_chain_length == 2 {
-                            new_locked_view = leaf.get_view_number();
+                            new_locked_view = leaf.view_number();
                             new_commit_reached = true;
                             // The next leaf in the chain, if there is one, is decided, so this
                             // leaf's justify_qc would become the QC for the decided chain.
-                            new_decide_qc = Some(leaf.get_justify_qc().clone());
+                            new_decide_qc = Some(leaf.justify_qc().clone());
                         } else if current_chain_length == 3 {
-                            new_anchor_view = leaf.get_view_number();
+                            new_anchor_view = leaf.view_number();
                             new_decide_reached = true;
                         }
                     } else {
@@ -853,13 +853,13 @@ pub async fn handle_quorum_proposal_validated<TYPES: NodeType, I: NodeImplementa
                 // starting from the first iteration with a three chain, e.g. right after the else if case nested in the if case above
                 if new_decide_reached {
                     let mut leaf = leaf.clone();
-                    if leaf.get_view_number() == new_anchor_view {
+                    if leaf.view_number() == new_anchor_view {
                         consensus
                             .metrics
                             .last_synced_block_height
-                            .set(usize::try_from(leaf.get_height()).unwrap_or(0));
+                            .set(usize::try_from(leaf.height()).unwrap_or(0));
                     }
-                    if let Some(cert) = leaf.get_upgrade_certificate() {
+                    if let Some(cert) = leaf.upgrade_certificate() {
                         if cert.data.decide_by < view {
                             warn!("Failed to decide an upgrade certificate in time. Ignoring.");
                         } else {
@@ -880,13 +880,10 @@ pub async fn handle_quorum_proposal_validated<TYPES: NodeType, I: NodeImplementa
                     }
                     // If the block payload is available for this leaf, include it in
                     // the leaf chain that we send to the client.
-                    if let Some(encoded_txns) =
-                        consensus.saved_payloads().get(&leaf.get_view_number())
+                    if let Some(encoded_txns) = consensus.saved_payloads().get(&leaf.view_number())
                     {
-                        let payload = BlockPayload::from_bytes(
-                            encoded_txns,
-                            leaf.get_block_header().metadata(),
-                        );
+                        let payload =
+                            BlockPayload::from_bytes(encoded_txns, leaf.block_header().metadata());
 
                         leaf.fill_block_payload_unchecked(payload);
                     }
@@ -895,7 +892,7 @@ pub async fn handle_quorum_proposal_validated<TYPES: NodeType, I: NodeImplementa
                     // (if one exists)
                     let vid_share = consensus
                         .vid_shares()
-                        .get(&leaf.get_view_number())
+                        .get(&leaf.view_number())
                         .unwrap_or(&HashMap::new())
                         .get(&task_state.public_key)
                         .cloned()
@@ -909,10 +906,8 @@ pub async fn handle_quorum_proposal_validated<TYPES: NodeType, I: NodeImplementa
                         vid_share,
                     ));
                     leafs_decided.push(leaf.clone());
-                    if let Some(ref payload) = leaf.get_block_payload() {
-                        for txn in
-                            payload.transaction_commitments(leaf.get_block_header().metadata())
-                        {
+                    if let Some(ref payload) = leaf.block_payload() {
+                        for txn in payload.transaction_commitments(leaf.block_header().metadata()) {
                             included_txns.insert(txn);
                         }
                     }
@@ -951,8 +946,7 @@ pub async fn handle_quorum_proposal_validated<TYPES: NodeType, I: NodeImplementa
         let new_view = task_state.current_proposal.clone().unwrap().view_number + 1;
         // In future we can use the mempool model where we fetch the proposal if we don't have it, instead of having to wait for it here
         // This is for the case where we form a QC but have not yet seen the previous proposal ourselves
-        let should_propose = task_state.quorum_membership.get_leader(new_view)
-            == task_state.public_key
+        let should_propose = task_state.quorum_membership.leader(new_view) == task_state.public_key
             && task_state.consensus.read().await.high_qc().view_number
                 == task_state.current_proposal.clone().unwrap().view_number;
 
@@ -1003,16 +997,16 @@ pub async fn handle_quorum_proposal_validated<TYPES: NodeType, I: NodeImplementa
         consensus
             .metrics
             .last_decided_view
-            .set(usize::try_from(consensus.last_decided_view().get_u64()).unwrap());
+            .set(usize::try_from(consensus.last_decided_view().u64()).unwrap());
         let cur_number_of_views_per_decide_event = {
             #[cfg(not(feature = "dependency-tasks"))]
             {
-                *task_state.cur_view - consensus.last_decided_view().get_u64()
+                *task_state.cur_view - consensus.last_decided_view().u64()
             }
 
             #[cfg(feature = "dependency-tasks")]
             {
-                *task_state.latest_proposed_view - consensus.last_decided_view().get_u64()
+                *task_state.latest_proposed_view - consensus.last_decided_view().u64()
             }
         };
         consensus
@@ -1113,20 +1107,19 @@ pub async fn update_state_and_vote_if_able<TYPES: NodeType, I: NodeImplementatio
     let justify_qc = proposal.justify_qc.clone();
     let parent = read_consnesus
         .saved_leaves()
-        .get(&justify_qc.get_data().leaf_commit)
+        .get(&justify_qc.date().leaf_commit)
         .cloned();
 
     // Justify qc's leaf commitment is not the same as the parent's leaf commitment, but it should be (in this case)
     let Some(parent) = parent else {
         error!(
             "Proposal's parent missing from storage with commitment: {:?}, proposal view {:?}",
-            justify_qc.get_data().leaf_commit,
+            justify_qc.date().leaf_commit,
             proposal.view_number,
         );
         return false;
     };
-    let (Some(parent_state), _) = read_consnesus.get_state_and_delta(parent.get_view_number())
-    else {
+    let (Some(parent_state), _) = read_consnesus.state_and_delta(parent.view_number()) else {
         warn!("Parent state not found! Consensus internally inconsistent");
         return false;
     };
@@ -1149,7 +1142,7 @@ pub async fn update_state_and_vote_if_able<TYPES: NodeType, I: NodeImplementatio
     let parent_commitment = parent.commit();
 
     let proposed_leaf = Leaf::from_quorum_proposal(&proposal);
-    if proposed_leaf.get_parent_commitment() != parent_commitment {
+    if proposed_leaf.parent_commitment() != parent_commitment {
         return false;
     }
 
@@ -1160,7 +1153,7 @@ pub async fn update_state_and_vote_if_able<TYPES: NodeType, I: NodeImplementatio
         // Validate the DAC.
         message = if cert.is_valid_cert(vote_info.2.as_ref()) {
             // Validate the block payload commitment for non-genesis DAC.
-            if cert.get_data().payload_commit != proposal.block_header.payload_commitment() {
+            if cert.date().payload_commit != proposal.block_header.payload_commitment() {
                 warn!(
                     "Block payload commitment does not equal da cert payload commitment. View = {}",
                     *view
@@ -1219,7 +1212,7 @@ pub async fn update_state_and_vote_if_able<TYPES: NodeType, I: NodeImplementatio
         if let GeneralConsensusMessage::Vote(vote) = message {
             debug!(
                 "Sending vote to next quorum leader {:?}",
-                vote.get_view_number() + 1
+                vote.view_number() + 1
             );
             // Add to the storage that we have received the VID disperse for a specific view
             if let Err(e) = storage.write().await.append_vid(&vid_share).await {
@@ -1234,7 +1227,7 @@ pub async fn update_state_and_vote_if_able<TYPES: NodeType, I: NodeImplementatio
         }
         debug!(
             "Received VID share, but couldn't find DAC cert for view {:?}",
-            *proposal.get_view_number(),
+            *proposal.view_number(),
         );
     }
     false

--- a/crates/task-impls/src/consensus/mod.rs
+++ b/crates/task-impls/src/consensus/mod.rs
@@ -162,7 +162,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> ConsensusTaskState<TYPES, I>
     /// Validate the VID disperse is correctly signed and has the correct share.
     #[cfg(not(feature = "dependency-tasks"))]
     fn validate_disperse(&self, disperse: &Proposal<TYPES, VidDisperseShare<TYPES>>) -> bool {
-        let view = disperse.data.get_view_number();
+        let view = disperse.data.view_number();
         let payload_commitment = disperse.data.payload_commitment;
 
         // Check whether the data satisfies one of the following.
@@ -171,14 +171,14 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> ConsensusTaskState<TYPES, I>
         // * Signed by one of the staked DA committee members.
         if !self
             .quorum_membership
-            .get_leader(view)
+            .leader(view)
             .validate(&disperse.signature, payload_commitment.as_ref())
             && !self
                 .public_key
                 .validate(&disperse.signature, payload_commitment.as_ref())
         {
             let mut validated = false;
-            for da_member in self.da_membership.get_staked_committee(view) {
+            for da_member in self.da_membership.staked_committee(view) {
                 if da_member.validate(&disperse.signature, payload_commitment.as_ref()) {
                     validated = true;
                     break;
@@ -248,7 +248,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> ConsensusTaskState<TYPES, I>
         let Some(proposal) = self.current_proposal.clone() else {
             return;
         };
-        if proposal.get_view_number() != view {
+        if proposal.view_number() != view {
             return;
         }
         let upgrade = self.decided_upgrade_cert.clone();
@@ -285,12 +285,12 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> ConsensusTaskState<TYPES, I>
         match event.as_ref() {
             #[cfg(not(feature = "dependency-tasks"))]
             HotShotEvent::QuorumProposalRecv(proposal, sender) => {
-                debug!("proposal recv view: {:?}", proposal.data.get_view_number());
+                debug!("proposal recv view: {:?}", proposal.data.view_number());
                 match handle_quorum_proposal_recv(proposal, sender, event_stream.clone(), self)
                     .await
                 {
                     Ok(Some(current_proposal)) => {
-                        let view = current_proposal.get_view_number();
+                        let view = current_proposal.view_number();
                         self.current_proposal = Some(current_proposal);
                         self.spawn_vote_task(view, event_stream);
                     }
@@ -300,7 +300,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> ConsensusTaskState<TYPES, I>
             }
             #[cfg(not(feature = "dependency-tasks"))]
             HotShotEvent::QuorumProposalValidated(proposal, _) => {
-                debug!("proposal validated view: {:?}", proposal.get_view_number());
+                debug!("proposal validated view: {:?}", proposal.view_number());
                 if let Err(e) =
                     handle_quorum_proposal_validated(proposal, event_stream.clone(), self).await
                 {
@@ -308,30 +308,23 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> ConsensusTaskState<TYPES, I>
                 }
             }
             HotShotEvent::QuorumVoteRecv(ref vote) => {
-                debug!("Received quorum vote: {:?}", vote.get_view_number());
-                if self
-                    .quorum_membership
-                    .get_leader(vote.get_view_number() + 1)
-                    != self.public_key
-                {
+                debug!("Received quorum vote: {:?}", vote.view_number());
+                if self.quorum_membership.leader(vote.view_number() + 1) != self.public_key {
                     error!(
                         "We are not the leader for view {} are we the leader for view + 1? {}",
-                        *vote.get_view_number() + 1,
-                        self.quorum_membership
-                            .get_leader(vote.get_view_number() + 2)
-                            == self.public_key
+                        *vote.view_number() + 1,
+                        self.quorum_membership.leader(vote.view_number() + 2) == self.public_key
                     );
                     return;
                 }
                 let mut collector = self.vote_collector.write().await;
 
-                if collector.is_none() || vote.get_view_number() > collector.as_ref().unwrap().view
-                {
-                    debug!("Starting vote handle for view {:?}", vote.get_view_number());
+                if collector.is_none() || vote.view_number() > collector.as_ref().unwrap().view {
+                    debug!("Starting vote handle for view {:?}", vote.view_number());
                     let info = AccumulatorInfo {
                         public_key: self.public_key.clone(),
                         membership: Arc::clone(&self.quorum_membership),
-                        view: vote.get_view_number(),
+                        view: vote.view_number(),
                         id: self.id,
                     };
                     *collector = create_vote_accumulator::<
@@ -355,29 +348,22 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> ConsensusTaskState<TYPES, I>
                 }
             }
             HotShotEvent::TimeoutVoteRecv(ref vote) => {
-                if self
-                    .timeout_membership
-                    .get_leader(vote.get_view_number() + 1)
-                    != self.public_key
-                {
+                if self.timeout_membership.leader(vote.view_number() + 1) != self.public_key {
                     error!(
                         "We are not the leader for view {} are we the leader for view + 1? {}",
-                        *vote.get_view_number() + 1,
-                        self.timeout_membership
-                            .get_leader(vote.get_view_number() + 2)
-                            == self.public_key
+                        *vote.view_number() + 1,
+                        self.timeout_membership.leader(vote.view_number() + 2) == self.public_key
                     );
                     return;
                 }
                 let mut collector = self.timeout_vote_collector.write().await;
 
-                if collector.is_none() || vote.get_view_number() > collector.as_ref().unwrap().view
-                {
-                    debug!("Starting vote handle for view {:?}", vote.get_view_number());
+                if collector.is_none() || vote.view_number() > collector.as_ref().unwrap().view {
+                    debug!("Starting vote handle for view {:?}", vote.view_number());
                     let info = AccumulatorInfo {
                         public_key: self.public_key.clone(),
                         membership: Arc::clone(&self.quorum_membership),
-                        view: vote.get_view_number(),
+                        view: vote.view_number(),
                         id: self.id,
                     };
                     *collector = create_vote_accumulator::<
@@ -463,14 +449,14 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> ConsensusTaskState<TYPES, I>
                 let Some(proposal) = self.current_proposal.clone() else {
                     return;
                 };
-                if proposal.get_view_number() != view {
+                if proposal.view_number() != view {
                     return;
                 }
                 self.spawn_vote_task(view, event_stream);
             }
             #[cfg(not(feature = "dependency-tasks"))]
             HotShotEvent::VIDShareRecv(disperse) => {
-                let view = disperse.data.get_view_number();
+                let view = disperse.data.view_number();
 
                 debug!(
                     "VID disperse received for view: {:?} in consensus task",
@@ -503,7 +489,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> ConsensusTaskState<TYPES, I>
                 let Some(proposal) = self.current_proposal.clone() else {
                     return;
                 };
-                if proposal.get_view_number() != view {
+                if proposal.view_number() != view {
                     return;
                 }
                 self.spawn_vote_task(view, event_stream.clone());
@@ -637,8 +623,8 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> ConsensusTaskState<TYPES, I>
                     fee: fee.clone(),
                     block_view: view,
                 });
-                if self.quorum_membership.get_leader(view) == self.public_key
-                    && self.consensus.read().await.high_qc().get_view_number() + 1 == view
+                if self.quorum_membership.leader(view) == self.public_key
+                    && self.consensus.read().await.high_qc().view_number() + 1 == view
                 {
                     if let Err(e) = self.publish_proposal(view, event_stream.clone()).await {
                         error!("Failed to propose; error = {e:?}");
@@ -653,7 +639,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> ConsensusTaskState<TYPES, I>
                     }
                     match cert {
                         ViewChangeEvidence::Timeout(tc) => {
-                            if self.quorum_membership.get_leader(tc.get_view_number() + 1)
+                            if self.quorum_membership.leader(tc.view_number() + 1)
                                 == self.public_key
                             {
                                 if let Err(e) = self.publish_proposal(view, event_stream).await {
@@ -662,9 +648,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> ConsensusTaskState<TYPES, I>
                             }
                         }
                         ViewChangeEvidence::ViewSync(vsc) => {
-                            if self.quorum_membership.get_leader(vsc.get_view_number())
-                                == self.public_key
-                            {
+                            if self.quorum_membership.leader(vsc.view_number()) == self.public_key {
                                 if let Err(e) = self.publish_proposal(view, event_stream).await {
                                     debug!("Failed to propose; error = {e:?}");
                                 };
@@ -678,14 +662,14 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> ConsensusTaskState<TYPES, I>
                 if !certificate.is_valid_cert(self.quorum_membership.as_ref()) {
                     error!(
                         "View Sync Finalize certificate {:?} was invalid",
-                        certificate.get_data()
+                        certificate.date()
                     );
                     return;
                 }
 
                 let view = certificate.view_number;
 
-                if self.quorum_membership.get_leader(view) == self.public_key {
+                if self.quorum_membership.leader(view) == self.public_key {
                     self.proposal_cert = Some(ViewChangeEvidence::ViewSync(certificate.clone()));
 
                     debug!(
@@ -703,12 +687,11 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> ConsensusTaskState<TYPES, I>
                 let Some(proposal) = self.current_proposal.clone() else {
                     return;
                 };
-                let new_view = proposal.get_view_number() + 1;
+                let new_view = proposal.view_number() + 1;
                 // In future we can use the mempool model where we fetch the proposal if we don't have it, instead of having to wait for it here
                 // This is for the case where we form a QC but have not yet seen the previous proposal ourselves
-                let should_propose = self.quorum_membership.get_leader(new_view) == self.public_key
-                    && self.consensus.read().await.high_qc().view_number
-                        == proposal.get_view_number();
+                let should_propose = self.quorum_membership.leader(new_view) == self.public_key
+                    && self.consensus.read().await.high_qc().view_number == proposal.view_number();
 
                 if should_propose {
                     debug!(
@@ -719,7 +702,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> ConsensusTaskState<TYPES, I>
                         debug!("failed to propose e = {:?}", e);
                     }
                 }
-                if proposal.get_view_number() <= vote.get_view_number() {
+                if proposal.view_number() <= vote.view_number() {
                     self.current_proposal = None;
                 }
             }
@@ -727,16 +710,16 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> ConsensusTaskState<TYPES, I>
                 if self
                     .payload_commitment_and_metadata
                     .as_ref()
-                    .is_some_and(|p| p.block_view <= proposal.data.get_view_number())
+                    .is_some_and(|p| p.block_view <= proposal.data.view_number())
                 {
                     self.payload_commitment_and_metadata = None;
                 }
                 if let Some(cert) = &self.proposal_cert {
                     let view = match cert {
-                        ViewChangeEvidence::Timeout(tc) => tc.get_view_number() + 1,
-                        ViewChangeEvidence::ViewSync(vsc) => vsc.get_view_number(),
+                        ViewChangeEvidence::Timeout(tc) => tc.view_number() + 1,
+                        ViewChangeEvidence::ViewSync(vsc) => vsc.view_number(),
                     };
-                    if view < proposal.data.get_view_number() {
+                    if view < proposal.data.view_number() {
                         self.proposal_cert = None;
                     }
                 }

--- a/crates/task-impls/src/consensus/view_change.rs
+++ b/crates/task-impls/src/consensus/view_change.rs
@@ -86,16 +86,16 @@ pub(crate) async fn update_view<TYPES: NodeType>(
     consensus
         .metrics
         .current_view
-        .set(usize::try_from(cur_view.get_u64()).unwrap());
+        .set(usize::try_from(cur_view.u64()).unwrap());
 
     // Do the comparison before the subtraction to avoid potential overflow, since
     // `last_decided_view` may be greater than `cur_view` if the node is catching up.
-    if usize::try_from(cur_view.get_u64()).unwrap()
-        > usize::try_from(consensus.last_decided_view().get_u64()).unwrap()
+    if usize::try_from(cur_view.u64()).unwrap()
+        > usize::try_from(consensus.last_decided_view().u64()).unwrap()
     {
         consensus.metrics.number_of_views_since_last_decide.set(
-            usize::try_from(cur_view.get_u64()).unwrap()
-                - usize::try_from(consensus.last_decided_view().get_u64()).unwrap(),
+            usize::try_from(cur_view.u64()).unwrap()
+                - usize::try_from(consensus.last_decided_view().u64()).unwrap(),
         );
     }
     let mut consensus = RwLockUpgradableReadGuard::upgrade(consensus).await;

--- a/crates/task-impls/src/da.rs
+++ b/crates/task-impls/src/da.rs
@@ -96,10 +96,10 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                 let sender = sender.clone();
                 debug!(
                     "DA proposal received for view: {:?}",
-                    proposal.data.get_view_number()
+                    proposal.data.view_number()
                 );
                 // ED NOTE: Assuming that the next view leader is the one who sends DA proposal for this view
-                let view = proposal.data.get_view_number();
+                let view = proposal.data.view_number();
 
                 // Allow a DA proposal that is one view older, in case we have voted on a quorum
                 // proposal and updated the view.
@@ -127,7 +127,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                 let encoded_transactions_hash = Sha256::digest(&proposal.data.encoded_transactions);
 
                 // ED Is this the right leader?
-                let view_leader_key = self.da_membership.get_leader(view);
+                let view_leader_key = self.da_membership.leader(view);
                 if view_leader_key != sender {
                     error!("DA proposal doesn't have expected leader key for view {} \n DA proposal is: {:?}", *view, proposal.data.clone());
                     return None;
@@ -177,7 +177,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                 #[cfg(async_executor_impl = "tokio")]
                 let payload_commitment = payload_commitment.unwrap();
 
-                let view = proposal.data.get_view_number();
+                let view = proposal.data.view_number();
                 // Generate and send vote
                 let Ok(vote) = DaVote::create_signed_vote(
                     DaData {
@@ -191,7 +191,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                     return None;
                 };
 
-                debug!("Sending vote to the DA leader {:?}", vote.get_view_number());
+                debug!("Sending vote to the DA leader {:?}", vote.view_number());
 
                 broadcast_event(Arc::new(HotShotEvent::DaVoteSend(vote)), &event_stream).await;
                 let mut consensus = self.consensus.write().await;
@@ -216,22 +216,21 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                 }
             }
             HotShotEvent::DaVoteRecv(ref vote) => {
-                debug!("DA vote recv, Main Task {:?}", vote.get_view_number());
+                debug!("DA vote recv, Main Task {:?}", vote.view_number());
                 // Check if we are the leader and the vote is from the sender.
-                let view = vote.get_view_number();
-                if self.da_membership.get_leader(view) != self.public_key {
-                    error!("We are not the DA committee leader for view {} are we leader for next view? {}", *view, self.da_membership.get_leader(view + 1) == self.public_key);
+                let view = vote.view_number();
+                if self.da_membership.leader(view) != self.public_key {
+                    error!("We are not the DA committee leader for view {} are we leader for next view? {}", *view, self.da_membership.leader(view + 1) == self.public_key);
                     return None;
                 }
                 let mut collector = self.vote_collector.write().await;
 
-                if collector.is_none() || vote.get_view_number() > collector.as_ref().unwrap().view
-                {
-                    debug!("Starting vote handle for view {:?}", vote.get_view_number());
+                if collector.is_none() || vote.view_number() > collector.as_ref().unwrap().view {
+                    debug!("Starting vote handle for view {:?}", vote.view_number());
                     let info = AccumulatorInfo {
                         public_key: self.public_key.clone(),
                         membership: Arc::clone(&self.da_membership),
-                        view: vote.get_view_number(),
+                        view: vote.view_number(),
                         id: self.id,
                     };
                     *collector = create_vote_accumulator::<
@@ -266,7 +265,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                 self.cur_view = view;
 
                 // If we are not the next leader (DA leader for this view) immediately exit
-                if self.da_membership.get_leader(self.cur_view + 1) != self.public_key {
+                if self.da_membership.leader(self.cur_view + 1) != self.public_key {
                     return None;
                 }
                 debug!("Polling for DA votes for view {}", *self.cur_view + 1);

--- a/crates/task-impls/src/quorum_proposal.rs
+++ b/crates/task-impls/src/quorum_proposal.rs
@@ -435,7 +435,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> QuorumProposalTaskState<TYPE
         event: Arc<HotShotEvent<TYPES>>,
     ) {
         // Don't even bother making the task if we are not entitled to propose anyay.
-        if self.quorum_membership.get_leader(view_number) != self.public_key {
+        if self.quorum_membership.leader(view_number) != self.public_key {
             return;
         }
 
@@ -573,7 +573,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> QuorumProposalTaskState<TYPE
                 if !certificate.is_valid_cert(self.quorum_membership.as_ref()) {
                     warn!(
                         "View Sync Finalize certificate {:?} was invalid",
-                        certificate.get_data()
+                        certificate.date()
                     );
                     return;
                 }

--- a/crates/task-impls/src/request.rs
+++ b/crates/task-impls/src/request.rs
@@ -87,7 +87,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, Ver: StaticVersionType + 'st
         match event.as_ref() {
             HotShotEvent::QuorumProposalValidated(proposal, _) => {
                 let state = task.state();
-                let prop_view = proposal.get_view_number();
+                let prop_view = proposal.view_number();
                 if prop_view >= state.view {
                     state
                         .spawn_requests(prop_view, task.clone_sender(), Ver::instance())
@@ -169,7 +169,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, Ver: StaticVersionType + 'st
     ) {
         let mut recipients: Vec<_> = self
             .da_membership
-            .get_whole_committee(view)
+            .whole_committee(view)
             .into_iter()
             .collect();
         // Randomize the recipients so all replicas don't overload the same 1 recipients

--- a/crates/task-impls/src/transactions.rs
+++ b/crates/task-impls/src/transactions.rs
@@ -118,12 +118,12 @@ impl<
                 let mut make_block = false;
                 if *view - *self.cur_view > 1 {
                     error!("View changed by more than 1 going to view {:?}", view);
-                    make_block = self.membership.get_leader(view) == self.public_key;
+                    make_block = self.membership.leader(view) == self.public_key;
                 }
                 self.cur_view = view;
 
                 // return if we aren't the next leader or we skipped last view and aren't the current leader.
-                if !make_block && self.membership.get_leader(self.cur_view + 1) != self.public_key {
+                if !make_block && self.membership.leader(self.cur_view + 1) != self.public_key {
                     debug!("Not next leader for view {:?}", self.cur_view);
                     return None;
                 }
@@ -237,7 +237,7 @@ impl<
                         ViewInner::Leaf { leaf, .. } => consensus
                             .saved_leaves()
                             .get(&leaf)
-                            .map(Leaf::get_payload_commitment),
+                            .map(Leaf::payload_commitment),
                         ViewInner::Failed => None,
                     })
             {
@@ -247,10 +247,7 @@ impl<
         }
 
         // If not found, return commitment for last decided block
-        (
-            prev_view,
-            consensus.get_decided_leaf().get_payload_commitment(),
-        )
+        (prev_view, consensus.decided_leaf().payload_commitment())
     }
 
     #[instrument(skip_all, fields(id = self.id, view = *self.cur_view), name = "wait_for_block", level = "error")]
@@ -275,7 +272,7 @@ impl<
                 self.api
                     .builder_timeout()
                     .saturating_sub(task_start_time.elapsed()),
-                self.get_block_from_builder(parent_comm, view_num, &parent_comm_sig),
+                self.block_from_builder(parent_comm, view_num, &parent_comm_sig),
             )
             .await
             {
@@ -304,8 +301,8 @@ impl<
         None
     }
 
-    #[instrument(skip_all, fields(id = self.id, view = *self.cur_view), name = "get_block_from_builder", level = "error")]
-    async fn get_block_from_builder(
+    #[instrument(skip_all, fields(id = self.id, view = *self.cur_view), name = "block_from_builder", level = "error")]
+    async fn block_from_builder(
         &self,
         parent_comm: VidCommitment,
         view_number: TYPES::Time,
@@ -313,9 +310,9 @@ impl<
     ) -> anyhow::Result<BuilderResponses<TYPES>> {
         let available_blocks = self
             .builder_client
-            .get_available_blocks(
+            .available_blocks(
                 parent_comm,
-                view_number.get_u64(),
+                view_number.u64(),
                 self.public_key.clone(),
                 parent_comm_sig,
             )
@@ -356,8 +353,8 @@ impl<
         .context("signing block hash")?;
 
         let (block, header_input) = futures::join! {
-            self.builder_client.claim_block(block_info.block_hash.clone(), view_number.get_u64(), self.public_key.clone(), &request_signature),
-            self.builder_client.claim_block_header_input(block_info.block_hash.clone(), view_number.get_u64(), self.public_key.clone(), &request_signature)
+            self.builder_client.claim_block(block_info.block_hash.clone(), view_number.u64(), self.public_key.clone(), &request_signature),
+            self.builder_client.claim_block_header_input(block_info.block_hash.clone(), view_number.u64(), self.public_key.clone(), &request_signature)
         };
 
         let block_data = block.context("claiming block data")?;

--- a/crates/task-impls/src/vid.rs
+++ b/crates/task-impls/src/vid.rs
@@ -145,7 +145,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                 self.cur_view = view;
 
                 // If we are not the next leader, we should exit
-                if self.membership.get_leader(self.cur_view + 1) != self.public_key {
+                if self.membership.leader(self.cur_view + 1) != self.public_key {
                     // panic!("We are not the DA leader for view {}", *self.cur_view + 1);
                     return None;
                 }

--- a/crates/task-impls/src/vote_collection.rs
+++ b/crates/task-impls/src/vote_collection.rs
@@ -53,7 +53,7 @@ pub trait AggregatableVote<
 >
 {
     /// return the leader for this votes
-    fn get_leader(&self, membership: &TYPES::Membership) -> TYPES::SignatureKey;
+    fn leader(&self, membership: &TYPES::Membership) -> TYPES::SignatureKey;
 
     /// return the Hotshot event for the completion of this CERT
     fn make_cert_event(certificate: CERT, key: &TYPES::SignatureKey) -> HotShotEvent<TYPES>;
@@ -73,15 +73,15 @@ impl<
         vote: &VOTE,
         event_stream: &Sender<Arc<HotShotEvent<TYPES>>>,
     ) -> Option<HotShotTaskCompleted> {
-        if vote.get_leader(&self.membership) != self.public_key {
+        if vote.leader(&self.membership) != self.public_key {
             error!("Received vote for a view in which we were not the leader.");
             return None;
         }
 
-        if vote.get_view_number() != self.view {
+        if vote.view_number() != self.view {
             error!(
                 "Vote view does not match! vote view is {} current view is {}",
-                *vote.get_view_number(),
+                *vote.view_number(),
                 *self.view
             );
             return None;
@@ -189,10 +189,10 @@ where
         + 'static,
     VoteCollectionTaskState<TYPES, VOTE, CERT>: HandleVoteEvent<TYPES, VOTE, CERT>,
 {
-    if vote.get_view_number() != info.view {
+    if vote.view_number() != info.view {
         error!(
             "Vote view does not match! vote view is {} current view is {}",
-            *vote.get_view_number(),
+            *vote.view_number(),
             *info.view
         );
         return None;
@@ -251,8 +251,8 @@ type ViewSyncFinalizeVoteState<TYPES> = VoteCollectionTaskState<
 impl<TYPES: NodeType> AggregatableVote<TYPES, QuorumVote<TYPES>, QuorumCertificate<TYPES>>
     for QuorumVote<TYPES>
 {
-    fn get_leader(&self, membership: &TYPES::Membership) -> TYPES::SignatureKey {
-        membership.get_leader(self.get_view_number() + 1)
+    fn leader(&self, membership: &TYPES::Membership) -> TYPES::SignatureKey {
+        membership.leader(self.view_number() + 1)
     }
     fn make_cert_event(
         certificate: QuorumCertificate<TYPES>,
@@ -265,8 +265,8 @@ impl<TYPES: NodeType> AggregatableVote<TYPES, QuorumVote<TYPES>, QuorumCertifica
 impl<TYPES: NodeType> AggregatableVote<TYPES, UpgradeVote<TYPES>, UpgradeCertificate<TYPES>>
     for UpgradeVote<TYPES>
 {
-    fn get_leader(&self, membership: &TYPES::Membership) -> TYPES::SignatureKey {
-        membership.get_leader(self.get_view_number())
+    fn leader(&self, membership: &TYPES::Membership) -> TYPES::SignatureKey {
+        membership.leader(self.view_number())
     }
     fn make_cert_event(
         certificate: UpgradeCertificate<TYPES>,
@@ -279,8 +279,8 @@ impl<TYPES: NodeType> AggregatableVote<TYPES, UpgradeVote<TYPES>, UpgradeCertifi
 impl<TYPES: NodeType> AggregatableVote<TYPES, DaVote<TYPES>, DaCertificate<TYPES>>
     for DaVote<TYPES>
 {
-    fn get_leader(&self, membership: &TYPES::Membership) -> TYPES::SignatureKey {
-        membership.get_leader(self.get_view_number())
+    fn leader(&self, membership: &TYPES::Membership) -> TYPES::SignatureKey {
+        membership.leader(self.view_number())
     }
     fn make_cert_event(
         certificate: DaCertificate<TYPES>,
@@ -293,8 +293,8 @@ impl<TYPES: NodeType> AggregatableVote<TYPES, DaVote<TYPES>, DaCertificate<TYPES
 impl<TYPES: NodeType> AggregatableVote<TYPES, TimeoutVote<TYPES>, TimeoutCertificate<TYPES>>
     for TimeoutVote<TYPES>
 {
-    fn get_leader(&self, membership: &TYPES::Membership) -> TYPES::SignatureKey {
-        membership.get_leader(self.get_view_number() + 1)
+    fn leader(&self, membership: &TYPES::Membership) -> TYPES::SignatureKey {
+        membership.leader(self.view_number() + 1)
     }
     fn make_cert_event(
         certificate: TimeoutCertificate<TYPES>,
@@ -308,8 +308,8 @@ impl<TYPES: NodeType>
     AggregatableVote<TYPES, ViewSyncCommitVote<TYPES>, ViewSyncCommitCertificate2<TYPES>>
     for ViewSyncCommitVote<TYPES>
 {
-    fn get_leader(&self, membership: &TYPES::Membership) -> TYPES::SignatureKey {
-        membership.get_leader(self.get_data().round + self.get_data().relay)
+    fn leader(&self, membership: &TYPES::Membership) -> TYPES::SignatureKey {
+        membership.leader(self.date().round + self.date().relay)
     }
     fn make_cert_event(
         certificate: ViewSyncCommitCertificate2<TYPES>,
@@ -323,8 +323,8 @@ impl<TYPES: NodeType>
     AggregatableVote<TYPES, ViewSyncPreCommitVote<TYPES>, ViewSyncPreCommitCertificate2<TYPES>>
     for ViewSyncPreCommitVote<TYPES>
 {
-    fn get_leader(&self, membership: &TYPES::Membership) -> TYPES::SignatureKey {
-        membership.get_leader(self.get_data().round + self.get_data().relay)
+    fn leader(&self, membership: &TYPES::Membership) -> TYPES::SignatureKey {
+        membership.leader(self.date().round + self.date().relay)
     }
     fn make_cert_event(
         certificate: ViewSyncPreCommitCertificate2<TYPES>,
@@ -338,8 +338,8 @@ impl<TYPES: NodeType>
     AggregatableVote<TYPES, ViewSyncFinalizeVote<TYPES>, ViewSyncFinalizeCertificate2<TYPES>>
     for ViewSyncFinalizeVote<TYPES>
 {
-    fn get_leader(&self, membership: &TYPES::Membership) -> TYPES::SignatureKey {
-        membership.get_leader(self.get_data().round + self.get_data().relay)
+    fn leader(&self, membership: &TYPES::Membership) -> TYPES::SignatureKey {
+        membership.leader(self.date().round + self.date().relay)
     }
     fn make_cert_event(
         certificate: ViewSyncFinalizeCertificate2<TYPES>,

--- a/crates/testing/src/block_builder.rs
+++ b/crates/testing/src/block_builder.rs
@@ -209,7 +209,7 @@ impl<TYPES: NodeType> ReadState for RandomBuilderSource<TYPES> {
 
 #[async_trait]
 impl<TYPES: NodeType> BuilderDataSource<TYPES> for RandomBuilderSource<TYPES> {
-    async fn get_available_blocks(
+    async fn available_blocks(
         &self,
         _for_parent: &VidCommitment,
         _view_number: u64,
@@ -260,7 +260,7 @@ impl<TYPES: NodeType> BuilderDataSource<TYPES> for RandomBuilderSource<TYPES> {
         Ok(header_input)
     }
 
-    async fn get_builder_address(&self) -> Result<TYPES::BuilderSignatureKey, BuildError> {
+    async fn builder_address(&self) -> Result<TYPES::BuilderSignatureKey, BuildError> {
         Ok(self.pub_key.clone())
     }
 }
@@ -322,7 +322,7 @@ impl<TYPES: NodeType> BuilderDataSource<TYPES> for SimpleBuilderSource<TYPES>
 where
     <TYPES as NodeType>::InstanceState: Default,
 {
-    async fn get_available_blocks(
+    async fn available_blocks(
         &self,
         _for_parent: &VidCommitment,
         _view_number: u64,
@@ -419,7 +419,7 @@ where
         entry.header_input.take().ok_or(BuildError::Missing)
     }
 
-    async fn get_builder_address(&self) -> Result<TYPES::BuilderSignatureKey, BuildError> {
+    async fn builder_address(&self) -> Result<TYPES::BuilderSignatureKey, BuildError> {
         Ok(self.pub_key.clone())
     }
 }
@@ -473,9 +473,9 @@ impl<TYPES: NodeType> BuilderTask<TYPES> for SimpleBuilderTask<TYPES> {
                         EventType::Decide { leaf_chain, .. } => {
                             let mut queue = self.transactions.write().await;
                             for leaf_info in leaf_chain.iter() {
-                                if let Some(ref payload) = leaf_info.leaf.get_block_payload() {
+                                if let Some(ref payload) = leaf_info.leaf.block_payload() {
                                     for txn in payload.transaction_commitments(
-                                        leaf_info.leaf.get_block_header().metadata(),
+                                        leaf_info.leaf.block_header().metadata(),
                                     ) {
                                         self.decided_transactions.put(txn, ());
                                         queue.remove(&txn);

--- a/crates/testing/src/overall_safety_task.rs
+++ b/crates/testing/src/overall_safety_task.rs
@@ -160,7 +160,7 @@ impl<TYPES: NodeType, I: TestableNodeImplementation<TYPES>> TestTaskState
                 block_size: maybe_block_size,
             } => {
                 // Skip the genesis leaf.
-                if leaf_chain.last().unwrap().leaf.get_view_number() == TYPES::Time::genesis() {
+                if leaf_chain.last().unwrap().leaf.view_number() == TYPES::Time::genesis() {
                     return None;
                 }
                 let paired_up = (leaf_chain.to_vec(), (*qc).clone());
@@ -373,7 +373,7 @@ impl<TYPES: NodeType> RoundResult<TYPES> {
                 }
             }
 
-            let payload_commitment = leaf.get_payload_commitment();
+            let payload_commitment = leaf.payload_commitment();
 
             match self.block_map.entry(payload_commitment) {
                 std::collections::hash_map::Entry::Occupied(mut o) => {
@@ -430,7 +430,7 @@ impl<TYPES: NodeType> RoundResult<TYPES> {
                 .unwrap();
             if *count >= threshold {
                 for leaf in self.leaf_map.keys() {
-                    if leaf.get_view_number() > quorum_leaf.get_view_number() {
+                    if leaf.view_number() > quorum_leaf.view_number() {
                         error!("LEAF MAP (that is mismatched) IS: {:?}", self.leaf_map);
                         self.status = ViewStatus::Err(OverallSafetyTaskErr::MismatchedLeaf);
                         return;
@@ -465,7 +465,7 @@ impl<TYPES: NodeType> RoundResult<TYPES> {
             // if not, return error
             // if neither, continue through
 
-            let block_key = key.get_payload_commitment();
+            let block_key = key.payload_commitment();
 
             if *self.block_map.get(&block_key).unwrap() == threshold
                 && *self.leaf_map.get(key).unwrap() == threshold

--- a/crates/testing/src/spinning_task.rs
+++ b/crates/testing/src/spinning_task.rs
@@ -92,7 +92,7 @@ where
         } = event
         {
             let leaf = leaf_chain.first().unwrap().leaf.clone();
-            if leaf.get_view_number() > state.last_decided_leaf.get_view_number() {
+            if leaf.view_number() > state.last_decided_leaf.view_number() {
                 state.last_decided_leaf = leaf;
             }
         } else if let EventType::QuorumProposal {
@@ -100,7 +100,7 @@ where
             sender: _,
         } = event
         {
-            if proposal.data.justify_qc.get_view_number() > state.high_qc.get_view_number() {
+            if proposal.data.justify_qc.view_number() > state.high_qc.view_number() {
                 state.high_qc = proposal.data.justify_qc;
             }
         }

--- a/crates/testing/src/task_helpers.rs
+++ b/crates/testing/src/task_helpers.rs
@@ -126,15 +126,15 @@ pub fn build_cert<
         SimpleVote::<TYPES, DATAType>::create_signed_vote(data, view, public_key, private_key)
             .expect("Failed to sign data!");
     let cert = CERT::create_signed_certificate(
-        vote.get_data_commitment(),
-        vote.get_data().clone(),
+        vote.date_commitment(),
+        vote.date().clone(),
         real_qc_sig,
-        vote.get_view_number(),
+        vote.view_number(),
     );
     cert
 }
 
-pub fn get_vid_share<TYPES: NodeType>(
+pub fn vid_share<TYPES: NodeType>(
     shares: &[Proposal<TYPES, VidDisperseShare<TYPES>>],
     pub_key: TYPES::SignatureKey,
 ) -> Proposal<TYPES, VidDisperseShare<TYPES>> {
@@ -161,9 +161,9 @@ pub fn build_assembled_sig<
     membership: &TYPES::Membership,
     view: TYPES::Time,
 ) -> <TYPES::SignatureKey as SignatureKey>::QCType {
-    let stake_table = membership.get_committee_qc_stake_table();
+    let stake_table = membership.committee_qc_stake_table();
     let real_qc_pp: <TYPES::SignatureKey as SignatureKey>::QCParams =
-        <TYPES::SignatureKey as SignatureKey>::get_public_parameter(
+        <TYPES::SignatureKey as SignatureKey>::public_parameter(
             stake_table.clone(),
             U256::from(CERT::threshold(membership)),
         );
@@ -182,7 +182,7 @@ pub fn build_assembled_sig<
         )
         .expect("Failed to sign data!");
         let original_signature: <TYPES::SignatureKey as SignatureKey>::PureAssembledSignatureType =
-            vote.get_signature();
+            vote.signature();
         sig_lists.push(original_signature);
     }
 
@@ -212,7 +212,7 @@ pub fn vid_scheme_from_view_number<TYPES: NodeType>(
     membership: &TYPES::Membership,
     view_number: TYPES::Time,
 ) -> VidSchemeType {
-    let num_storage_nodes = membership.get_staked_committee(view_number).len();
+    let num_storage_nodes = membership.staked_committee(view_number).len();
     vid_scheme(num_storage_nodes)
 }
 
@@ -301,7 +301,7 @@ pub async fn build_vote(
             leaf_commit: leaf.commit(),
         },
         view,
-        handle.public_key(),
+        &handle.public_key(),
         handle.private_key(),
     )
     .expect("Failed to create quorum vote");

--- a/crates/testing/src/test_builder.rs
+++ b/crates/testing/src/test_builder.rs
@@ -258,10 +258,10 @@ impl TestDescription {
 
                 // Add the node to the known DA nodes based on the index (for tests)
                 if node_id_ < da_staked_committee_size {
-                    known_da_nodes.push(cur_validator_config.get_public_config());
+                    known_da_nodes.push(cur_validator_config.public_config());
                 }
 
-                cur_validator_config.get_public_config()
+                cur_validator_config.public_config()
             })
             .collect();
         // But now to test validator's config, we input the info of my_own_validator from config file when node_id == 0.

--- a/crates/testing/src/test_runner.rs
+++ b/crates/testing/src/test_runner.rs
@@ -154,11 +154,11 @@ where
         let mut internal_event_rxs = vec![];
 
         for node in &self.nodes {
-            let r = node.handle.get_event_stream_known_impl();
+            let r = node.handle.event_stream_known_impl();
             event_rxs.push(r);
         }
         for node in &self.nodes {
-            let r = node.handle.get_internal_event_stream_known_impl();
+            let r = node.handle.internal_event_stream_known_impl();
             internal_event_rxs.push(r);
         }
 
@@ -406,7 +406,7 @@ where
                     let handle = hotshot.run_tasks().await;
                     if node_id == 1 {
                         if let Some(task) = builder_task.take() {
-                            task.start(Box::new(handle.get_event_stream()))
+                            task.start(Box::new(handle.event_stream()))
                         }
                     }
 

--- a/crates/testing/src/txn_task.rs
+++ b/crates/testing/src/txn_task.rs
@@ -69,7 +69,7 @@ impl<TYPES: NodeType, I: TestableNodeImplementation<TYPES>> TxnTask<TYPES, I> {
                     // we're assuming all nodes have the same leaf.
                     // If they don't match, this is probably fine since
                     // it should be caught by an assertion (and the txn will be rejected anyway)
-                    let leaf = node.handle.get_decided_leaf().await;
+                    let leaf = node.handle.decided_leaf().await;
                     let txn = I::leaf_create_random_transaction(&leaf, &mut thread_rng(), 0);
                     node.handle
                         .submit_transaction(txn.clone())

--- a/crates/testing/src/view_generator.rs
+++ b/crates/testing/src/view_generator.rs
@@ -361,7 +361,7 @@ impl TestView {
                 leaf_commit: self.leaf.commit(),
             },
             self.view_number,
-            handle.public_key(),
+            &handle.public_key(),
             handle.private_key(),
         )
         .expect("Failed to generate a signature on QuorumVote")
@@ -375,7 +375,7 @@ impl TestView {
         UpgradeVote::<TestTypes>::create_signed_vote(
             data,
             self.view_number,
-            handle.public_key(),
+            &handle.public_key(),
             handle.private_key(),
         )
         .expect("Failed to generate a signature on UpgradVote")
@@ -389,7 +389,7 @@ impl TestView {
         DaVote::create_signed_vote(
             data,
             self.view_number,
-            handle.public_key(),
+            &handle.public_key(),
             handle.private_key(),
         )
         .expect("Failed to sign DaData")

--- a/crates/testing/tests/tests_1/block_builder.rs
+++ b/crates/testing/tests/tests_1/block_builder.rs
@@ -54,7 +54,7 @@ async fn test_random_block_builder() {
     let mut blocks = loop {
         // Test getting blocks
         let blocks = client
-            .get_available_blocks(
+            .available_blocks(
                 vid_commitment(&[], 1),
                 dummy_view_number,
                 pub_key,

--- a/crates/testing/tests/tests_1/consensus_task.rs
+++ b/crates/testing/tests/tests_1/consensus_task.rs
@@ -15,7 +15,7 @@ use hotshot_testing::{
     },
     script::{run_test_script, TestScriptStage},
     task_helpers::{
-        build_system_handle, get_vid_share, key_pair_for_id, vid_scheme_from_view_number,
+        build_system_handle, vid_share, key_pair_for_id, vid_scheme_from_view_number,
     },
     test_helpers::permute_input_with_index_order,
     view_generator::TestViewGenerator,
@@ -72,7 +72,7 @@ async fn test_consensus_task() {
         inputs: vec![
             QuorumProposalRecv(proposals[0].clone(), leaders[0]),
             DaCertificateRecv(dacs[0].clone()),
-            VIDShareRecv(get_vid_share(&vids[0].0, handle.get_public_key())),
+            VIDShareRecv(vid_share(&vids[0].0, handle.public_key())),
         ],
         outputs: vec![
             exact(ViewChange(ViewNumber::new(1))),
@@ -88,7 +88,7 @@ async fn test_consensus_task() {
     // Run view 2 and propose.
     let view_2 = TestScriptStage {
         inputs: vec![
-            VIDShareRecv(get_vid_share(&vids[1].0, handle.get_public_key())),
+            VIDShareRecv(vid_share(&vids[1].0, handle.public_key())),
             QuorumProposalRecv(proposals[1].clone(), leaders[1]),
             QCFormed(either::Left(cert)),
             // We must have a payload commitment and metadata to propose.
@@ -155,7 +155,7 @@ async fn test_consensus_vote() {
         inputs: vec![
             QuorumProposalRecv(proposals[0].clone(), leaders[0]),
             DaCertificateRecv(dacs[0].clone()),
-            VIDShareRecv(get_vid_share(&vids[0].0, handle.get_public_key())),
+            VIDShareRecv(vid_share(&vids[0].0, handle.public_key())),
             QuorumVoteRecv(votes[0].clone()),
         ],
         outputs: vec![
@@ -204,7 +204,7 @@ async fn test_vote_with_specific_order(input_permutation: Vec<usize>) {
         inputs: vec![
             QuorumProposalRecv(proposals[0].clone(), leaders[0]),
             DaCertificateRecv(dacs[0].clone()),
-            VIDShareRecv(get_vid_share(&vids[0].0, handle.get_public_key())),
+            VIDShareRecv(vid_share(&vids[0].0, handle.public_key())),
         ],
         outputs: vec![
             exact(ViewChange(ViewNumber::new(1))),
@@ -216,7 +216,7 @@ async fn test_vote_with_specific_order(input_permutation: Vec<usize>) {
 
     let inputs = vec![
         // We need a VID share for view 2 otherwise we cannot vote at view 2 (as node 2).
-        VIDShareRecv(get_vid_share(&vids[1].0, handle.get_public_key())),
+        VIDShareRecv(vid_share(&vids[1].0, handle.public_key())),
         DaCertificateRecv(dacs[1].clone()),
         QuorumProposalRecv(proposals[1].clone(), leaders[1]),
     ];
@@ -317,7 +317,7 @@ async fn test_view_sync_finalize_propose() {
         inputs: vec![
             QuorumProposalRecv(proposals[0].clone(), leaders[0]),
             DaCertificateRecv(dacs[0].clone()),
-            VIDShareRecv(get_vid_share(&vids[0].0, handle.get_public_key())),
+            VIDShareRecv(vid_share(&vids[0].0, handle.public_key())),
         ],
         outputs: vec![
             exact(ViewChange(ViewNumber::new(1))),
@@ -366,7 +366,7 @@ async fn test_view_sync_finalize_propose() {
     let builder_commitment = BuilderCommitment::from_raw_digest(sha2::Sha256::new().finalize());
     let view_4 = TestScriptStage {
         inputs: vec![
-            VIDShareRecv(get_vid_share(&vids[1].0, handle.get_public_key())),
+            VIDShareRecv(vid_share(&vids[1].0, handle.public_key())),
             QuorumProposalRecv(proposals[1].clone(), leaders[1]),
             TimeoutVoteRecv(timeout_vote_view_2),
             TimeoutVoteRecv(timeout_vote_view_3),
@@ -443,7 +443,7 @@ async fn test_view_sync_finalize_vote() {
         inputs: vec![
             QuorumProposalRecv(proposals[0].clone(), leaders[0]),
             DaCertificateRecv(dacs[0].clone()),
-            VIDShareRecv(get_vid_share(&vids[0].0, handle.get_public_key())),
+            VIDShareRecv(vid_share(&vids[0].0, handle.public_key())),
         ],
         outputs: vec![
             exact(ViewChange(ViewNumber::new(1))),
@@ -540,7 +540,7 @@ async fn test_view_sync_finalize_vote_fail_view_number() {
         inputs: vec![
             QuorumProposalRecv(proposals[0].clone(), leaders[0]),
             DaCertificateRecv(dacs[0].clone()),
-            VIDShareRecv(get_vid_share(&vids[0].0, handle.get_public_key())),
+            VIDShareRecv(vid_share(&vids[0].0, handle.public_key())),
         ],
         outputs: vec![
             exact(ViewChange(ViewNumber::new(1))),
@@ -609,7 +609,7 @@ async fn test_vid_disperse_storage_failure() {
     let handle = build_system_handle(2).await.0;
 
     // Set the error flag here for the system handle. This causes it to emit an error on append.
-    handle.get_storage().write().await.should_return_err = true;
+    handle.storage().write().await.should_return_err = true;
     let quorum_membership = handle.hotshot.memberships.quorum_membership.clone();
     let da_membership = handle.hotshot.memberships.da_membership.clone();
 
@@ -634,7 +634,7 @@ async fn test_vid_disperse_storage_failure() {
         inputs: vec![
             QuorumProposalRecv(proposals[0].clone(), leaders[0]),
             DaCertificateRecv(dacs[0].clone()),
-            VIDShareRecv(get_vid_share(&vids[0].0, handle.get_public_key())),
+            VIDShareRecv(vid_share(&vids[0].0, handle.public_key())),
         ],
         outputs: vec![
             exact(ViewChange(ViewNumber::new(1))),

--- a/crates/testing/tests/tests_1/da_task.rs
+++ b/crates/testing/tests/tests_1/da_task.rs
@@ -110,7 +110,7 @@ async fn test_da_task_storage_failure() {
     let handle = build_system_handle(2).await.0;
 
     // Set the error flag here for the system handle. This causes it to emit an error on append.
-    handle.get_storage().write().await.should_return_err = true;
+    handle.storage().write().await.should_return_err = true;
     let quorum_membership = handle.hotshot.memberships.quorum_membership.clone();
     let da_membership = handle.hotshot.memberships.da_membership.clone();
 

--- a/crates/testing/tests/tests_1/proposal_ordering.rs
+++ b/crates/testing/tests/tests_1/proposal_ordering.rs
@@ -11,7 +11,7 @@ use hotshot_example_types::{
 use hotshot_task_impls::{consensus::ConsensusTaskState, events::HotShotEvent::*};
 use hotshot_testing::{
     predicates::event::{all_predicates, exact, quorum_proposal_send, quorum_proposal_validated},
-    task_helpers::{get_vid_share, vid_scheme_from_view_number},
+    task_helpers::{vid_share, vid_scheme_from_view_number},
     test_helpers::permute_input_with_index_order,
     view_generator::TestViewGenerator,
 };
@@ -69,7 +69,7 @@ async fn test_ordering_with_specific_order(input_permutation: Vec<usize>) {
         inputs: vec![
             QuorumProposalRecv(proposals[0].clone(), leaders[0]),
             DaCertificateRecv(dacs[0].clone()),
-            VIDShareRecv(get_vid_share(&vids[0].0, handle.get_public_key())),
+            VIDShareRecv(vid_share(&vids[0].0, handle.public_key())),
         ],
         outputs: vec![
             exact(ViewChange(ViewNumber::new(1))),
@@ -101,11 +101,11 @@ async fn test_ordering_with_specific_order(input_permutation: Vec<usize>) {
     view_2_inputs.insert(0, DaCertificateRecv(dacs[1].clone()));
     view_2_inputs.insert(
         0,
-        VIDShareRecv(get_vid_share(&vids[2].0, handle.get_public_key())),
+        VIDShareRecv(vid_share(&vids[2].0, handle.public_key())),
     );
     view_2_inputs.insert(
         0,
-        VIDShareRecv(get_vid_share(&vids[1].0, handle.get_public_key())),
+        VIDShareRecv(vid_share(&vids[1].0, handle.public_key())),
     );
 
     // This stage transitions from view 1 to view 2.

--- a/crates/testing/tests/tests_1/quorum_proposal_task.rs
+++ b/crates/testing/tests/tests_1/quorum_proposal_task.rs
@@ -51,7 +51,7 @@ async fn insert_vid_shares_for_view(
         <TestTypes as NodeType>::SignatureKey,
     ),
 ) {
-    let consensus = handle.get_consensus();
+    let consensus = handle.consensus();
     let mut consensus = consensus.write().await;
 
     // `create_and_send_proposal` depends on the `vid_shares` obtaining a vid dispersal.
@@ -151,7 +151,7 @@ async fn test_quorum_proposal_task_quorum_proposal_view_gt_1() {
     }
 
     insert_vid_shares_for_view(ViewNumber::new(node_id), &handle, vids[2].clone()).await;
-    let consensus = handle.get_consensus();
+    let consensus = handle.consensus();
     let mut consensus = consensus.write().await;
 
     // `validate_proposal_safety_and_liveness` depends on the existence of prior values in the consensus
@@ -164,7 +164,7 @@ async fn test_quorum_proposal_task_quorum_proposal_view_gt_1() {
         ViewNumber::new(2),
         View {
             view_inner: ViewInner::Leaf {
-                leaf: leaves[1].get_parent_commitment(),
+                leaf: leaves[1].parent_commitment(),
                 state: TestValidatedState::default().into(),
                 delta: None,
             },

--- a/crates/testing/tests/tests_1/quorum_vote_task.rs
+++ b/crates/testing/tests/tests_1/quorum_vote_task.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::panic)]
 use hotshot::tasks::task_state::CreateTaskState;
 use hotshot_example_types::node_types::{MemoryImpl, TestTypes};
-use hotshot_testing::task_helpers::get_vid_share;
+use hotshot_testing::task_helpers::vid_share;
 use hotshot_types::{data::ViewNumber, traits::node_implementation::ConsensusTime};
 
 #[cfg(test)]
@@ -147,7 +147,7 @@ async fn test_quorum_vote_task_miss_dependency() {
     let view_no_dac = TestScriptStage {
         inputs: vec![
             QuorumProposalValidated(proposals[0].data.clone(), leaves[0].clone()),
-            VIDShareRecv(get_vid_share(&vids[0].0, handle.get_public_key())),
+            VIDShareRecv(vid_share(&vids[0].0, handle.public_key())),
         ],
         outputs: vec![exact(VIDShareValidated(vids[0].0[0].clone()))],
         asserts: vec![],
@@ -163,7 +163,7 @@ async fn test_quorum_vote_task_miss_dependency() {
     let view_no_quorum_proposal = TestScriptStage {
         inputs: vec![
             DaCertificateRecv(dacs[2].clone()),
-            VIDShareRecv(get_vid_share(&vids[2].0, handle.get_public_key())),
+            VIDShareRecv(vid_share(&vids[2].0, handle.public_key())),
         ],
         outputs: vec![
             exact(DaCertificateValidated(dacs[2].clone())),

--- a/crates/testing/tests/tests_1/upgrade_task.rs
+++ b/crates/testing/tests/tests_1/upgrade_task.rs
@@ -16,7 +16,7 @@ use hotshot_task_impls::{
 use hotshot_testing::{
     predicates::{event::*, upgrade::*},
     script::{Expectations, TaskScript},
-    task_helpers::get_vid_share,
+    task_helpers::vid_share,
     view_generator::TestViewGenerator,
 };
 use hotshot_types::{
@@ -84,7 +84,7 @@ async fn test_consensus_task_upgrade() {
     let view_1 = TestScriptStage {
         inputs: vec![
             QuorumProposalRecv(proposals[0].clone(), leaders[0]),
-            VIDShareRecv(get_vid_share(&vids[0].0, handle.get_public_key())),
+            VIDShareRecv(vid_share(&vids[0].0, handle.public_key())),
             DaCertificateRecv(dacs[0].clone()),
         ],
         outputs: vec![
@@ -98,7 +98,7 @@ async fn test_consensus_task_upgrade() {
     let view_2 = TestScriptStage {
         inputs: vec![
             QuorumProposalRecv(proposals[1].clone(), leaders[1]),
-            VIDShareRecv(get_vid_share(&vids[1].0, handle.get_public_key())),
+            VIDShareRecv(vid_share(&vids[1].0, handle.public_key())),
             DaCertificateRecv(dacs[1].clone()),
         ],
         outputs: vec![
@@ -113,7 +113,7 @@ async fn test_consensus_task_upgrade() {
         inputs: vec![
             QuorumProposalRecv(proposals[2].clone(), leaders[2]),
             DaCertificateRecv(dacs[2].clone()),
-            VIDShareRecv(get_vid_share(&vids[2].0, handle.get_public_key())),
+            VIDShareRecv(vid_share(&vids[2].0, handle.public_key())),
         ],
         outputs: vec![
             exact(ViewChange(ViewNumber::new(3))),
@@ -128,7 +128,7 @@ async fn test_consensus_task_upgrade() {
         inputs: vec![
             QuorumProposalRecv(proposals[3].clone(), leaders[3]),
             DaCertificateRecv(dacs[3].clone()),
-            VIDShareRecv(get_vid_share(&vids[3].0, handle.get_public_key())),
+            VIDShareRecv(vid_share(&vids[3].0, handle.public_key())),
         ],
         outputs: vec![
             exact(ViewChange(ViewNumber::new(4))),
@@ -237,17 +237,17 @@ async fn test_upgrade_and_consensus_task() {
     let inputs = vec![
         vec![
             QuorumProposalRecv(proposals[0].clone(), leaders[0]),
-            VIDShareRecv(get_vid_share(&vids[0].0, handle.get_public_key())),
+            VIDShareRecv(vid_share(&vids[0].0, handle.public_key())),
             DaCertificateRecv(dacs[0].clone()),
         ],
         upgrade_vote_recvs,
         vec![
             QuorumProposalRecv(proposals[1].clone(), leaders[1]),
             DaCertificateRecv(dacs[1].clone()),
-            VIDShareRecv(get_vid_share(&vids[1].0, handle.get_public_key())),
+            VIDShareRecv(vid_share(&vids[1].0, handle.public_key())),
         ],
         vec![
-            VIDShareRecv(get_vid_share(&vids[2].0, handle.get_public_key())),
+            VIDShareRecv(vid_share(&vids[2].0, handle.public_key())),
             SendPayloadCommitmentAndMetadata(
                 vids[2].0[0].data.payload_commitment,
                 proposals[2].data.block_header.builder_commitment.clone(),
@@ -428,12 +428,12 @@ async fn test_upgrade_and_consensus_task_blank_blocks() {
     let inputs = vec![
         vec![
             QuorumProposalRecv(proposals[0].clone(), leaders[0]),
-            VIDShareRecv(get_vid_share(&vids[0].0, handle.get_public_key())),
+            VIDShareRecv(vid_share(&vids[0].0, handle.public_key())),
             DaCertificateRecv(dacs[0].clone()),
         ],
         vec![
             QuorumProposalRecv(proposals[1].clone(), leaders[1]),
-            VIDShareRecv(get_vid_share(&vids[1].0, handle.get_public_key())),
+            VIDShareRecv(vid_share(&vids[1].0, handle.public_key())),
             DaCertificateRecv(dacs[1].clone()),
             SendPayloadCommitmentAndMetadata(
                 vids[1].0[0].data.payload_commitment,
@@ -446,7 +446,7 @@ async fn test_upgrade_and_consensus_task_blank_blocks() {
         ],
         vec![
             DaCertificateRecv(dacs[2].clone()),
-            VIDShareRecv(get_vid_share(&vids[2].0, handle.get_public_key())),
+            VIDShareRecv(vid_share(&vids[2].0, handle.public_key())),
             SendPayloadCommitmentAndMetadata(
                 vids[2].0[0].data.payload_commitment,
                 proposals[2].data.block_header.builder_commitment.clone(),
@@ -459,7 +459,7 @@ async fn test_upgrade_and_consensus_task_blank_blocks() {
         ],
         vec![
             DaCertificateRecv(dacs[3].clone()),
-            VIDShareRecv(get_vid_share(&vids[3].0, handle.get_public_key())),
+            VIDShareRecv(vid_share(&vids[3].0, handle.public_key())),
             SendPayloadCommitmentAndMetadata(
                 vids[3].0[0].data.payload_commitment,
                 proposals[3].data.block_header.builder_commitment.clone(),
@@ -472,7 +472,7 @@ async fn test_upgrade_and_consensus_task_blank_blocks() {
         ],
         vec![
             DaCertificateRecv(dacs[4].clone()),
-            VIDShareRecv(get_vid_share(&vids[4].0, handle.get_public_key())),
+            VIDShareRecv(vid_share(&vids[4].0, handle.public_key())),
             SendPayloadCommitmentAndMetadata(
                 vids[4].0[0].data.payload_commitment,
                 proposals[4].data.block_header.builder_commitment.clone(),
@@ -485,7 +485,7 @@ async fn test_upgrade_and_consensus_task_blank_blocks() {
         ],
         vec![
             DaCertificateRecv(dacs[5].clone()),
-            VIDShareRecv(get_vid_share(&vids[5].0, handle.get_public_key())),
+            VIDShareRecv(vid_share(&vids[5].0, handle.public_key())),
             SendPayloadCommitmentAndMetadata(
                 vids[5].0[0].data.payload_commitment,
                 proposals[5].data.block_header.builder_commitment.clone(),
@@ -498,7 +498,7 @@ async fn test_upgrade_and_consensus_task_blank_blocks() {
         ],
         vec![
             DaCertificateRecv(dacs[6].clone()),
-            VIDShareRecv(get_vid_share(&vids[6].0, handle.get_public_key())),
+            VIDShareRecv(vid_share(&vids[6].0, handle.public_key())),
             SendPayloadCommitmentAndMetadata(
                 vids[6].0[0].data.payload_commitment,
                 proposals[6].data.block_header.builder_commitment.clone(),

--- a/crates/testing/tests/tests_1/vid_task.rs
+++ b/crates/testing/tests/tests_1/vid_task.rs
@@ -30,7 +30,7 @@ async fn test_vid_task() {
 
     // Build the API for node 2.
     let handle = build_system_handle(2).await.0;
-    let pub_key = *handle.public_key();
+    let pub_key = handle.public_key();
 
     // quorum membership for VID share distribution
     let quorum_membership = handle.hotshot.memberships.quorum_membership.clone();
@@ -124,12 +124,12 @@ async fn test_vid_task() {
 
     let vid_state = VIDTaskState {
         api: handle.clone(),
-        consensus: handle.hotshot.get_consensus(),
+        consensus: handle.hotshot.consensus(),
         cur_view: ViewNumber::new(0),
         vote_collector: None,
         network: handle.hotshot.networks.quorum_network.clone(),
         membership: handle.hotshot.memberships.vid_membership.clone().into(),
-        public_key: *handle.public_key(),
+        public_key: handle.public_key(),
         private_key: handle.private_key().clone(),
         id: handle.hotshot.id,
     };

--- a/crates/testing/tests/tests_3/memory_network.rs
+++ b/crates/testing/tests/tests_3/memory_network.rs
@@ -85,7 +85,7 @@ fn fake_message_eq(message_1: Message<Test>, message_2: Message<Test>) {
 }
 
 #[instrument]
-fn get_pubkey() -> BLSPubKey {
+fn pubkey() -> BLSPubKey {
     // random 32 bytes
     let mut bytes = [0; 32];
     rand::thread_rng().fill_bytes(&mut bytes);
@@ -121,7 +121,7 @@ async fn memory_network_spawn_single() {
     setup_logging();
     let group: Arc<MasterMap<Message<Test>, <Test as NodeType>::SignatureKey>> = MasterMap::new();
     trace!(?group);
-    let _pub_key = get_pubkey();
+    let _pub_key = pubkey();
 }
 
 // // Spawning a two MemoryNetworks and connecting them should produce no errors
@@ -132,8 +132,8 @@ async fn memory_network_spawn_double() {
     setup_logging();
     let group: Arc<MasterMap<Message<Test>, <Test as NodeType>::SignatureKey>> = MasterMap::new();
     trace!(?group);
-    let _pub_key_1 = get_pubkey();
-    let _pub_key_2 = get_pubkey();
+    let _pub_key_1 = pubkey();
+    let _pub_key_2 = pubkey();
 }
 
 // Check to make sure direct queue works
@@ -148,7 +148,7 @@ async fn memory_network_direct_queue() {
     let group: Arc<MasterMap<Message<Test>, <Test as NodeType>::SignatureKey>> = MasterMap::new();
     trace!(?group);
 
-    let pub_key_1 = get_pubkey();
+    let pub_key_1 = pubkey();
     let network1 = MemoryNetwork::new(
         pub_key_1,
         NetworkingMetricsValue::default(),
@@ -156,7 +156,7 @@ async fn memory_network_direct_queue() {
         Option::None,
     );
 
-    let pub_key_2 = get_pubkey();
+    let pub_key_2 = pubkey();
     let network2 = MemoryNetwork::new(
         pub_key_2,
         NetworkingMetricsValue::default(),
@@ -210,14 +210,14 @@ async fn memory_network_broadcast_queue() {
     // Make and connect the networking instances
     let group: Arc<MasterMap<Message<Test>, <Test as NodeType>::SignatureKey>> = MasterMap::new();
     trace!(?group);
-    let pub_key_1 = get_pubkey();
+    let pub_key_1 = pubkey();
     let network1 = MemoryNetwork::new(
         pub_key_1,
         NetworkingMetricsValue::default(),
         group.clone(),
         Option::None,
     );
-    let pub_key_2 = get_pubkey();
+    let pub_key_2 = pubkey();
     let network2 = MemoryNetwork::new(
         pub_key_2,
         NetworkingMetricsValue::default(),
@@ -279,14 +279,14 @@ async fn memory_network_test_in_flight_message_count() {
 
     let group: Arc<MasterMap<Message<Test>, <Test as NodeType>::SignatureKey>> = MasterMap::new();
     trace!(?group);
-    let pub_key_1 = get_pubkey();
+    let pub_key_1 = pubkey();
     let network1 = MemoryNetwork::new(
         pub_key_1,
         NetworkingMetricsValue::default(),
         group.clone(),
         Option::None,
     );
-    let pub_key_2 = get_pubkey();
+    let pub_key_2 = pubkey();
     let network2 = MemoryNetwork::new(
         pub_key_2,
         NetworkingMetricsValue::default(),

--- a/crates/types/src/consensus.rs
+++ b/crates/types/src/consensus.rs
@@ -473,7 +473,7 @@ impl<TYPES: NodeType> Consensus<TYPES> {
         ) -> bool,
     {
         let mut next_leaf = if let Some(view) = self.validated_state_map.get(&start_from) {
-            view.get_leaf_commitment()
+            view.leaf_commitment()
                 .ok_or_else(|| HotShotError::InvalidState {
                     context: format!(
                         "Visited failed view {start_from:?} leaf. Expected successfuil leaf"
@@ -486,8 +486,8 @@ impl<TYPES: NodeType> Consensus<TYPES> {
         };
 
         while let Some(leaf) = self.saved_leaves.get(&next_leaf) {
-            let view = leaf.get_view_number();
-            if let (Some(state), delta) = self.get_state_and_delta(view) {
+            let view = leaf.view_number();
+            if let (Some(state), delta) = self.state_and_delta(view) {
                 if let Terminator::Exclusive(stop_before) = terminator {
                     if stop_before == view {
                         if ok_when_finished {
@@ -496,7 +496,7 @@ impl<TYPES: NodeType> Consensus<TYPES> {
                         break;
                     }
                 }
-                next_leaf = leaf.get_parent_commitment();
+                next_leaf = leaf.parent_commitment();
                 if !f(leaf, state, delta) {
                     return Ok(());
                 }
@@ -538,7 +538,7 @@ impl<TYPES: NodeType> Consensus<TYPES> {
             .retain(|view_number, _| *view_number >= old_anchor_view);
         self.validated_state_map
             .range(old_anchor_view..new_anchor_view)
-            .filter_map(|(_view_number, view)| view.get_leaf_commitment())
+            .filter_map(|(_view_number, view)| view.leaf_commitment())
             .for_each(|leaf| {
                 self.saved_leaves.remove(&leaf);
             });
@@ -553,29 +553,29 @@ impl<TYPES: NodeType> Consensus<TYPES> {
     /// if the last decided view's leaf does not exist in the state map or saved leaves, which
     /// should never happen.
     #[must_use]
-    pub fn get_decided_leaf(&self) -> Leaf<TYPES> {
+    pub fn decided_leaf(&self) -> Leaf<TYPES> {
         let decided_view_num = self.last_decided_view;
         let view = self.validated_state_map.get(&decided_view_num).unwrap();
         let leaf = view
-            .get_leaf_commitment()
+            .leaf_commitment()
             .expect("Decided leaf not found! Consensus internally inconsistent");
         self.saved_leaves.get(&leaf).unwrap().clone()
     }
 
     /// Gets the validated state with the given view number, if in the state map.
     #[must_use]
-    pub fn get_state(&self, view_number: TYPES::Time) -> Option<&Arc<TYPES::ValidatedState>> {
+    pub fn state(&self, view_number: TYPES::Time) -> Option<&Arc<TYPES::ValidatedState>> {
         match self.validated_state_map.get(&view_number) {
-            Some(view) => view.get_state(),
+            Some(view) => view.state(),
             None => None,
         }
     }
 
     /// Gets the validated state and state delta with the given view number, if in the state map.
     #[must_use]
-    pub fn get_state_and_delta(&self, view_number: TYPES::Time) -> StateAndDelta<TYPES> {
+    pub fn state_and_delta(&self, view_number: TYPES::Time) -> StateAndDelta<TYPES> {
         match self.validated_state_map.get(&view_number) {
-            Some(view) => view.get_state_and_delta(),
+            Some(view) => view.state_and_delta(),
             None => (None, None),
         }
     }
@@ -586,9 +586,9 @@ impl<TYPES: NodeType> Consensus<TYPES> {
     /// If the last decided view's state does not exist in the state map, which should never
     /// happen.
     #[must_use]
-    pub fn get_decided_state(&self) -> Arc<TYPES::ValidatedState> {
+    pub fn decided_state(&self) -> Arc<TYPES::ValidatedState> {
         let decided_view_num = self.last_decided_view;
-        self.get_state_and_delta(decided_view_num)
+        self.state_and_delta(decided_view_num)
             .0
             .expect("Decided state not found! Consensus internally inconsistent")
     }

--- a/crates/types/src/data.rs
+++ b/crates/types/src/data.rs
@@ -70,7 +70,7 @@ impl ConsensusTime for ViewNumber {
         Self(n)
     }
     /// Returen the u64 format
-    fn get_u64(&self) -> u64 {
+    fn u64(&self) -> u64 {
         self.0
     }
 }
@@ -162,7 +162,7 @@ impl<TYPES: NodeType> VidDisperse<TYPES> {
         membership: &TYPES::Membership,
     ) -> Self {
         let shares = membership
-            .get_staked_committee(view_number)
+            .staked_committee(view_number)
             .iter()
             .map(|node| (node.clone(), vid_disperse.shares.remove(0)))
             .collect();
@@ -191,7 +191,7 @@ impl<TYPES: NodeType> ViewChangeEvidence<TYPES> {
     /// Check that the given ViewChangeEvidence is relevant to the current view.
     pub fn is_valid_for_view(&self, view: &TYPES::Time) -> bool {
         match self {
-            ViewChangeEvidence::Timeout(timeout_cert) => timeout_cert.get_data().view == *view - 1,
+            ViewChangeEvidence::Timeout(timeout_cert) => timeout_cert.date().view == *view - 1,
             ViewChangeEvidence::ViewSync(view_sync_cert) => view_sync_cert.view_number == *view,
         }
     }
@@ -319,31 +319,31 @@ pub struct QuorumProposal<TYPES: NodeType> {
 }
 
 impl<TYPES: NodeType> HasViewNumber<TYPES> for DaProposal<TYPES> {
-    fn get_view_number(&self) -> TYPES::Time {
+    fn view_number(&self) -> TYPES::Time {
         self.view_number
     }
 }
 
 impl<TYPES: NodeType> HasViewNumber<TYPES> for VidDisperse<TYPES> {
-    fn get_view_number(&self) -> TYPES::Time {
+    fn view_number(&self) -> TYPES::Time {
         self.view_number
     }
 }
 
 impl<TYPES: NodeType> HasViewNumber<TYPES> for VidDisperseShare<TYPES> {
-    fn get_view_number(&self) -> TYPES::Time {
+    fn view_number(&self) -> TYPES::Time {
         self.view_number
     }
 }
 
 impl<TYPES: NodeType> HasViewNumber<TYPES> for QuorumProposal<TYPES> {
-    fn get_view_number(&self) -> TYPES::Time {
+    fn view_number(&self) -> TYPES::Time {
         self.view_number
     }
 }
 
 impl<TYPES: NodeType> HasViewNumber<TYPES> for UpgradeProposal<TYPES> {
-    fn get_view_number(&self) -> TYPES::Time {
+    fn view_number(&self) -> TYPES::Time {
         self.view_number
     }
 }
@@ -424,7 +424,7 @@ impl<TYPES: NodeType> Display for Leaf<TYPES> {
             f,
             "view: {:?}, height: {:?}, justify: {}",
             self.view_number,
-            self.get_height(),
+            self.height(),
             self.justify_qc
         )
     }
@@ -494,34 +494,34 @@ impl<TYPES: NodeType> Leaf<TYPES> {
     }
 
     /// Time when this leaf was created.
-    pub fn get_view_number(&self) -> TYPES::Time {
+    pub fn view_number(&self) -> TYPES::Time {
         self.view_number
     }
     /// Height of this leaf in the chain.
     ///
     /// Equivalently, this is the number of leaves before this one in the chain.
-    pub fn get_height(&self) -> u64 {
+    pub fn height(&self) -> u64 {
         self.block_header.block_number()
     }
     /// The QC linking this leaf to its parent in the chain.
-    pub fn get_justify_qc(&self) -> QuorumCertificate<TYPES> {
+    pub fn justify_qc(&self) -> QuorumCertificate<TYPES> {
         self.justify_qc.clone()
     }
     /// The QC linking this leaf to its parent in the chain.
-    pub fn get_upgrade_certificate(&self) -> Option<UpgradeCertificate<TYPES>> {
+    pub fn upgrade_certificate(&self) -> Option<UpgradeCertificate<TYPES>> {
         self.upgrade_certificate.clone()
     }
     /// Commitment to this leaf's parent.
-    pub fn get_parent_commitment(&self) -> Commitment<Self> {
+    pub fn parent_commitment(&self) -> Commitment<Self> {
         self.parent_commitment
     }
     /// The block header contained in this leaf.
-    pub fn get_block_header(&self) -> &<TYPES as NodeType>::BlockHeader {
+    pub fn block_header(&self) -> &<TYPES as NodeType>::BlockHeader {
         &self.block_header
     }
 
     /// Get a mutable reference to the block header contained in this leaf.
-    pub fn get_block_header_mut(&mut self) -> &mut <TYPES as NodeType>::BlockHeader {
+    pub fn block_header_mut(&mut self) -> &mut <TYPES as NodeType>::BlockHeader {
         &mut self.block_header
     }
     /// Fill this leaf with the block payload.
@@ -553,13 +553,13 @@ impl<TYPES: NodeType> Leaf<TYPES> {
     }
 
     /// Optional block payload.
-    pub fn get_block_payload(&self) -> Option<TYPES::BlockPayload> {
+    pub fn block_payload(&self) -> Option<TYPES::BlockPayload> {
         self.block_payload.clone()
     }
 
     /// A commitment to the block payload contained in this leaf.
-    pub fn get_payload_commitment(&self) -> VidCommitment {
-        self.get_block_header().payload_commitment()
+    pub fn payload_commitment(&self) -> VidCommitment {
+        self.block_header().payload_commitment()
     }
 
     /// Validate that a leaf has the right upgrade certificate to be the immediate child of another leaf
@@ -574,10 +574,7 @@ impl<TYPES: NodeType> Leaf<TYPES> {
         parent: &Self,
         decided_upgrade_certificate: &Option<UpgradeCertificate<TYPES>>,
     ) -> Result<()> {
-        match (
-            self.get_upgrade_certificate(),
-            parent.get_upgrade_certificate(),
-        ) {
+        match (self.upgrade_certificate(), parent.upgrade_certificate()) {
             // Easiest cases are:
             //   - no upgrade certificate on either: this is the most common case, and is always fine.
             //   - if the parent didn't have a certificate, but we see one now, it just means that we have begun an upgrade: again, this is always fine.
@@ -586,8 +583,8 @@ impl<TYPES: NodeType> Leaf<TYPES> {
             //    - no longer care because we have passed new_version_first_view, or
             //    - no longer care because we have passed `decide_by` without deciding the certificate.
             (None, Some(parent_cert)) => {
-                ensure!(self.get_view_number() > parent_cert.data.new_version_first_view
-                    || (self.get_view_number() > parent_cert.data.decide_by && decided_upgrade_certificate.is_none()),
+                ensure!(self.view_number() > parent_cert.data.new_version_first_view
+                    || (self.view_number() > parent_cert.data.decide_by && decided_upgrade_certificate.is_none()),
                        "The new leaf is missing an upgrade certificate that was present in its parent, and should still be live."
                 );
             }
@@ -600,7 +597,7 @@ impl<TYPES: NodeType> Leaf<TYPES> {
         }
 
         // This check should be added once we sort out the genesis leaf/justify_qc issue.
-        // ensure!(self.get_parent_commitment() == parent_leaf.commit(), "The commitment of the parent leaf does not match the specified parent commitment.");
+        // ensure!(self.parent_commitment() == parent_leaf.commit(), "The commitment of the parent leaf does not match the specified parent commitment.");
 
         Ok(())
     }
@@ -646,7 +643,7 @@ pub fn serialize_signature2<TYPES: NodeType>(
     let mut signatures_bytes = vec![];
     signatures_bytes.extend("Yes".as_bytes());
 
-    let (sig, proof) = TYPES::SignatureKey::get_sig_proof(signatures);
+    let (sig, proof) = TYPES::SignatureKey::sig_proof(signatures);
     let proof_bytes = bincode_opts()
         .serialize(&proof.as_bitslice())
         .expect("This serialization shouldn't be able to fail");
@@ -665,11 +662,11 @@ impl<TYPES: NodeType> Committable for Leaf<TYPES> {
         // Skip the transaction commitments, so that the repliacs can reconstruct the leaf.
         RawCommitmentBuilder::new("leaf commitment")
             .u64_field("view number", *self.view_number)
-            .u64_field("block number", self.get_height())
+            .u64_field("block number", self.height())
             .field("parent Leaf commitment", self.parent_commitment)
             .var_size_field(
                 "block payload commitment",
-                self.get_payload_commitment().as_ref(),
+                self.payload_commitment().as_ref(),
             )
             .field("justify qc", self.justify_qc.commit())
             .optional("upgrade certificate", &self.upgrade_certificate)
@@ -692,7 +689,7 @@ impl<TYPES: NodeType> Leaf<TYPES> {
         Leaf {
             view_number: *view_number,
             justify_qc: justify_qc.clone(),
-            parent_commitment: justify_qc.get_data().leaf_commit,
+            parent_commitment: justify_qc.date().leaf_commit,
             block_header: block_header.clone(),
             upgrade_certificate: upgrade_certificate.clone(),
             block_payload: None,

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -93,9 +93,9 @@ impl<KEY: SignatureKey> ValidatorConfig<KEY> {
     }
 
     /// get the public config of the validator
-    pub fn get_public_config(&self) -> PeerConfig<KEY> {
+    pub fn public_config(&self) -> PeerConfig<KEY> {
         PeerConfig {
-            stake_table_entry: self.public_key.get_stake_table_entry(self.stake_value),
+            stake_table_entry: self.public_key.stake_table_entry(self.stake_value),
             state_ver_key: self.state_key_pair.0.ver_key(),
         }
     }
@@ -148,7 +148,7 @@ impl<KEY: SignatureKey> PeerConfig<KEY> {
 impl<KEY: SignatureKey> Default for PeerConfig<KEY> {
     fn default() -> Self {
         let default_validator_config = ValidatorConfig::<KEY>::default();
-        default_validator_config.get_public_config()
+        default_validator_config.public_config()
     }
 }
 

--- a/crates/types/src/signature_key.rs
+++ b/crates/types/src/signature_key.rs
@@ -80,18 +80,18 @@ impl SignatureKey for BLSPubKey {
         (kp.ver_key(), kp.sign_key_ref().clone())
     }
 
-    fn get_stake_table_entry(&self, stake: u64) -> Self::StakeTableEntry {
+    fn stake_table_entry(&self, stake: u64) -> Self::StakeTableEntry {
         StakeTableEntry {
             stake_key: *self,
             stake_amount: U256::from(stake),
         }
     }
 
-    fn get_public_key(entry: &Self::StakeTableEntry) -> Self {
+    fn public_key(entry: &Self::StakeTableEntry) -> Self {
         entry.stake_key
     }
 
-    fn get_public_parameter(
+    fn public_parameter(
         stake_entries: Vec<Self::StakeTableEntry>,
         threshold: U256,
     ) -> Self::QCParams {
@@ -107,7 +107,7 @@ impl SignatureKey for BLSPubKey {
         BitVectorQC::<BLSOverBN254CurveSignatureScheme>::check(real_qc_pp, msg, qc).is_ok()
     }
 
-    fn get_sig_proof(signature: &Self::QCType) -> (Self::PureAssembledSignatureType, BitVec) {
+    fn sig_proof(signature: &Self::QCType) -> (Self::PureAssembledSignatureType, BitVec) {
         signature.clone()
     }
 

--- a/crates/types/src/simple_certificate.rs
+++ b/crates/types/src/simple_certificate.rs
@@ -117,8 +117,8 @@ impl<TYPES: NodeType, VOTEABLE: Voteable + 'static, THRESHOLD: Threshold<TYPES>>
         if self.view_number == TYPES::Time::genesis() {
             return true;
         }
-        let real_qc_pp = <TYPES::SignatureKey as SignatureKey>::get_public_parameter(
-            membership.get_committee_qc_stake_table(),
+        let real_qc_pp = <TYPES::SignatureKey as SignatureKey>::public_parameter(
+            membership.committee_qc_stake_table(),
             U256::from(Self::threshold(membership)),
         );
         <TYPES::SignatureKey as SignatureKey>::check(
@@ -130,10 +130,10 @@ impl<TYPES: NodeType, VOTEABLE: Voteable + 'static, THRESHOLD: Threshold<TYPES>>
     fn threshold<MEMBERSHIP: Membership<TYPES>>(membership: &MEMBERSHIP) -> u64 {
         THRESHOLD::threshold(membership)
     }
-    fn get_data(&self) -> &Self::Voteable {
+    fn date(&self) -> &Self::Voteable {
         &self.data
     }
-    fn get_data_commitment(&self) -> Commitment<Self::Voteable> {
+    fn date_commitment(&self) -> Commitment<Self::Voteable> {
         self.vote_commitment
     }
 }
@@ -141,7 +141,7 @@ impl<TYPES: NodeType, VOTEABLE: Voteable + 'static, THRESHOLD: Threshold<TYPES>>
 impl<TYPES: NodeType, VOTEABLE: Voteable + 'static, THRESHOLD: Threshold<TYPES>>
     HasViewNumber<TYPES> for SimpleCertificate<TYPES, VOTEABLE, THRESHOLD>
 {
-    fn get_view_number(&self) -> TYPES::Time {
+    fn view_number(&self) -> TYPES::Time {
         self.view_number
     }
 }

--- a/crates/types/src/simple_vote.rs
+++ b/crates/types/src/simple_vote.rs
@@ -116,7 +116,7 @@ pub struct SimpleVote<TYPES: NodeType, DATA: Voteable> {
 }
 
 impl<TYPES: NodeType, DATA: Voteable + 'static> HasViewNumber<TYPES> for SimpleVote<TYPES, DATA> {
-    fn get_view_number(&self) -> <TYPES as NodeType>::Time {
+    fn view_number(&self) -> <TYPES as NodeType>::Time {
         self.view_number
     }
 }
@@ -124,19 +124,19 @@ impl<TYPES: NodeType, DATA: Voteable + 'static> HasViewNumber<TYPES> for SimpleV
 impl<TYPES: NodeType, DATA: Voteable + 'static> Vote<TYPES> for SimpleVote<TYPES, DATA> {
     type Commitment = DATA;
 
-    fn get_signing_key(&self) -> <TYPES as NodeType>::SignatureKey {
+    fn signing_key(&self) -> <TYPES as NodeType>::SignatureKey {
         self.signature.0.clone()
     }
 
-    fn get_signature(&self) -> <TYPES::SignatureKey as SignatureKey>::PureAssembledSignatureType {
+    fn signature(&self) -> <TYPES::SignatureKey as SignatureKey>::PureAssembledSignatureType {
         self.signature.1.clone()
     }
 
-    fn get_data(&self) -> &DATA {
+    fn date(&self) -> &DATA {
         &self.data
     }
 
-    fn get_data_commitment(&self) -> Commitment<DATA> {
+    fn date_commitment(&self) -> Commitment<DATA> {
         self.data.commit()
     }
 }

--- a/crates/types/src/stake_table.rs
+++ b/crates/types/src/stake_table.rs
@@ -17,14 +17,14 @@ pub struct StakeTableEntry<K: SignatureKey> {
 
 impl<K: SignatureKey> StakeTableEntryType for StakeTableEntry<K> {
     /// Get the stake amount
-    fn get_stake(&self) -> U256 {
+    fn stake(&self) -> U256 {
         self.stake_amount
     }
 }
 
 impl<K: SignatureKey> StakeTableEntry<K> {
     /// Get the public key
-    pub fn get_key(&self) -> &K {
+    pub fn key(&self) -> &K {
         &self.stake_key
     }
 }

--- a/crates/types/src/traits/block_contents.rs
+++ b/crates/types/src/traits/block_contents.rs
@@ -91,21 +91,19 @@ pub trait BlockPayload:
         &self,
         metadata: &Self::Metadata,
     ) -> Vec<Commitment<Self::Transaction>> {
-        self.get_transactions(metadata)
-            .map(|tx| tx.commit())
-            .collect()
+        self.transactions(metadata).map(|tx| tx.commit()).collect()
     }
 
     /// Number of transactions in the block.
     fn num_transactions(&self, metadata: &Self::Metadata) -> usize {
-        self.get_transactions(metadata).count()
+        self.transactions(metadata).count()
     }
 
     /// Generate commitment that builders use to sign block options.
     fn builder_commitment(&self, metadata: &Self::Metadata) -> BuilderCommitment;
 
     /// Get the transactions in the payload.
-    fn get_transactions<'a>(
+    fn transactions<'a>(
         &'a self,
         metadata: &'a Self::Metadata,
     ) -> impl 'a + Iterator<Item = Self::Transaction>;

--- a/crates/types/src/traits/election.rs
+++ b/crates/types/src/traits/election.rs
@@ -34,28 +34,28 @@ pub trait Membership<TYPES: NodeType>:
     ) -> Self;
 
     /// Clone the public key and corresponding stake table for current elected committee
-    fn get_committee_qc_stake_table(
+    fn committee_qc_stake_table(
         &self,
     ) -> Vec<<TYPES::SignatureKey as SignatureKey>::StakeTableEntry>;
 
     /// The leader of the committee for view `view_number`.
-    fn get_leader(&self, view_number: TYPES::Time) -> TYPES::SignatureKey;
+    fn leader(&self, view_number: TYPES::Time) -> TYPES::SignatureKey;
 
     /// The staked members of the committee for view `view_number`.
-    fn get_staked_committee(&self, view_number: TYPES::Time) -> BTreeSet<TYPES::SignatureKey>;
+    fn staked_committee(&self, view_number: TYPES::Time) -> BTreeSet<TYPES::SignatureKey>;
 
     /// The non-staked members of the committee for view `view_number`.
-    fn get_non_staked_committee(&self, view_number: TYPES::Time) -> BTreeSet<TYPES::SignatureKey>;
+    fn non_staked_committee(&self, view_number: TYPES::Time) -> BTreeSet<TYPES::SignatureKey>;
 
     /// Get whole (staked + non-staked) committee for view `view_number`.
-    fn get_whole_committee(&self, view_number: TYPES::Time) -> BTreeSet<TYPES::SignatureKey>;
+    fn whole_committee(&self, view_number: TYPES::Time) -> BTreeSet<TYPES::SignatureKey>;
 
     /// Check if a key has stake
     fn has_stake(&self, pub_key: &TYPES::SignatureKey) -> bool;
 
     /// Get the stake table entry for a public key, returns `None` if the
     /// key is not in the table
-    fn get_stake(
+    fn stake(
         &self,
         pub_key: &TYPES::SignatureKey,
     ) -> Option<<TYPES::SignatureKey as SignatureKey>::StakeTableEntry>;

--- a/crates/types/src/traits/network.rs
+++ b/crates/types/src/traits/network.rs
@@ -181,7 +181,7 @@ impl NetworkMsg for Vec<u8> {}
 /// a message
 pub trait ViewMessage<TYPES: NodeType> {
     /// get the view out of the message
-    fn get_view_number(&self) -> TYPES::Time;
+    fn view_number(&self) -> TYPES::Time;
     // TODO move out of this trait.
     /// get the purpose of the message
     fn purpose(&self) -> MessagePurpose;

--- a/crates/types/src/traits/node_implementation.rs
+++ b/crates/types/src/traits/node_implementation.rs
@@ -172,7 +172,7 @@ pub trait ConsensusTime:
     /// Create a new instance of this time unit
     fn new(val: u64) -> Self;
     /// Get the u64 format of time
-    fn get_u64(&self) -> u64;
+    fn u64(&self) -> u64;
 }
 
 /// Trait with all the type definitions that are used in the current hotshot setup.

--- a/crates/types/src/traits/signature_key.rs
+++ b/crates/types/src/traits/signature_key.rs
@@ -17,7 +17,7 @@ use crate::{utils::BuilderCommitment, vid::VidSchemeType};
 /// Type representing stake table entries in a `StakeTable`
 pub trait StakeTableEntryType {
     /// Get the stake value
-    fn get_stake(&self) -> U256;
+    fn stake(&self) -> U256;
 }
 
 /// Trait for abstracting public key signatures
@@ -117,13 +117,13 @@ pub trait SignatureKey:
     fn generated_from_seed_indexed(seed: [u8; 32], index: u64) -> (Self, Self::PrivateKey);
 
     /// get the stake table entry from the public key and stake value
-    fn get_stake_table_entry(&self, stake: u64) -> Self::StakeTableEntry;
+    fn stake_table_entry(&self, stake: u64) -> Self::StakeTableEntry;
 
     /// only get the public key from the stake table entry
-    fn get_public_key(entry: &Self::StakeTableEntry) -> Self;
+    fn public_key(entry: &Self::StakeTableEntry) -> Self;
 
     /// get the public parameter for the assembled signature checking
-    fn get_public_parameter(
+    fn public_parameter(
         stake_entries: Vec<Self::StakeTableEntry>,
         threshold: U256,
     ) -> Self::QCParams;
@@ -132,7 +132,7 @@ pub trait SignatureKey:
     fn check(real_qc_pp: &Self::QCParams, data: &[u8], qc: &Self::QCType) -> bool;
 
     /// get the assembled signature and the `BitVec` separately from the assembled signature
-    fn get_sig_proof(signature: &Self::QCType) -> (Self::PureAssembledSignatureType, BitVec);
+    fn sig_proof(signature: &Self::QCType) -> (Self::PureAssembledSignatureType, BitVec);
 
     /// assemble the signature from the partial signature and the indication of signers in `BitVec`
     fn assemble(

--- a/crates/types/src/utils.rs
+++ b/crates/types/src/utils.rs
@@ -75,9 +75,7 @@ pub type StateAndDelta<TYPES> = (
 impl<TYPES: NodeType> ViewInner<TYPES> {
     /// Return the underlying undecide leaf commitment and validated state if they exist.
     #[must_use]
-    pub fn get_leaf_and_state(
-        &self,
-    ) -> Option<(LeafCommitment<TYPES>, &Arc<TYPES::ValidatedState>)> {
+    pub fn leaf_and_state(&self) -> Option<(LeafCommitment<TYPES>, &Arc<TYPES::ValidatedState>)> {
         if let Self::Leaf { leaf, state, .. } = self {
             Some((*leaf, state))
         } else {
@@ -87,7 +85,7 @@ impl<TYPES: NodeType> ViewInner<TYPES> {
 
     /// return the underlying leaf hash if it exists
     #[must_use]
-    pub fn get_leaf_commitment(&self) -> Option<LeafCommitment<TYPES>> {
+    pub fn leaf_commitment(&self) -> Option<LeafCommitment<TYPES>> {
         if let Self::Leaf { leaf, .. } = self {
             Some(*leaf)
         } else {
@@ -97,7 +95,7 @@ impl<TYPES: NodeType> ViewInner<TYPES> {
 
     /// return the underlying validated state if it exists
     #[must_use]
-    pub fn get_state(&self) -> Option<&Arc<TYPES::ValidatedState>> {
+    pub fn state(&self) -> Option<&Arc<TYPES::ValidatedState>> {
         if let Self::Leaf { state, .. } = self {
             Some(state)
         } else {
@@ -107,7 +105,7 @@ impl<TYPES: NodeType> ViewInner<TYPES> {
 
     /// Return the underlying validated state and state delta if they exist.
     #[must_use]
-    pub fn get_state_and_delta(&self) -> StateAndDelta<TYPES> {
+    pub fn state_and_delta(&self) -> StateAndDelta<TYPES> {
         if let Self::Leaf { state, delta, .. } = self {
             (Some(Arc::clone(state)), delta.clone())
         } else {
@@ -117,7 +115,7 @@ impl<TYPES: NodeType> ViewInner<TYPES> {
 
     /// return the underlying block paylod commitment if it exists
     #[must_use]
-    pub fn get_payload_commitment(&self) -> Option<VidCommitment> {
+    pub fn payload_commitment(&self) -> Option<VidCommitment> {
         if let Self::Da { payload_commitment } = self {
             Some(*payload_commitment)
         } else {


### PR DESCRIPTION
Closes #3104.

### This PR: 
* Removes `get_` from getters except for:
  * `get_or_calc_vid_share`, because it's either get or calculate.
  * `VidScheme` implementations, because it's defined in jellyfish.
* Removes duplicated functions that differ only in names.

### Key places to review: 
* Whether it makes sense to remove `get` from each name.

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
