### PR TITLE
Bf/proposal fetch

### DIFF
--- a/crates/hotshot/src/lib.rs
+++ b/crates/hotshot/src/lib.rs
@@ -36,9 +36,9 @@ use hotshot_types::{
     constants::{
         Version01, BASE_VERSION, EVENT_CHANNEL_SIZE, EXTERNAL_EVENT_CHANNEL_SIZE, STATIC_VER_0_1,
     },
-    data::Leaf,
+    data::{Leaf, QuorumProposal},
     event::{EventType, LeafInfo},
-    message::{DataMessage, Message, MessageKind},
+    message::{DataMessage, Message, MessageKind, Proposal},
     simple_certificate::QuorumCertificate,
     traits::{
         consensus_api::ConsensusApi,
@@ -263,6 +263,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> SystemContext<TYPES, I> {
             // TODO this is incorrect
             // https://github.com/EspressoSystems/HotShot/issues/560
             anchored_leaf.view_number(),
+            initializer.saved_proposals,
             saved_leaves,
             saved_payloads,
             initializer.high_qc,
@@ -680,6 +681,8 @@ pub struct HotShotInitializer<TYPES: NodeType> {
     undecided_leafs: Vec<Leaf<TYPES>>,
     /// Not yet decided state
     undecided_state: BTreeMap<TYPES::Time, View<TYPES>>,
+    /// Proposals we have sent out to provide to others for catchup
+    saved_proposals: BTreeMap<TYPES::Time, Proposal<TYPES, QuorumProposal<TYPES>>>,
 }
 
 impl<TYPES: NodeType> HotShotInitializer<TYPES> {
@@ -697,6 +700,7 @@ impl<TYPES: NodeType> HotShotInitializer<TYPES> {
             validated_state: Some(Arc::new(validated_state)),
             state_delta: Some(Arc::new(state_delta)),
             start_view: TYPES::Time::new(0),
+            saved_proposals: BTreeMap::new(),
             high_qc,
             undecided_leafs: Vec::new(),
             undecided_state: BTreeMap::new(),
@@ -711,11 +715,13 @@ impl<TYPES: NodeType> HotShotInitializer<TYPES> {
     /// after restart.
     /// * `validated_state` - Optional validated state that if given, will be used to construct the
     /// `SystemContext`.
+    #[allow(clippy::too_many_arguments)]
     pub fn from_reload(
         anchor_leaf: Leaf<TYPES>,
         instance_state: TYPES::InstanceState,
         validated_state: Option<Arc<TYPES::ValidatedState>>,
         start_view: TYPES::Time,
+        saved_proposals: BTreeMap<TYPES::Time, Proposal<TYPES, QuorumProposal<TYPES>>>,
         high_qc: QuorumCertificate<TYPES>,
         undecided_leafs: Vec<Leaf<TYPES>>,
         undecided_state: BTreeMap<TYPES::Time, View<TYPES>>,
@@ -726,6 +732,7 @@ impl<TYPES: NodeType> HotShotInitializer<TYPES> {
             validated_state,
             state_delta: None,
             start_view,
+            saved_proposals,
             high_qc,
             undecided_leafs,
             undecided_state,

--- a/crates/task-impls/src/consensus/helpers.rs
+++ b/crates/task-impls/src/consensus/helpers.rs
@@ -231,7 +231,11 @@ pub async fn create_and_send_proposal<TYPES: NodeType>(
         "Sending null proposal for view {:?}",
         proposed_leaf.view_number(),
     );
-    if let Err(e) = consensus.write().await.update_last_proposed_view(view) {
+    if let Err(e) = consensus
+        .write()
+        .await
+        .update_last_proposed_view(message.clone())
+    {
         tracing::trace!("{e:?}");
         return;
     }

--- a/crates/task-impls/src/network.rs
+++ b/crates/task-impls/src/network.rs
@@ -409,13 +409,21 @@ impl<
         async_spawn(async move {
             if NetworkEventTaskState::<TYPES, COMMCHANNEL, S>::maybe_record_action(
                 maybe_action,
-                storage,
+                Arc::clone(&storage),
                 view,
             )
             .await
             .is_err()
             {
                 return;
+            }
+            if let MessageKind::Consensus(SequencingMessage::General(
+                GeneralConsensusMessage::Proposal(prop),
+            )) = &message.kind
+            {
+                if storage.write().await.append_proposal(prop).await.is_err() {
+                    return;
+                }
             }
 
             let transmit_result = if version == BASE_VERSION {

--- a/crates/task-impls/src/quorum_proposal/dependency_handle.rs
+++ b/crates/task-impls/src/quorum_proposal/dependency_handle.rs
@@ -157,7 +157,7 @@ impl<TYPES: NodeType> ProposalDependencyHandle<TYPES> {
         self.consensus
             .write()
             .await
-            .update_last_proposed_view(self.view_number)?;
+            .update_last_proposed_view(message.clone())?;
         async_sleep(Duration::from_millis(self.round_start_delay)).await;
         broadcast_event(
             Arc::new(HotShotEvent::QuorumProposalSend(

--- a/crates/testing/src/spinning_task.rs
+++ b/crates/testing/src/spinning_task.rs
@@ -110,6 +110,7 @@ where
                                             TestInstanceState {},
                                             None,
                                             view_number,
+                                            BTreeMap::new(),
                                             self.high_qc.clone(),
                                             Vec::new(),
                                             BTreeMap::new(),

--- a/crates/types/src/consensus.rs
+++ b/crates/types/src/consensus.rs
@@ -12,19 +12,20 @@ use tracing::{debug, error};
 
 pub use crate::utils::{View, ViewInner};
 use crate::{
-    data::{Leaf, VidDisperse, VidDisperseShare},
+    data::{Leaf, QuorumProposal, VidDisperse, VidDisperseShare},
     error::HotShotError,
     message::Proposal,
     simple_certificate::{DaCertificate, QuorumCertificate, UpgradeCertificate},
     traits::{
         block_contents::BuilderFee,
         metrics::{Counter, Gauge, Histogram, Metrics, NoMetrics},
-        node_implementation::NodeType,
+        node_implementation::{ConsensusTime, NodeType},
         signature_key::SignatureKey,
         BlockPayload, ValidatedState,
     },
     utils::{BuilderCommitment, StateAndDelta, Terminator},
     vid::VidCommitment,
+    vote::HasViewNumber,
 };
 
 /// A type alias for `HashMap<Commitment<T>, T>`
@@ -57,8 +58,9 @@ pub struct Consensus<TYPES: NodeType> {
     /// View number that is currently on.
     cur_view: TYPES::Time,
 
-    /// View we proposed in last.  To prevent duplicate proposals
-    last_proposed_view: TYPES::Time,
+    /// Last proposals we sent out, None if we haven't proposed yet.
+    /// Prevents duplicate proposals, and can be served to those trying to catchup
+    last_proposals: BTreeMap<TYPES::Time, Proposal<TYPES, QuorumProposal<TYPES>>>,
 
     /// last view had a successful decide event
     last_decided_view: TYPES::Time,
@@ -169,6 +171,7 @@ impl<TYPES: NodeType> Consensus<TYPES> {
         cur_view: TYPES::Time,
         locked_view: TYPES::Time,
         last_decided_view: TYPES::Time,
+        last_proposals: BTreeMap<TYPES::Time, Proposal<TYPES, QuorumProposal<TYPES>>>,
         saved_leaves: CommitmentMap<Leaf<TYPES>>,
         saved_payloads: BTreeMap<TYPES::Time, Arc<[u8]>>,
         high_qc: QuorumCertificate<TYPES>,
@@ -180,7 +183,7 @@ impl<TYPES: NodeType> Consensus<TYPES> {
             saved_da_certs: HashMap::new(),
             cur_view,
             last_decided_view,
-            last_proposed_view: last_decided_view,
+            last_proposals,
             locked_view,
             saved_leaves,
             saved_payloads,
@@ -248,16 +251,24 @@ impl<TYPES: NodeType> Consensus<TYPES> {
         Ok(())
     }
 
-    /// Update the last proposed view.
+    /// Update the last proposal.
     ///
     /// # Errors
     /// Can return an error when the new view_number is not higher than the existing proposed view number.
-    pub fn update_last_proposed_view(&mut self, view_number: TYPES::Time) -> Result<()> {
+    pub fn update_last_proposed_view(
+        &mut self,
+        proposal: Proposal<TYPES, QuorumProposal<TYPES>>,
+    ) -> Result<()> {
         ensure!(
-            view_number > self.last_proposed_view,
+            proposal.data.view_number()
+                > self
+                    .last_proposals
+                    .first_key_value()
+                    .map_or(TYPES::Time::genesis(), |(k, _)| { *k }),
             "New view isn't newer than the previously proposed view."
         );
-        self.last_proposed_view = view_number;
+        self.last_proposals
+            .insert(proposal.data.view_number(), proposal);
         Ok(())
     }
 

--- a/crates/types/src/consensus.rs
+++ b/crates/types/src/consensus.rs
@@ -451,6 +451,7 @@ impl<TYPES: NodeType> Consensus<TYPES> {
         self.validated_state_map = self.validated_state_map.split_off(&new_anchor_view);
         self.saved_payloads = self.saved_payloads.split_off(&new_anchor_view);
         self.vid_shares = self.vid_shares.split_off(&new_anchor_view);
+        self.last_proposals = self.last_proposals.split_off(&new_anchor_view);
     }
 
     /// Gets the last decided leaf.

--- a/crates/types/src/consensus.rs
+++ b/crates/types/src/consensus.rs
@@ -263,7 +263,7 @@ impl<TYPES: NodeType> Consensus<TYPES> {
             proposal.data.view_number()
                 > self
                     .last_proposals
-                    .first_key_value()
+                    .last_key_value()
                     .map_or(TYPES::Time::genesis(), |(k, _)| { *k }),
             "New view isn't newer than the previously proposed view."
         );

--- a/crates/types/src/traits/storage.rs
+++ b/crates/types/src/traits/storage.rs
@@ -11,7 +11,7 @@ use async_trait::async_trait;
 use super::node_implementation::NodeType;
 use crate::{
     consensus::{CommitmentMap, View},
-    data::{DaProposal, Leaf, VidDisperseShare},
+    data::{DaProposal, Leaf, QuorumProposal, VidDisperseShare},
     event::HotShotAction,
     message::Proposal,
     simple_certificate::QuorumCertificate,
@@ -24,6 +24,11 @@ pub trait Storage<TYPES: NodeType>: Send + Sync + Clone {
     async fn append_vid(&self, proposal: &Proposal<TYPES, VidDisperseShare<TYPES>>) -> Result<()>;
     /// Add a proposal to the stored DA proposals.
     async fn append_da(&self, proposal: &Proposal<TYPES, DaProposal<TYPES>>) -> Result<()>;
+    /// Add a proposal we sent to the store
+    async fn append_proposal(
+        &self,
+        proposal: &Proposal<TYPES, QuorumProposal<TYPES>>,
+    ) -> Result<()>;
     /// Record a HotShotAction taken.
     async fn record_action(&self, view: TYPES::Time, action: HotShotAction) -> Result<()>;
     /// Update the current high QC in storage.


### PR DESCRIPTION
Closes #3240 
<!-- See here for keywords in Github -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

### This PR: 

- Stores most recent proposals in memory
- Adds interface for sequencer to store proposals we send
- Calls this interface before sending out a proposal
- Adds the stored proposals to the `HotshotInitializer` so they can be loaded from the sequencer on startup

### This PR does not: 
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->

### Key places to review: 

New interface and init code

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
