### PR TITLE
Make metrics labels more compatible with Prometheus

### DIFF
--- a/crates/hotshot/src/traits/networking.rs
+++ b/crates/hotshot/src/traits/networking.rs
@@ -10,13 +10,9 @@ pub mod libp2p_network;
 pub mod memory_network;
 /// The Push CDN network
 pub mod push_cdn_network;
-use std::{
-    collections::HashMap,
-    sync::{Arc, Mutex},
-};
 
 use custom_debug::Debug;
-use hotshot_types::traits::metrics::{Counter, Gauge, Histogram, Label, Metrics, NoMetrics};
+use hotshot_types::traits::metrics::{Counter, Gauge, Metrics, NoMetrics};
 pub use hotshot_types::traits::network::{
     FailedToSerializeSnafu, NetworkError, NetworkReliability,
 };
@@ -41,119 +37,6 @@ pub struct NetworkingMetricsValue {
     // pub kademlia_entries: Box<dyn Gauge>,
     // A [`Gauge`] which tracks how many kademlia buckets there are
     // pub kademlia_buckets: Box<dyn Gauge>,
-}
-
-/// The wrapper with a string name for the networking metrics
-#[derive(Clone, Debug)]
-pub struct NetworkingMetrics {
-    /// a prefix which tracks the name of the metric
-    prefix: String,
-    /// a map of values
-    values: Arc<Mutex<InnerNetworkingMetrics>>,
-}
-
-/// the set of counters and gauges for the networking metrics
-#[derive(Clone, Debug, Default)]
-pub struct InnerNetworkingMetrics {
-    /// All the counters of the networking metrics
-    counters: HashMap<String, usize>,
-    /// All the gauges of the networking metrics
-    gauges: HashMap<String, usize>,
-    /// All the histograms of the networking metrics
-    histograms: HashMap<String, Vec<f64>>,
-    /// All the labels of the networking metrics
-    labels: HashMap<String, String>,
-}
-
-impl NetworkingMetrics {
-    /// For the creation and naming of gauge, counter, histogram and label.
-    pub fn sub(&self, name: String) -> Self {
-        let prefix = if self.prefix.is_empty() {
-            name
-        } else {
-            format!("{}-{name}", self.prefix)
-        };
-        Self {
-            prefix,
-            values: Arc::clone(&self.values),
-        }
-    }
-}
-
-impl Metrics for NetworkingMetrics {
-    fn create_counter(&self, label: String, _unit_label: Option<String>) -> Box<dyn Counter> {
-        Box::new(self.sub(label))
-    }
-
-    fn create_gauge(&self, label: String, _unit_label: Option<String>) -> Box<dyn Gauge> {
-        Box::new(self.sub(label))
-    }
-
-    fn create_histogram(&self, label: String, _unit_label: Option<String>) -> Box<dyn Histogram> {
-        Box::new(self.sub(label))
-    }
-
-    fn create_label(&self, label: String) -> Box<dyn Label> {
-        Box::new(self.sub(label))
-    }
-
-    fn subgroup(&self, subgroup_name: String) -> Box<dyn Metrics> {
-        Box::new(self.sub(subgroup_name))
-    }
-}
-
-impl Counter for NetworkingMetrics {
-    fn add(&self, amount: usize) {
-        *self
-            .values
-            .lock()
-            .unwrap()
-            .counters
-            .entry(self.prefix.clone())
-            .or_default() += amount;
-    }
-}
-
-impl Gauge for NetworkingMetrics {
-    fn set(&self, amount: usize) {
-        *self
-            .values
-            .lock()
-            .unwrap()
-            .gauges
-            .entry(self.prefix.clone())
-            .or_default() = amount;
-    }
-    fn update(&self, delta: i64) {
-        let mut values = self.values.lock().unwrap();
-        let value = values.gauges.entry(self.prefix.clone()).or_default();
-        let signed_value = i64::try_from(*value).unwrap_or(i64::MAX);
-        *value = usize::try_from(signed_value + delta).unwrap_or(0);
-    }
-}
-
-impl Histogram for NetworkingMetrics {
-    fn add_point(&self, point: f64) {
-        self.values
-            .lock()
-            .unwrap()
-            .histograms
-            .entry(self.prefix.clone())
-            .or_default()
-            .push(point);
-    }
-}
-
-impl Label for NetworkingMetrics {
-    fn set(&self, value: String) {
-        *self
-            .values
-            .lock()
-            .unwrap()
-            .labels
-            .entry(self.prefix.clone())
-            .or_default() = value;
-    }
 }
 
 impl NetworkingMetricsValue {


### PR DESCRIPTION
### This PR: 

* Add `MetricsFamily` trait to group related metrics that are partitioned by values of their labels. This gives us a way to create metrics that actually use Prometheus labels, a capability we haven't had until now.
* Rename `Label` to `Text` to distinguish it from the Prometheus concept of a label
* Change the way `Text` works. Prometheus doesn't support top-level key-value pairs with text values, so implementing the old `Label` trait for Prometheus, we were forced to hack it by putting the value in a comment. A better approach is to have a "text" metric where the value of the metric is the name (this can be implemented, e.g., as a gauge with a dummy value of 1). Additional key-value pairs can be added using families/labels as described above.
* Remove dead code `Metrics` implementations in consensus and networking

The motivation for this is a request from node operators to make the version metrics populated by the sequencer more parseable. For this, we only need a family with a single instance, whose label values contain information like git revision and whatnot. However, this implementation is more general, and will allow us to fully take advantage of Prometheus labels if we want to in the future.

Examples of both the simple "version label" usage and a more complex use of labels can be found in the doc comments.

### This PR does not: 

Provide a real, prometheus-based implementation of the metrics functionality. As before, the implementation lives in `hotshot-query-service`.

### Key places to review: 

crates/hotshot-types/src/traits/metrics.rs

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
