### PR TITLE
Make BlockPayload::from_transactions async and pass ValidatedState

### DIFF
--- a/crates/builder-api/src/block_info.rs
+++ b/crates/builder-api/src/block_info.rs
@@ -23,7 +23,7 @@ pub struct AvailableBlockInfo<TYPES: NodeType> {
 #[serde(bound = "")]
 pub struct AvailableBlockData<TYPES: NodeType> {
     pub block_payload: TYPES::BlockPayload,
-    pub metadata: <TYPES::BlockPayload as BlockPayload>::Metadata,
+    pub metadata: <TYPES::BlockPayload as BlockPayload<TYPES>>::Metadata,
     pub signature:
         <<TYPES as NodeType>::BuilderSignatureKey as BuilderSignatureKey>::BuilderSignature,
     pub sender: <TYPES as NodeType>::BuilderSignatureKey,

--- a/crates/example-types/src/block_types.rs
+++ b/crates/example-types/src/block_types.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use committable::{Commitment, Committable, RawCommitmentBuilder};
-use futures::{future::BoxFuture, FutureExt};
+use futures::Future;
 use hotshot_types::{
     data::{BlockError, Leaf},
     traits::{
@@ -174,16 +174,16 @@ impl<TYPES: NodeType> BlockPayload<TYPES> for TestBlockPayload {
         transactions: impl IntoIterator<Item = Self::Transaction>,
         _validated_state: &Self::ValidatedState,
         _instance_state: &Self::Instance,
-    ) -> BoxFuture<'static, Result<(Self, Self::Metadata), Self::Error>> {
+    ) -> impl Future<Output = Result<(Self, Self::Metadata), Self::Error>> + Send + 'static {
         let txns_vec: Vec<TestTransaction> = transactions.into_iter().collect();
-        Box::pin(async {
+        async {
             Ok((
                 Self {
                     transactions: txns_vec,
                 },
                 TestMetadata,
             ))
-        })
+        }
     }
 
     fn from_bytes(encoded_transactions: &[u8], _metadata: &Self::Metadata) -> Self {
@@ -207,8 +207,8 @@ impl<TYPES: NodeType> BlockPayload<TYPES> for TestBlockPayload {
         Self { transactions }
     }
 
-    fn genesis() -> BoxFuture<'static, (Self, Self::Metadata)> {
-        async { (Self::genesis(), TestMetadata) }.boxed()
+    async fn genesis() -> (Self, Self::Metadata) {
+        (Self::genesis(), TestMetadata)
     }
 
     fn builder_commitment(&self, _metadata: &Self::Metadata) -> BuilderCommitment {

--- a/crates/example-types/src/block_types.rs
+++ b/crates/example-types/src/block_types.rs
@@ -134,7 +134,7 @@ impl Display for TestBlockPayload {
     }
 }
 
-impl TestableBlock for TestBlockPayload {
+impl<TYPES: NodeType> TestableBlock<TYPES> for TestBlockPayload {
     fn genesis() -> Self {
         Self::genesis()
     }
@@ -159,7 +159,7 @@ impl EncodeBytes for TestBlockPayload {
     }
 }
 
-impl BlockPayload for TestBlockPayload {
+impl<TYPES: NodeType> BlockPayload<TYPES> for TestBlockPayload {
     type Error = BlockError;
     type Instance = TestInstanceState;
     type Transaction = TestTransaction;
@@ -167,6 +167,7 @@ impl BlockPayload for TestBlockPayload {
 
     fn from_transactions(
         transactions: impl IntoIterator<Item = Self::Transaction>,
+        _validated_state: &TYPES::ValidatedState,
         _instance_state: &Self::Instance,
     ) -> Result<(Self, Self::Metadata), Self::Error> {
         let txns_vec: Vec<TestTransaction> = transactions.into_iter().collect();
@@ -239,7 +240,7 @@ impl<TYPES: NodeType<BlockHeader = Self, BlockPayload = TestBlockPayload>> Block
         parent_leaf: &Leaf<TYPES>,
         payload_commitment: VidCommitment,
         builder_commitment: BuilderCommitment,
-        _metadata: <TYPES::BlockPayload as BlockPayload>::Metadata,
+        _metadata: <TYPES::BlockPayload as BlockPayload<TYPES>>::Metadata,
         _builder_fee: BuilderFee<TYPES>,
         _vid_common: VidCommon,
         _version: Version,
@@ -264,7 +265,7 @@ impl<TYPES: NodeType<BlockHeader = Self, BlockPayload = TestBlockPayload>> Block
         _instance_state: &<TYPES::ValidatedState as ValidatedState<TYPES>>::Instance,
         payload_commitment: VidCommitment,
         builder_commitment: BuilderCommitment,
-        _metadata: <TYPES::BlockPayload as BlockPayload>::Metadata,
+        _metadata: <TYPES::BlockPayload as BlockPayload<TYPES>>::Metadata,
     ) -> Self {
         Self {
             block_number: 0,
@@ -282,7 +283,7 @@ impl<TYPES: NodeType<BlockHeader = Self, BlockPayload = TestBlockPayload>> Block
         self.payload_commitment
     }
 
-    fn metadata(&self) -> &<TYPES::BlockPayload as BlockPayload>::Metadata {
+    fn metadata(&self) -> &<TYPES::BlockPayload as BlockPayload<TYPES>>::Metadata {
         &TestMetadata
     }
 

--- a/crates/example-types/src/block_types.rs
+++ b/crates/example-types/src/block_types.rs
@@ -206,7 +206,7 @@ impl<TYPES: NodeType> BlockPayload<TYPES> for TestBlockPayload {
         Self { transactions }
     }
 
-    async fn genesis() -> (Self, Self::Metadata) {
+    fn empty() -> (Self, Self::Metadata) {
         (Self::genesis(), TestMetadata)
     }
 

--- a/crates/example-types/src/block_types.rs
+++ b/crates/example-types/src/block_types.rs
@@ -21,7 +21,10 @@ use snafu::Snafu;
 use time::OffsetDateTime;
 use vbs::version::Version;
 
-use crate::{node_types::TestTypes, state_types::TestInstanceState};
+use crate::{
+    node_types::TestTypes,
+    state_types::{TestInstanceState, TestValidatedState},
+};
 
 /// The transaction in a [`TestBlockPayload`].
 #[derive(Default, PartialEq, Eq, Hash, Serialize, Deserialize, Clone, Debug)]
@@ -164,10 +167,11 @@ impl<TYPES: NodeType> BlockPayload<TYPES> for TestBlockPayload {
     type Instance = TestInstanceState;
     type Transaction = TestTransaction;
     type Metadata = TestMetadata;
+    type ValidatedState = TestValidatedState;
 
     fn from_transactions(
         transactions: impl IntoIterator<Item = Self::Transaction>,
-        _validated_state: &TYPES::ValidatedState,
+        _validated_state: &Self::ValidatedState,
         _instance_state: &Self::Instance,
     ) -> Result<(Self, Self::Metadata), Self::Error> {
         let txns_vec: Vec<TestTransaction> = transactions.into_iter().collect();
@@ -198,6 +202,10 @@ impl<TYPES: NodeType> BlockPayload<TYPES> for TestBlockPayload {
         }
 
         Self { transactions }
+    }
+
+    fn genesis() -> (Self, Self::Metadata) {
+        (Self::genesis(), TestMetadata)
     }
 
     fn builder_commitment(&self, _metadata: &Self::Metadata) -> BuilderCommitment {

--- a/crates/example-types/src/state_types.rs
+++ b/crates/example-types/src/state_types.rs
@@ -107,7 +107,7 @@ impl<TYPES: NodeType<BlockPayload = TestBlockPayload>> TestableState<TYPES> for 
         _state: Option<&Self>,
         rng: &mut dyn rand::RngCore,
         padding: u64,
-    ) -> <TYPES::BlockPayload as BlockPayload>::Transaction {
+    ) -> <TYPES::BlockPayload as BlockPayload<TYPES>>::Transaction {
         /// clippy appeasement for `RANDOM_TX_BASE_SIZE`
         const RANDOM_TX_BASE_SIZE: usize = 8;
 

--- a/crates/example-types/src/state_types.rs
+++ b/crates/example-types/src/state_types.rs
@@ -102,14 +102,7 @@ impl<TYPES: NodeType> ValidatedState<TYPES> for TestValidatedState {
     }
 }
 
-impl<
-        TYPES: NodeType<
-            BlockPayload = TestBlockPayload,
-            ValidatedState = TestValidatedState,
-            Transaction = TestTransaction,
-        >,
-    > TestableState<TYPES> for TestValidatedState
-{
+impl<TYPES: NodeType<BlockPayload = TestBlockPayload>> TestableState<TYPES> for TestValidatedState {
     fn create_random_transaction(
         _state: Option<&Self>,
         rng: &mut dyn rand::RngCore,

--- a/crates/example-types/src/state_types.rs
+++ b/crates/example-types/src/state_types.rs
@@ -102,7 +102,14 @@ impl<TYPES: NodeType> ValidatedState<TYPES> for TestValidatedState {
     }
 }
 
-impl<TYPES: NodeType<BlockPayload = TestBlockPayload>> TestableState<TYPES> for TestValidatedState {
+impl<
+        TYPES: NodeType<
+            BlockPayload = TestBlockPayload,
+            ValidatedState = TestValidatedState,
+            Transaction = TestTransaction,
+        >,
+    > TestableState<TYPES> for TestValidatedState
+{
     fn create_random_transaction(
         _state: Option<&Self>,
         rng: &mut dyn rand::RngCore,

--- a/crates/examples/infra/mod.rs
+++ b/crates/examples/infra/mod.rs
@@ -31,7 +31,7 @@ use hotshot::{
 use hotshot_example_types::{
     block_types::{TestBlockHeader, TestBlockPayload, TestTransaction},
     node_types::{Libp2pImpl, PushCdnImpl},
-    state_types::{TestInstanceState, TestValidatedState},
+    state_types::TestInstanceState,
     storage_types::TestStorage,
 };
 use hotshot_orchestrator::{
@@ -866,10 +866,8 @@ where
 pub async fn main_entry_point<
     TYPES: NodeType<
         Transaction = TestTransaction,
-        BlockPayload = TestBlockPayload,
         BlockHeader = TestBlockHeader,
         InstanceState = TestInstanceState,
-        ValidatedState = TestValidatedState,
     >,
     DACHANNEL: ConnectedNetwork<Message<TYPES>, TYPES::SignatureKey>,
     QUORUMCHANNEL: ConnectedNetwork<Message<TYPES>, TYPES::SignatureKey>,

--- a/crates/examples/infra/mod.rs
+++ b/crates/examples/infra/mod.rs
@@ -353,6 +353,7 @@ pub trait RunDa<
     /// Note: sequencing leaf does not have state, so does not return state
     async fn initialize_state_and_hotshot(&self) -> SystemContextHandle<TYPES, NODE> {
         let initializer = hotshot::HotShotInitializer::<TYPES>::from_genesis(TestInstanceState {})
+            .await
             .expect("Couldn't generate genesis block");
 
         let config = self.config();

--- a/crates/examples/infra/mod.rs
+++ b/crates/examples/infra/mod.rs
@@ -31,7 +31,7 @@ use hotshot::{
 use hotshot_example_types::{
     block_types::{TestBlockHeader, TestBlockPayload, TestTransaction},
     node_types::{Libp2pImpl, PushCdnImpl},
-    state_types::TestInstanceState,
+    state_types::{TestInstanceState, TestValidatedState},
     storage_types::TestStorage,
 };
 use hotshot_orchestrator::{
@@ -336,7 +336,7 @@ pub trait RunDa<
     >,
 > where
     <TYPES as NodeType>::ValidatedState: TestableState<TYPES>,
-    <TYPES as NodeType>::BlockPayload: TestableBlock,
+    <TYPES as NodeType>::BlockPayload: TestableBlock<TYPES>,
     TYPES: NodeType<Transaction = TestTransaction>,
     Leaf<TYPES>: TestableLeaf,
     Self: Sync,
@@ -608,7 +608,7 @@ impl<
     > RunDa<TYPES, PushCdnNetwork<TYPES>, PushCdnNetwork<TYPES>, NODE> for PushCdnDaRun<TYPES>
 where
     <TYPES as NodeType>::ValidatedState: TestableState<TYPES>,
-    <TYPES as NodeType>::BlockPayload: TestableBlock,
+    <TYPES as NodeType>::BlockPayload: TestableBlock<TYPES>,
     Leaf<TYPES>: TestableLeaf,
     Self: Sync,
 {
@@ -700,7 +700,7 @@ impl<
     > for Libp2pDaRun<TYPES>
 where
     <TYPES as NodeType>::ValidatedState: TestableState<TYPES>,
-    <TYPES as NodeType>::BlockPayload: TestableBlock,
+    <TYPES as NodeType>::BlockPayload: TestableBlock<TYPES>,
     Leaf<TYPES>: TestableLeaf,
     Self: Sync,
 {
@@ -792,7 +792,7 @@ impl<
     > RunDa<TYPES, CombinedNetworks<TYPES>, CombinedNetworks<TYPES>, NODE> for CombinedDaRun<TYPES>
 where
     <TYPES as NodeType>::ValidatedState: TestableState<TYPES>,
-    <TYPES as NodeType>::BlockPayload: TestableBlock,
+    <TYPES as NodeType>::BlockPayload: TestableBlock<TYPES>,
     Leaf<TYPES>: TestableLeaf,
     Self: Sync,
 {
@@ -868,6 +868,7 @@ pub async fn main_entry_point<
         BlockPayload = TestBlockPayload,
         BlockHeader = TestBlockHeader,
         InstanceState = TestInstanceState,
+        ValidatedState = TestValidatedState,
     >,
     DACHANNEL: ConnectedNetwork<Message<TYPES>, TYPES::SignatureKey>,
     QUORUMCHANNEL: ConnectedNetwork<Message<TYPES>, TYPES::SignatureKey>,
@@ -882,7 +883,7 @@ pub async fn main_entry_point<
     args: ValidatorArgs,
 ) where
     <TYPES as NodeType>::ValidatedState: TestableState<TYPES>,
-    <TYPES as NodeType>::BlockPayload: TestableBlock,
+    <TYPES as NodeType>::BlockPayload: TestableBlock<TYPES>,
     Leaf<TYPES>: TestableLeaf,
 {
     setup_logging();

--- a/crates/hotshot/src/lib.rs
+++ b/crates/hotshot/src/lib.rs
@@ -57,15 +57,13 @@ use tasks::{add_request_network_task, add_response_task, add_vid_task};
 use tracing::{debug, instrument, trace};
 use vbs::version::Version;
 
+#[cfg(not(feature = "dependency-tasks"))]
+use crate::tasks::add_consensus_task;
 #[cfg(feature = "dependency-tasks")]
 use crate::tasks::{
     add_consensus2_task, add_quorum_proposal_recv_task, add_quorum_proposal_task,
     add_quorum_vote_task,
 };
-
-#[cfg(not(feature = "dependency-tasks"))]
-use crate::tasks::add_consensus_task;
-
 use crate::{
     tasks::{
         add_da_task, add_network_event_task, add_network_message_task, add_transaction_task,

--- a/crates/hotshot/src/lib.rs
+++ b/crates/hotshot/src/lib.rs
@@ -342,7 +342,9 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> SystemContext<TYPES, I> {
                                 Some(Arc::new(state_delta)),
                                 None,
                             )]),
-                            qc: Arc::new(QuorumCertificate::genesis(self.instance_state.as_ref())),
+                            qc: Arc::new(
+                                QuorumCertificate::genesis(self.instance_state.as_ref()).await,
+                            ),
                             block_size: None,
                         },
                     },
@@ -765,14 +767,16 @@ impl<TYPES: NodeType> HotShotInitializer<TYPES> {
     /// initialize from genesis
     /// # Errors
     /// If we are unable to apply the genesis block to the default state
-    pub fn from_genesis(instance_state: TYPES::InstanceState) -> Result<Self, HotShotError<TYPES>> {
+    pub async fn from_genesis(
+        instance_state: TYPES::InstanceState,
+    ) -> Result<Self, HotShotError<TYPES>> {
         let (validated_state, state_delta) = TYPES::ValidatedState::genesis(&instance_state);
         Ok(Self {
-            inner: Leaf::genesis(&instance_state),
+            inner: Leaf::genesis(&instance_state).await,
             validated_state: Some(Arc::new(validated_state)),
             state_delta: Some(Arc::new(state_delta)),
             start_view: TYPES::Time::new(0),
-            high_qc: QuorumCertificate::genesis(&instance_state),
+            high_qc: QuorumCertificate::genesis(&instance_state).await,
             undecided_leafs: Vec::new(),
             undecided_state: BTreeMap::new(),
             instance_state,

--- a/crates/hotshot/src/tasks/task_state.rs
+++ b/crates/hotshot/src/tasks/task_state.rs
@@ -1,3 +1,9 @@
+use std::{
+    collections::{BTreeMap, HashMap},
+    marker::PhantomData,
+    sync::{atomic::AtomicBool, Arc},
+};
+
 use async_trait::async_trait;
 use hotshot_task_impls::{
     builder::BuilderClient, consensus::ConsensusTaskState, consensus2::Consensus2TaskState,
@@ -10,12 +16,6 @@ use hotshot_types::traits::{
     consensus_api::ConsensusApi,
     node_implementation::{ConsensusTime, NodeImplementation, NodeType},
 };
-use std::{
-    collections::{BTreeMap, HashMap},
-    marker::PhantomData,
-    sync::{atomic::AtomicBool, Arc},
-};
-
 use vbs::version::StaticVersionType;
 
 use crate::types::SystemContextHandle;

--- a/crates/hotshot/src/types/handle.rs
+++ b/crates/hotshot/src/types/handle.rs
@@ -1,6 +1,6 @@
 //! Provides an event-streaming handle for a [`SystemContext`] running in the background
 
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use async_broadcast::{InactiveReceiver, Receiver, Sender};
 use async_compatibility_layer::art::{async_sleep, async_spawn};
@@ -18,7 +18,6 @@ use hotshot_types::{
     traits::{election::Membership, node_implementation::NodeType},
     BoxSyncFuture,
 };
-use std::time::Duration;
 #[cfg(async_executor_impl = "tokio")]
 use tokio::task::JoinHandle;
 

--- a/crates/task-impls/src/consensus/helpers.rs
+++ b/crates/task-impls/src/consensus/helpers.rs
@@ -395,10 +395,12 @@ pub(crate) async fn publish_proposal_from_upgrade_cert<TYPES: NodeType>(
     )
     .await?;
 
+    let validated_state = consensus.read().await.decided_state();
     // Special case: if we have a decided upgrade certificate AND it does not apply a version to the current view, we MUST propose with a null block.
     ensure!(upgrade_cert.in_interim(cur_view), "Cert is not in interim");
-    let (payload, metadata) = <TYPES::BlockPayload as BlockPayload>::from_transactions(
+    let (payload, metadata) = <TYPES::BlockPayload as BlockPayload<TYPES>>::from_transactions(
         Vec::new(),
+        validated_state.as_ref(),
         instance_state.as_ref(),
     )
     .context("Failed to build null block payload and metadata")?;
@@ -407,9 +409,12 @@ pub(crate) async fn publish_proposal_from_upgrade_cert<TYPES: NodeType>(
     let null_block_commitment = null_block::commitment(quorum_membership.total_nodes())
         .context("Failed to calculate null block commitment")?;
 
-    let null_block_fee =
-        null_block::builder_fee::<TYPES>(quorum_membership.total_nodes(), instance_state.as_ref())
-            .context("Failed to calculate null block fee info")?;
+    let null_block_fee = null_block::builder_fee::<TYPES>(
+        quorum_membership.total_nodes(),
+        validated_state.as_ref(),
+        instance_state.as_ref(),
+    )
+    .context("Failed to calculate null block fee info")?;
 
     Ok(async_spawn(async move {
         create_and_send_proposal(

--- a/crates/task-impls/src/consensus/helpers.rs
+++ b/crates/task-impls/src/consensus/helpers.rs
@@ -410,17 +410,10 @@ pub(crate) async fn publish_proposal_from_upgrade_cert<TYPES: NodeType>(
     let null_block_commitment = null_block::commitment(quorum_membership.total_nodes())
         .context("Failed to calculate null block commitment")?;
 
+    let null_block_fee = null_block::builder_fee::<TYPES>(quorum_membership.total_nodes())
+        .context("Failed to calculate null block fee info")?;
+
     Ok(async_spawn(async move {
-        let Some(null_block_fee) = null_block::builder_fee::<TYPES>(
-            quorum_membership.total_nodes(),
-            validated_state.as_ref(),
-            instance_state.as_ref(),
-        )
-        .await
-        else {
-            error!("Failed to calculate null block fee info");
-            return;
-        };
         create_and_send_proposal(
             public_key,
             private_key,

--- a/crates/task-impls/src/consensus/helpers.rs
+++ b/crates/task-impls/src/consensus/helpers.rs
@@ -403,6 +403,7 @@ pub(crate) async fn publish_proposal_from_upgrade_cert<TYPES: NodeType>(
         validated_state.as_ref(),
         instance_state.as_ref(),
     )
+    .await
     .context("Failed to build null block payload and metadata")?;
 
     let builder_commitment = payload.builder_commitment(&metadata);
@@ -414,6 +415,7 @@ pub(crate) async fn publish_proposal_from_upgrade_cert<TYPES: NodeType>(
         validated_state.as_ref(),
         instance_state.as_ref(),
     )
+    .await
     .context("Failed to calculate null block fee info")?;
 
     Ok(async_spawn(async move {

--- a/crates/task-impls/src/consensus/helpers.rs
+++ b/crates/task-impls/src/consensus/helpers.rs
@@ -410,15 +410,17 @@ pub(crate) async fn publish_proposal_from_upgrade_cert<TYPES: NodeType>(
     let null_block_commitment = null_block::commitment(quorum_membership.total_nodes())
         .context("Failed to calculate null block commitment")?;
 
-    let null_block_fee = null_block::builder_fee::<TYPES>(
-        quorum_membership.total_nodes(),
-        validated_state.as_ref(),
-        instance_state.as_ref(),
-    )
-    .await
-    .context("Failed to calculate null block fee info")?;
-
     Ok(async_spawn(async move {
+        let Some(null_block_fee) = null_block::builder_fee::<TYPES>(
+            quorum_membership.total_nodes(),
+            validated_state.as_ref(),
+            instance_state.as_ref(),
+        )
+        .await
+        else {
+            error!("Failed to calculate null block fee info");
+            return;
+        };
         create_and_send_proposal(
             public_key,
             private_key,

--- a/crates/task-impls/src/consensus2/handlers.rs
+++ b/crates/task-impls/src/consensus2/handlers.rs
@@ -15,13 +15,12 @@ use hotshot_types::{
 };
 use tracing::debug;
 
+use super::Consensus2TaskState;
 use crate::{
     events::{HotShotEvent, HotShotTaskCompleted},
     helpers::{broadcast_event, cancel_task},
     vote_collection::{create_vote_accumulator, AccumulatorInfo, HandleVoteEvent},
 };
-
-use super::Consensus2TaskState;
 
 /// Handle a `QuorumVoteRecv` event.
 pub(crate) async fn handle_quorum_vote_recv<TYPES: NodeType, I: NodeImplementation<TYPES>>(

--- a/crates/task-impls/src/consensus2/mod.rs
+++ b/crates/task-impls/src/consensus2/mod.rs
@@ -1,10 +1,10 @@
-use async_broadcast::Sender;
-use hotshot_task::task::Task;
 use std::sync::Arc;
-use tracing::instrument;
 
+use async_broadcast::Sender;
 use async_lock::RwLock;
-use hotshot_task::task::TaskState;
+#[cfg(async_executor_impl = "async-std")]
+use async_std::task::JoinHandle;
+use hotshot_task::task::{Task, TaskState};
 use hotshot_types::{
     consensus::Consensus,
     event::Event,
@@ -15,17 +15,14 @@ use hotshot_types::{
         signature_key::SignatureKey,
     },
 };
-
-#[cfg(async_executor_impl = "async-std")]
-use async_std::task::JoinHandle;
 #[cfg(async_executor_impl = "tokio")]
 use tokio::task::JoinHandle;
-
-use crate::{events::HotShotEvent, vote_collection::VoteCollectionTaskState};
+use tracing::instrument;
 
 use self::handlers::{
     handle_quorum_vote_recv, handle_timeout, handle_timeout_vote_recv, handle_view_change,
 };
+use crate::{events::HotShotEvent, vote_collection::VoteCollectionTaskState};
 
 /// Alias for Optional type for Vote Collectors
 type VoteCollectorOption<TYPES, VOTE, CERT> = Option<VoteCollectionTaskState<TYPES, VOTE, CERT>>;

--- a/crates/task-impls/src/events.rs
+++ b/crates/task-impls/src/events.rs
@@ -111,14 +111,14 @@ pub enum HotShotEvent<TYPES: NodeType> {
     SendPayloadCommitmentAndMetadata(
         VidCommitment,
         BuilderCommitment,
-        <TYPES::BlockPayload as BlockPayload>::Metadata,
+        <TYPES::BlockPayload as BlockPayload<TYPES>>::Metadata,
         TYPES::Time,
         BuilderFee<TYPES>,
     ),
     /// Event when the transactions task has sequenced transactions. Contains the encoded transactions, the metadata, and the view number
     BlockRecv(
         Arc<[u8]>,
-        <TYPES::BlockPayload as BlockPayload>::Metadata,
+        <TYPES::BlockPayload as BlockPayload<TYPES>>::Metadata,
         TYPES::Time,
         BuilderFee<TYPES>,
         VidPrecomputeData,

--- a/crates/task-impls/src/quorum_proposal/handlers.rs
+++ b/crates/task-impls/src/quorum_proposal/handlers.rs
@@ -20,9 +20,8 @@ use hotshot_types::{
 };
 use tracing::debug;
 
-use crate::{events::HotShotEvent, helpers::broadcast_event};
-
 use super::QuorumProposalTaskState;
+use crate::{events::HotShotEvent, helpers::broadcast_event};
 
 /// Helper type to give names and to the output values of the leaf chain traversal operation.
 #[derive(Debug)]

--- a/crates/task-impls/src/quorum_proposal/mod.rs
+++ b/crates/task-impls/src/quorum_proposal/mod.rs
@@ -26,14 +26,13 @@ use tokio::task::JoinHandle;
 use tracing::{debug, instrument, warn};
 use vbs::version::Version;
 
-use crate::{
-    events::HotShotEvent,
-    helpers::{broadcast_event, cancel_task},
-};
-
 use self::{
     dependency_handle::{ProposalDependency, ProposalDependencyHandle},
     handlers::handle_quorum_proposal_validated,
+};
+use crate::{
+    events::HotShotEvent,
+    helpers::{broadcast_event, cancel_task},
 };
 
 mod dependency_handle;

--- a/crates/task-impls/src/transactions.rs
+++ b/crates/task-impls/src/transactions.rs
@@ -172,7 +172,9 @@ impl<
                         self.membership.total_nodes(),
                         validated_state.as_ref(),
                         self.instance_state.as_ref(),
-                    ) else {
+                    )
+                    .await
+                    else {
                         error!("Failed to get builder fee");
                         return None;
                     };
@@ -182,7 +184,9 @@ impl<
                         vec![],
                         validated_state.as_ref(),
                         &self.instance_state,
-                    ) else {
+                    )
+                    .await
+                    else {
                         error!("Failed to create empty block payload");
                         return None;
                     };

--- a/crates/task-impls/src/transactions.rs
+++ b/crates/task-impls/src/transactions.rs
@@ -165,9 +165,12 @@ impl<
                         .number_of_empty_blocks_proposed
                         .add(1);
 
+                    let validated_state = self.consensus.read().await.decided_state();
+
                     // Calculate the builder fee for the empty block
                     let Some(builder_fee) = null_block::builder_fee(
                         self.membership.total_nodes(),
+                        validated_state.as_ref(),
                         self.instance_state.as_ref(),
                     ) else {
                         error!("Failed to get builder fee");
@@ -177,6 +180,7 @@ impl<
                     // Create an empty block payload and metadata
                     let Ok((_, metadata)) = <TYPES as NodeType>::BlockPayload::from_transactions(
                         vec![],
+                        validated_state.as_ref(),
                         &self.instance_state,
                     ) else {
                         error!("Failed to create empty block payload");

--- a/crates/testing/src/block_builder.rs
+++ b/crates/testing/src/block_builder.rs
@@ -566,6 +566,7 @@ where
         &Default::default(),
         &Default::default(),
     )
+    .await
     .expect("failed to build block payload from transactions");
 
     let commitment = block_payload.builder_commitment(&metadata);

--- a/crates/testing/src/block_builder.rs
+++ b/crates/testing/src/block_builder.rs
@@ -561,9 +561,12 @@ async fn build_block<TYPES: NodeType>(
 where
     <TYPES as NodeType>::InstanceState: Default,
 {
-    let (block_payload, metadata) =
-        TYPES::BlockPayload::from_transactions(transactions, &Default::default())
-            .expect("failed to build block payload from transactions");
+    let (block_payload, metadata) = TYPES::BlockPayload::from_transactions(
+        transactions,
+        &Default::default(),
+        &Default::default(),
+    )
+    .expect("failed to build block payload from transactions");
 
     let commitment = block_payload.builder_commitment(&metadata);
 

--- a/crates/testing/src/spinning_task.rs
+++ b/crates/testing/src/spinning_task.rs
@@ -2,7 +2,10 @@ use std::collections::{BTreeMap, HashMap};
 
 use either::{Left, Right};
 use hotshot::{traits::TestableNodeImplementation, types::EventType, HotShotInitializer};
-use hotshot_example_types::{state_types::TestInstanceState, storage_types::TestStorage};
+use hotshot_example_types::{
+    state_types::{TestInstanceState, TestValidatedState},
+    storage_types::TestStorage,
+};
 use hotshot_task::task::{Task, TaskState, TestTaskState};
 use hotshot_types::{
     data::Leaf,
@@ -62,7 +65,7 @@ impl<TYPES: NodeType, I: TestableNodeImplementation<TYPES>> TaskState for Spinni
 }
 
 impl<
-        TYPES: NodeType<InstanceState = TestInstanceState>,
+        TYPES: NodeType<InstanceState = TestInstanceState, ValidatedState = TestValidatedState>,
         I: TestableNodeImplementation<TYPES>,
         N: ConnectedNetwork<Message<TYPES>, TYPES::SignatureKey>,
     > TestTaskState for SpinningTask<TYPES, I>

--- a/crates/testing/src/task_helpers.rs
+++ b/crates/testing/src/task_helpers.rs
@@ -53,7 +53,9 @@ pub async fn build_system_handle(
     let storage = (launcher.resource_generator.storage)(node_id);
     let config = launcher.resource_generator.config.clone();
 
-    let initializer = HotShotInitializer::<TestTypes>::from_genesis(TestInstanceState {}).unwrap();
+    let initializer = HotShotInitializer::<TestTypes>::from_genesis(TestInstanceState {})
+        .await
+        .unwrap();
 
     let known_nodes_with_stake = config.known_nodes_with_stake.clone();
     let private_key = config.my_own_validator_config.private_key.clone();

--- a/crates/testing/src/test_runner.rs
+++ b/crates/testing/src/test_runner.rs
@@ -213,8 +213,8 @@ where
             late_start,
             latest_view: None,
             changes,
-            last_decided_leaf: Leaf::genesis(&TestInstanceState {}),
-            high_qc: QuorumCertificate::genesis(&TestInstanceState {}),
+            last_decided_leaf: Leaf::genesis(&TestInstanceState {}).await,
+            high_qc: QuorumCertificate::genesis(&TestInstanceState {}).await,
         };
         let spinning_task = TestTask::<SpinningTask<TYPES, I>, SpinningTask<TYPES, I>>::new(
             Task::new(tx.clone(), rx.clone(), reg.clone(), spinning_task_state),
@@ -391,8 +391,9 @@ where
                     },
                 );
             } else {
-                let initializer =
-                    HotShotInitializer::<TYPES>::from_genesis(TestInstanceState {}).unwrap();
+                let initializer = HotShotInitializer::<TYPES>::from_genesis(TestInstanceState {})
+                    .await
+                    .unwrap();
 
                 // See whether or not we should be DA
                 let is_da = node_id < config.da_staked_committee_size as u64;

--- a/crates/testing/src/test_runner.rs
+++ b/crates/testing/src/test_runner.rs
@@ -12,7 +12,10 @@ use hotshot::{
     traits::TestableNodeImplementation, types::SystemContextHandle, HotShotInitializer,
     Memberships, SystemContext,
 };
-use hotshot_example_types::{state_types::TestInstanceState, storage_types::TestStorage};
+use hotshot_example_types::{
+    state_types::{TestInstanceState, TestValidatedState},
+    storage_types::TestStorage,
+};
 use hotshot_task::task::{Task, TaskRegistry, TestTask};
 use hotshot_types::{
     consensus::ConsensusMetricsValue,
@@ -114,7 +117,7 @@ pub trait TaskErr: std::error::Error + Sync + Send + 'static {}
 impl<T: std::error::Error + Sync + Send + 'static> TaskErr for T {}
 
 impl<
-        TYPES: NodeType<InstanceState = TestInstanceState>,
+        TYPES: NodeType<InstanceState = TestInstanceState, ValidatedState = TestValidatedState>,
         I: TestableNodeImplementation<TYPES>,
         N: ConnectedNetwork<Message<TYPES>, TYPES::SignatureKey>,
     > TestRunner<TYPES, I, N>
@@ -213,8 +216,13 @@ where
             late_start,
             latest_view: None,
             changes,
-            last_decided_leaf: Leaf::genesis(&TestInstanceState {}).await,
-            high_qc: QuorumCertificate::genesis(&TestInstanceState {}).await,
+            last_decided_leaf: Leaf::genesis(&TestValidatedState::default(), &TestInstanceState {})
+                .await,
+            high_qc: QuorumCertificate::genesis(
+                &TestValidatedState::default(),
+                &TestInstanceState {},
+            )
+            .await,
         };
         let spinning_task = TestTask::<SpinningTask<TYPES, I>, SpinningTask<TYPES, I>>::new(
             Task::new(tx.clone(), rx.clone(), reg.clone(), spinning_task_state),

--- a/crates/testing/src/view_generator.rs
+++ b/crates/testing/src/view_generator.rs
@@ -113,7 +113,11 @@ impl TestView {
         let quorum_proposal_inner = QuorumProposal::<TestTypes> {
             block_header: block_header.clone(),
             view_number: genesis_view,
-            justify_qc: QuorumCertificate::genesis(&TestInstanceState {}).await,
+            justify_qc: QuorumCertificate::genesis(
+                &TestValidatedState::default(),
+                &TestInstanceState {},
+            )
+            .await,
             upgrade_certificate: None,
             proposal_certificate: None,
         };

--- a/crates/testing/src/view_generator.rs
+++ b/crates/testing/src/view_generator.rs
@@ -5,7 +5,7 @@ use hotshot::types::{BLSPubKey, SignatureKey, SystemContextHandle};
 use hotshot_example_types::{
     block_types::{TestBlockHeader, TestBlockPayload, TestMetadata, TestTransaction},
     node_types::{MemoryImpl, TestTypes},
-    state_types::TestInstanceState,
+    state_types::{TestInstanceState, TestValidatedState},
 };
 use hotshot_types::{
     data::{DaProposal, Leaf, QuorumProposal, VidDisperseShare, ViewChangeEvidence, ViewNumber},
@@ -61,9 +61,17 @@ impl TestView {
         let transactions = Vec::new();
 
         let (block_payload, metadata) =
-            TestBlockPayload::from_transactions(transactions.clone(), &TestInstanceState {})
-                .unwrap();
-        let builder_commitment = block_payload.builder_commitment(&metadata);
+            <TestBlockPayload as BlockPayload<TestTypes>>::from_transactions(
+                transactions.clone(),
+                &TestValidatedState::default(),
+                &TestInstanceState {},
+            )
+            .unwrap();
+
+        let builder_commitment = <TestBlockPayload as BlockPayload<TestTypes>>::builder_commitment(
+            &block_payload,
+            &metadata,
+        );
 
         let (private_key, public_key) = key_pair_for_id(*genesis_view);
 
@@ -181,9 +189,16 @@ impl TestView {
         let leader_public_key = public_key;
 
         let (block_payload, metadata) =
-            TestBlockPayload::from_transactions(transactions.clone(), &TestInstanceState {})
-                .unwrap();
-        let builder_commitment = block_payload.builder_commitment(&metadata);
+            <TestBlockPayload as BlockPayload<TestTypes>>::from_transactions(
+                transactions.clone(),
+                &TestValidatedState::default(),
+                &TestInstanceState {},
+            )
+            .unwrap();
+        let builder_commitment = <TestBlockPayload as BlockPayload<TestTypes>>::builder_commitment(
+            &block_payload,
+            &metadata,
+        );
 
         let payload_commitment = da_payload_commitment(quorum_membership, transactions.clone());
 

--- a/crates/testing/tests/tests_1/block_builder.rs
+++ b/crates/testing/tests/tests_1/block_builder.rs
@@ -86,10 +86,14 @@ async fn test_random_block_builder() {
         .expect("Failed to claim block");
 
     // Test claiming non-existent block
-    let commitment_for_non_existent_block = TestBlockPayload {
-        transactions: vec![TestTransaction::new(vec![0; 1])],
-    }
-    .builder_commitment(&TestMetadata);
+    let commitment_for_non_existent_block =
+        <TestBlockPayload as BlockPayload<TestTypes>>::builder_commitment(
+            &TestBlockPayload {
+                transactions: vec![TestTransaction::new(vec![0; 1])],
+            },
+            &TestMetadata,
+        );
+
     let result = client
         .claim_block(
             commitment_for_non_existent_block,

--- a/crates/testing/tests/tests_1/consensus_task.rs
+++ b/crates/testing/tests/tests_1/consensus_task.rs
@@ -96,13 +96,7 @@ async fn test_consensus_task() {
                 builder_commitment,
                 TestMetadata,
                 ViewNumber::new(2),
-                null_block::builder_fee(
-                    quorum_membership.total_nodes(),
-                    &TestValidatedState::default(),
-                    &TestInstanceState {},
-                )
-                .await
-                .unwrap(),
+                null_block::builder_fee(quorum_membership.total_nodes()).unwrap(),
             ),
         ],
         outputs: vec![
@@ -380,9 +374,7 @@ async fn test_view_sync_finalize_propose() {
                 builder_commitment,
                 TestMetadata,
                 ViewNumber::new(4),
-                null_block::builder_fee(4, &TestValidatedState::default(), &TestInstanceState {})
-                    .await
-                    .unwrap(),
+                null_block::builder_fee(4).unwrap(),
             ),
         ],
         outputs: vec![

--- a/crates/testing/tests/tests_1/consensus_task.rs
+++ b/crates/testing/tests/tests_1/consensus_task.rs
@@ -3,6 +3,7 @@
 
 use std::sync::Arc;
 
+use futures::StreamExt;
 use hotshot::tasks::task_state::CreateTaskState;
 use hotshot_example_types::{
     node_types::{MemoryImpl, TestTypes},
@@ -32,7 +33,6 @@ use sha2::Digest;
 #[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 async fn test_consensus_task() {
-    use futures::StreamExt;
     use hotshot_example_types::{block_types::TestMetadata, state_types::TestValidatedState};
     use hotshot_types::data::null_block;
 
@@ -123,7 +123,6 @@ async fn test_consensus_task() {
 #[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 async fn test_consensus_vote() {
-    use futures::StreamExt;
     use hotshot::tasks::task_state::CreateTaskState;
     use hotshot_task_impls::{consensus::ConsensusTaskState, events::HotShotEvent::*};
     use hotshot_testing::{
@@ -181,8 +180,6 @@ async fn test_consensus_vote() {
 /// events occur. The permutation is specified as `input_permutation` and is a vector of indices.
 #[cfg(not(feature = "dependency-tasks"))]
 async fn test_vote_with_specific_order(input_permutation: Vec<usize>) {
-    use futures::StreamExt;
-
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
 
@@ -266,7 +263,6 @@ async fn test_consensus_vote_with_permuted_dac() {
 #[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 async fn test_view_sync_finalize_propose() {
-    use futures::StreamExt;
     use hotshot_example_types::{block_types::TestMetadata, state_types::TestValidatedState};
     use hotshot_types::data::null_block;
 
@@ -411,8 +407,6 @@ async fn test_view_sync_finalize_propose() {
 /// Makes sure that, when a valid ViewSyncFinalize certificate is available, the consensus task
 /// will indeed vote if the cert is valid and matches the correct view number.
 async fn test_view_sync_finalize_vote() {
-    use futures::StreamExt;
-
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
 
@@ -510,8 +504,6 @@ async fn test_view_sync_finalize_vote() {
 /// Makes sure that, when a valid ViewSyncFinalize certificate is available, the consensus task
 /// will NOT vote when the certificate matches a different view number.
 async fn test_view_sync_finalize_vote_fail_view_number() {
-    use futures::StreamExt;
-
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
 
@@ -617,8 +609,6 @@ async fn test_view_sync_finalize_vote_fail_view_number() {
 #[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 async fn test_vid_disperse_storage_failure() {
-    use futures::StreamExt;
-
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
 

--- a/crates/testing/tests/tests_1/consensus_task.rs
+++ b/crates/testing/tests/tests_1/consensus_task.rs
@@ -510,7 +510,7 @@ async fn test_view_sync_finalize_vote() {
 /// Makes sure that, when a valid ViewSyncFinalize certificate is available, the consensus task
 /// will NOT vote when the certificate matches a different view number.
 async fn test_view_sync_finalize_vote_fail_view_number() {
-    use async_std::stream::StreamExt;
+    use futures::StreamExt;
 
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();

--- a/crates/testing/tests/tests_1/consensus_task.rs
+++ b/crates/testing/tests/tests_1/consensus_task.rs
@@ -14,9 +14,7 @@ use hotshot_testing::{
         exact, quorum_proposal_send, quorum_proposal_validated, quorum_vote_send, timeout_vote_send,
     },
     script::{run_test_script, TestScriptStage},
-    task_helpers::{
-        build_system_handle, vid_share, key_pair_for_id, vid_scheme_from_view_number,
-    },
+    task_helpers::{build_system_handle, key_pair_for_id, vid_scheme_from_view_number, vid_share},
     test_helpers::permute_input_with_index_order,
     view_generator::TestViewGenerator,
 };
@@ -34,7 +32,7 @@ use sha2::Digest;
 #[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 async fn test_consensus_task() {
-    use hotshot_example_types::block_types::TestMetadata;
+    use hotshot_example_types::{block_types::TestMetadata, state_types::TestValidatedState};
     use hotshot_types::data::null_block;
 
     async_compatibility_layer::logging::setup_logging();
@@ -97,8 +95,12 @@ async fn test_consensus_task() {
                 builder_commitment,
                 TestMetadata,
                 ViewNumber::new(2),
-                null_block::builder_fee(quorum_membership.total_nodes(), &TestInstanceState {})
-                    .unwrap(),
+                null_block::builder_fee(
+                    quorum_membership.total_nodes(),
+                    &TestValidatedState::default(),
+                    &TestInstanceState {},
+                )
+                .unwrap(),
             ),
         ],
         outputs: vec![
@@ -259,7 +261,7 @@ async fn test_consensus_vote_with_permuted_dac() {
 #[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 async fn test_view_sync_finalize_propose() {
-    use hotshot_example_types::block_types::TestMetadata;
+    use hotshot_example_types::{block_types::TestMetadata, state_types::TestValidatedState};
     use hotshot_types::data::null_block;
 
     async_compatibility_layer::logging::setup_logging();
@@ -376,7 +378,8 @@ async fn test_view_sync_finalize_propose() {
                 builder_commitment,
                 TestMetadata,
                 ViewNumber::new(4),
-                null_block::builder_fee(4, &TestInstanceState {}).unwrap(),
+                null_block::builder_fee(4, &TestValidatedState::default(), &TestInstanceState {})
+                    .unwrap(),
             ),
         ],
         outputs: vec![

--- a/crates/testing/tests/tests_1/da_task.rs
+++ b/crates/testing/tests/tests_1/da_task.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use futures::StreamExt;
 use hotshot::{tasks::task_state::CreateTaskState, types::SystemContextHandle};
 use hotshot_example_types::{
     block_types::{TestMetadata, TestTransaction},
@@ -49,7 +50,7 @@ async fn test_da_task() {
     let mut dacs = Vec::new();
     let mut vids = Vec::new();
 
-    for view in (&mut generator).take(1) {
+    for view in (&mut generator).take(1).collect::<Vec<_>>().await {
         proposals.push(view.da_proposal.clone());
         leaders.push(view.leader_public_key);
         votes.push(view.create_da_vote(DaData { payload_commit }, &handle));
@@ -59,7 +60,7 @@ async fn test_da_task() {
 
     generator.add_transactions(vec![TestTransaction::new(vec![0])]);
 
-    for view in (&mut generator).take(1) {
+    for view in (&mut generator).take(1).collect::<Vec<_>>().await {
         proposals.push(view.da_proposal.clone());
         leaders.push(view.leader_public_key);
         votes.push(view.create_da_vote(DaData { payload_commit }, &handle));
@@ -81,6 +82,7 @@ async fn test_da_task() {
                     &TestValidatedState::default(),
                     &TestInstanceState {},
                 )
+                .await
                 .unwrap(),
                 precompute,
             ),
@@ -135,7 +137,7 @@ async fn test_da_task_storage_failure() {
     let mut dacs = Vec::new();
     let mut vids = Vec::new();
 
-    for view in (&mut generator).take(1) {
+    for view in (&mut generator).take(1).collect::<Vec<_>>().await {
         proposals.push(view.da_proposal.clone());
         leaders.push(view.leader_public_key);
         votes.push(view.create_da_vote(DaData { payload_commit }, &handle));
@@ -145,7 +147,7 @@ async fn test_da_task_storage_failure() {
 
     generator.add_transactions(transactions);
 
-    for view in (&mut generator).take(1) {
+    for view in (&mut generator).take(1).collect::<Vec<_>>().await {
         proposals.push(view.da_proposal.clone());
         leaders.push(view.leader_public_key);
         votes.push(view.create_da_vote(DaData { payload_commit }, &handle));
@@ -167,6 +169,7 @@ async fn test_da_task_storage_failure() {
                     &TestValidatedState::default(),
                     &TestInstanceState {},
                 )
+                .await
                 .unwrap(),
                 precompute,
             ),

--- a/crates/testing/tests/tests_1/da_task.rs
+++ b/crates/testing/tests/tests_1/da_task.rs
@@ -5,7 +5,6 @@ use hotshot::{tasks::task_state::CreateTaskState, types::SystemContextHandle};
 use hotshot_example_types::{
     block_types::{TestMetadata, TestTransaction},
     node_types::{MemoryImpl, TestTypes},
-    state_types::{TestInstanceState, TestValidatedState},
 };
 use hotshot_task_impls::{da::DaTaskState, events::HotShotEvent::*};
 use hotshot_testing::{
@@ -77,13 +76,7 @@ async fn test_da_task() {
                 encoded_transactions,
                 TestMetadata,
                 ViewNumber::new(2),
-                null_block::builder_fee(
-                    quorum_membership.total_nodes(),
-                    &TestValidatedState::default(),
-                    &TestInstanceState {},
-                )
-                .await
-                .unwrap(),
+                null_block::builder_fee(quorum_membership.total_nodes()).unwrap(),
                 precompute,
             ),
         ],
@@ -164,13 +157,7 @@ async fn test_da_task_storage_failure() {
                 encoded_transactions,
                 TestMetadata,
                 ViewNumber::new(2),
-                null_block::builder_fee(
-                    quorum_membership.total_nodes(),
-                    &TestValidatedState::default(),
-                    &TestInstanceState {},
-                )
-                .await
-                .unwrap(),
+                null_block::builder_fee(quorum_membership.total_nodes()).unwrap(),
                 precompute,
             ),
         ],

--- a/crates/testing/tests/tests_1/da_task.rs
+++ b/crates/testing/tests/tests_1/da_task.rs
@@ -4,7 +4,7 @@ use hotshot::{tasks::task_state::CreateTaskState, types::SystemContextHandle};
 use hotshot_example_types::{
     block_types::{TestMetadata, TestTransaction},
     node_types::{MemoryImpl, TestTypes},
-    state_types::TestInstanceState,
+    state_types::{TestInstanceState, TestValidatedState},
 };
 use hotshot_task_impls::{da::DaTaskState, events::HotShotEvent::*};
 use hotshot_testing::{
@@ -76,8 +76,12 @@ async fn test_da_task() {
                 encoded_transactions,
                 TestMetadata,
                 ViewNumber::new(2),
-                null_block::builder_fee(quorum_membership.total_nodes(), &TestInstanceState {})
-                    .unwrap(),
+                null_block::builder_fee(
+                    quorum_membership.total_nodes(),
+                    &TestValidatedState::default(),
+                    &TestInstanceState {},
+                )
+                .unwrap(),
                 precompute,
             ),
         ],
@@ -158,8 +162,12 @@ async fn test_da_task_storage_failure() {
                 encoded_transactions,
                 TestMetadata,
                 ViewNumber::new(2),
-                null_block::builder_fee(quorum_membership.total_nodes(), &TestInstanceState {})
-                    .unwrap(),
+                null_block::builder_fee(
+                    quorum_membership.total_nodes(),
+                    &TestValidatedState::default(),
+                    &TestInstanceState {},
+                )
+                .unwrap(),
                 precompute,
             ),
         ],

--- a/crates/testing/tests/tests_1/network_task.rs
+++ b/crates/testing/tests/tests_1/network_task.rs
@@ -26,6 +26,8 @@ use hotshot_types::{
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 #[allow(clippy::too_many_lines)]
 async fn test_network_task() {
+    use futures::StreamExt;
+
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
 
@@ -63,7 +65,7 @@ async fn test_network_task() {
     task_reg.run_task(task).await;
 
     let mut generator = TestViewGenerator::generate(membership.clone(), membership);
-    let view = generator.next().unwrap();
+    let view = generator.next().await.unwrap();
 
     let (out_tx, mut out_rx) = async_broadcast::broadcast(10);
     add_network_message_task(task_reg, out_tx.clone(), channel.clone()).await;
@@ -88,6 +90,8 @@ async fn test_network_task() {
 #[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 async fn test_network_storage_fail() {
+    use futures::StreamExt;
+
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
 
@@ -126,7 +130,7 @@ async fn test_network_storage_fail() {
     task_reg.run_task(task).await;
 
     let mut generator = TestViewGenerator::generate(membership.clone(), membership);
-    let view = generator.next().unwrap();
+    let view = generator.next().await.unwrap();
 
     let (out_tx, mut out_rx) = async_broadcast::broadcast(10);
     add_network_message_task(task_reg, out_tx.clone(), channel.clone()).await;

--- a/crates/testing/tests/tests_1/proposal_ordering.rs
+++ b/crates/testing/tests/tests_1/proposal_ordering.rs
@@ -27,6 +27,7 @@ use sha2::Digest;
 /// This proposal should happen no matter how the `input_permutation` is specified.
 #[cfg(not(feature = "dependency-tasks"))]
 async fn test_ordering_with_specific_order(input_permutation: Vec<usize>) {
+    use futures::StreamExt;
     use hotshot_example_types::state_types::TestValidatedState;
     use hotshot_testing::{
         script::{run_test_script, TestScriptStage},
@@ -57,7 +58,7 @@ async fn test_ordering_with_specific_order(input_permutation: Vec<usize>) {
     let mut votes = Vec::new();
     let mut dacs = Vec::new();
     let mut vids = Vec::new();
-    for view in (&mut generator).take(3) {
+    for view in (&mut generator).take(3).collect::<Vec<_>>().await {
         proposals.push(view.quorum_proposal.clone());
         votes.push(view.create_quorum_vote(&handle));
         leaders.push(view.leader_public_key);
@@ -98,6 +99,7 @@ async fn test_ordering_with_specific_order(input_permutation: Vec<usize>) {
                 &TestValidatedState::default(),
                 &TestInstanceState {},
             )
+            .await
             .unwrap(),
         ),
     ];

--- a/crates/testing/tests/tests_1/proposal_ordering.rs
+++ b/crates/testing/tests/tests_1/proposal_ordering.rs
@@ -94,13 +94,7 @@ async fn test_ordering_with_specific_order(input_permutation: Vec<usize>) {
             builder_commitment,
             TestMetadata,
             ViewNumber::new(node_id),
-            null_block::builder_fee(
-                quorum_membership.total_nodes(),
-                &TestValidatedState::default(),
-                &TestInstanceState {},
-            )
-            .await
-            .unwrap(),
+            null_block::builder_fee(quorum_membership.total_nodes()).unwrap(),
         ),
     ];
 

--- a/crates/testing/tests/tests_1/quorum_proposal_recv_task.rs
+++ b/crates/testing/tests/tests_1/quorum_proposal_recv_task.rs
@@ -32,7 +32,7 @@ async fn test_quorum_proposal_recv_task() {
     let mut votes = Vec::new();
     let mut dacs = Vec::new();
     let mut vids = Vec::new();
-    for view in (&mut generator).take(2) {
+    for view in (&mut generator).take(2).collect::<Vec<_>>().await {
         proposals.push(view.quorum_proposal.clone());
         leaders.push(view.leader_public_key);
         votes.push(view.create_quorum_vote(&handle));

--- a/crates/testing/tests/tests_1/quorum_proposal_task.rs
+++ b/crates/testing/tests/tests_1/quorum_proposal_task.rs
@@ -110,8 +110,12 @@ async fn test_quorum_proposal_task_quorum_proposal_view_1() {
                 builder_commitment,
                 TestMetadata,
                 ViewNumber::new(1),
-                null_block::builder_fee(quorum_membership.total_nodes(), &TestInstanceState {})
-                    .unwrap(),
+                null_block::builder_fee(
+                    quorum_membership.total_nodes(),
+                    &TestValidatedState::default(),
+                    &TestInstanceState {},
+                )
+                .unwrap(),
             ),
             VidShareValidated(vid_share(&vids[0].0, handle.public_key())),
             ValidatedStateUpdated(ViewNumber::new(0), create_fake_view_with_leaf(genesis_leaf)),
@@ -181,8 +185,12 @@ async fn test_quorum_proposal_task_quorum_proposal_view_gt_1() {
                 builder_commitment.clone(),
                 TestMetadata,
                 ViewNumber::new(1),
-                null_block::builder_fee(quorum_membership.total_nodes(), &TestInstanceState {})
-                    .unwrap(),
+                null_block::builder_fee(
+                    quorum_membership.total_nodes(),
+                    &TestValidatedState::default(),
+                    &TestInstanceState {},
+                )
+                .unwrap(),
             ),
             VidShareValidated(vid_share(&vids[0].0, handle.public_key())),
             ValidatedStateUpdated(
@@ -204,8 +212,12 @@ async fn test_quorum_proposal_task_quorum_proposal_view_gt_1() {
                 builder_commitment.clone(),
                 TestMetadata,
                 ViewNumber::new(2),
-                null_block::builder_fee(quorum_membership.total_nodes(), &TestInstanceState {})
-                    .unwrap(),
+                null_block::builder_fee(
+                    quorum_membership.total_nodes(),
+                    &TestValidatedState::default(),
+                    &TestInstanceState {},
+                )
+                .unwrap(),
             ),
             VidShareValidated(vid_share(&vids[1].0, handle.public_key())),
             ValidatedStateUpdated(
@@ -227,8 +239,12 @@ async fn test_quorum_proposal_task_quorum_proposal_view_gt_1() {
                 builder_commitment.clone(),
                 TestMetadata,
                 ViewNumber::new(3),
-                null_block::builder_fee(quorum_membership.total_nodes(), &TestInstanceState {})
-                    .unwrap(),
+                null_block::builder_fee(
+                    quorum_membership.total_nodes(),
+                    &TestValidatedState::default(),
+                    &TestInstanceState {},
+                )
+                .unwrap(),
             ),
             VidShareValidated(vid_share(&vids[2].0, handle.public_key())),
             ValidatedStateUpdated(
@@ -254,8 +270,12 @@ async fn test_quorum_proposal_task_quorum_proposal_view_gt_1() {
                 builder_commitment.clone(),
                 TestMetadata,
                 ViewNumber::new(4),
-                null_block::builder_fee(quorum_membership.total_nodes(), &TestInstanceState {})
-                    .unwrap(),
+                null_block::builder_fee(
+                    quorum_membership.total_nodes(),
+                    &TestValidatedState::default(),
+                    &TestInstanceState {},
+                )
+                .unwrap(),
             ),
             VidShareValidated(vid_share(&vids[3].0, handle.public_key())),
             ValidatedStateUpdated(
@@ -276,8 +296,12 @@ async fn test_quorum_proposal_task_quorum_proposal_view_gt_1() {
                 builder_commitment,
                 TestMetadata,
                 ViewNumber::new(5),
-                null_block::builder_fee(quorum_membership.total_nodes(), &TestInstanceState {})
-                    .unwrap(),
+                null_block::builder_fee(
+                    quorum_membership.total_nodes(),
+                    &TestValidatedState::default(),
+                    &TestInstanceState {},
+                )
+                .unwrap(),
             ),
             VidShareValidated(vid_share(&vids[4].0, handle.public_key())),
             ValidatedStateUpdated(
@@ -354,8 +378,12 @@ async fn test_quorum_proposal_task_qc_timeout() {
                 builder_commitment,
                 TestMetadata,
                 ViewNumber::new(3),
-                null_block::builder_fee(quorum_membership.total_nodes(), &TestInstanceState {})
-                    .unwrap(),
+                null_block::builder_fee(
+                    quorum_membership.total_nodes(),
+                    &TestValidatedState::default(),
+                    &TestInstanceState {},
+                )
+                .unwrap(),
             ),
             VidShareValidated(vid_share(&vids[2].0.clone(), handle.public_key())),
             ValidatedStateUpdated(
@@ -434,8 +462,12 @@ async fn test_quorum_proposal_task_view_sync() {
                 builder_commitment,
                 TestMetadata,
                 ViewNumber::new(2),
-                null_block::builder_fee(quorum_membership.total_nodes(), &TestInstanceState {})
-                    .unwrap(),
+                null_block::builder_fee(
+                    quorum_membership.total_nodes(),
+                    &TestValidatedState::default(),
+                    &TestInstanceState {},
+                )
+                .unwrap(),
             ),
             VidShareValidated(vid_share(&vids[1].0.clone(), handle.public_key())),
             ValidatedStateUpdated(
@@ -492,8 +524,12 @@ async fn test_quorum_proposal_task_propose_now() {
             commitment: payload_commitment,
             builder_commitment: builder_commitment.clone(),
             metadata: TestMetadata,
-            fee: null_block::builder_fee(quorum_membership.total_nodes(), &TestInstanceState {})
-                .unwrap(),
+            fee: null_block::builder_fee(
+                quorum_membership.total_nodes(),
+                &TestValidatedState::default(),
+                &TestInstanceState {},
+            )
+            .unwrap(),
             block_view: ViewNumber::new(2),
         },
         secondary_proposal_information:
@@ -555,8 +591,12 @@ async fn test_quorum_proposal_task_propose_now_timeout() {
             commitment: payload_commitment,
             builder_commitment: builder_commitment.clone(),
             metadata: TestMetadata,
-            fee: null_block::builder_fee(quorum_membership.total_nodes(), &TestInstanceState {})
-                .unwrap(),
+            fee: null_block::builder_fee(
+                quorum_membership.total_nodes(),
+                &TestValidatedState::default(),
+                &TestInstanceState {},
+            )
+            .unwrap(),
             block_view: ViewNumber::new(2),
         },
         secondary_proposal_information:
@@ -629,8 +669,12 @@ async fn test_quorum_proposal_task_propose_now_view_sync() {
             commitment: payload_commitment,
             builder_commitment,
             metadata: TestMetadata,
-            fee: null_block::builder_fee(quorum_membership.total_nodes(), &TestInstanceState {})
-                .unwrap(),
+            fee: null_block::builder_fee(
+                quorum_membership.total_nodes(),
+                &TestValidatedState::default(),
+                &TestInstanceState {},
+            )
+            .unwrap(),
             block_view: ViewNumber::new(2),
         },
         secondary_proposal_information:

--- a/crates/testing/tests/tests_1/quorum_proposal_task.rs
+++ b/crates/testing/tests/tests_1/quorum_proposal_task.rs
@@ -84,7 +84,7 @@ async fn test_quorum_proposal_task_quorum_proposal_view_1() {
     let mut vids = Vec::new();
     let consensus = handle.hotshot.consensus();
     let mut consensus_writer = consensus.write().await;
-    for view in (&mut generator).take(2) {
+    for view in (&mut generator).take(2).collect::<Vec<_>>().await {
         proposals.push(view.quorum_proposal.clone());
         leaders.push(view.leader_public_key);
         leaves.push(view.leaf.clone());
@@ -346,7 +346,7 @@ async fn test_quorum_proposal_task_qc_timeout() {
     let mut leaders = Vec::new();
     let mut vids = Vec::new();
     let mut leaves = Vec::new();
-    for view in (&mut generator).take(1) {
+    for view in (&mut generator).take(1).collect::<Vec<_>>().await {
         proposals.push(view.quorum_proposal.clone());
         leaders.push(view.leader_public_key);
         vids.push(view.vid_proposal.clone());
@@ -356,7 +356,7 @@ async fn test_quorum_proposal_task_qc_timeout() {
         view: ViewNumber::new(1),
     };
     generator.add_timeout(timeout_data);
-    for view in (&mut generator).take(2) {
+    for view in (&mut generator).take(2).collect::<Vec<_>>().await {
         proposals.push(view.quorum_proposal.clone());
         leaders.push(view.leader_public_key);
         vids.push(view.vid_proposal.clone());
@@ -428,7 +428,7 @@ async fn test_quorum_proposal_task_view_sync() {
     let mut leaders = Vec::new();
     let mut vids = Vec::new();
     let mut leaves = Vec::new();
-    for view in (&mut generator).take(1) {
+    for view in (&mut generator).take(1).collect::<Vec<_>>().await {
         proposals.push(view.quorum_proposal.clone());
         leaders.push(view.leader_public_key);
         vids.push(view.vid_proposal.clone());
@@ -440,7 +440,7 @@ async fn test_quorum_proposal_task_view_sync() {
         round: ViewNumber::new(node_id),
     };
     generator.add_view_sync_finalize(view_sync_finalize_data);
-    for view in (&mut generator).take(2) {
+    for view in (&mut generator).take(2).collect::<Vec<_>>().await {
         proposals.push(view.quorum_proposal.clone());
         leaders.push(view.leader_public_key);
         vids.push(view.vid_proposal.clone());
@@ -506,12 +506,12 @@ async fn test_quorum_proposal_task_propose_now() {
     let mut proposals = Vec::new();
     let mut leaders = Vec::new();
     let mut vids = Vec::new();
-    for view in (&mut generator).take(1) {
+    for view in (&mut generator).take(1).collect::<Vec<_>>().await {
         proposals.push(view.quorum_proposal.clone());
         leaders.push(view.leader_public_key);
         vids.push(view.vid_proposal.clone());
     }
-    for view in (&mut generator).take(1) {
+    for view in (&mut generator).take(1).collect::<Vec<_>>().await {
         proposals.push(view.quorum_proposal.clone());
         leaders.push(view.leader_public_key);
         vids.push(view.vid_proposal.clone());
@@ -573,12 +573,12 @@ async fn test_quorum_proposal_task_propose_now_timeout() {
     let mut proposals = Vec::new();
     let mut leaders = Vec::new();
     let mut vids = Vec::new();
-    for view in (&mut generator).take(1) {
+    for view in (&mut generator).take(1).collect::<Vec<_>>().await {
         proposals.push(view.quorum_proposal.clone());
         leaders.push(view.leader_public_key);
         vids.push(view.vid_proposal.clone());
     }
-    for view in (&mut generator).take(1) {
+    for view in (&mut generator).take(1).collect::<Vec<_>>().await {
         proposals.push(view.quorum_proposal.clone());
         leaders.push(view.leader_public_key);
         vids.push(view.vid_proposal.clone());
@@ -650,12 +650,12 @@ async fn test_quorum_proposal_task_propose_now_view_sync() {
     let mut proposals = Vec::new();
     let mut leaders = Vec::new();
     let mut vids = Vec::new();
-    for view in (&mut generator).take(1) {
+    for view in (&mut generator).take(1).collect::<Vec<_>>().await {
         proposals.push(view.quorum_proposal.clone());
         leaders.push(view.leader_public_key);
         vids.push(view.vid_proposal.clone());
     }
-    for view in (&mut generator).take(1) {
+    for view in (&mut generator).take(1).collect::<Vec<_>>().await {
         proposals.push(view.quorum_proposal.clone());
         leaders.push(view.leader_public_key);
         vids.push(view.vid_proposal.clone());
@@ -726,7 +726,7 @@ async fn test_quorum_proposal_task_with_incomplete_events() {
     let mut proposals = Vec::new();
     let mut leaders = Vec::new();
     let mut leaves = Vec::new();
-    for view in (&mut generator).take(2) {
+    for view in (&mut generator).take(2).collect::<Vec<_>>().await {
         proposals.push(view.quorum_proposal.clone());
         leaders.push(view.leader_public_key);
         leaves.push(view.leaf.clone());

--- a/crates/testing/tests/tests_1/quorum_vote_task.rs
+++ b/crates/testing/tests/tests_1/quorum_vote_task.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::panic)]
+use futures::StreamExt;
 use hotshot::tasks::task_state::CreateTaskState;
 use hotshot_example_types::node_types::{MemoryImpl, TestTypes};
 use hotshot_testing::task_helpers::vid_share;
@@ -8,7 +9,6 @@ use hotshot_types::{data::ViewNumber, traits::node_implementation::ConsensusTime
 #[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 async fn test_quorum_vote_task_success() {
-    use futures::StreamExt;
     use hotshot_task_impls::{events::HotShotEvent::*, quorum_vote::QuorumVoteTaskState};
     use hotshot_testing::{
         predicates::event::{exact, quorum_vote_send},
@@ -64,7 +64,6 @@ async fn test_quorum_vote_task_success() {
 #[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 async fn test_quorum_vote_task_vote_now() {
-    use futures::StreamExt;
     use hotshot_task_impls::{events::HotShotEvent::*, quorum_vote::QuorumVoteTaskState};
     use hotshot_testing::{
         predicates::event::{exact, quorum_vote_send},
@@ -113,7 +112,6 @@ async fn test_quorum_vote_task_vote_now() {
 #[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 async fn test_quorum_vote_task_miss_dependency() {
-    use futures::StreamExt;
     use hotshot_task_impls::{events::HotShotEvent::*, quorum_vote::QuorumVoteTaskState};
     use hotshot_testing::{
         predicates::event::exact,

--- a/crates/testing/tests/tests_1/upgrade_task.rs
+++ b/crates/testing/tests/tests_1/upgrade_task.rs
@@ -3,6 +3,7 @@
 
 use std::time::Duration;
 
+use futures::StreamExt;
 use hotshot::{tasks::task_state::CreateTaskState, types::SystemContextHandle};
 use hotshot_example_types::{
     block_types::{TestMetadata, TestTransaction},
@@ -31,7 +32,6 @@ use vbs::version::Version;
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 /// Tests that we correctly update our internal consensus state when reaching a decided upgrade certificate.
 async fn test_consensus_task_upgrade() {
-    use futures::StreamExt;
     use hotshot_testing::{
         script::{run_test_script, TestScriptStage},
         task_helpers::build_system_handle,
@@ -167,7 +167,6 @@ async fn test_consensus_task_upgrade() {
 async fn test_upgrade_and_consensus_task() {
     use std::sync::Arc;
 
-    use futures::StreamExt;
     use hotshot_example_types::state_types::TestValidatedState;
     use hotshot_testing::task_helpers::build_system_handle;
 
@@ -336,7 +335,6 @@ async fn test_upgrade_and_consensus_task() {
 ///   - we correctly propose with a null block payload in view 6, even if we have indications to do otherwise (via SendPayloadCommitmentAndMetadata, VID etc).
 ///   - we correctly reject a QuorumProposal with a non-null block payload in view 7.
 async fn test_upgrade_and_consensus_task_blank_blocks() {
-    use futures::StreamExt;
     use hotshot_example_types::state_types::TestValidatedState;
     use hotshot_testing::task_helpers::build_system_handle;
 

--- a/crates/testing/tests/tests_1/upgrade_task.rs
+++ b/crates/testing/tests/tests_1/upgrade_task.rs
@@ -255,13 +255,7 @@ async fn test_upgrade_and_consensus_task() {
                 proposals[2].data.block_header.builder_commitment.clone(),
                 TestMetadata,
                 ViewNumber::new(3),
-                null_block::builder_fee(
-                    quorum_membership.total_nodes(),
-                    &TestValidatedState::default(),
-                    &TestInstanceState {},
-                )
-                .await
-                .unwrap(),
+                null_block::builder_fee(quorum_membership.total_nodes()).unwrap(),
             ),
             QcFormed(either::Either::Left(proposals[2].data.justify_qc.clone())),
         ],
@@ -448,13 +442,7 @@ async fn test_upgrade_and_consensus_task_blank_blocks() {
                 proposals[1].data.block_header.builder_commitment.clone(),
                 TestMetadata,
                 ViewNumber::new(2),
-                null_block::builder_fee(
-                    quorum_membership.total_nodes(),
-                    &TestValidatedState::default(),
-                    &TestInstanceState {},
-                )
-                .await
-                .unwrap(),
+                null_block::builder_fee(quorum_membership.total_nodes()).unwrap(),
             ),
         ],
         vec![
@@ -465,13 +453,7 @@ async fn test_upgrade_and_consensus_task_blank_blocks() {
                 proposals[2].data.block_header.builder_commitment.clone(),
                 TestMetadata,
                 ViewNumber::new(3),
-                null_block::builder_fee(
-                    quorum_membership.total_nodes(),
-                    &TestValidatedState::default(),
-                    &TestInstanceState {},
-                )
-                .await
-                .unwrap(),
+                null_block::builder_fee(quorum_membership.total_nodes()).unwrap(),
             ),
             QuorumProposalRecv(proposals[2].clone(), leaders[2]),
         ],
@@ -483,13 +465,7 @@ async fn test_upgrade_and_consensus_task_blank_blocks() {
                 proposals[3].data.block_header.builder_commitment.clone(),
                 TestMetadata,
                 ViewNumber::new(4),
-                null_block::builder_fee(
-                    quorum_membership.total_nodes(),
-                    &TestValidatedState::default(),
-                    &TestInstanceState {},
-                )
-                .await
-                .unwrap(),
+                null_block::builder_fee(quorum_membership.total_nodes()).unwrap(),
             ),
             QuorumProposalRecv(proposals[3].clone(), leaders[3]),
         ],
@@ -501,13 +477,7 @@ async fn test_upgrade_and_consensus_task_blank_blocks() {
                 proposals[4].data.block_header.builder_commitment.clone(),
                 TestMetadata,
                 ViewNumber::new(5),
-                null_block::builder_fee(
-                    quorum_membership.total_nodes(),
-                    &TestValidatedState::default(),
-                    &TestInstanceState {},
-                )
-                .await
-                .unwrap(),
+                null_block::builder_fee(quorum_membership.total_nodes()).unwrap(),
             ),
             QuorumProposalRecv(proposals[4].clone(), leaders[4]),
         ],
@@ -519,13 +489,7 @@ async fn test_upgrade_and_consensus_task_blank_blocks() {
                 proposals[5].data.block_header.builder_commitment.clone(),
                 TestMetadata,
                 ViewNumber::new(6),
-                null_block::builder_fee(
-                    quorum_membership.total_nodes(),
-                    &TestValidatedState::default(),
-                    &TestInstanceState {},
-                )
-                .await
-                .unwrap(),
+                null_block::builder_fee(quorum_membership.total_nodes()).unwrap(),
             ),
             QcFormed(either::Either::Left(proposals[5].data.justify_qc.clone())),
         ],
@@ -537,13 +501,7 @@ async fn test_upgrade_and_consensus_task_blank_blocks() {
                 proposals[6].data.block_header.builder_commitment.clone(),
                 TestMetadata,
                 ViewNumber::new(7),
-                null_block::builder_fee(
-                    quorum_membership.total_nodes(),
-                    &TestValidatedState::default(),
-                    &TestInstanceState {},
-                )
-                .await
-                .unwrap(),
+                null_block::builder_fee(quorum_membership.total_nodes()).unwrap(),
             ),
             QuorumProposalRecv(proposals[6].clone(), leaders[6]),
         ],

--- a/crates/testing/tests/tests_1/upgrade_task.rs
+++ b/crates/testing/tests/tests_1/upgrade_task.rs
@@ -166,6 +166,7 @@ async fn test_consensus_task_upgrade() {
 async fn test_upgrade_and_consensus_task() {
     use std::sync::Arc;
 
+    use hotshot_example_types::state_types::TestValidatedState;
     use hotshot_testing::task_helpers::build_system_handle;
 
     async_compatibility_layer::logging::setup_logging();
@@ -253,8 +254,12 @@ async fn test_upgrade_and_consensus_task() {
                 proposals[2].data.block_header.builder_commitment.clone(),
                 TestMetadata,
                 ViewNumber::new(3),
-                null_block::builder_fee(quorum_membership.total_nodes(), &TestInstanceState {})
-                    .unwrap(),
+                null_block::builder_fee(
+                    quorum_membership.total_nodes(),
+                    &TestValidatedState::default(),
+                    &TestInstanceState {},
+                )
+                .unwrap(),
             ),
             QcFormed(either::Either::Left(proposals[2].data.justify_qc.clone())),
         ],
@@ -328,6 +333,7 @@ async fn test_upgrade_and_consensus_task() {
 ///   - we correctly propose with a null block payload in view 6, even if we have indications to do otherwise (via SendPayloadCommitmentAndMetadata, VID etc).
 ///   - we correctly reject a QuorumProposal with a non-null block payload in view 7.
 async fn test_upgrade_and_consensus_task_blank_blocks() {
+    use hotshot_example_types::state_types::TestValidatedState;
     use hotshot_testing::task_helpers::build_system_handle;
 
     async_compatibility_layer::logging::setup_logging();
@@ -440,8 +446,12 @@ async fn test_upgrade_and_consensus_task_blank_blocks() {
                 proposals[1].data.block_header.builder_commitment.clone(),
                 TestMetadata,
                 ViewNumber::new(2),
-                null_block::builder_fee(quorum_membership.total_nodes(), &TestInstanceState {})
-                    .unwrap(),
+                null_block::builder_fee(
+                    quorum_membership.total_nodes(),
+                    &TestValidatedState::default(),
+                    &TestInstanceState {},
+                )
+                .unwrap(),
             ),
         ],
         vec![
@@ -452,8 +462,12 @@ async fn test_upgrade_and_consensus_task_blank_blocks() {
                 proposals[2].data.block_header.builder_commitment.clone(),
                 TestMetadata,
                 ViewNumber::new(3),
-                null_block::builder_fee(quorum_membership.total_nodes(), &TestInstanceState {})
-                    .unwrap(),
+                null_block::builder_fee(
+                    quorum_membership.total_nodes(),
+                    &TestValidatedState::default(),
+                    &TestInstanceState {},
+                )
+                .unwrap(),
             ),
             QuorumProposalRecv(proposals[2].clone(), leaders[2]),
         ],
@@ -465,8 +479,12 @@ async fn test_upgrade_and_consensus_task_blank_blocks() {
                 proposals[3].data.block_header.builder_commitment.clone(),
                 TestMetadata,
                 ViewNumber::new(4),
-                null_block::builder_fee(quorum_membership.total_nodes(), &TestInstanceState {})
-                    .unwrap(),
+                null_block::builder_fee(
+                    quorum_membership.total_nodes(),
+                    &TestValidatedState::default(),
+                    &TestInstanceState {},
+                )
+                .unwrap(),
             ),
             QuorumProposalRecv(proposals[3].clone(), leaders[3]),
         ],
@@ -478,8 +496,12 @@ async fn test_upgrade_and_consensus_task_blank_blocks() {
                 proposals[4].data.block_header.builder_commitment.clone(),
                 TestMetadata,
                 ViewNumber::new(5),
-                null_block::builder_fee(quorum_membership.total_nodes(), &TestInstanceState {})
-                    .unwrap(),
+                null_block::builder_fee(
+                    quorum_membership.total_nodes(),
+                    &TestValidatedState::default(),
+                    &TestInstanceState {},
+                )
+                .unwrap(),
             ),
             QuorumProposalRecv(proposals[4].clone(), leaders[4]),
         ],
@@ -491,8 +513,12 @@ async fn test_upgrade_and_consensus_task_blank_blocks() {
                 proposals[5].data.block_header.builder_commitment.clone(),
                 TestMetadata,
                 ViewNumber::new(6),
-                null_block::builder_fee(quorum_membership.total_nodes(), &TestInstanceState {})
-                    .unwrap(),
+                null_block::builder_fee(
+                    quorum_membership.total_nodes(),
+                    &TestValidatedState::default(),
+                    &TestInstanceState {},
+                )
+                .unwrap(),
             ),
             QcFormed(either::Either::Left(proposals[5].data.justify_qc.clone())),
         ],
@@ -504,8 +530,12 @@ async fn test_upgrade_and_consensus_task_blank_blocks() {
                 proposals[6].data.block_header.builder_commitment.clone(),
                 TestMetadata,
                 ViewNumber::new(7),
-                null_block::builder_fee(quorum_membership.total_nodes(), &TestInstanceState {})
-                    .unwrap(),
+                null_block::builder_fee(
+                    quorum_membership.total_nodes(),
+                    &TestValidatedState::default(),
+                    &TestInstanceState {},
+                )
+                .unwrap(),
             ),
             QuorumProposalRecv(proposals[6].clone(), leaders[6]),
         ],

--- a/crates/testing/tests/tests_1/vid_task.rs
+++ b/crates/testing/tests/tests_1/vid_task.rs
@@ -44,6 +44,7 @@ async fn test_vid_task() {
         &TestValidatedState::default(),
         &TestInstanceState {},
     )
+    .await
     .unwrap();
     let builder_commitment =
         <TestBlockPayload as BlockPayload<TestTypes>>::builder_commitment(&payload, &metadata);
@@ -101,6 +102,7 @@ async fn test_vid_task() {
             &TestValidatedState::default(),
             &TestInstanceState {},
         )
+        .await
         .unwrap(),
         vid_precompute,
     ));
@@ -129,6 +131,7 @@ async fn test_vid_task() {
                 &TestValidatedState::default(),
                 &TestInstanceState {},
             )
+            .await
             .unwrap(),
         ),
         1,

--- a/crates/testing/tests/tests_1/vid_task.rs
+++ b/crates/testing/tests/tests_1/vid_task.rs
@@ -97,13 +97,7 @@ async fn test_vid_task() {
         encoded_transactions,
         TestMetadata,
         ViewNumber::new(2),
-        null_block::builder_fee(
-            quorum_membership.total_nodes(),
-            &TestValidatedState::default(),
-            &TestInstanceState {},
-        )
-        .await
-        .unwrap(),
+        null_block::builder_fee(quorum_membership.total_nodes()).unwrap(),
         vid_precompute,
     ));
     input.push(HotShotEvent::BlockReady(
@@ -126,13 +120,7 @@ async fn test_vid_task() {
             builder_commitment,
             TestMetadata,
             ViewNumber::new(2),
-            null_block::builder_fee(
-                quorum_membership.total_nodes(),
-                &TestValidatedState::default(),
-                &TestInstanceState {},
-            )
-            .await
-            .unwrap(),
+            null_block::builder_fee(quorum_membership.total_nodes()).unwrap(),
         ),
         1,
     );

--- a/crates/types/src/consensus.rs
+++ b/crates/types/src/consensus.rs
@@ -488,7 +488,7 @@ pub struct CommitmentAndMetadata<TYPES: NodeType> {
     /// Builder Commitment
     pub builder_commitment: BuilderCommitment,
     /// Metadata for the block payload
-    pub metadata: <TYPES::BlockPayload as BlockPayload>::Metadata,
+    pub metadata: <TYPES::BlockPayload as BlockPayload<TYPES>>::Metadata,
     /// Builder fee data
     pub fee: BuilderFee<TYPES>,
     /// View number this block is for

--- a/crates/types/src/data.rs
+++ b/crates/types/src/data.rs
@@ -734,7 +734,7 @@ pub mod null_block {
     #[must_use]
     pub async fn builder_fee<TYPES: NodeType>(
         num_storage_nodes: usize,
-        validated_state: &TYPES::ValidatedState,
+        validated_state: &<TYPES::BlockPayload as BlockPayload<TYPES>>::ValidatedState,
         instance_state: &<TYPES::BlockPayload as BlockPayload<TYPES>>::Instance,
     ) -> Option<BuilderFee<TYPES>> {
         /// Arbitrary fee amount, this block doesn't actually come from a builder

--- a/crates/types/src/data.rs
+++ b/crates/types/src/data.rs
@@ -434,9 +434,9 @@ impl<TYPES: NodeType> Display for Leaf<TYPES> {
 impl<TYPES: NodeType> QuorumCertificate<TYPES> {
     #[must_use]
     /// Creat the Genesis certificate
-    pub fn genesis(instance_state: &TYPES::InstanceState) -> Self {
+    pub async fn genesis(instance_state: &TYPES::InstanceState) -> Self {
         let data = QuorumData {
-            leaf_commit: Leaf::genesis(instance_state).commit(),
+            leaf_commit: Leaf::genesis(instance_state).await.commit(),
         };
         let commit = data.commit();
         Self {
@@ -457,9 +457,10 @@ impl<TYPES: NodeType> Leaf<TYPES> {
     /// Panics if the genesis payload (`TYPES::BlockPayload::genesis()`) is malformed (unable to be
     /// interpreted as bytes).
     #[must_use]
-    pub fn genesis(instance_state: &TYPES::InstanceState) -> Self {
+    pub async fn genesis(instance_state: &TYPES::InstanceState) -> Self {
         let (payload, metadata) =
             TYPES::BlockPayload::from_transactions([], &Default::default(), instance_state)
+                .await
                 .unwrap();
         let builder_commitment = payload.builder_commitment(&metadata);
         let payload_bytes = payload.encode();
@@ -731,7 +732,7 @@ pub mod null_block {
 
     /// Builder fee data for a null block payload
     #[must_use]
-    pub fn builder_fee<TYPES: NodeType>(
+    pub async fn builder_fee<TYPES: NodeType>(
         num_storage_nodes: usize,
         validated_state: &TYPES::ValidatedState,
         instance_state: &<TYPES::BlockPayload as BlockPayload<TYPES>>::Instance,
@@ -750,6 +751,7 @@ pub mod null_block {
                 validated_state,
                 instance_state,
             )
+            .await
             .ok()?;
 
         match TYPES::BuilderSignatureKey::sign_fee(

--- a/crates/types/src/error.rs
+++ b/crates/types/src/error.rs
@@ -38,7 +38,7 @@ pub enum HotShotError<TYPES: NodeType> {
     #[snafu(display("Failed to build or verify a block: {source}"))]
     BlockError {
         /// The underlying block error.
-        source: <TYPES::BlockPayload as BlockPayload>::Error,
+        source: <TYPES::BlockPayload as BlockPayload<TYPES>>::Error,
     },
     /// Failure in networking layer
     #[snafu(display("Failure in networking layer: {source}"))]

--- a/crates/types/src/traits/block_contents.rs
+++ b/crates/types/src/traits/block_contents.rs
@@ -93,16 +93,8 @@ pub trait BlockPayload<TYPES: NodeType>:
     /// and the associated number of VID storage nodes
     fn from_bytes(encoded_transactions: &[u8], metadata: &Self::Metadata) -> Self;
 
-    /// Build the genesis payload and metadata.
-    #[must_use]
-    async fn genesis() -> (Self, Self::Metadata)
-    where
-        <Self as BlockPayload<TYPES>>::Instance: Default,
-    {
-        Self::from_transactions([], &Default::default(), &Default::default())
-            .await
-            .unwrap()
-    }
+    /// Build the payload and metadata for genesis/null block.
+    fn empty() -> (Self, Self::Metadata);
 
     /// List of transaction commitments.
     fn transaction_commitments(

--- a/crates/types/src/traits/block_contents.rs
+++ b/crates/types/src/traits/block_contents.rs
@@ -64,6 +64,8 @@ pub trait BlockPayload<TYPES: NodeType>:
     type Instance: InstanceState;
     /// The type of the transitions we are applying
     type Transaction: Transaction;
+    /// Validated State
+    type ValidatedState: ValidatedState<TYPES>;
     /// Data created during block building which feeds into the block header
     type Metadata: Clone
         + Debug
@@ -81,7 +83,7 @@ pub trait BlockPayload<TYPES: NodeType>:
     /// If the transaction length conversion fails.
     fn from_transactions(
         transactions: impl IntoIterator<Item = Self::Transaction>,
-        validated_state: &TYPES::ValidatedState,
+        validated_state: &Self::ValidatedState,
         instance_state: &Self::Instance,
     ) -> Result<(Self, Self::Metadata), Self::Error>;
 

--- a/crates/types/src/traits/block_contents.rs
+++ b/crates/types/src/traits/block_contents.rs
@@ -82,6 +82,7 @@ pub trait BlockPayload<TYPES: NodeType>:
     ///
     /// # Errors
     /// If the transaction length conversion fails.
+    #[allow(clippy::type_complexity)]
     fn from_transactions(
         transactions: impl IntoIterator<Item = Self::Transaction>,
         validated_state: &Self::ValidatedState,

--- a/crates/types/src/traits/node_implementation.rs
+++ b/crates/types/src/traits/node_implementation.rs
@@ -205,6 +205,7 @@ pub trait NodeType:
         Self,
         Instance = Self::InstanceState,
         Transaction = Self::Transaction,
+        ValidatedState = Self::ValidatedState,
     >;
     /// The signature key that this hotshot setup is using.
     type SignatureKey: SignatureKey;

--- a/crates/types/src/traits/node_implementation.rs
+++ b/crates/types/src/traits/node_implementation.rs
@@ -65,7 +65,7 @@ pub trait TestableNodeImplementation<TYPES: NodeType>: NodeImplementation<TYPES>
         state: Option<&TYPES::ValidatedState>,
         rng: &mut dyn rand::RngCore,
         padding: u64,
-    ) -> <TYPES::BlockPayload as BlockPayload>::Transaction;
+    ) -> <TYPES::BlockPayload as BlockPayload<TYPES>>::Transaction;
 
     /// Creates random transaction if possible
     /// otherwise panics
@@ -74,7 +74,7 @@ pub trait TestableNodeImplementation<TYPES: NodeType>: NodeImplementation<TYPES>
         leaf: &Leaf<TYPES>,
         rng: &mut dyn rand::RngCore,
         padding: u64,
-    ) -> <TYPES::BlockPayload as BlockPayload>::Transaction;
+    ) -> <TYPES::BlockPayload as BlockPayload<TYPES>>::Transaction;
 
     /// generate a genesis block
     fn block_genesis() -> TYPES::BlockPayload;
@@ -96,7 +96,7 @@ pub trait TestableNodeImplementation<TYPES: NodeType>: NodeImplementation<TYPES>
 impl<TYPES: NodeType, I: NodeImplementation<TYPES>> TestableNodeImplementation<TYPES> for I
 where
     TYPES::ValidatedState: TestableState<TYPES>,
-    TYPES::BlockPayload: TestableBlock,
+    TYPES::BlockPayload: TestableBlock<TYPES>,
     I::QuorumNetwork: TestableNetworkingImplementation<TYPES>,
     I::DaNetwork: TestableNetworkingImplementation<TYPES>,
 {
@@ -104,7 +104,7 @@ where
         state: Option<&TYPES::ValidatedState>,
         rng: &mut dyn rand::RngCore,
         padding: u64,
-    ) -> <TYPES::BlockPayload as BlockPayload>::Transaction {
+    ) -> <TYPES::BlockPayload as BlockPayload<TYPES>>::Transaction {
         <TYPES::ValidatedState as TestableState<TYPES>>::create_random_transaction(
             state, rng, padding,
         )
@@ -114,16 +114,16 @@ where
         leaf: &Leaf<TYPES>,
         rng: &mut dyn rand::RngCore,
         padding: u64,
-    ) -> <TYPES::BlockPayload as BlockPayload>::Transaction {
+    ) -> <TYPES::BlockPayload as BlockPayload<TYPES>>::Transaction {
         Leaf::create_random_transaction(leaf, rng, padding)
     }
 
     fn block_genesis() -> TYPES::BlockPayload {
-        <TYPES::BlockPayload as TestableBlock>::genesis()
+        <TYPES::BlockPayload as TestableBlock<TYPES>>::genesis()
     }
 
     fn txn_count(block: &TYPES::BlockPayload) -> u64 {
-        <TYPES::BlockPayload as TestableBlock>::txn_count(block)
+        <TYPES::BlockPayload as TestableBlock<TYPES>>::txn_count(block)
     }
 
     fn gen_networks(
@@ -201,7 +201,11 @@ pub trait NodeType:
     /// The block type that this hotshot setup is using.
     ///
     /// This should be the same block that `ValidatedState::BlockPayload` is using.
-    type BlockPayload: BlockPayload<Instance = Self::InstanceState, Transaction = Self::Transaction>;
+    type BlockPayload: BlockPayload<
+        Self,
+        Instance = Self::InstanceState,
+        Transaction = Self::Transaction,
+    >;
     /// The signature key that this hotshot setup is using.
     type SignatureKey: SignatureKey;
     /// The transaction type that this hotshot setup is using.

--- a/crates/types/src/traits/states.rs
+++ b/crates/types/src/traits/states.rs
@@ -85,7 +85,7 @@ pub trait ValidatedState<TYPES: NodeType>:
 pub trait TestableState<TYPES>: ValidatedState<TYPES>
 where
     TYPES: NodeType,
-    TYPES::BlockPayload: TestableBlock,
+    TYPES::BlockPayload: TestableBlock<TYPES>,
 {
     /// Creates random transaction if possible
     /// otherwise panics
@@ -94,5 +94,5 @@ where
         state: Option<&Self>,
         rng: &mut dyn rand::RngCore,
         padding: u64,
-    ) -> <TYPES::BlockPayload as BlockPayload>::Transaction;
+    ) -> <TYPES::BlockPayload as BlockPayload<TYPES>>::Transaction;
 }


### PR DESCRIPTION
The `BlockPayload::from_transactions` function takes an `Instance` parameter, which contains `ChainConfig` on the sequencer side. To support updates to ChainConfig, we need to add it to a mutable `ValidatedState`. This requires the function to accept an additional `ValidatedState` parameter. When the chainconfig commitment does not match the instance chainconfig, this function on the sequencer side will do catchup from the peers (GET request) to get the updated ChainConfig so it needs to be async.

This PR:
- adds ValidatedState parameter to BlockPayload::from_transactions
- makes the from_transactions fn async



https://github.com/EspressoSystems/espresso-sequencer/issues/1475
https://github.com/EspressoSystems/espresso-sequencer/pull/1492#issuecomment-2127412305