### PR TITLE
[TECH_DEBT] Don't log private key

### DIFF
--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -2,6 +2,7 @@
 use std::{fmt::Debug, future::Future, num::NonZeroUsize, pin::Pin, time::Duration};
 
 use bincode::Options;
+use derivative::Derivative;
 use displaydoc::Display;
 use light_client::StateVerKey;
 use tracing::error;
@@ -56,13 +57,15 @@ pub enum ExecutionType {
     Incremental,
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Display)]
+#[derive(serde::Serialize, serde::Deserialize, Clone, Derivative, Display)]
 #[serde(bound(deserialize = ""))]
+#[derivative(Debug(bound = ""))]
 /// config for validator, including public key, private key, stake value
 pub struct ValidatorConfig<KEY: SignatureKey> {
     /// The validator's public key and stake value
     pub public_key: KEY,
     /// The validator's private key, should be in the mempool, not public
+    #[derivative(Debug = "ignore")]
     pub private_key: KEY::PrivateKey,
     /// The validator's stake
     pub stake_value: u64,


### PR DESCRIPTION
### This PR: 

Omits a private key from logging and debug output in `ValidatorConfig`.

### This PR does not: 

Omit private keys from debug output for types defined in Jellyfish (e.g. `schnorr::KeyPair`). I will make a PR in Jellyfish to fix that.
