### PR TITLE
Add SimpleBuilderConfig w/ default impl

### DIFF
--- a/crates/examples/infra/mod.rs
+++ b/crates/examples/infra/mod.rs
@@ -43,7 +43,8 @@ use hotshot_orchestrator::{
     },
 };
 use hotshot_testing::block_builder::{
-    RandomBuilderImplementation, SimpleBuilderImplementation, TestBuilderImplementation,
+    RandomBuilderImplementation, SimpleBuilderConfig, SimpleBuilderImplementation,
+    TestBuilderImplementation,
 };
 use hotshot_types::{
     consensus::ConsensusMetricsValue,
@@ -939,7 +940,7 @@ pub async fn main_entry_point<
             let (builder_task, builder_url) =
                 <SimpleBuilderImplementation as TestBuilderImplementation<TYPES>>::start(
                     run_config.config.num_nodes_with_stake.into(),
-                    (),
+                    SimpleBuilderConfig::default(),
                 )
                 .await;
 

--- a/crates/testing/src/block_builder.rs
+++ b/crates/testing/src/block_builder.rs
@@ -70,6 +70,19 @@ where
     }
 }
 
+/// Configuration for `SimpleBuilder`
+pub struct SimpleBuilderConfig {
+    port: u16,
+}
+
+impl Default for SimpleBuilderConfig {
+    fn default() -> Self {
+        Self {
+            port: portpicker::pick_unused_port().expect("No free ports"),
+        }
+    }
+}
+
 pub struct SimpleBuilderImplementation;
 
 #[async_trait]
@@ -77,14 +90,13 @@ impl<TYPES: NodeType> TestBuilderImplementation<TYPES> for SimpleBuilderImplemen
 where
     <TYPES as NodeType>::InstanceState: Default,
 {
-    type Config = ();
+    type Config = SimpleBuilderConfig;
 
     async fn start(
         num_storage_nodes: usize,
-        _config: Self::Config,
+        config: Self::Config,
     ) -> (Option<Box<dyn BuilderTask<TYPES>>>, Url) {
-        let port = portpicker::pick_unused_port().expect("No free ports");
-        let url = Url::parse(&format!("http://localhost:{port}")).expect("Valid URL");
+        let url = Url::parse(&format!("http://localhost:{0}", config.port)).expect("Valid URL");
         let (source, task) = make_simple_builder(num_storage_nodes).await;
 
         let builder_api = hotshot_builder_api::builder::define_api::<


### PR DESCRIPTION
Add SimpleBuilderConfig w/ default impl
-------

Resolves EspressoSystems/espresso-sequencer/issues/1522

### This PR: 
Enables config file for `SimpleBuilder` in order to pass in a port. This is needed by espresso-dev-node in order for use in integration test scenarios w/ a known builder url. A test using `SimpleBuilder` was also modified to support this change.