### PR TITLE
Reliably broadcast ViewFinished event

### DIFF
--- a/crates/task-impls/src/consensus/helpers.rs
+++ b/crates/task-impls/src/consensus/helpers.rs
@@ -582,11 +582,11 @@ pub async fn publish_proposal_if_able<TYPES: NodeType>(
 
 /// TEMPORARY TYPE: Quorum proposal recv task state when using dependency tasks
 #[cfg(feature = "dependency-tasks")]
-type TemporaryProposalRecvCombinedType<TYPES, I> = QuorumProposalRecvTaskState<TYPES, I>;
+pub(crate) type TemporaryProposalRecvCombinedType<TYPES, I> = QuorumProposalRecvTaskState<TYPES, I>;
 
 /// TEMPORARY TYPE: Consensus task state when not using dependency tasks
 #[cfg(not(feature = "dependency-tasks"))]
-type TemporaryProposalRecvCombinedType<TYPES, I> = ConsensusTaskState<TYPES, I>;
+pub(crate) type TemporaryProposalRecvCombinedType<TYPES, I> = ConsensusTaskState<TYPES, I>;
 
 // TODO: Fix `clippy::too_many_lines`.
 /// Handle the received quorum proposal.
@@ -597,7 +597,6 @@ pub async fn handle_quorum_proposal_recv<TYPES: NodeType, I: NodeImplementation<
     proposal: &Proposal<TYPES, QuorumProposal<TYPES>>,
     sender: &TYPES::SignatureKey,
     event_stream: Sender<Arc<HotShotEvent<TYPES>>>,
-    output_event_stream: Sender<Event<TYPES>>,
     task_state: &mut TemporaryProposalRecvCombinedType<TYPES, I>,
     version: Version,
 ) -> Result<Option<QuorumProposal<TYPES>>> {
@@ -627,14 +626,11 @@ pub async fn handle_quorum_proposal_recv<TYPES: NodeType, I: NodeImplementation<
     }
 
     // NOTE: We could update our view with a valid TC but invalid QC, but that is not what we do here
-    if let Err(e) = update_view::<TYPES>(
+    if let Err(e) = update_view::<TYPES, I>(
+        task_state,
         view,
         &event_stream,
-        &output_event_stream,
-        task_state.timeout,
         Arc::clone(&task_state.consensus),
-        &mut task_state.cur_view,
-        &mut task_state.timeout_task,
         SEND_VIEW_CHANGE_EVENT,
     )
     .await

--- a/crates/task-impls/src/consensus/helpers.rs
+++ b/crates/task-impls/src/consensus/helpers.rs
@@ -597,6 +597,7 @@ pub async fn handle_quorum_proposal_recv<TYPES: NodeType, I: NodeImplementation<
     proposal: &Proposal<TYPES, QuorumProposal<TYPES>>,
     sender: &TYPES::SignatureKey,
     event_stream: Sender<Arc<HotShotEvent<TYPES>>>,
+    output_event_stream: Sender<Event<TYPES>>,
     task_state: &mut TemporaryProposalRecvCombinedType<TYPES, I>,
     version: Version,
 ) -> Result<Option<QuorumProposal<TYPES>>> {
@@ -629,6 +630,7 @@ pub async fn handle_quorum_proposal_recv<TYPES: NodeType, I: NodeImplementation<
     if let Err(e) = update_view::<TYPES>(
         view,
         &event_stream,
+        &output_event_stream,
         task_state.timeout,
         Arc::clone(&task_state.consensus),
         &mut task_state.cur_view,

--- a/crates/task-impls/src/consensus/mod.rs
+++ b/crates/task-impls/src/consensus/mod.rs
@@ -294,7 +294,6 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> ConsensusTaskState<TYPES, I>
                     proposal,
                     sender,
                     event_stream.clone(),
-                    self.output_event_stream.clone(),
                     self,
                     version,
                 )
@@ -539,14 +538,11 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> ConsensusTaskState<TYPES, I>
                 // update the view in state to the one in the message
                 // Publish a view change event to the application
                 // Returns if the view does not need updating.
-                if let Err(e) = update_view::<TYPES>(
+                if let Err(e) = update_view::<TYPES, _>(
+                    self,
                     new_view,
                     &event_stream,
-                    &self.output_event_stream,
-                    self.timeout,
                     Arc::clone(&self.consensus),
-                    &mut self.cur_view,
-                    &mut self.timeout_task,
                     DONT_SEND_VIEW_CHANGE_EVENT,
                 )
                 .await

--- a/crates/task-impls/src/consensus/mod.rs
+++ b/crates/task-impls/src/consensus/mod.rs
@@ -294,6 +294,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> ConsensusTaskState<TYPES, I>
                     proposal,
                     sender,
                     event_stream.clone(),
+                    self.output_event_stream.clone(),
                     self,
                     version,
                 )
@@ -541,6 +542,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> ConsensusTaskState<TYPES, I>
                 if let Err(e) = update_view::<TYPES>(
                     new_view,
                     &event_stream,
+                    &self.output_event_stream,
                     self.timeout,
                     Arc::clone(&self.consensus),
                     &mut self.cur_view,
@@ -552,17 +554,6 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> ConsensusTaskState<TYPES, I>
                     tracing::trace!("Failed to update view; error = {e}");
                     return;
                 }
-
-                broadcast_event(
-                    Event {
-                        view_number: old_view_number,
-                        event: EventType::ViewFinished {
-                            view_number: old_view_number,
-                        },
-                    },
-                    &self.output_event_stream,
-                )
-                .await;
             }
             HotShotEvent::Timeout(view) => {
                 let view = *view;


### PR DESCRIPTION
Closes #0000

### This PR: 
Fixes a bug where we wouldn't generate `ViewFinished` event for successful views

### This PR does not: 
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->

### Key places to review: 
All changed files

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
