### PR TITLE
[CX_HARDENING] - Modernize and Audit Vid Task Tests

### DIFF
--- a/crates/hotshot/src/tasks/task_state.rs
+++ b/crates/hotshot/src/tasks/task_state.rs
@@ -80,13 +80,10 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> CreateTaskState<TYPES, I>
 
 #[async_trait]
 impl<TYPES: NodeType, I: NodeImplementation<TYPES>> CreateTaskState<TYPES, I>
-    for VidTaskState<TYPES, I, SystemContextHandle<TYPES, I>>
+    for VidTaskState<TYPES, I>
 {
-    async fn create_from(
-        handle: &SystemContextHandle<TYPES, I>,
-    ) -> VidTaskState<TYPES, I, SystemContextHandle<TYPES, I>> {
+    async fn create_from(handle: &SystemContextHandle<TYPES, I>) -> VidTaskState<TYPES, I> {
         VidTaskState {
-            api: handle.clone(),
             consensus: handle.hotshot.consensus(),
             cur_view: handle.cur_view().await,
             vote_collector: None,

--- a/crates/task-impls/src/vid.rs
+++ b/crates/task-impls/src/vid.rs
@@ -8,7 +8,6 @@ use hotshot_types::{
     data::VidDisperseShare,
     message::Proposal,
     traits::{
-        consensus_api::ConsensusApi,
         election::Membership,
         node_implementation::{NodeImplementation, NodeType},
         signature_key::SignatureKey,
@@ -23,14 +22,7 @@ use crate::{
 };
 
 /// Tracks state of a VID task
-pub struct VidTaskState<
-    TYPES: NodeType,
-    I: NodeImplementation<TYPES>,
-    A: ConsensusApi<TYPES, I> + 'static,
-> {
-    /// The state's api
-    pub api: A,
-
+pub struct VidTaskState<TYPES: NodeType, I: NodeImplementation<TYPES>> {
     /// View number this view is executing in.
     pub cur_view: TYPES::Time,
 
@@ -50,9 +42,7 @@ pub struct VidTaskState<
     pub id: u64,
 }
 
-impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 'static>
-    VidTaskState<TYPES, I, A>
-{
+impl<TYPES: NodeType, I: NodeImplementation<TYPES>> VidTaskState<TYPES, I> {
     /// main task event handler
     #[instrument(skip_all, fields(id = self.id, view = *self.cur_view), name = "VID Main Task", level = "error")]
     pub async fn handle(
@@ -165,9 +155,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
 }
 
 /// task state implementation for VID Task
-impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 'static> TaskState
-    for VidTaskState<TYPES, I, A>
-{
+impl<TYPES: NodeType, I: NodeImplementation<TYPES>> TaskState for VidTaskState<TYPES, I> {
     type Event = Arc<HotShotEvent<TYPES>>;
 
     type Output = HotShotTaskCompleted;

--- a/crates/testing/tests/tests_1/vid_task.rs
+++ b/crates/testing/tests/tests_1/vid_task.rs
@@ -1,137 +1,113 @@
-use std::{collections::HashMap, marker::PhantomData, sync::Arc};
+use std::marker::PhantomData;
 
-use hotshot::types::SignatureKey;
 use hotshot_example_types::{
-    block_types::{TestBlockPayload, TestMetadata, TestTransaction},
+    block_types::{TestMetadata},
     node_types::TestTypes,
     state_types::TestInstanceState,
 };
 use hotshot_task_impls::{events::HotShotEvent, vid::VidTaskState};
-use hotshot_testing::task_helpers::{build_system_handle, vid_scheme_from_view_number};
+use hotshot_testing::{
+    predicates::event::exact,
+    script::{run_test_script, TestScriptStage},
+    task_helpers::key_pair_for_id,
+    task_helpers::{build_system_handle, vid_scheme_from_view_number},
+    view_generator::TestViewGenerator,
+};
 use hotshot_types::{
-    data::{null_block, DaProposal, VidDisperse, VidDisperseShare, ViewNumber},
+    data::{null_block, VidDisperse, ViewNumber},
+    message::Proposal,
     traits::{
-        consensus_api::ConsensusApi,
         election::Membership,
         node_implementation::{ConsensusTime, NodeType},
-        BlockPayload,
+        signature_key::SignatureKey,
     },
+    utils::BuilderCommitment,
 };
 use jf_vid::{precomputable::Precomputable, VidScheme};
+use sha2::Digest;
 
+#[cfg(test)]
 #[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 async fn test_vid_task() {
-    use hotshot_task_impls::harness::run_harness;
-    use hotshot_types::message::Proposal;
+    use hotshot::tasks::task_state::CreateTaskState;
+    use hotshot_example_types::node_types::MemoryImpl;
+    
 
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
 
-    // Build the API for node 2.
-    let handle = build_system_handle(2).await.0;
-    let pub_key = handle.public_key();
-
-    // quorum membership for VID share distribution
+    let node_id = 2;
+    let handle = build_system_handle(node_id).await.0;
     let quorum_membership = handle.hotshot.memberships.quorum_membership.clone();
+    let da_membership = handle.hotshot.memberships.da_membership.clone();
+    let encoded_transactions = Vec::new();
+    let (private_key, public_key) = key_pair_for_id(node_id);
 
-    let mut vid = vid_scheme_from_view_number::<TestTypes>(&quorum_membership, ViewNumber::new(0));
-    let transactions = vec![TestTransaction::new(vec![0])];
-    let (payload, metadata) =
-        TestBlockPayload::from_transactions(transactions.clone(), &TestInstanceState {}).unwrap();
-    let builder_commitment = payload.builder_commitment(&metadata);
-    let encoded_transactions = Arc::from(TestTransaction::encode(&transactions));
-    let vid_disperse = vid.disperse(&encoded_transactions).unwrap();
+    let mut generator = TestViewGenerator::generate(quorum_membership.clone(), da_membership);
+    let mut das = Vec::new();
+    let mut vids = Vec::new();
+    for view in (&mut generator).take(2) {
+        das.push(view.da_proposal.clone());
+        vids.push(view.vid_proposal.clone());
+    }
+
+    let proposal = das[1].clone();
+
+    let mut vid = vid_scheme_from_view_number::<TestTypes>(&quorum_membership, ViewNumber::new(2));
     let (_, vid_precompute) = vid.commit_only_precompute(&encoded_transactions).unwrap();
-    let payload_commitment = vid_disperse.commit;
 
+    let vid_disperse = vid.disperse(&encoded_transactions).unwrap();
+    let payload_commitment = vid_disperse.commit;
+    let vid_disperse =
+        VidDisperse::from_membership(proposal.data.view_number, vid_disperse, &quorum_membership);
     let signature = <TestTypes as NodeType>::SignatureKey::sign(
-        handle.private_key(),
-        payload_commitment.as_ref(),
+        &private_key,
+        vid_disperse.payload_commitment.as_ref(),
     )
-    .expect("Failed to sign block payload!");
-    let proposal: DaProposal<TestTypes> = DaProposal {
-        encoded_transactions: encoded_transactions.clone(),
-        metadata: TestMetadata,
-        view_number: ViewNumber::new(2),
-    };
-    let message = Proposal {
-        data: proposal.clone(),
+    .unwrap();
+    let vid_proposal = Proposal {
+        data: vid_disperse.clone(),
         signature,
         _pd: PhantomData,
     };
 
-    let vid_disperse =
-        VidDisperse::from_membership(message.data.view_number, vid_disperse, &quorum_membership);
+    let builder_commitment = BuilderCommitment::from_raw_digest(sha2::Sha256::new().finalize());
 
-    let vid_proposal = Proposal {
-        data: vid_disperse.clone(),
-        signature: message.signature.clone(),
-        _pd: PhantomData,
+    let stage_1 = TestScriptStage {
+        inputs: vec![
+            HotShotEvent::ViewChange(ViewNumber::new(1)),
+            HotShotEvent::ViewChange(ViewNumber::new(2)),
+            HotShotEvent::BlockRecv(
+                encoded_transactions.into(),
+                TestMetadata,
+                ViewNumber::new(2),
+                null_block::builder_fee(quorum_membership.total_nodes(), &TestInstanceState {})
+                    .unwrap(),
+                vid_precompute,
+            ),
+        ],
+        outputs: vec![
+            exact(HotShotEvent::SendPayloadCommitmentAndMetadata(
+                payload_commitment,
+                builder_commitment,
+                TestMetadata,
+                ViewNumber::new(2),
+                null_block::builder_fee(quorum_membership.total_nodes(), &TestInstanceState {})
+                    .unwrap(),
+            )),
+            exact(HotShotEvent::BlockReady(
+                vid_disperse.clone(),
+                ViewNumber::new(2),
+            )),
+            exact(HotShotEvent::VidDisperseSend(
+                vid_proposal.clone(),
+                public_key,
+            )),
+        ],
+        asserts: vec![],
     };
-    let vid_share_proposals: Vec<_> = VidDisperseShare::from_vid_disperse(vid_disperse.clone())
-        .into_iter()
-        .map(|vid_disperse_share| {
-            vid_disperse_share
-                .to_proposal(handle.private_key())
-                .expect("Failed to sign block payload!")
-        })
-        .collect();
-    let vid_share_proposal = vid_share_proposals[0].clone();
 
-    let mut input = Vec::new();
-    let mut output = HashMap::new();
-
-    // In view 1, node 2 is the next leader.
-    input.push(HotShotEvent::ViewChange(ViewNumber::new(1)));
-    input.push(HotShotEvent::ViewChange(ViewNumber::new(2)));
-    input.push(HotShotEvent::BlockRecv(
-        encoded_transactions,
-        TestMetadata,
-        ViewNumber::new(2),
-        null_block::builder_fee(quorum_membership.total_nodes(), &TestInstanceState {}).unwrap(),
-        vid_precompute,
-    ));
-    input.push(HotShotEvent::BlockReady(
-        vid_disperse.clone(),
-        ViewNumber::new(2),
-    ));
-
-    input.push(HotShotEvent::VidDisperseSend(vid_proposal.clone(), pub_key));
-    input.push(HotShotEvent::VidShareRecv(vid_share_proposal.clone()));
-    input.push(HotShotEvent::Shutdown);
-
-    output.insert(
-        HotShotEvent::BlockReady(vid_disperse, ViewNumber::new(2)),
-        1,
-    );
-
-    output.insert(
-        HotShotEvent::SendPayloadCommitmentAndMetadata(
-            payload_commitment,
-            builder_commitment,
-            TestMetadata,
-            ViewNumber::new(2),
-            null_block::builder_fee(quorum_membership.total_nodes(), &TestInstanceState {})
-                .unwrap(),
-        ),
-        1,
-    );
-    output.insert(
-        HotShotEvent::VidDisperseSend(vid_proposal.clone(), pub_key),
-        1,
-    );
-
-    let vid_state = VidTaskState {
-        api: handle.clone(),
-        consensus: handle.hotshot.consensus(),
-        cur_view: ViewNumber::new(0),
-        vote_collector: None,
-        network: handle.hotshot.networks.quorum_network.clone(),
-        membership: handle.hotshot.memberships.vid_membership.clone().into(),
-        public_key: handle.public_key(),
-        private_key: handle.private_key().clone(),
-        id: handle.hotshot.id,
-    };
-    run_harness(input, output, vid_state, false).await;
+    let vid_task_state = VidTaskState::<TestTypes, MemoryImpl>::create_from(&handle).await;
+    run_test_script(vec![stage_1], vid_task_state).await;
 }


### PR DESCRIPTION
Closes #3165 
<!-- See here for keywords in Github -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

### This PR: 
Modernizes the Vid Task to use the newer test suite, removes the old test, and removes `ConsensusApi` from the task since it's unused.

### This PR does not: 
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->

### Key places to review: 
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
