### PR TITLE
Use alternate display to log anyhow error

### DIFF
--- a/crates/task-impls/src/transactions.rs
+++ b/crates/task-impls/src/transactions.rs
@@ -274,7 +274,7 @@ impl<
 
                 // We failed to get a block
                 Ok(Err(err)) => {
-                    tracing::warn!(%err, "Couldn't get a block");
+                    tracing::warn!("Couldn't get a block: {err:#}");
                     // pause a bit
                     async_sleep(Duration::from_millis(100)).await;
                     continue;


### PR DESCRIPTION

### This PR: 

Uses the alternative display format (`{:#}`) to log an anyhow error. The default display (which tracing supports for event fields) only shows the most recent `context(...)` instead of the full chain of error causes.

### This PR does not: 
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->

### Key places to review: 
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
