### PR TITLE
Fix network task filters

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -41,8 +41,9 @@ jobs:
         name: Enable Rust Caching
         with:
           shared-key: "build-and-test"
-          prefix-key: ${{ matrix.just_variants }}-${{ github.ref }}
+          prefix-key: ${{ matrix.just_variants }}
           cache-on-failure: "true"
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install Just
         run: |
@@ -118,8 +119,9 @@ jobs:
         name: Enable Rust Caching
         with:
           shared-key: "build-and-test"
-          prefix-key: ${{ matrix.just_variants }}-${{ github.ref }}
+          prefix-key: ${{ matrix.just_variants }}
           cache-on-failure: "true"
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install Just
         run: |
@@ -151,8 +153,9 @@ jobs:
         name: Enable Rust Caching
         with:
           shared-key: "build-and-test"
-          prefix-key: ${{ matrix.just_variants }}-${{ github.ref }}
+          prefix-key: ${{ matrix.just_variants }}
           cache-on-failure: "true"
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install Just
         run: |
@@ -194,8 +197,9 @@ jobs:
         name: Enable Rust Caching
         with:
           shared-key: "build-and-test"
-          prefix-key: ${{ matrix.just_variants }}-${{ github.ref }}
+          prefix-key: ${{ matrix.just_variants }}
           cache-on-failure: "true"
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Build examples in release mode
         run: just ${{ matrix.just_variants }} build_release --examples --package hotshot-examples --no-default-features

--- a/crates/task-impls/src/network.rs
+++ b/crates/task-impls/src/network.rs
@@ -38,6 +38,8 @@ pub fn quorum_filter<TYPES: NodeType>(event: &Arc<HotShotEvent<TYPES>>) -> bool 
             | HotShotEvent::QuorumVoteSend(_)
             | HotShotEvent::DacSend(_, _)
             | HotShotEvent::TimeoutVoteSend(_)
+            | HotShotEvent::VersionUpgrade(_)
+            | HotShotEvent::ViewChange(_)
     )
 }
 
@@ -45,7 +47,10 @@ pub fn quorum_filter<TYPES: NodeType>(event: &Arc<HotShotEvent<TYPES>>) -> bool 
 pub fn upgrade_filter<TYPES: NodeType>(event: &Arc<HotShotEvent<TYPES>>) -> bool {
     !matches!(
         event.as_ref(),
-        HotShotEvent::UpgradeProposalSend(_, _) | HotShotEvent::UpgradeVoteSend(_)
+        HotShotEvent::UpgradeProposalSend(_, _)
+            | HotShotEvent::UpgradeVoteSend(_)
+            | HotShotEvent::VersionUpgrade(_)
+            | HotShotEvent::ViewChange(_)
     )
 }
 
@@ -53,13 +58,21 @@ pub fn upgrade_filter<TYPES: NodeType>(event: &Arc<HotShotEvent<TYPES>>) -> bool
 pub fn da_filter<TYPES: NodeType>(event: &Arc<HotShotEvent<TYPES>>) -> bool {
     !matches!(
         event.as_ref(),
-        HotShotEvent::DaProposalSend(_, _) | HotShotEvent::DaVoteSend(_)
+        HotShotEvent::DaProposalSend(_, _)
+            | HotShotEvent::DaVoteSend(_)
+            | HotShotEvent::VersionUpgrade(_)
+            | HotShotEvent::ViewChange(_)
     )
 }
 
 /// vid filter
 pub fn vid_filter<TYPES: NodeType>(event: &Arc<HotShotEvent<TYPES>>) -> bool {
-    !matches!(event.as_ref(), HotShotEvent::VidDisperseSend(_, _))
+    !matches!(
+        event.as_ref(),
+        HotShotEvent::VidDisperseSend(_, _)
+            | HotShotEvent::VersionUpgrade(_)
+            | HotShotEvent::ViewChange(_)
+    )
 }
 
 /// view sync filter
@@ -72,6 +85,8 @@ pub fn view_sync_filter<TYPES: NodeType>(event: &Arc<HotShotEvent<TYPES>>) -> bo
             | HotShotEvent::ViewSyncPreCommitVoteSend(_)
             | HotShotEvent::ViewSyncCommitVoteSend(_)
             | HotShotEvent::ViewSyncFinalizeVoteSend(_)
+            | HotShotEvent::VersionUpgrade(_)
+            | HotShotEvent::ViewChange(_)
     )
 }
 /// the network message task state

--- a/crates/task-impls/src/response.rs
+++ b/crates/task-impls/src/response.rs
@@ -1,5 +1,4 @@
-use std::sync::Arc;
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 
 use async_broadcast::Receiver;
 use async_compatibility_layer::art::{async_sleep, async_spawn};


### PR DESCRIPTION
No linked issue.

### This PR: 
Some of the events allowed through the network task filters were inadvertently removed in #3133. This PR fixes that.

CI appears to be randomly canceling, so I'm lumping in a revert of the workflow changes from that PR at the same time.

### This PR does not: 

### Key places to review: 
