### PR TITLE
[CATCHUP] Add Types for Proposal Fetching

### DIFF
--- a/crates/task-impls/src/events.rs
+++ b/crates/task-impls/src/events.rs
@@ -64,6 +64,8 @@ pub enum HotShotEvent<TYPES: NodeType> {
     QuorumVoteDependenciesValidated(TYPES::Time),
     /// A quorum proposal with the given parent leaf is validated.
     QuorumProposalValidated(QuorumProposal<TYPES>, Leaf<TYPES>),
+    /// A quorum proposal is missing for a view that we meed
+    QuorumProposalMissing(TYPES::Time),
     /// Send a DA proposal to the DA committee; emitted by the DA leader (which is the same node as the leader of view v + 1) in the DA task
     DaProposalSend(Proposal<TYPES, DaProposal<TYPES>>, TYPES::SignatureKey),
     /// Send a DA vote to the DA leader; emitted by DA committee members in the DA task after seeing a valid DA proposal

--- a/crates/task-impls/src/request.rs
+++ b/crates/task-impls/src/request.rs
@@ -115,6 +115,15 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, Ver: StaticVersionType + 'st
                 }
                 Ok(())
             }
+            HotShotEvent::QuorumProposalMissing(view) => {
+                self.run_delay(
+                    RequestKind::Proposal(*view),
+                    sender.clone(),
+                    *view,
+                    Ver::instance(),
+                );
+                Ok(())
+            }
             _ => Ok(()),
         }
     }
@@ -181,6 +190,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, Ver: StaticVersionType + 'st
             .whole_committee(view)
             .into_iter()
             .collect();
+        let leader = self.da_membership.leader(view);
         // Randomize the recipients so all replicas don't overload the same 1 recipients
         // and so we don't implicitly rely on the same replica all the time.
         recipients.shuffle(&mut thread_rng());
@@ -190,6 +200,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, Ver: StaticVersionType + 'st
             sender,
             delay: self.delay,
             recipients,
+            leader,
             shutdown_flag: Arc::clone(&self.shutdown_flag),
         };
         let Ok(data) = Serializer::<Ver>::serialize(&request) else {
@@ -202,7 +213,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, Ver: StaticVersionType + 'st
             return;
         };
         debug!("Requesting data: {:?}", request);
-        let handle = async_spawn(requester.run::<Ver>(request, signature));
+        let handle = async_spawn(requester.run::<Ver>(request, signature, self.public_key.clone()));
 
         self.spawned_tasks.entry(view).or_default().push(handle);
     }
@@ -227,12 +238,15 @@ struct DelayedRequester<TYPES: NodeType, I: NodeImplementation<TYPES>> {
     delay: Duration,
     /// The peers we will request in a random order
     recipients: Vec<TYPES::SignatureKey>,
+    /// Leader for the view of the request
+    leader: TYPES::SignatureKey,
     /// A flag indicating that `HotShotEvent::Shutdown` has been received
     shutdown_flag: Arc<AtomicBool>,
 }
 
 /// Wrapper for the info in a VID request
 struct VidRequest<TYPES: NodeType>(TYPES::Time, TYPES::SignatureKey);
+struct ProposalRequest<TYPES: NodeType>(TYPES::Time, TYPES::SignatureKey);
 
 impl<TYPES: NodeType, I: NodeImplementation<TYPES>> DelayedRequester<TYPES, I> {
     /// Wait the delay, then try to complete the request.  Iterates over peers
@@ -241,19 +255,34 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> DelayedRequester<TYPES, I> {
         self,
         request: RequestKind<TYPES>,
         signature: Signature<TYPES>,
+        pub_key: TYPES::SignatureKey,
     ) {
-        // Do the delay only if primary is up and then start sending
-        if !self.network.is_primary_down() {
-            async_sleep(self.delay).await;
-        }
         match request {
             RequestKind::Vid(view, key) => {
+                // Do the delay only if primary is up and then start sending
+                if !self.network.is_primary_down() {
+                    async_sleep(self.delay).await;
+                }
                 self.do_vid::<Ver>(VidRequest(view, key), signature).await;
+            }
+            RequestKind::Proposal(view) => {
+                self.do_proposal::<Ver>(ProposalRequest(view, pub_key), signature)
+                    .await;
             }
             RequestKind::DaProposal(..) => {}
         }
     }
-
+    async fn do_proposal<Ver: StaticVersionType + 'static>(
+        &self,
+        req: ProposalRequest<TYPES>,
+        signature: Signature<TYPES>,
+    ) {
+        self.network.request_data::<TYPES, Ver>(
+            make_proposal_req(&req, signature),
+            &self.leader,
+            Ver::instance(),
+        );
+    }
     /// Handle sending a VID Share request, runs the loop until the data exists
     async fn do_vid<Ver: StaticVersionType + 'static>(
         &self,
@@ -333,6 +362,22 @@ fn make_vid<TYPES: NodeType>(
     };
     Message {
         sender: req.1.clone(),
+        kind: MessageKind::Data(DataMessage::RequestData(data_request)),
+    }
+}
+
+fn make_proposal_req<TYPES: NodeType>(
+    req: &ProposalRequest<TYPES>,
+    signature: Signature<TYPES>,
+) -> Message<TYPES> {
+    let kind = RequestKind::Proposal(req.0);
+    let data_request = DataRequest {
+        view: req.0,
+        request: kind,
+        signature,
+    };
+    Message {
+        sender: req.1,
         kind: MessageKind::Data(DataMessage::RequestData(data_request)),
     }
 }

--- a/crates/task-impls/src/response.rs
+++ b/crates/task-impls/src/response.rs
@@ -182,6 +182,7 @@ impl<TYPES: NodeType> NetworkResponseState<TYPES> {
             }
             // TODO impl for DA Proposal: https://github.com/EspressoSystems/HotShot/issues/2651
             RequestKind::DaProposal(_view) => self.make_msg(ResponseMessage::NotFound),
+            RequestKind::Proposal(view) => self.make_msg(self.respond_with_proposal(view).await),
         }
     }
 
@@ -196,6 +197,12 @@ impl<TYPES: NodeType> NetworkResponseState<TYPES> {
     /// Makes sure the sender is allowed to send a request.
     fn valid_sender(&self, sender: &TYPES::SignatureKey) -> bool {
         self.quorum.has_stake(sender)
+    }
+    /// Lookup the proposal for the view and respond if it's found/not found
+    async fn respond_with_proposal(&self, _view: TYPES::Time) -> ResponseMessage<TYPES> {
+        // Complete after we are storing our last proposed view:
+        // https://github.com/EspressoSystems/HotShot/issues/3240
+        todo!();
     }
 }
 

--- a/crates/task-impls/src/response.rs
+++ b/crates/task-impls/src/response.rs
@@ -202,6 +202,7 @@ impl<TYPES: NodeType> NetworkResponseState<TYPES> {
     async fn respond_with_proposal(&self, _view: TYPES::Time) -> ResponseMessage<TYPES> {
         // Complete after we are storing our last proposed view:
         // https://github.com/EspressoSystems/HotShot/issues/3240
+        async {}.await;
         todo!();
     }
 }

--- a/crates/types/src/traits/network.rs
+++ b/crates/types/src/traits/network.rs
@@ -210,6 +210,8 @@ pub enum RequestKind<TYPES: NodeType> {
     Vid(TYPES::Time, TYPES::SignatureKey),
     /// Request a DA proposal for a certain view
     DaProposal(TYPES::Time),
+    /// Request for quorum proposal for a view
+    Proposal(TYPES::Time),
 }
 
 /// A response for a request.  `SequencingMessage` is the same as other network messages


### PR DESCRIPTION
Closes: https://github.com/EspressoSystems/HotShot/issues/3237
<!-- See here for keywords in Github -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

### This PR: 

Adds the types to request a proposal we are missing as well as the logic in the request task to send the request out.
We can't yet handle the response because we aren't storing the proposals locally yet.  

### This PR does not: 

Doesn't actually trigger the catch-up

### Key places to review: 

The request task

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
