### PR TITLE
[Dependency Tasks] Fix Test Build, Update State in Vote Task

### DIFF
--- a/crates/hotshot/src/tasks/task_state.rs
+++ b/crates/hotshot/src/tasks/task_state.rs
@@ -234,6 +234,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> CreateTaskState<TYPES, I>
             output_event_stream: handle.hotshot.external_event_stream.0.clone(),
             id: handle.hotshot.id,
             storage: Arc::clone(&handle.storage),
+            version: *handle.hotshot.version.read().await,
         }
     }
 }

--- a/crates/task-impls/src/consensus/helpers.rs
+++ b/crates/task-impls/src/consensus/helpers.rs
@@ -332,12 +332,6 @@ pub(crate) async fn parent_leaf_and_state<TYPES: NodeType>(
     let parent_view = consensus_reader.validated_state_map().get(&parent_view_number).context(
         format!("Couldn't find parent view in state map, waiting for replica to see proposal; parent_view_number: {}", *parent_view_number)
     )?;
-    tracing::error!(
-        "VALIDATED STATE MAP {:?}\nPARENT_VIEW {:?}\nPARENT_VIEW_NUMBER {:?}",
-        consensus_reader.validated_state_map(),
-        parent_view,
-        parent_view_number,
-    );
 
     // Leaf hash in view inner does not match high qc hash - Why?
     let (leaf_commitment, state) = parent_view.leaf_and_state().context(

--- a/crates/task-impls/src/consensus/helpers.rs
+++ b/crates/task-impls/src/consensus/helpers.rs
@@ -332,6 +332,12 @@ pub(crate) async fn parent_leaf_and_state<TYPES: NodeType>(
     let parent_view = consensus_reader.validated_state_map().get(&parent_view_number).context(
         format!("Couldn't find parent view in state map, waiting for replica to see proposal; parent_view_number: {}", *parent_view_number)
     )?;
+    tracing::error!(
+        "VALIDATED STATE MAP {:?}\nPARENT_VIEW {:?}\nPARENT_VIEW_NUMBER {:?}",
+        consensus_reader.validated_state_map(),
+        parent_view,
+        parent_view_number,
+    );
 
     // Leaf hash in view inner does not match high qc hash - Why?
     let (leaf_commitment, state) = parent_view.leaf_and_state().context(

--- a/crates/task-impls/src/quorum_proposal/dependency_handle.rs
+++ b/crates/task-impls/src/quorum_proposal/dependency_handle.rs
@@ -40,7 +40,7 @@ pub(crate) enum ProposalDependency {
     TimeoutCert,
 
     /// For the `QuroumProposalValidated` event after validating `QuorumProposalRecv` or the
-    /// `LivenessCheckProposalRecv` event during the liveness check in `QuorumProposalRecv`.
+    /// `QuorumProposalLivenessValidated` event during the liveness check in `QuorumProposalRecv`.
     Proposal,
 
     /// For the `VidShareValidated` event.
@@ -212,7 +212,7 @@ impl<TYPES: NodeType> HandleDepOutput for ProposalDependencyHandle<TYPES> {
                     vid_share = Some(share.clone());
                 }
                 _ => {
-                    // LivenessCheckProposalRecv and QuorumProposalValidated are implicitly
+                    // QuorumProposalLivenessValidated and QuorumProposalValidated are implicitly
                     // handled here.
                 }
             }

--- a/crates/task-impls/src/quorum_proposal/handlers.rs
+++ b/crates/task-impls/src/quorum_proposal/handlers.rs
@@ -267,6 +267,7 @@ pub(crate) async fn handle_quorum_proposal_validated<
         // Bring in the cleanup crew. When a new decide is indeed valid, we need to clear out old memory.
 
         let old_decided_view = consensus_writer.last_decided_view();
+        tracing::error!("COLLECTING GARBAGE");
         consensus_writer.collect_garbage(old_decided_view, decided_view_number);
 
         // Set the new decided view.

--- a/crates/task-impls/src/quorum_proposal/handlers.rs
+++ b/crates/task-impls/src/quorum_proposal/handlers.rs
@@ -267,7 +267,6 @@ pub(crate) async fn handle_quorum_proposal_validated<
         // Bring in the cleanup crew. When a new decide is indeed valid, we need to clear out old memory.
 
         let old_decided_view = consensus_writer.last_decided_view();
-        tracing::error!("COLLECTING GARBAGE");
         consensus_writer.collect_garbage(old_decided_view, decided_view_number);
 
         // Set the new decided view.

--- a/crates/task-impls/src/quorum_proposal/mod.rs
+++ b/crates/task-impls/src/quorum_proposal/mod.rs
@@ -166,7 +166,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> QuorumProposalTaskState<TYPE
                     }
                     ProposalDependency::ValidatedState => {
                         if let HotShotEvent::ValidatedStateUpdated(view_number, _) = event {
-                            *view_number + 1
+                            *view_number
                         } else {
                             return false;
                         }
@@ -280,13 +280,15 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> QuorumProposalTaskState<TYPE
             secondary_deps.push(AndDependency::from_deps(vec![qc_dependency]));
         }
 
+        let mut primary_deps = vec![payload_commitment_dependency, vid_share_dependency];
+
+        if *view_number > 1 {
+            primary_deps.push(validated_state_update_dependency);
+        }
+
         AndDependency::from_deps(vec![OrDependency::from_deps(vec![
             AndDependency::from_deps(vec![
-                OrDependency::from_deps(vec![AndDependency::from_deps(vec![
-                    payload_commitment_dependency,
-                    vid_share_dependency,
-                    validated_state_update_dependency,
-                ])]),
+                OrDependency::from_deps(vec![AndDependency::from_deps(primary_deps)]),
                 OrDependency::from_deps(secondary_deps),
             ]),
         ])])
@@ -505,7 +507,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> QuorumProposalTaskState<TYPE
                     .update_validated_state_map(*view_number, view.clone());
 
                 self.create_dependency_task_if_new(
-                    *view_number + 1,
+                    *view_number,
                     event_receiver,
                     event_sender,
                     Arc::clone(&event),

--- a/crates/task-impls/src/quorum_proposal/mod.rs
+++ b/crates/task-impls/src/quorum_proposal/mod.rs
@@ -166,7 +166,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> QuorumProposalTaskState<TYPE
                     }
                     ProposalDependency::ValidatedState => {
                         if let HotShotEvent::ValidatedStateUpdated(view_number, _) = event {
-                            *view_number
+                            *view_number + 1
                         } else {
                             return false;
                         }
@@ -507,7 +507,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> QuorumProposalTaskState<TYPE
                     .update_validated_state_map(*view_number, view.clone());
 
                 self.create_dependency_task_if_new(
-                    *view_number,
+                    *view_number + 1,
                     event_receiver,
                     event_sender,
                     Arc::clone(&event),

--- a/crates/task-impls/src/quorum_proposal_recv/handlers.rs
+++ b/crates/task-impls/src/quorum_proposal_recv/handlers.rs
@@ -200,18 +200,17 @@ pub(crate) async fn handle_quorum_proposal_recv<TYPES: NodeType, I: NodeImplemen
         parent
     };
 
-    {
-        let mut consensus_write = task_state.consensus.write().await;
-        if let Err(e) = consensus_write.update_high_qc(justify_qc.clone()) {
-            tracing::trace!("{e:?}");
-        }
-
-        broadcast_event(
-            HotShotEvent::UpdateHighQc(justify_qc.clone()).into(),
-            event_sender,
-        )
-        .await;
+    let mut consensus_write = task_state.consensus.write().await;
+    if let Err(e) = consensus_write.update_high_qc(justify_qc.clone()) {
+        tracing::trace!("{e:?}");
     }
+    drop(consensus_write);
+
+    broadcast_event(
+        HotShotEvent::UpdateHighQc(justify_qc.clone()).into(),
+        event_sender,
+    )
+    .await;
 
     let Some((parent_leaf, _parent_state)) = parent else {
         warn!(

--- a/crates/task-impls/src/quorum_proposal_recv/handlers.rs
+++ b/crates/task-impls/src/quorum_proposal_recv/handlers.rs
@@ -57,7 +57,6 @@ async fn validate_proposal_liveness<TYPES: NodeType, I: NodeImplementation<TYPES
         },
     };
 
-    tracing::error!("Updating validated state map");
     consensus_write.update_validated_state_map(view_number, view.clone());
     consensus_write.update_saved_leaves(leaf.clone());
 

--- a/crates/task-impls/src/quorum_vote.rs
+++ b/crates/task-impls/src/quorum_vote.rs
@@ -14,7 +14,7 @@ use hotshot_task::{
 };
 use hotshot_types::{
     consensus::Consensus,
-    data::{Leaf, QuorumProposal, VidDisperseShare},
+    data::{Leaf, VidDisperseShare},
     event::Event,
     message::{GeneralConsensusMessage, Proposal},
     simple_vote::{QuorumData, QuorumVote},
@@ -291,7 +291,6 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static> HandleDepOutput
                 HotShotEvent::VoteNow(_, vote_dependency_data) => {
                     leaf = Some(vote_dependency_data.parent_leaf.clone());
                     vid_share = Some(vote_dependency_data.vid_share.clone());
-                    cur_proposal = Some(vote_dependency_data.quorum_proposal.clone());
                 }
                 _ => {}
             }
@@ -317,11 +316,6 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static> HandleDepOutput
                 "We don't have the leaf for this view {:?}, but we should, because the vote dependencies have completed.",
                 self.view_number
             );
-            return;
-        };
-
-        let Some(cur_proposal) = cur_proposal else {
-            error!("We don't have the Quorum Proposal for this view {:?}, but we should, ecause the vote dependencies have completed.", self.view_number);
             return;
         };
 

--- a/crates/task-impls/src/quorum_vote.rs
+++ b/crates/task-impls/src/quorum_vote.rs
@@ -156,7 +156,6 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static> VoteDependencyHand
         // We will defer broadcast until all states are updated to avoid holding onto the lock during a network call.
         let mut consensus_writer = self.consensus.write().await;
 
-        // Note: There's a potential inconsistency here between `self.view_number` and `leaf.data.view_number()`.
         let view = View {
             view_inner: ViewInner::Leaf {
                 leaf: proposed_leaf.commit(),
@@ -164,7 +163,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static> VoteDependencyHand
                 delta: Some(Arc::clone(&delta)),
             },
         };
-        consensus_writer.update_validated_state_map(self.view_number, view.clone());
+        consensus_writer.update_validated_state_map(proposed_leaf.view_number(), view.clone());
         consensus_writer.update_saved_leaves(proposed_leaf.clone());
 
         // Kick back our updated structures for downstream usage.

--- a/crates/task-impls/src/quorum_vote.rs
+++ b/crates/task-impls/src/quorum_vote.rs
@@ -173,7 +173,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static> VoteDependencyHand
 
         // Broadcast now that the lock is dropped.
         broadcast_event(
-            HotShotEvent::ValidatedStateUpdated(self.view_number, view).into(),
+            HotShotEvent::ValidatedStateUpdated(proposed_leaf.view_number(), view).into(),
             &self.sender,
         )
         .await;

--- a/crates/task-impls/src/quorum_vote.rs
+++ b/crates/task-impls/src/quorum_vote.rs
@@ -17,7 +17,7 @@ use hotshot_types::{
     consensus::Consensus,
     data::{Leaf, VidDisperseShare},
     event::Event,
-    message::{GeneralConsensusMessage, Proposal},
+    message::Proposal,
     simple_vote::{QuorumData, QuorumVote},
     traits::{
         block_contents::BlockHeader,

--- a/crates/task-impls/src/quorum_vote.rs
+++ b/crates/task-impls/src/quorum_vote.rs
@@ -120,38 +120,6 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static> VoteDependencyHand
         let state = Arc::new(validated_state);
         let delta = Arc::new(state_delta);
 
-        // TODO Upgrades
-        // Validate the DAC.
-        // let message = if cert.is_valid_cert(Upgrade Certificate) {
-        //     // Validate the block payload commitment for non-genesis DAC.
-        //     if cert.date().payload_commit != proposal.block_header.payload_commitment() {
-        //         warn!(
-        //             "Block payload commitment does not equal da cert payload commitment. View = {}",
-        //             *view
-        //         );
-        //         return false;
-        //     }
-        //     if let Ok(vote) = QuorumVote::<TYPES>::create_signed_vote(
-        //         QuorumData {
-        //             leaf_commit: proposed_leaf.commit(),
-        //         },
-        //         view,
-        //         &public_key,
-        //         &self.private_key
-        //     ) {
-        //         GeneralConsensusMessage::<TYPES>::Vote(vote)
-        //     } else {
-        //         error!("Unable to sign quorum vote!");
-        //         return false;
-        //     }
-        // } else {
-        //     error!(
-        //         "Invalid DAC in proposal! Skipping proposal. {:?} cur view is: {:?}",
-        //         cert, cur_view
-        //     );
-        //     return false;
-        // };
-
         // Now that we've rounded everyone up, we need to update the shared state and broadcast our events.
         // We will defer broadcast until all states are updated to avoid holding onto the lock during a network call.
         let mut consensus_writer = self.consensus.write().await;

--- a/crates/task-impls/src/quorum_vote.rs
+++ b/crates/task-impls/src/quorum_vote.rs
@@ -180,21 +180,18 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static> VoteDependencyHand
             &self.private_key,
         )
         .context("Failed to sign vote")?;
-        let message = GeneralConsensusMessage::<TYPES>::Vote(vote);
-        if let GeneralConsensusMessage::Vote(vote) = message {
-            debug!(
-                "Sending vote to next quorum leader {:?}",
-                vote.view_number() + 1
-            );
-            // Add to the storage.
-            self.storage
-                .write()
-                .await
-                .append_vid(&vid_share)
-                .await
-                .context("Failed to store VID share")?;
-            broadcast_event(Arc::new(HotShotEvent::QuorumVoteSend(vote)), &self.sender).await;
-        }
+        debug!(
+            "Sending vote to next quorum leader {:?}",
+            vote.view_number() + 1
+        );
+        // Add to the storage.
+        self.storage
+            .write()
+            .await
+            .append_vid(&vid_share)
+            .await
+            .context("Failed to store VID share")?;
+        broadcast_event(Arc::new(HotShotEvent::QuorumVoteSend(vote)), &self.sender).await;
 
         Ok(())
     }

--- a/crates/task-impls/src/quorum_vote.rs
+++ b/crates/task-impls/src/quorum_vote.rs
@@ -79,6 +79,7 @@ struct VoteDependencyHandle<TYPES: NodeType, I: NodeImplementation<TYPES>> {
 }
 
 impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static> VoteDependencyHandle<TYPES, I> {
+    /// Updates the shared consensus state with the new voting data.
     async fn update_shared_state(
         &self,
         proposal: &QuorumProposal<TYPES>,
@@ -188,6 +189,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static> VoteDependencyHand
         Ok(())
     }
 
+    /// Submits the `QuorumVoteSend` event if all the dependencies are met.
     async fn submit_vote(
         &self,
         leaf: Leaf<TYPES>,
@@ -529,7 +531,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> QuorumVoteTaskState<TYPES, I
                 storage: Arc::clone(&self.storage),
                 view_number,
                 sender: event_sender.clone(),
-                version: self.version.clone(),
+                version: self.version,
             },
         );
         self.vote_dependencies

--- a/crates/testing/src/predicates/event.rs
+++ b/crates/testing/src/predicates/event.rs
@@ -236,13 +236,13 @@ where
     Box::new(EventPredicate { check, info })
 }
 
-
 pub fn validated_state_updated<TYPES>() -> Box<EventPredicate<TYPES>>
 where
     TYPES: NodeType,
 {
     let info = "ValidatedStateUpdated".to_string();
-    let check: EventCallback<TYPES> =
-        Arc::new(move |e: Arc<HotShotEvent<TYPES>>| matches!(e.as_ref(), ValidatedStateUpdated(..)));
+    let check: EventCallback<TYPES> = Arc::new(move |e: Arc<HotShotEvent<TYPES>>| {
+        matches!(e.as_ref(), ValidatedStateUpdated(..))
+    });
     Box::new(EventPredicate { check, info })
 }

--- a/crates/testing/src/predicates/event.rs
+++ b/crates/testing/src/predicates/event.rs
@@ -235,3 +235,14 @@ where
         Arc::new(move |e: Arc<HotShotEvent<TYPES>>| matches!(e.as_ref(), VoteNow(..)));
     Box::new(EventPredicate { check, info })
 }
+
+
+pub fn validated_state_updated<TYPES>() -> Box<EventPredicate<TYPES>>
+where
+    TYPES: NodeType,
+{
+    let info = "ValidatedStateUpdated".to_string();
+    let check: EventCallback<TYPES> =
+        Arc::new(move |e: Arc<HotShotEvent<TYPES>>| matches!(e.as_ref(), ValidatedStateUpdated(..)));
+    Box::new(EventPredicate { check, info })
+}

--- a/crates/testing/tests/tests_1/da_task.rs
+++ b/crates/testing/tests/tests_1/da_task.rs
@@ -8,9 +8,9 @@ use hotshot_example_types::{
 };
 use hotshot_task_impls::{da::DaTaskState, events::HotShotEvent::*};
 use hotshot_testing::{
-    predicates::event::exact,
-    script::{run_test_script, TestScriptStage},
     helpers::build_system_handle,
+    predicates::event::{exact, validated_state_updated},
+    script::{run_test_script, TestScriptStage},
     view_generator::TestViewGenerator,
 };
 use hotshot_types::{
@@ -90,6 +90,7 @@ async fn test_da_task() {
         outputs: vec![
             exact(DaProposalValidated(proposals[1].clone(), leaders[1])),
             exact(DaVoteSend(votes[1].clone())),
+            validated_state_updated(),
         ],
         asserts: vec![],
     };

--- a/crates/testing/tests/tests_1/quorum_proposal_recv_task.rs
+++ b/crates/testing/tests/tests_1/quorum_proposal_recv_task.rs
@@ -1,6 +1,7 @@
 // TODO: Remove after integration
 #![allow(unused_imports)]
 
+use futures::StreamExt;
 use hotshot::tasks::task_state::CreateTaskState;
 use hotshot_example_types::node_types::{MemoryImpl, TestTypes};
 use hotshot_task_impls::{
@@ -161,7 +162,7 @@ async fn test_quorum_proposal_recv_task_liveness_check() {
                 ),
             )),
             exact(NewUndecidedView(leaves[2].clone())),
-            exact(LivenessCheckProposalRecv(proposals[2].data.clone())),
+            exact(QuorumProposalLivenessValidated(proposals[2].data.clone())),
             vote_now(),
         ],
         asserts: vec![],

--- a/crates/testing/tests/tests_1/quorum_proposal_task.rs
+++ b/crates/testing/tests/tests_1/quorum_proposal_task.rs
@@ -196,8 +196,8 @@ async fn test_quorum_proposal_task_quorum_proposal_view_gt_1() {
             ),
             VidShareValidated(vid_share(&vids[0].0, handle.public_key())),
             ValidatedStateUpdated(
-                proposals[0].data.view_number(),
-                build_fake_view_with_leaf(leaves[0].clone()),
+                genesis_cert.view_number(),
+                build_fake_view_with_leaf(genesis_leaf.clone()),
             ),
         ],
         outputs: vec![exact(UpdateHighQc(genesis_cert.clone()))],
@@ -218,8 +218,8 @@ async fn test_quorum_proposal_task_quorum_proposal_view_gt_1() {
             ),
             VidShareValidated(vid_share(&vids[1].0, handle.public_key())),
             ValidatedStateUpdated(
-                proposals[1].data.view_number(),
-                build_fake_view_with_leaf(leaves[1].clone()),
+                proposals[0].data.view_number(),
+                build_fake_view_with_leaf(leaves[0].clone()),
             ),
         ],
         outputs: vec![exact(UpdateHighQc(proposals[1].data.justify_qc.clone()))],
@@ -240,8 +240,8 @@ async fn test_quorum_proposal_task_quorum_proposal_view_gt_1() {
             ),
             VidShareValidated(vid_share(&vids[2].0, handle.public_key())),
             ValidatedStateUpdated(
-                proposals[2].data.view_number(),
-                build_fake_view_with_leaf(leaves[2].clone()),
+                proposals[1].data.view_number(),
+                build_fake_view_with_leaf(leaves[1].clone()),
             ),
         ],
         outputs: vec![
@@ -266,8 +266,8 @@ async fn test_quorum_proposal_task_quorum_proposal_view_gt_1() {
             ),
             VidShareValidated(vid_share(&vids[3].0, handle.public_key())),
             ValidatedStateUpdated(
-                proposals[3].data.view_number(),
-                build_fake_view_with_leaf(leaves[3].clone()),
+                proposals[2].data.view_number(),
+                build_fake_view_with_leaf(leaves[2].clone()),
             ),
         ],
         outputs: vec![exact(UpdateHighQc(proposals[3].data.justify_qc.clone()))],
@@ -287,8 +287,8 @@ async fn test_quorum_proposal_task_quorum_proposal_view_gt_1() {
             ),
             VidShareValidated(vid_share(&vids[4].0, handle.public_key())),
             ValidatedStateUpdated(
-                proposals[4].data.view_number(),
-                build_fake_view_with_leaf(leaves[4].clone()),
+                proposals[3].data.view_number(),
+                build_fake_view_with_leaf(leaves[3].clone()),
             ),
         ],
         outputs: vec![
@@ -364,8 +364,8 @@ async fn test_quorum_proposal_task_qc_timeout() {
             ),
             VidShareValidated(vid_share(&vids[2].0.clone(), handle.public_key())),
             ValidatedStateUpdated(
-                proposals[2].data.view_number(),
-                build_fake_view_with_leaf(leaves[2].clone()),
+                proposals[1].data.view_number(),
+                build_fake_view_with_leaf(leaves[1].clone()),
             ),
         ],
         outputs: vec![quorum_proposal_send()],
@@ -443,8 +443,8 @@ async fn test_quorum_proposal_task_view_sync() {
             ),
             VidShareValidated(vid_share(&vids[1].0.clone(), handle.public_key())),
             ValidatedStateUpdated(
-                proposals[1].data.view_number(),
-                build_fake_view_with_leaf(leaves[1].clone()),
+                proposals[0].data.view_number(),
+                build_fake_view_with_leaf(leaves[0].clone()),
             ),
         ],
         outputs: vec![quorum_proposal_send()],
@@ -458,7 +458,6 @@ async fn test_quorum_proposal_task_view_sync() {
     run_test_script(script, quorum_proposal_task_state).await;
 }
 
-#[ignore]
 #[cfg(test)]
 #[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
@@ -515,8 +514,8 @@ async fn test_quorum_proposal_livness_check_proposal() {
             ),
             VidShareValidated(vid_share(&vids[0].0, handle.public_key())),
             ValidatedStateUpdated(
-                proposals[0].data.view_number(),
-                build_fake_view_with_leaf(leaves[0].clone()),
+                genesis_cert.view_number(),
+                build_fake_view_with_leaf(genesis_leaf.clone()),
             ),
         ],
         outputs: vec![exact(UpdateHighQc(genesis_cert.clone()))],
@@ -526,7 +525,7 @@ async fn test_quorum_proposal_livness_check_proposal() {
     // We send all the events that we'd have otherwise received to ensure the states are updated.
     let view_1 = TestScriptStage {
         inputs: vec![
-            QuorumProposalValidated(proposals[0].data.clone(), genesis_leaf),
+            QuorumProposalValidated(proposals[0].data.clone(), genesis_leaf.clone()),
             QcFormed(either::Left(proposals[1].data.justify_qc.clone())),
             SendPayloadCommitmentAndMetadata(
                 make_payload_commitment(&quorum_membership, ViewNumber::new(2)),
@@ -537,8 +536,8 @@ async fn test_quorum_proposal_livness_check_proposal() {
             ),
             VidShareValidated(vid_share(&vids[1].0, handle.public_key())),
             ValidatedStateUpdated(
-                proposals[1].data.view_number(),
-                build_fake_view_with_leaf(leaves[1].clone()),
+                proposals[0].data.view_number(),
+                build_fake_view_with_leaf(leaves[0].clone()),
             ),
         ],
         outputs: vec![exact(UpdateHighQc(proposals[1].data.justify_qc.clone()))],
@@ -561,8 +560,8 @@ async fn test_quorum_proposal_livness_check_proposal() {
             ),
             VidShareValidated(vid_share(&vids[2].0, handle.public_key())),
             ValidatedStateUpdated(
-                proposals[2].data.view_number(),
-                build_fake_view_with_leaf(leaves[2].clone()),
+                proposals[1].data.view_number(),
+                build_fake_view_with_leaf(leaves[1].clone()),
             ),
         ],
         outputs: vec![
@@ -586,8 +585,8 @@ async fn test_quorum_proposal_livness_check_proposal() {
             ),
             VidShareValidated(vid_share(&vids[3].0, handle.public_key())),
             ValidatedStateUpdated(
-                proposals[3].data.view_number(),
-                build_fake_view_with_leaf(leaves[3].clone()),
+                proposals[2].data.view_number(),
+                build_fake_view_with_leaf(leaves[2].clone()),
             ),
         ],
         outputs: vec![exact(UpdateHighQc(proposals[3].data.justify_qc.clone()))],
@@ -607,8 +606,8 @@ async fn test_quorum_proposal_livness_check_proposal() {
             ),
             VidShareValidated(vid_share(&vids[4].0, handle.public_key())),
             ValidatedStateUpdated(
-                proposals[4].data.view_number(),
-                build_fake_view_with_leaf(leaves[4].clone()),
+                proposals[3].data.view_number(),
+                build_fake_view_with_leaf(leaves[3].clone()),
             ),
         ],
         outputs: vec![

--- a/crates/testing/tests/tests_1/quorum_vote_task.rs
+++ b/crates/testing/tests/tests_1/quorum_vote_task.rs
@@ -82,7 +82,7 @@ async fn test_quorum_vote_task_vote_now() {
     use hotshot_task_impls::{events::HotShotEvent::*, quorum_vote::QuorumVoteTaskState};
     use hotshot_testing::{
         helpers::build_system_handle,
-        predicates::event::{exact, quorum_vote_send, validated_state_updated},
+        predicates::event::{exact, quorum_vote_send},
         script::{run_test_script, TestScriptStage},
         view_generator::TestViewGenerator,
     };

--- a/crates/testing/tests/tests_1/quorum_vote_task.rs
+++ b/crates/testing/tests/tests_1/quorum_vote_task.rs
@@ -82,7 +82,7 @@ async fn test_quorum_vote_task_vote_now() {
     use hotshot_task_impls::{events::HotShotEvent::*, quorum_vote::QuorumVoteTaskState};
     use hotshot_testing::{
         helpers::build_system_handle,
-        predicates::event::{exact, quorum_vote_send},
+        predicates::event::{exact, quorum_vote_send, validated_state_updated},
         script::{run_test_script, TestScriptStage},
         view_generator::TestViewGenerator,
     };


### PR DESCRIPTION
Closes #<ISSUE_NUMBER>
<!-- See here for keywords in Github -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

### This PR: 
The recent change to the Quorum Vote Task did not include the state updates that happen in the legacy consensus module. This adds them so that way consensus may proceed with proper validated state updates.

### This PR does not: 
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->

### Key places to review: 
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
