### PR TITLE
Make SimpleBuilder listen on 0.0.0.0

### DIFF
--- a/crates/testing/src/block_builder.rs
+++ b/crates/testing/src/block_builder.rs
@@ -96,7 +96,7 @@ where
         num_storage_nodes: usize,
         config: Self::Config,
     ) -> (Option<Box<dyn BuilderTask<TYPES>>>, Url) {
-        let url = Url::parse(&format!("http://localhost:{0}", config.port)).expect("Valid URL");
+        let url = Url::parse(&format!("http://0.0.0.0:{0}", config.port)).expect("Valid URL");
         let (source, task) = make_simple_builder(num_storage_nodes).await;
 
         let builder_api = hotshot_builder_api::builder::define_api::<


### PR DESCRIPTION
### This PR: 
For convenience, we usually prefer to run the `SimpleBuilder` in a Docker environment. Listening only to `localhost` makes the Builder API inaccessible from outside the docker container. Although I think this change is unreasonable for HotShot, it is currently the most suitable option.

### This PR does not: 
- introduce any risk since the change is under the `testing` feature
