### PR TITLE
Minor test fixes

### DIFF
--- a/crates/hotshot/src/lib.rs
+++ b/crates/hotshot/src/lib.rs
@@ -194,7 +194,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> SystemContext<TYPES, I> {
     /// To do a full initialization, use `fn init` instead, which will set up background tasks as
     /// well.
     #[allow(clippy::too_many_arguments)]
-    #[instrument(skip(private_key, memberships, networks, initializer, metrics, storage))]
+    #[instrument(skip_all)]
     pub async fn new(
         public_key: TYPES::SignatureKey,
         private_key: <TYPES::SignatureKey as SignatureKey>::PrivateKey,
@@ -206,7 +206,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> SystemContext<TYPES, I> {
         metrics: ConsensusMetricsValue,
         storage: I::Storage,
     ) -> Result<Arc<Self>, HotShotError<TYPES>> {
-        debug!("Creating a new hotshot");
+        trace!("Creating a new instance of hotshot");
 
         let consensus_metrics = Arc::new(metrics);
         let anchored_leaf = initializer.inner;

--- a/crates/hotshot/src/tasks/mod.rs
+++ b/crates/hotshot/src/tasks/mod.rs
@@ -19,13 +19,11 @@ use hotshot_task_impls::{
     vid::VidTaskState,
     view_sync::ViewSyncTaskState,
 };
-
 #[cfg(feature = "dependency-tasks")]
 use hotshot_task_impls::{
     consensus2::Consensus2TaskState, quorum_proposal::QuorumProposalTaskState,
     quorum_proposal_recv::QuorumProposalRecvTaskState, quorum_vote::QuorumVoteTaskState,
 };
-
 use hotshot_types::{
     constants::{Version01, VERSION_0_1},
     message::{Message, Messages},

--- a/crates/hotshot/src/tasks/task_state.rs
+++ b/crates/hotshot/src/tasks/task_state.rs
@@ -4,7 +4,6 @@ use std::{
     sync::{atomic::AtomicBool, Arc},
 };
 
-use crate::types::SystemContextHandle;
 use async_trait::async_trait;
 use chrono::Utc;
 use hotshot_task_impls::{
@@ -19,6 +18,8 @@ use hotshot_types::traits::{
     node_implementation::{ConsensusTime, NodeImplementation, NodeType},
 };
 use vbs::version::StaticVersionType;
+
+use crate::types::SystemContextHandle;
 
 /// Trait for creating task states.
 #[async_trait]

--- a/crates/hotshot/src/traits/networking/memory_network.rs
+++ b/crates/hotshot/src/traits/networking/memory_network.rs
@@ -142,7 +142,6 @@ impl<M: NetworkMsg, K: SignatureKey> MemoryNetwork<M, K> {
                             warn!(?e, "Failed to decode incoming message, skipping");
                         }
                     }
-                    warn!("Stream shutdown");
                 }
             }
             .instrument(info_span!("MemoryNetwork Background task", map = ?master_map)),

--- a/crates/task-impls/src/consensus/view_change.rs
+++ b/crates/task-impls/src/consensus/view_change.rs
@@ -1,3 +1,4 @@
+use core::time::Duration;
 use std::sync::Arc;
 
 use anyhow::{ensure, Result};
@@ -7,7 +8,6 @@ use async_lock::{RwLock, RwLockUpgradableReadGuard};
 #[cfg(async_executor_impl = "async-std")]
 use async_std::task::JoinHandle;
 use chrono::Utc;
-use core::time::Duration;
 use hotshot_types::{
     consensus::Consensus,
     event::{Event, EventType},

--- a/crates/task-impls/src/quorum_vote.rs
+++ b/crates/task-impls/src/quorum_vote.rs
@@ -1,7 +1,6 @@
-use anyhow::{bail, ensure, Context, Result};
 use std::{collections::HashMap, sync::Arc};
-use vbs::version::Version;
 
+use anyhow::{bail, ensure, Context, Result};
 use async_broadcast::{Receiver, Sender};
 use async_lock::RwLock;
 #[cfg(async_executor_impl = "async-std")]
@@ -35,6 +34,7 @@ use jf_vid::VidScheme;
 #[cfg(async_executor_impl = "tokio")]
 use tokio::task::JoinHandle;
 use tracing::{debug, error, instrument, trace, warn};
+use vbs::version::Version;
 
 use crate::{
     events::HotShotEvent,

--- a/crates/testing/src/overall_safety_task.rs
+++ b/crates/testing/src/overall_safety_task.rs
@@ -222,18 +222,16 @@ impl<TYPES: NodeType, I: TestableNodeImplementation<TYPES>> TestTaskState
             }));
         }
 
-        let failures = self.ctx.failed_views.len() + num_incomplete_views;
-
-        if failures > num_failed_rounds_total {
+        if self.ctx.failed_views.len() + num_incomplete_views > num_failed_rounds_total {
             return TestResult::Fail(Box::new(OverallSafetyTaskErr::<TYPES>::TooManyFailures {
                 failed_views: self.ctx.failed_views.clone(),
             }));
         }
 
-        if failures < num_failed_rounds_total {
+        if self.ctx.failed_views.len() < num_failed_rounds_total {
             return TestResult::Fail(Box::new(OverallSafetyTaskErr::<TYPES>::NotEnoughFailures {
                 expected: num_failed_rounds_total,
-                actual: failures,
+                actual: self.ctx.failed_views.len(),
             }));
         }
         TestResult::Pass

--- a/crates/testing/src/overall_safety_task.rs
+++ b/crates/testing/src/overall_safety_task.rs
@@ -66,7 +66,11 @@ pub enum OverallSafetyTaskErr<TYPES: NodeType> {
     /// mismatched blocks for a view
     InconsistentBlocks,
     /// not enough failures. this likely means there is an issue in the test
-    NotEnoughFailures { expected: usize, actual: usize },
+    NotEnoughFailures {
+        expected: usize,
+
+        failed_views: HashSet<TYPES::Time>,
+    },
 }
 
 /// Data availability task state
@@ -231,7 +235,7 @@ impl<TYPES: NodeType, I: TestableNodeImplementation<TYPES>> TestTaskState
         if self.ctx.failed_views.len() < num_failed_rounds_total {
             return TestResult::Fail(Box::new(OverallSafetyTaskErr::<TYPES>::NotEnoughFailures {
                 expected: num_failed_rounds_total,
-                actual: self.ctx.failed_views.len(),
+                failed_views: self.ctx.failed_views.clone(),
             }));
         }
         TestResult::Pass

--- a/crates/testing/tests/tests_2/catchup.rs
+++ b/crates/testing/tests/tests_2/catchup.rs
@@ -46,7 +46,7 @@ async fn test_catchup() {
     metadata.overall_safety_properties = OverallSafetyPropertiesDescription {
         // Make sure we keep committing rounds after the catchup, but not the full 50.
         num_successful_views: 22,
-        num_failed_views: 5,
+        num_failed_views: 0,
         ..Default::default()
     };
 
@@ -99,7 +99,7 @@ async fn test_catchup_cdn() {
             },
         );
     metadata.overall_safety_properties = OverallSafetyPropertiesDescription {
-        num_failed_views: 5,
+        num_failed_views: 0,
         ..Default::default()
     };
 
@@ -154,7 +154,7 @@ async fn test_catchup_one_node() {
     metadata.overall_safety_properties = OverallSafetyPropertiesDescription {
         // Make sure we keep committing rounds after the catchup, but not the full 50.
         num_successful_views: 22,
-        num_failed_views: 2,
+        num_failed_views: 0,
         ..Default::default()
     };
 
@@ -215,7 +215,7 @@ async fn test_catchup_in_view_sync() {
             },
         );
     metadata.overall_safety_properties = OverallSafetyPropertiesDescription {
-        num_failed_views: 5,
+        num_failed_views: 0,
         ..Default::default()
     };
 

--- a/crates/testing/tests/tests_2/push_cdn.rs
+++ b/crates/testing/tests/tests_2/push_cdn.rs
@@ -26,7 +26,7 @@ async fn push_cdn_network() {
             ..Default::default()
         },
         overall_safety_properties: OverallSafetyPropertiesDescription {
-            num_failed_views: 33,
+            num_failed_views: 0,
             num_successful_views: 35,
             ..Default::default()
         },

--- a/crates/testing/tests/tests_2/test_with_failures_one.rs
+++ b/crates/testing/tests/tests_2/test_with_failures_one.rs
@@ -31,7 +31,7 @@ cross_tests!(
         metadata.spinning_properties = SpinningTaskDescription {
             node_changes: vec![(5, dead_nodes)]
         };
-        metadata.overall_safety_properties.num_failed_views = 3;
+        metadata.overall_safety_properties.num_failed_views = 1;
         metadata.overall_safety_properties.num_successful_views = 25;
         metadata
     }

--- a/crates/testing/tests/tests_4/test_with_failures_f.rs
+++ b/crates/testing/tests/tests_4/test_with_failures_f.rs
@@ -15,7 +15,6 @@ cross_tests!(
     Types: [TestTypes],
     Ignore: false,
     Metadata: {
-
         let mut metadata = TestDescription::default_more_nodes();
         metadata.overall_safety_properties.num_failed_views = 6;
         // Make sure we keep committing rounds after the bad leaders, but not the full 50 because of the numerous timeouts

--- a/crates/testing/tests/tests_4/test_with_failures_f.rs
+++ b/crates/testing/tests/tests_4/test_with_failures_f.rs
@@ -16,7 +16,7 @@ cross_tests!(
     Ignore: false,
     Metadata: {
         let mut metadata = TestDescription::default_more_nodes();
-        metadata.overall_safety_properties.num_failed_views = 6;
+        metadata.overall_safety_properties.num_failed_views = 5;
         // Make sure we keep committing rounds after the bad leaders, but not the full 50 because of the numerous timeouts
         metadata.overall_safety_properties.num_successful_views = 22;
         metadata.num_bootstrap_nodes = 14;

--- a/crates/testing/tests/tests_5/combined_network.rs
+++ b/crates/testing/tests/tests_5/combined_network.rs
@@ -30,7 +30,7 @@ async fn test_combined_network() {
             ..Default::default()
         },
         overall_safety_properties: OverallSafetyPropertiesDescription {
-            num_failed_views: 33,
+            num_failed_views: 0,
             num_successful_views: 25,
             ..Default::default()
         },
@@ -63,7 +63,7 @@ async fn test_combined_network_cdn_crash() {
             ..Default::default()
         },
         overall_safety_properties: OverallSafetyPropertiesDescription {
-            num_failed_views: 33,
+            num_failed_views: 0,
             num_successful_views: 35,
             ..Default::default()
         },
@@ -112,7 +112,7 @@ async fn test_combined_network_reup() {
             ..Default::default()
         },
         overall_safety_properties: OverallSafetyPropertiesDescription {
-            num_failed_views: 33,
+            num_failed_views: 0,
             num_successful_views: 35,
             ..Default::default()
         },
@@ -165,7 +165,7 @@ async fn test_combined_network_half_dc() {
             ..Default::default()
         },
         overall_safety_properties: OverallSafetyPropertiesDescription {
-            num_failed_views: 33,
+            num_failed_views: 0,
             num_successful_views: 35,
             ..Default::default()
         },

--- a/crates/testing/tests/tests_5/timeout.rs
+++ b/crates/testing/tests/tests_5/timeout.rs
@@ -34,7 +34,7 @@ async fn test_timeout() {
     metadata.timing_data = timing_data;
 
     metadata.overall_safety_properties = OverallSafetyPropertiesDescription {
-        num_failed_views: 25,
+        num_failed_views: 3,
         num_successful_views: 25,
         ..Default::default()
     };

--- a/crates/testing/tests/tests_5/unreliable_network.rs
+++ b/crates/testing/tests/tests_5/unreliable_network.rs
@@ -222,7 +222,7 @@ async fn libp2p_network_partially_sync() {
     async_compatibility_layer::logging::setup_backtrace();
     let metadata = TestDescription {
         overall_safety_properties: OverallSafetyPropertiesDescription {
-            num_failed_views: 2,
+            num_failed_views: 0,
             ..Default::default()
         },
         completion_task_description: CompletionTaskDescription::TimeBasedCompletionTaskBuilder(

--- a/crates/testing/tests/tests_5/unreliable_network.rs
+++ b/crates/testing/tests/tests_5/unreliable_network.rs
@@ -178,7 +178,7 @@ async fn test_memory_network_partially_sync() {
     async_compatibility_layer::logging::setup_backtrace();
     let metadata = TestDescription {
         overall_safety_properties: OverallSafetyPropertiesDescription {
-            num_failed_views: 2,
+            num_failed_views: 0,
             ..Default::default()
         },
         // allow more time to pass in CI


### PR DESCRIPTION
No linked issue.

### This PR: 
Several tests had `num_failed_views` set far too generously, which allowed them to pass when they should not have. This PR fixes that, and causes integration tests to fail we do not fail exactly `num_failed_views` views.

### This PR does not: 

### Key places to review: 
