### PR TITLE
Allow genesis to time out

### DIFF
--- a/crates/hotshot/src/tasks/task_state.rs
+++ b/crates/hotshot/src/tasks/task_state.rs
@@ -8,20 +8,12 @@ use std::{
 use async_compatibility_layer::art::{async_sleep, async_spawn};
 use async_trait::async_trait;
 use hotshot_task_impls::{
-    builder::BuilderClient,
-    consensus::ConsensusTaskState,
-    consensus2::Consensus2TaskState,
-    da::DaTaskState,
-    events::HotShotEvent,
-    helpers::broadcast_event,
-    quorum_proposal::QuorumProposalTaskState,
-    quorum_proposal_recv::QuorumProposalRecvTaskState,
-    quorum_vote::QuorumVoteTaskState,
-    request::NetworkRequestState,
-    transactions::TransactionTaskState,
-    upgrade::UpgradeTaskState,
-    vid::VidTaskState,
-    view_sync::{ViewSyncReplicaTaskState, ViewSyncTaskState},
+    builder::BuilderClient, consensus::ConsensusTaskState, consensus2::Consensus2TaskState,
+    da::DaTaskState, events::HotShotEvent, helpers::broadcast_event,
+    quorum_proposal::QuorumProposalTaskState, quorum_proposal_recv::QuorumProposalRecvTaskState,
+    quorum_vote::QuorumVoteTaskState, request::NetworkRequestState,
+    transactions::TransactionTaskState, upgrade::UpgradeTaskState, vid::VidTaskState,
+    view_sync::ViewSyncTaskState,
 };
 use hotshot_types::traits::{
     consensus_api::ConsensusApi,
@@ -200,7 +192,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> CreateTaskState<TYPES, I>
         let next_view_timeout = handle.hotshot.config.next_view_timeout;
         let timeout_task = async_spawn({
             // Nuance: We timeout on the 1 here because that means that we have
-            // not seen evidence to transition to transition to it.
+            // not seen evidence to transition to it.
             let view_number = 1;
             async move {
                 async_sleep(Duration::from_millis(next_view_timeout)).await;
@@ -280,7 +272,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> CreateTaskState<TYPES, I>
         let next_view_timeout = handle.hotshot.config.next_view_timeout;
         let timeout_task = async_spawn({
             // Nuance: We timeout on the 1 here because that means that we have
-            // not seen evidence to transition to transition to it.
+            // not seen evidence to transition to it.
             let view_number = 1;
             async move {
                 async_sleep(Duration::from_millis(next_view_timeout)).await;
@@ -327,7 +319,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> CreateTaskState<TYPES, I>
         let next_view_timeout = handle.hotshot.config.next_view_timeout;
         let timeout_task = async_spawn({
             // Nuance: We timeout on the 1 here because that means that we have
-            // not seen evidence to transition to transition to it.
+            // not seen evidence to transition to it.
             let view_number = 1;
             async move {
                 async_sleep(Duration::from_millis(next_view_timeout)).await;
@@ -372,7 +364,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> CreateTaskState<TYPES, I>
         let next_view_timeout = handle.hotshot.config.next_view_timeout;
         let timeout_task = async_spawn({
             // Nuance: We timeout on the 1 here because that means that we have
-            // not seen evidence to transition to transition to it.
+            // not seen evidence to transition to it.
             let view_number = 1;
             async move {
                 async_sleep(Duration::from_millis(next_view_timeout)).await;

--- a/crates/hotshot/src/tasks/task_state.rs
+++ b/crates/hotshot/src/tasks/task_state.rs
@@ -44,6 +44,7 @@ fn timeout_task_from_handle<TYPES: NodeType, I: NodeImplementation<TYPES>>(
     // Clone the event stream that we send the timeout event to
     let event_stream = handle.internal_event_stream.0.clone();
     let next_view_timeout = handle.hotshot.config.next_view_timeout;
+    let start_view = handle.hotshot.start_view;
 
     // Spawn a task that will sleep for the next view timeout and then send a timeout event
     // if not cancelled
@@ -51,7 +52,7 @@ fn timeout_task_from_handle<TYPES: NodeType, I: NodeImplementation<TYPES>>(
         async move {
             async_sleep(Duration::from_millis(next_view_timeout)).await;
             broadcast_event(
-                Arc::new(HotShotEvent::Timeout(TYPES::Time::new(1))),
+                Arc::new(HotShotEvent::Timeout(start_view + 1)),
                 &event_stream,
             )
             .await;

--- a/crates/task-impls/src/consensus/mod.rs
+++ b/crates/task-impls/src/consensus/mod.rs
@@ -108,7 +108,7 @@ pub struct ConsensusTaskState<TYPES: NodeType, I: NodeImplementation<TYPES>> {
         RwLock<VoteCollectorOption<TYPES, TimeoutVote<TYPES>, TimeoutCertificate<TYPES>>>,
 
     /// timeout task handle
-    pub timeout_task: Option<JoinHandle<()>>,
+    pub timeout_task: JoinHandle<()>,
 
     /// Spawned tasks related to a specific view, so we can cancel them when
     /// they are stale

--- a/crates/task-impls/src/consensus2/mod.rs
+++ b/crates/task-impls/src/consensus2/mod.rs
@@ -77,7 +77,7 @@ pub struct Consensus2TaskState<TYPES: NodeType, I: NodeImplementation<TYPES>> {
     pub output_event_stream: async_broadcast::Sender<Event<TYPES>>,
 
     /// Timeout task handle
-    pub timeout_task: Option<JoinHandle<()>>,
+    pub timeout_task: JoinHandle<()>,
 
     /// View timeout from config.
     pub timeout: u64,

--- a/crates/task-impls/src/quorum_proposal.rs
+++ b/crates/task-impls/src/quorum_proposal.rs
@@ -243,7 +243,7 @@ pub struct QuorumProposalTaskState<TYPES: NodeType, I: NodeImplementation<TYPES>
     pub round_start_delay: u64,
 
     /// timeout task handle
-    pub timeout_task: Option<JoinHandle<()>>,
+    pub timeout_task: JoinHandle<()>,
 
     /// This node's storage ref
     pub storage: Arc<RwLock<I::Storage>>,

--- a/crates/task-impls/src/quorum_proposal_recv.rs
+++ b/crates/task-impls/src/quorum_proposal_recv.rs
@@ -54,7 +54,7 @@ pub struct QuorumProposalRecvTaskState<TYPES: NodeType, I: NodeImplementation<TY
     pub timeout_membership: Arc<TYPES::Membership>,
 
     /// timeout task handle
-    pub timeout_task: Option<JoinHandle<()>>,
+    pub timeout_task: JoinHandle<()>,
 
     /// View timeout from config.
     pub timeout: u64,


### PR DESCRIPTION
No linked issue.

During test deployments, we ran into a case where the genesis block would never time out. If we ever didn't see genesis for any reason (not enough nodes saw it from the CDN, builder has wrong commitment), the network would hang indefinitely. 


### This PR
Fixes that fragility by always requiring a timeout task to be present. 

I tested it upstream on the sequencer and we can indeed time out view 0 now