### PR TITLE
Don't send `ResponseMessage::NotFound` right away, wait for txns

### DIFF
--- a/crates/task-impls/src/da.rs
+++ b/crates/task-impls/src/da.rs
@@ -226,8 +226,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, A: ConsensusApi<TYPES, I> + 
                     let membership = Arc::clone(&self.quorum_membership);
                     let pk = self.private_key.clone();
                     async_spawn(async move {
-                        Consensus::calculate_and_update_vid(consensus, view, membership, &pk)
-                            .await;
+                        Consensus::calculate_and_update_vid(consensus, view, membership, &pk).await;
                     });
                 }
             }

--- a/crates/task-impls/src/response.rs
+++ b/crates/task-impls/src/response.rs
@@ -124,7 +124,8 @@ impl<TYPES: NodeType> NetworkResponseState<TYPES> {
         view: TYPES::Time,
         key: &TYPES::SignatureKey,
     ) -> Option<Proposal<TYPES, VidDisperseShare<TYPES>>> {
-        let contained = self.consensus
+        let contained = self
+            .consensus
             .read()
             .await
             .vid_shares()
@@ -150,9 +151,22 @@ impl<TYPES: NodeType> NetworkResponseState<TYPES> {
                 )
                 .await?;
             }
-            return self.consensus.read().await.vid_shares().get(&view)?.get(key).cloned();
+            return self
+                .consensus
+                .read()
+                .await
+                .vid_shares()
+                .get(&view)?
+                .get(key)
+                .cloned();
         }
-        self.consensus.read().await.vid_shares().get(&view)?.get(key).cloned()
+        self.consensus
+            .read()
+            .await
+            .vid_shares()
+            .get(&view)?
+            .get(key)
+            .cloned()
     }
 
     /// Handle the request contained in the message. Returns the response we should send

--- a/crates/types/src/consensus.rs
+++ b/crates/types/src/consensus.rs
@@ -39,7 +39,6 @@ pub type VidShares<TYPES> = BTreeMap<
 /// Type alias for consensus state wrapped in a lock.
 pub type LockedConsensusState<TYPES> = Arc<RwLock<Consensus<TYPES>>>;
 
-
 /// A reference to the consensus algorithm
 ///
 /// This will contain the state of all rounds.


### PR DESCRIPTION
Closes #3046
<!-- See here for keywords in Github -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

### This PR: 
<!-- Describe what this PR adds to HotSHot -->
<!-- E.g. -->
<!-- * Implements feature 1 -->
<!-- * Implements feature 2 -->
<!-- * Fixes bug 3 -->
* Delays sending `ResponseMessage::NotFound` immediately
* Sleeps for a specified time
* Retries to calculate VID in hope transactions have been received during sleeping

### This PR does not: 
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->
This change delays the response to the requester which blocks the requester from moving to the next possible responder.
This might be viewed as undesirable behaviour depending on the scenario. 

### Key places to review: 
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->
`get_or_calc_vid_share` method

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->
All tests should pass.

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
