### PR TITLE
[METRICS] - Individual node health

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3107,6 +3107,7 @@ dependencies = [
  "cdn-broker",
  "cdn-client",
  "cdn-marshal",
+ "chrono",
  "clap",
  "committable",
  "custom_debug",

--- a/crates/hotshot/Cargo.toml
+++ b/crates/hotshot/Cargo.toml
@@ -31,6 +31,7 @@ async-lock = { workspace = true }
 async-trait = { workspace = true }
 bimap = "0.6"
 bincode = { workspace = true }
+chrono = "0.4"
 clap = { workspace = true, optional = true }
 committable = { workspace = true }
 custom_debug = { workspace = true }

--- a/crates/hotshot/src/tasks/task_state.rs
+++ b/crates/hotshot/src/tasks/task_state.rs
@@ -4,6 +4,7 @@ use std::{
     sync::{atomic::AtomicBool, Arc},
 };
 
+use crate::types::SystemContextHandle;
 use async_trait::async_trait;
 use chrono::Utc;
 use hotshot_task_impls::{
@@ -18,7 +19,6 @@ use hotshot_types::traits::{
     node_implementation::{ConsensusTime, NodeImplementation, NodeType},
 };
 use vbs::version::StaticVersionType;
-use crate::types::SystemContextHandle;
 
 /// Trait for creating task states.
 #[async_trait]

--- a/crates/hotshot/src/tasks/task_state.rs
+++ b/crates/hotshot/src/tasks/task_state.rs
@@ -1,4 +1,6 @@
+use crate::types::SystemContextHandle;
 use async_trait::async_trait;
+use chrono::Utc;
 use hotshot_task_impls::{
     builder::BuilderClient, consensus::ConsensusTaskState, consensus2::Consensus2TaskState,
     da::DaTaskState, quorum_proposal::QuorumProposalTaskState,
@@ -10,15 +12,13 @@ use hotshot_types::traits::{
     consensus_api::ConsensusApi,
     node_implementation::{ConsensusTime, NodeImplementation, NodeType},
 };
+use vbs::version::StaticVersionType;
+
 use std::{
     collections::{BTreeMap, HashMap},
     marker::PhantomData,
     sync::{atomic::AtomicBool, Arc},
 };
-
-use vbs::version::StaticVersionType;
-
-use crate::types::SystemContextHandle;
 
 /// Trait for creating task states.
 #[async_trait]
@@ -192,6 +192,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> CreateTaskState<TYPES, I>
             timeout: handle.hotshot.config.next_view_timeout,
             round_start_delay: handle.hotshot.config.round_start_delay,
             cur_view: handle.cur_view().await,
+            cur_view_time: Utc::now().timestamp(),
             payload_commitment_and_metadata: None,
             vote_collector: None.into(),
             timeout_vote_collector: None.into(),
@@ -328,6 +329,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> CreateTaskState<TYPES, I>
             timeout_vote_collector: None.into(),
             storage: Arc::clone(&handle.storage),
             cur_view: handle.cur_view().await,
+            cur_view_time: Utc::now().timestamp(),
             output_event_stream: handle.hotshot.external_event_stream.0.clone(),
             timeout_task,
             timeout: handle.hotshot.config.next_view_timeout,

--- a/crates/hotshot/src/tasks/task_state.rs
+++ b/crates/hotshot/src/tasks/task_state.rs
@@ -289,6 +289,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> CreateTaskState<TYPES, I>
             private_key: handle.private_key().clone(),
             consensus,
             cur_view: handle.cur_view().await,
+            cur_view_time: Utc::now().timestamp(),
             quorum_network: Arc::clone(&handle.hotshot.networks.quorum_network),
             quorum_membership: handle.hotshot.memberships.quorum_membership.clone().into(),
             timeout_membership: handle.hotshot.memberships.quorum_membership.clone().into(),

--- a/crates/task-impls/src/consensus/helpers.rs
+++ b/crates/task-impls/src/consensus/helpers.rs
@@ -598,6 +598,8 @@ pub(crate) async fn handle_quorum_proposal_recv<TYPES: NodeType, I: NodeImplemen
         *proposal.data.view_number
     );
 
+    let cur_view = task_state.cur_view;
+
     validate_proposal_view_and_certs(
         proposal,
         &sender,
@@ -624,9 +626,11 @@ pub(crate) async fn handle_quorum_proposal_recv<TYPES: NodeType, I: NodeImplemen
         task_state.timeout,
         Arc::clone(&task_state.consensus),
         &mut task_state.cur_view,
+        &mut task_state.cur_view_time,
         &mut task_state.timeout_task,
         &task_state.output_event_stream,
         SEND_VIEW_CHANGE_EVENT,
+        task_state.quorum_membership.leader(cur_view) == task_state.public_key,
     )
     .await
     {

--- a/crates/task-impls/src/consensus/mod.rs
+++ b/crates/task-impls/src/consensus/mod.rs
@@ -547,9 +547,11 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> ConsensusTaskState<TYPES, I>
                     self.timeout,
                     Arc::clone(&self.consensus),
                     &mut self.cur_view,
+                    &mut self.cur_view_time,
                     &mut self.timeout_task,
                     &self.output_event_stream,
                     DONT_SEND_VIEW_CHANGE_EVENT,
+                    self.quorum_membership.leader(old_view_number) == self.public_key,
                 )
                 .await
                 {

--- a/crates/task-impls/src/consensus/mod.rs
+++ b/crates/task-impls/src/consensus/mod.rs
@@ -81,6 +81,9 @@ pub struct ConsensusTaskState<TYPES: NodeType, I: NodeImplementation<TYPES>> {
     /// View number this view is executing in.
     pub cur_view: TYPES::Time,
 
+    /// Timestamp this view starts at.
+    pub cur_view_time: i64,
+
     /// The commitment to the current block payload and its metadata submitted to DA.
     pub payload_commitment_and_metadata: Option<CommitmentAndMetadata<TYPES>>,
 
@@ -599,6 +602,9 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> ConsensusTaskState<TYPES, I>
                 .await;
                 let consensus = self.consensus.read().await;
                 consensus.metrics.number_of_timeouts.add(1);
+                if self.quorum_membership.leader(view) == self.public_key {
+                    consensus.metrics.number_of_timeouts_as_leader.add(1);
+                }
             }
             #[cfg(not(feature = "dependency-tasks"))]
             HotShotEvent::SendPayloadCommitmentAndMetadata(

--- a/crates/task-impls/src/consensus/view_change.rs
+++ b/crates/task-impls/src/consensus/view_change.rs
@@ -4,10 +4,10 @@ use anyhow::{ensure, Result};
 use async_broadcast::Sender;
 use async_compatibility_layer::art::{async_sleep, async_spawn};
 use async_lock::{RwLock, RwLockUpgradableReadGuard};
-use chrono::Utc;
-use core::time::Duration;
 #[cfg(async_executor_impl = "async-std")]
 use async_std::task::JoinHandle;
+use chrono::Utc;
+use core::time::Duration;
 use hotshot_types::{
     consensus::Consensus,
     event::{Event, EventType},

--- a/crates/task-impls/src/consensus2/handlers.rs
+++ b/crates/task-impls/src/consensus2/handlers.rs
@@ -3,6 +3,7 @@ use std::{sync::Arc, time::Duration};
 use anyhow::{ensure, Context, Result};
 use async_broadcast::Sender;
 use async_compatibility_layer::art::{async_sleep, async_spawn};
+use chrono::Utc;
 use hotshot_types::{
     event::{Event, EventType},
     simple_certificate::{QuorumCertificate, TimeoutCertificate},
@@ -162,6 +163,15 @@ pub(crate) async fn handle_view_change<TYPES: NodeType, I: NodeImplementation<TY
         .metrics
         .current_view
         .set(usize::try_from(task_state.cur_view.u64()).unwrap());
+    let cur_view_time = Utc::now().timestamp();
+    if task_state.quorum_membership.leader(old_view_number) == task_state.public_key {
+        #[allow(clippy::cast_precision_loss)]
+        consensus
+            .metrics
+            .view_duration_as_leader
+            .add_point((cur_view_time - task_state.cur_view_time) as f64);
+    }
+    task_state.cur_view_time = cur_view_time;
 
     // Do the comparison before the subtraction to avoid potential overflow, since
     // `last_decided_view` may be greater than `cur_view` if the node is catching up.
@@ -244,6 +254,15 @@ pub(crate) async fn handle_timeout<TYPES: NodeType, I: NodeImplementation<TYPES>
         .metrics
         .number_of_timeouts
         .add(1);
+    if task_state.quorum_membership.leader(view_number) == task_state.public_key {
+        task_state
+            .consensus
+            .read()
+            .await
+            .metrics
+            .number_of_timeouts_as_leader
+            .add(1);
+    }
 
     Ok(())
 }

--- a/crates/task-impls/src/consensus2/mod.rs
+++ b/crates/task-impls/src/consensus2/mod.rs
@@ -73,6 +73,9 @@ pub struct Consensus2TaskState<TYPES: NodeType, I: NodeImplementation<TYPES>> {
     /// The view number that this node is currently executing in.
     pub cur_view: TYPES::Time,
 
+    /// Timestamp this view starts at.
+    pub cur_view_time: i64,
+
     /// Output events to application
     pub output_event_stream: async_broadcast::Sender<Event<TYPES>>,
 

--- a/crates/task-impls/src/quorum_proposal_recv/handlers.rs
+++ b/crates/task-impls/src/quorum_proposal_recv/handlers.rs
@@ -130,6 +130,7 @@ pub(crate) async fn handle_quorum_proposal_recv<TYPES: NodeType, I: NodeImplemen
     task_state: &mut QuorumProposalRecvTaskState<TYPES, I>,
 ) -> Result<Option<QuorumProposal<TYPES>>> {
     let sender = sender.clone();
+    let cur_view = task_state.cur_view;
 
     validate_proposal_view_and_certs(
         proposal,
@@ -157,9 +158,11 @@ pub(crate) async fn handle_quorum_proposal_recv<TYPES: NodeType, I: NodeImplemen
         task_state.timeout,
         Arc::clone(&task_state.consensus),
         &mut task_state.cur_view,
+        &mut task_state.cur_view_time,
         &mut task_state.timeout_task,
         &task_state.output_event_stream,
         SEND_VIEW_CHANGE_EVENT,
+        task_state.quorum_membership.leader(cur_view) == task_state.public_key,
     )
     .await
     {

--- a/crates/task-impls/src/quorum_proposal_recv/mod.rs
+++ b/crates/task-impls/src/quorum_proposal_recv/mod.rs
@@ -50,6 +50,9 @@ pub struct QuorumProposalRecvTaskState<TYPES: NodeType, I: NodeImplementation<TY
     /// View number this view is executing in.
     pub cur_view: TYPES::Time,
 
+    /// Timestamp this view starts at.
+    pub cur_view_time: i64,
+
     /// Network for all nodes
     pub quorum_network: Arc<I::QuorumNetwork>,
 

--- a/crates/types/src/consensus.rs
+++ b/crates/types/src/consensus.rs
@@ -107,6 +107,8 @@ pub struct ConsensusMetricsValue {
     pub number_of_views_since_last_decide: Box<dyn Gauge>,
     /// Number of views that are in-flight since the last anchor view
     pub number_of_views_per_decide_event: Box<dyn Histogram>,
+    /// Duration of views as leader
+    pub view_duration_as_leader: Box<dyn Histogram>,
     /// Number of invalid QCs we've seen since the last commit.
     pub invalid_qc: Box<dyn Gauge>,
     /// Number of outstanding transactions
@@ -115,6 +117,8 @@ pub struct ConsensusMetricsValue {
     pub outstanding_transactions_memory_size: Box<dyn Gauge>,
     /// Number of views that timed out
     pub number_of_timeouts: Box<dyn Counter>,
+    /// Number of views that timed out as leader
+    pub number_of_timeouts_as_leader: Box<dyn Counter>,
     /// The number of empty blocks that have been proposed
     pub number_of_empty_blocks_proposed: Box<dyn Counter>,
 }
@@ -133,12 +137,16 @@ impl ConsensusMetricsValue {
                 .create_gauge(String::from("number_of_views_since_last_decide"), None),
             number_of_views_per_decide_event: metrics
                 .create_histogram(String::from("number_of_views_per_decide_event"), None),
+            view_duration_as_leader: metrics
+                .create_histogram(String::from("view_duration_as_leader"), None),
             invalid_qc: metrics.create_gauge(String::from("invalid_qc"), None),
             outstanding_transactions: metrics
                 .create_gauge(String::from("outstanding_transactions"), None),
             outstanding_transactions_memory_size: metrics
                 .create_gauge(String::from("outstanding_transactions_memory_size"), None),
             number_of_timeouts: metrics.create_counter(String::from("number_of_timeouts"), None),
+            number_of_timeouts_as_leader: metrics
+                .create_counter(String::from("number_of_timeouts_as_leader"), None),
             number_of_empty_blocks_proposed: metrics
                 .create_counter(String::from("number_of_empty_blocks_proposed"), None),
         }

--- a/crates/types/src/event.rs
+++ b/crates/types/src/event.rs
@@ -123,11 +123,6 @@ pub enum EventType<TYPES: NodeType> {
         /// The view that timed out
         view_number: TYPES::Time,
     },
-    /// A next leader task was canceled by a timeout interrupt
-    NextLeaderViewTimeout {
-        /// The view that timed out
-        view_number: TYPES::Time,
-    },
     /// The view has finished.  If values were decided on, a `Decide` event will also be emitted.
     ViewFinished {
         /// The view number that has just finished


### PR DESCRIPTION
Closes #3222.

### This PR: 
* Adds `view_duration_as_leader` and `number_of_timeouts_as_leader` metrics.
* Adds `cur_view_time` field to the task states, which is needed for the `view_duration_as_leader` metric.
* Updates the `update_view` function to take additional arguments to update `view_duration_as_leader` when being a leader.
* Removes unused `NextLeaderViewTimeout` event.

### This PR does not: 
* Modify existing metrics.

### Key places to review: 
* Whether the metrics are updated correctly in:
  * `crates/task-impls/src/consensus/mod.rs`
  * `crates/task-impls/src/consensus/view_change.rs`
  * `crates/task-impls/src/consensus2/handlers.rs`

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
