### PR TITLE
Add Rewind Task for Replaying All Node Events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@
 config/ValidatorConfigOutput
 scripts/preserve_ci_ecs_benchmarks.sh
 **/*.bin
+*.log

--- a/crates/hotshot/Cargo.toml
+++ b/crates/hotshot/Cargo.toml
@@ -12,6 +12,7 @@ default = ["docs", "doc-images"]
 example-upgrade = ["hotshot-task-impls/example-upgrade"]
 gpu-vid = ["hotshot-task-impls/gpu-vid"]
 dependency-tasks = ["hotshot-task-impls/dependency-tasks"]
+rewind = ["hotshot-task-impls/rewind"]
 
 # Features required for binaries
 bin-orchestrator = ["clap"]
@@ -73,7 +74,10 @@ cdn-broker = { workspace = true, features = [
   "runtime-async-std",
   "global-permits",
 ] }
-cdn-marshal = { workspace = true, features = ["runtime-async-std", "global-permits"] }
+cdn-marshal = { workspace = true, features = [
+  "runtime-async-std",
+  "global-permits",
+] }
 
 
 [dev-dependencies]

--- a/crates/hotshot/src/lib.rs
+++ b/crates/hotshot/src/lib.rs
@@ -306,9 +306,6 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> SystemContext<TYPES, I> {
         #[cfg(feature = "dependncy-tasks")]
         error!("HotShot is running with the dependency tasks feature enabled!!");
 
-        #[cfg(all(feature = "rewind", not(debug_assertions)))]
-        compile_error!("Cannot run rewind in production builds!");
-
         debug!("Starting Consensus");
         let consensus = self.consensus.read().await;
 

--- a/crates/hotshot/src/lib.rs
+++ b/crates/hotshot/src/lib.rs
@@ -306,6 +306,9 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> SystemContext<TYPES, I> {
         #[cfg(feature = "dependncy-tasks")]
         error!("HotShot is running with the dependency tasks feature enabled!!");
 
+        #[cfg(all(feature = "rewind", not(debug_assertions)))]
+        compile_error!("Cannot run rewind in production builds!");
+
         debug!("Starting Consensus");
         let consensus = self.consensus.read().await;
 

--- a/crates/hotshot/src/lib.rs
+++ b/crates/hotshot/src/lib.rs
@@ -307,7 +307,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> SystemContext<TYPES, I> {
         error!("HotShot is running with the dependency tasks feature enabled!!");
 
         #[cfg(all(feature = "rewind", not(debug_assertions)))]
-        panic!("Cannot run rewind in production builds!");
+        compile_error!("Cannot run rewind in production builds!");
 
         debug!("Starting Consensus");
         let consensus = self.consensus.read().await;

--- a/crates/hotshot/src/lib.rs
+++ b/crates/hotshot/src/lib.rs
@@ -305,6 +305,10 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> SystemContext<TYPES, I> {
     pub async fn start_consensus(&self) {
         #[cfg(feature = "dependncy-tasks")]
         error!("HotShot is running with the dependency tasks feature enabled!!");
+
+        #[cfg(all(feature = "rewind", not(debug_assertions)))]
+        panic!("Cannot run rewind in production builds!");
+
         debug!("Starting Consensus");
         let consensus = self.consensus.read().await;
 

--- a/crates/hotshot/src/tasks/mod.rs
+++ b/crates/hotshot/src/tasks/mod.rs
@@ -7,6 +7,8 @@ use std::{sync::Arc, time::Duration};
 
 use async_compatibility_layer::art::{async_sleep, async_spawn};
 use hotshot_task::task::Task;
+#[cfg(feature = "rewind")]
+use hotshot_task_impls::rewind::RewindTaskState;
 use hotshot_task_impls::{
     consensus::ConsensusTaskState,
     da::DaTaskState,
@@ -168,4 +170,7 @@ pub async fn add_consensus_tasks<
         handle.add_task(QuorumProposalRecvTaskState::<TYPES, I>::create_from(handle).await);
         handle.add_task(Consensus2TaskState::<TYPES, I>::create_from(handle).await);
     }
+
+    #[cfg(feature = "rewind")]
+    handle.add_task(RewindTaskState::<TYPES>::create_from(&handle).await);
 }

--- a/crates/hotshot/src/tasks/task_state.rs
+++ b/crates/hotshot/src/tasks/task_state.rs
@@ -7,6 +7,8 @@ use std::{
 use crate::types::SystemContextHandle;
 use async_trait::async_trait;
 use chrono::Utc;
+#[cfg(feature = "rewind")]
+use hotshot_task_impls::rewind::RewindTaskState;
 use hotshot_task_impls::{
     builder::BuilderClient, consensus::ConsensusTaskState, consensus2::Consensus2TaskState,
     da::DaTaskState, quorum_proposal::QuorumProposalTaskState,
@@ -329,6 +331,20 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> CreateTaskState<TYPES, I>
             timeout: handle.hotshot.config.next_view_timeout,
             consensus,
             last_decided_view: handle.cur_view().await,
+            id: handle.hotshot.id,
+        }
+    }
+}
+
+#[cfg(feature = "rewind")]
+#[async_trait]
+impl<TYPES: NodeType, I: NodeImplementation<TYPES>> CreateTaskState<TYPES, I>
+    for RewindTaskState<TYPES>
+{
+    async fn create_from(handle: &SystemContextHandle<TYPES, I>) -> RewindTaskState<TYPES> {
+        eprintln!("Creating handle id {}", handle.hotshot.id);
+        RewindTaskState {
+            events: Vec::new(),
             id: handle.hotshot.id,
         }
     }

--- a/crates/hotshot/src/tasks/task_state.rs
+++ b/crates/hotshot/src/tasks/task_state.rs
@@ -342,7 +342,6 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> CreateTaskState<TYPES, I>
     for RewindTaskState<TYPES>
 {
     async fn create_from(handle: &SystemContextHandle<TYPES, I>) -> RewindTaskState<TYPES> {
-        eprintln!("Creating handle id {}", handle.hotshot.id);
         RewindTaskState {
             events: Vec::new(),
             id: handle.hotshot.id,

--- a/crates/task-impls/Cargo.toml
+++ b/crates/task-impls/Cargo.toml
@@ -9,6 +9,7 @@ version = { workspace = true }
 example-upgrade = []
 gpu-vid = ["hotshot-types/gpu-vid"]
 dependency-tasks = []
+rewind = []
 
 [dependencies]
 anyhow = { workspace = true }

--- a/crates/task-impls/src/events.rs
+++ b/crates/task-impls/src/events.rs
@@ -187,6 +187,7 @@ pub enum HotShotEvent<TYPES: NodeType> {
 }
 
 impl<TYPES: NodeType> Display for HotShotEvent<TYPES> {
+    #[allow(clippy::too_many_lines)]
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             HotShotEvent::Shutdown => write!(f, "Shutdown"),
@@ -357,7 +358,7 @@ impl<TYPES: NodeType> Display for HotShotEvent<TYPES> {
             }
             HotShotEvent::LeafDecided(leaves) => {
                 let view_numbers: Vec<<TYPES as NodeType>::Time> =
-                    leaves.iter().map(|leaf| leaf.view_number()).collect();
+                    leaves.iter().map(Leaf::view_number).collect();
                 write!(f, "LeafDecided({view_numbers:?})")
             }
             HotShotEvent::VidDisperseSend(proposal, _) => write!(
@@ -408,19 +409,19 @@ impl<TYPES: NodeType> Display for HotShotEvent<TYPES> {
                 write!(f, "UpgradeDecided(view_number{:?})", cert.view_number())
             }
             HotShotEvent::QuorumProposalMissing(view_number) => {
-                write!(f, "QuorumProposalMissing(view_number={:?})", view_number)
+                write!(f, "QuorumProposalMissing(view_number={view_number:?})")
             }
             HotShotEvent::VoteNow(view_number, _) => {
-                write!(f, "VoteNow(view_number={:?})", view_number)
+                write!(f, "VoteNow(view_number={view_number:?})")
             }
             HotShotEvent::ValidatedStateUpdated(view_number, _) => {
-                write!(f, "ValidatedStateUpdated(view_number={:?})", view_number)
+                write!(f, "ValidatedStateUpdated(view_number={view_number:?})")
             }
             HotShotEvent::LockedViewUpdated(view_number) => {
-                write!(f, "LockedViewUpdated(view_number={:?})", view_number)
+                write!(f, "LockedViewUpdated(view_number={view_number:?})")
             }
             HotShotEvent::LastDecidedViewUpdated(view_number) => {
-                write!(f, "LastDecidedViewUpdated(view_number={:?})", view_number)
+                write!(f, "LastDecidedViewUpdated(view_number={view_number:?})")
             }
             HotShotEvent::UpdateHighQc(cert) => {
                 write!(f, "UpdateHighQc(view_number={:?})", cert.view_number())

--- a/crates/task-impls/src/events.rs
+++ b/crates/task-impls/src/events.rs
@@ -197,7 +197,7 @@ impl<TYPES: NodeType> Display for HotShotEvent<TYPES> {
                 proposal.data.view_number()
             ),
             HotShotEvent::QuorumVoteRecv(v) => {
-                write!(f, "QuorumVoteRecv(view_number={:?}", v.view_number())
+                write!(f, "QuorumVoteRecv(view_number={:?})", v.view_number())
             }
             HotShotEvent::TimeoutVoteRecv(v) => {
                 write!(f, "TimeoutVoteRecv(view_number={:?})", v.view_number())
@@ -254,7 +254,7 @@ impl<TYPES: NodeType> Display for HotShotEvent<TYPES> {
                 write!(f, "DaVoteSend(view_number={:?})", vote.view_number())
             }
             HotShotEvent::QcFormed(cert) => match cert {
-                either::Left(qc) => write!(f, "QcFormed(view_number={:?}", qc.view_number()),
+                either::Left(qc) => write!(f, "QcFormed(view_number={:?})", qc.view_number()),
                 either::Right(tc) => write!(f, "QcFormed(view_number={:?})", tc.view_number()),
             },
             HotShotEvent::DacSend(cert, _) => {

--- a/crates/task-impls/src/events.rs
+++ b/crates/task-impls/src/events.rs
@@ -46,15 +46,15 @@ pub enum HotShotEvent<TYPES: NodeType> {
     TimeoutVoteRecv(TimeoutVote<TYPES>),
     /// Send a timeout vote to the network; emitted by consensus task replicas
     TimeoutVoteSend(TimeoutVote<TYPES>),
-    /// A Da proposal has been received from the network; handled by the Da task
+    /// A DA proposal has been received from the network; handled by the DA task
     DaProposalRecv(Proposal<TYPES, DaProposal<TYPES>>, TYPES::SignatureKey),
-    /// A Da proposal has been validated; handled by the Da task and VID task
+    /// A DA proposal has been validated; handled by the DA task and VID task
     DaProposalValidated(Proposal<TYPES, DaProposal<TYPES>>, TYPES::SignatureKey),
-    /// A Da vote has been received by the network; handled by the Da task
+    /// A DA vote has been received by the network; handled by the DA task
     DaVoteRecv(DaVote<TYPES>),
-    /// A Data Availability Certificate (Dac) has been recieved by the network; handled by the consensus task
+    /// A Data Availability Certificate (DAC) has been recieved by the network; handled by the consensus task
     DaCertificateRecv(DaCertificate<TYPES>),
-    /// A DaC is validated.
+    /// A DAC is validated.
     DaCertificateValidated(DaCertificate<TYPES>),
     /// Send a quorum proposal to the network; emitted by the leader in the consensus task
     QuorumProposalSend(Proposal<TYPES, QuorumProposal<TYPES>>, TYPES::SignatureKey),
@@ -66,13 +66,13 @@ pub enum HotShotEvent<TYPES: NodeType> {
     QuorumProposalValidated(QuorumProposal<TYPES>, Leaf<TYPES>),
     /// A quorum proposal is missing for a view that we meed
     QuorumProposalMissing(TYPES::Time),
-    /// Send a Da proposal to the Da committee; emitted by the Da leader (which is the same node as the leader of view v + 1) in the Da task
+    /// Send a DA proposal to the DA committee; emitted by the DA leader (which is the same node as the leader of view v + 1) in the DA task
     DaProposalSend(Proposal<TYPES, DaProposal<TYPES>>, TYPES::SignatureKey),
-    /// Send a Da vote to the Da leader; emitted by Da committee members in the Da task after seeing a valid Da proposal
+    /// Send a DA vote to the DA leader; emitted by DA committee members in the DA task after seeing a valid DA proposal
     DaVoteSend(DaVote<TYPES>),
     /// The next leader has collected enough votes to form a QC; emitted by the next leader in the consensus task; an internal event only
     QcFormed(Either<QuorumCertificate<TYPES>, TimeoutCertificate<TYPES>>),
-    /// The Da leader has collected enough votes to form a DaC; emitted by the Da leader in the Da task; sent to the entire network via the networking task
+    /// The DA leader has collected enough votes to form a DAC; emitted by the DA leader in the DA task; sent to the entire network via the networking task
     DacSend(DaCertificate<TYPES>, TYPES::SignatureKey),
     /// The current view has changed; emitted by the replica in the consensus task or replica in the view sync task; received by almost all other tasks
     ViewChange(TYPES::Time),
@@ -115,7 +115,7 @@ pub enum HotShotEvent<TYPES: NodeType> {
     TransactionsRecv(Vec<TYPES::Transaction>),
     /// Send transactions to the network
     TransactionSend(TYPES::Transaction, TYPES::SignatureKey),
-    /// Event to send block payload commitment and metadata from Da leader to the quorum; internal event only
+    /// Event to send block payload commitment and metadata from DA leader to the quorum; internal event only
     SendPayloadCommitmentAndMetadata(
         VidCommitment,
         BuilderCommitment,
@@ -135,7 +135,7 @@ pub enum HotShotEvent<TYPES: NodeType> {
     BlockReady(VidDisperse<TYPES>, TYPES::Time),
     /// Event when consensus decided on a leaf
     LeafDecided(Vec<Leaf<TYPES>>),
-    /// Send VID shares to VID storage nodes; emitted by the Da leader
+    /// Send VID shares to VID storage nodes; emitted by the DA leader
     ///
     /// Like [`HotShotEvent::DaProposalSend`].
     VidDisperseSend(Proposal<TYPES, VidDisperse<TYPES>>, TYPES::SignatureKey),

--- a/crates/task-impls/src/events.rs
+++ b/crates/task-impls/src/events.rs
@@ -52,7 +52,7 @@ pub enum HotShotEvent<TYPES: NodeType> {
     DaProposalValidated(Proposal<TYPES, DaProposal<TYPES>>, TYPES::SignatureKey),
     /// A Da vote has been received by the network; handled by the Da task
     DaVoteRecv(DaVote<TYPES>),
-    /// A Data Availability Certificate (DaC) has been recieved by the network; handled by the consensus task
+    /// A Data Availability Certificate (Dac) has been recieved by the network; handled by the consensus task
     DaCertificateRecv(DaCertificate<TYPES>),
     /// A DaC is validated.
     DaCertificateValidated(DaCertificate<TYPES>),

--- a/crates/task-impls/src/lib.rs
+++ b/crates/task-impls/src/lib.rs
@@ -55,3 +55,6 @@ pub mod quorum_proposal;
 
 /// Task for handling QuorumProposalRecv events
 pub mod quorum_proposal_recv;
+
+#[cfg(feature = "rewind")]
+pub mod rewind;

--- a/crates/task-impls/src/lib.rs
+++ b/crates/task-impls/src/lib.rs
@@ -56,5 +56,6 @@ pub mod quorum_proposal;
 /// Task for handling QuorumProposalRecv events
 pub mod quorum_proposal_recv;
 
+/// Task for storing and replaying all received tasks by a node
 #[cfg(feature = "rewind")]
 pub mod rewind;

--- a/crates/task-impls/src/rewind.rs
+++ b/crates/task-impls/src/rewind.rs
@@ -1,0 +1,69 @@
+use std::sync::Arc;
+
+use anyhow::Result;
+use async_broadcast::{Receiver, Sender};
+use async_trait::async_trait;
+use hotshot_task::task::TaskState;
+use hotshot_types::traits::node_implementation::NodeType;
+use std::fs::OpenOptions;
+use std::io::Write;
+
+use crate::events::HotShotEvent;
+
+/// The task state for the `Rewind` task is used to capture all events received
+/// by a particular node, in the order they've been received.
+pub struct RewindTaskState<TYPES: NodeType> {
+    /// All events received by this node since the beginning of time.
+    pub events: Vec<Arc<HotShotEvent<TYPES>>>,
+
+    /// The id of this node
+    pub id: u64,
+}
+
+impl<TYPES: NodeType> RewindTaskState<TYPES> {
+    /// Handles all events, storing them to the private state
+    pub fn handle(&mut self, event: Arc<HotShotEvent<TYPES>>) {
+        self.events.push(Arc::clone(&event));
+    }
+}
+
+#[async_trait]
+impl<TYPES: NodeType> TaskState for RewindTaskState<TYPES> {
+    type Event = HotShotEvent<TYPES>;
+
+    async fn handle_event(
+        &mut self,
+        event: Arc<Self::Event>,
+        _sender: &Sender<Arc<Self::Event>>,
+        _receiver: &Receiver<Arc<Self::Event>>,
+    ) -> Result<()> {
+        self.handle(event);
+        Ok(())
+    }
+
+    async fn cancel_subtasks(&mut self) {
+        tracing::info!("Node ID {} Recording {} events", self.id, self.events.len());
+        let filename = format!("rewind_{}.log", self.id);
+        let mut file = match OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(&filename)
+        {
+            Ok(file) => file,
+            Err(e) => {
+                tracing::error!("Failed to write file {}; error = {}", filename, e);
+                return;
+            }
+        };
+
+        for (event_number, event) in self.events.iter().enumerate() {
+            // We do not want to die here, so we log and move on capturing as many events as we can.
+            if let Err(e) = writeln!(file, "{event_number}: {event}") {
+                tracing::error!(
+                    "Failed to write event number {event_number} and event {event}; error = {e}"
+                );
+            }
+        }
+    }
+}

--- a/crates/task-impls/src/rewind.rs
+++ b/crates/task-impls/src/rewind.rs
@@ -1,4 +1,3 @@
-use std::collections::VecDeque;
 use std::sync::Arc;
 
 use anyhow::Result;
@@ -11,19 +10,11 @@ use std::io::Write;
 
 use crate::events::HotShotEvent;
 
-#[cfg(not(any(debug_assertions, test)))]
-const REWIND_MAX_DEPTH: usize = 1_000;
-
-/// We want the depth to be huge for tests because we don't care that much about a long-running
-/// memory leak
-#[cfg(any(debug_assertions, test))]
-const REWIND_MAX_DEPTH: usize = 100_000;
-
 /// The task state for the `Rewind` task is used to capture all events received
 /// by a particular node, in the order they've been received.
 pub struct RewindTaskState<TYPES: NodeType> {
     /// All events received by this node since the beginning of time.
-    pub events: VecDeque<Arc<HotShotEvent<TYPES>>>,
+    pub events: Vec<Arc<HotShotEvent<TYPES>>>,
 
     /// The id of this node
     pub id: u64,
@@ -32,10 +23,7 @@ pub struct RewindTaskState<TYPES: NodeType> {
 impl<TYPES: NodeType> RewindTaskState<TYPES> {
     /// Handles all events, storing them to the private state
     pub fn handle(&mut self, event: Arc<HotShotEvent<TYPES>>) {
-        if self.events.len() == REWIND_MAX_DEPTH {
-            self.events.pop_front();
-        }
-        self.events.push_back(Arc::clone(&event));
+        self.events.push(Arc::clone(&event));
     }
 }
 

--- a/crates/testing/Cargo.toml
+++ b/crates/testing/Cargo.toml
@@ -11,6 +11,7 @@ default = []
 slow-tests = []
 gpu-vid = ["hotshot-types/gpu-vid"]
 dependency-tasks = ["hotshot/dependency-tasks"]
+rewind = ["hotshot/rewind"]
 
 [dependencies]
 automod = "1.0.14"

--- a/crates/testing/src/test_runner.rs
+++ b/crates/testing/src/test_runner.rs
@@ -264,16 +264,16 @@ where
             completion_handle.abort();
         }
 
-        assert!(
-            error_list.is_empty(),
-            "TEST FAILED! Results: {error_list:?}"
-        );
-
         let mut nodes = handles.write().await;
 
         for node in &mut *nodes {
             node.handle.shut_down().await;
         }
+
+        assert!(
+            error_list.is_empty(),
+            "TEST FAILED! Results: {error_list:?}"
+        );
     }
 
     /// Add nodes.


### PR DESCRIPTION
No Linked Issue
<!-- See here for keywords in Github -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

### This PR: 
The rewind task gives us the ability to store all events that a node has seen since startup. This is useful for a number of situations including test and deployment debugging.

The rewind task works very simply, it has the following high level structure:
```rust
#[cfg(not(any(debug_assertions, test)))]
const REWIND_MAX_DEPTH: usize = 1_000;

/// We want the depth to be huge for tests because we don't care that much about a long-running
/// memory leak
#[cfg(any(debug_assertions, test))]
const REWIND_MAX_DEPTH: usize = 100_000;

/// The task state for the `Rewind` task is used to capture all events received
/// by a particular node, in the order they've been received.
pub struct RewindTaskState<TYPES: NodeType> {
    /// All events received by this node since the beginning of time.
    pub events: VecDeque<Arc<HotShotEvent<TYPES>>>,

    /// The id of this node
    pub id: u64,
}

impl<TYPES: NodeType> RewindTaskState<TYPES> {
    /// Handles all events, storing them to the private state
    pub fn handle(&mut self, event: Arc<HotShotEvent<TYPES>>) {
        if self.events.len() == REWIND_MAX_DEPTH {
            self.events.pop_front();
        }
        self.events.push_back(Arc::clone(&event));
    }
}
```
We implement a shallow cache for non debug or test deployments (i.e. production) to prevent resource exhaustion on the node. The cache size of 1000 is somewhat arbitrary, but should give us a decently long history of the node's life. The intention here being that by the time a performance or service degradation is detected, we may have missed the sliding window that contains the erroneous events. This allows us to correlate with the logs. I'm open to another number if this one seems too large, however.


With the recent architecture changes, we no longer need to filter, so this task will receive and save every single event that it receives. Once the task shuts down, it will write out all of its events in a way which never panics. 

Future work on this task would be correlating the events with timestamps, and sliding windows for deployments inside of staging to enable engineers debugging to have an easier time discovering issues.

Lastly, this PR implements `Display` for the `HotShotEvent`. In most debugging situations, we are typically only concerned with the view that we're receiving an event for (outside of a few cases such as inspecting the justify qc). The intention with this implementation is to strip back the irrelevant metadata fields that pollute the output. This is especially helpful as the logging is completely untouched, so when debugging and correlating events with the log files, one could still easily check other fields as they're unchanged in the logs.

The format for the rewind output is simple, `<sequence no>: <event>`. An example of this format can be seen here:
```
0: ViewChange(view_number=ViewNumber(0))
1: ValidatedStateUpdated(view_number=ViewNumber(0))
2: QcFormed(view_number=ViewNumber(0)
3: UpdateHighQc(view_number=ViewNumber(0))
4: TransactionsRecv
5: TransactionsRecv
6: TransactionsRecv
7: DaProposalRecv(view_number=ViewNumber(1))
8: TransactionsRecv
9: DaProposalValidated(view_number=ViewNumber(1))
```

### This PR does not: 
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->

### Key places to review: 
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->
- `events.rs`
- `rewind.rs`
- `hotshot/src/lib.rs` --> This one kills the entire HotShot instance if rewind is on in production (i.e. `--release`), this prevents accidental activation.

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->
To run with the rewind task, turn on any test that spawns the hotshot suite (like `test_success`) and enable `--features rewind`. Outputs are usually in `crates/testing/rewind_*.log` where `*` corresponds to the node ID.

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
