### PR TITLE
[CATCHUP] Fetch Proposals in Dependecny Task

### DIFF
--- a/crates/task-impls/src/consensus/helpers.rs
+++ b/crates/task-impls/src/consensus/helpers.rs
@@ -535,8 +535,7 @@ pub async fn publish_proposal_if_able<TYPES: NodeType>(
 }
 
 /// Trigger a request to the network for a proposal for a view and wait for the response
-#[cfg(not(feature = "dependency-tasks"))]
-async fn fetch_proposal<TYPES: NodeType>(
+pub(crate) async fn fetch_proposal<TYPES: NodeType>(
     view: TYPES::Time,
     event_stream: Sender<Arc<HotShotEvent<TYPES>>>,
     quorum_membership: Arc<TYPES::Membership>,

--- a/crates/task-impls/src/consensus/helpers.rs
+++ b/crates/task-impls/src/consensus/helpers.rs
@@ -3,8 +3,11 @@ use std::{
     sync::Arc,
 };
 
+use crate::{events::ProposalMissing, request::REQUEST_TIMEOUT};
+use anyhow::bail;
 use anyhow::{ensure, Context, Result};
-use async_broadcast::Sender;
+use async_broadcast::{broadcast, Sender};
+use async_compatibility_layer::art::async_timeout;
 use async_lock::RwLock;
 #[cfg(async_executor_impl = "async-std")]
 use async_std::task::JoinHandle;
@@ -32,10 +35,6 @@ use {
         consensus::{update_view, view_change::SEND_VIEW_CHANGE_EVENT},
         helpers::AnyhowTracing,
     },
-    crate::{events::ProposalMissing, request::REQUEST_TIMEOUT},
-    anyhow::bail,
-    async_broadcast::broadcast,
-    async_compatibility_layer::art::async_timeout,
     async_compatibility_layer::art::{async_sleep, async_spawn},
     chrono::Utc,
     core::time::Duration,

--- a/crates/testing/src/predicates/event.rs
+++ b/crates/testing/src/predicates/event.rs
@@ -208,6 +208,17 @@ where
     Box::new(EventPredicate { check, info })
 }
 
+pub fn quorum_proposal_missing<TYPES>() -> Box<EventPredicate<TYPES>>
+where
+    TYPES: NodeType,
+{
+    let info = "QuorumProposalRequest".to_string();
+    let check: EventCallback<TYPES> = Arc::new(move |e: Arc<HotShotEvent<TYPES>>| {
+        matches!(*e.clone(), QuorumProposalRequest(..))
+    });
+    Box::new(EventPredicate { check, info })
+}
+
 pub fn quorum_proposal_send<TYPES>() -> Box<EventPredicate<TYPES>>
 where
     TYPES: NodeType,

--- a/crates/testing/tests/tests_1/quorum_proposal_recv_task.rs
+++ b/crates/testing/tests/tests_1/quorum_proposal_recv_task.rs
@@ -13,7 +13,7 @@ use hotshot_task_impls::{
 };
 use hotshot_testing::{
     helpers::{build_fake_view_with_leaf_and_state, build_system_handle},
-    predicates::event::{all_predicates, exact, vote_now},
+    predicates::event::{all_predicates, quorum_proposal_missing, exact, vote_now},
     script::InputOrder,
     serial,
     view_generator::TestViewGenerator,
@@ -191,6 +191,7 @@ async fn test_quorum_proposal_recv_task_liveness_check() {
                 ),
             ),
         )),
+        quorum_proposal_missing(),
         exact(UpdateHighQc(proposals[2].data.justify_qc.clone())),
         vote_now(),
     ])];


### PR DESCRIPTION
Closes #3244 
<!-- See here for keywords in Github -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

### This PR: 

1. Fetches proposals if we can from the vote task if the parent proposal is missing
2. Fetches proposals from the proposal task if we form a QC for a proposal we don't have
3. Emits the validated state event after updating state in the `fetch_proposal` function

### This PR does not: 
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->

### Key places to review: 
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
