### PR TITLE
Add default `genesis` to trait

### DIFF
--- a/crates/example-types/src/block_types.rs
+++ b/crates/example-types/src/block_types.rs
@@ -198,10 +198,6 @@ impl BlockPayload for TestBlockPayload {
         Self { transactions }
     }
 
-    fn genesis() -> (Self, Self::Metadata) {
-        (Self::genesis(), TestMetadata)
-    }
-
     fn builder_commitment(&self, _metadata: &Self::Metadata) -> BuilderCommitment {
         let mut digest = sha2::Sha256::new();
         for txn in &self.transactions {

--- a/crates/types/src/traits/block_contents.rs
+++ b/crates/types/src/traits/block_contents.rs
@@ -88,7 +88,13 @@ pub trait BlockPayload:
     fn from_bytes(encoded_transactions: &[u8], metadata: &Self::Metadata) -> Self;
 
     /// Build the genesis payload and metadata.
-    fn genesis() -> (Self, Self::Metadata);
+    #[must_use]
+    fn genesis() -> (Self, Self::Metadata)
+    where
+        <Self as BlockPayload>::Instance: Default,
+    {
+        Self::from_transactions([], &Default::default()).unwrap()
+    }
 
     /// List of transaction commitments.
     fn transaction_commitments(


### PR DESCRIPTION
Avoids downstream implementations.

-------
We have a TODO in sequencer here: 
https://github.com/EspressoSystems/espresso-sequencer/blob/77484507b7b8a5e94ecbc38dcae356e90d9bbba6/sequencer/src/block.rs#L65
<!-- See here for keywords in Github -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

### This PR: 
Adds a default implantation of `genesis` to `BlockPayload`.

### This PR does not: 
It should not change any functionality and only make changes that are required to complete the above.
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->

### Key places to review: 
The intended change is in `BlockPayload` trait in
`crates/types/src/traits/block_contents.rs`. That default
implementation allows us to remove the implementation from
`crates/example-types/src/block_types.rs`.


<!-- Describe key places
for reviewers to pay close attention to --> <!-- * file.rs,
`add_integers` function -->

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->