### PR TITLE
remove TestTransaction bound from simple builder

### DIFF
--- a/crates/testing/src/block_builder/mod.rs
+++ b/crates/testing/src/block_builder/mod.rs
@@ -10,7 +10,6 @@ use hotshot_builder_api::{
     builder::{Error, Options},
     data_source::BuilderDataSource,
 };
-use hotshot_example_types::block_types::TestTransaction;
 use hotshot_types::{
     constants::Base,
     traits::{
@@ -68,7 +67,7 @@ pub fn run_builder_source<TYPES, Source>(
     mut change_receiver: Receiver<BuilderChange>,
     source: Source,
 ) where
-    TYPES: NodeType<Transaction = TestTransaction>,
+    TYPES: NodeType,
     <TYPES as NodeType>::InstanceState: Default,
     Source: Clone + Send + Sync + tide_disco::method::ReadState + 'static,
     <Source as ReadState>::State: Sync + Send + BuilderDataSource<TYPES>,

--- a/crates/testing/src/block_builder/simple.rs
+++ b/crates/testing/src/block_builder/simple.rs
@@ -23,7 +23,6 @@ use hotshot_builder_api::{
     builder::{BuildError, Error, Options},
     data_source::BuilderDataSource,
 };
-use hotshot_example_types::block_types::TestTransaction;
 use hotshot_types::{
     constants::Base,
     traits::{
@@ -91,8 +90,7 @@ impl Default for SimpleBuilderConfig {
 }
 
 #[async_trait]
-impl<TYPES: NodeType<Transaction = TestTransaction>> TestBuilderImplementation<TYPES>
-    for SimpleBuilderImplementation
+impl<TYPES: NodeType> TestBuilderImplementation<TYPES> for SimpleBuilderImplementation
 where
     <TYPES as NodeType>::InstanceState: Default,
 {


### PR DESCRIPTION
We are not using Test types in the sequencer, so this constraint forces us to use TestTransaction.