### PR TITLE
Docs rectify typographical inaccuracies

### DIFF
--- a/.github/ISSUE_TEMPLATE/EXTERNAL_ISSUE_FORM.yml
+++ b/.github/ISSUE_TEMPLATE/EXTERNAL_ISSUE_FORM.yml
@@ -24,7 +24,7 @@ body:
       placeholder: | 
         Include other details here such as: open questions, directions to reproduce a bug, relevant error logs, etc. 
 
-        E.g. To reproduce this bug run `just async_std test_basic`. You should see logs similar to the below: 
+        E.g. To reproduce this bug run `just async_std test_basic`. You should see logs similar to the ones below: 
         `ERROR: This is an important error!`
     validations:
       required: false

--- a/crates/builder-api/api/builder.toml
+++ b/crates/builder-api/api/builder.toml
@@ -74,7 +74,7 @@ Returns application-specific block header type
 [route.builder_address]
 PATH = ["builderaddress"]
 DOC = """
-Get the builder address.
+Get the builder's address.
 
 Returns the builder's public key
 """

--- a/crates/builder-api/src/data_source.rs
+++ b/crates/builder-api/src/data_source.rs
@@ -40,7 +40,7 @@ pub trait BuilderDataSource<TYPES: NodeType> {
         signature: &<TYPES::SignatureKey as SignatureKey>::PureAssembledSignatureType,
     ) -> Result<AvailableBlockHeaderInput<TYPES>, BuildError>;
 
-    /// To get the builder address
+    /// To get the builder's address
     async fn builder_address(&self) -> Result<TYPES::BuilderSignatureKey, BuildError>;
 }
 

--- a/crates/example-types/src/block_types.rs
+++ b/crates/example-types/src/block_types.rs
@@ -44,7 +44,7 @@ impl TryFrom<Vec<u8>> for TestTransaction {
 }
 
 impl TestTransaction {
-    /// Construct new transaction
+    /// Construct a new transaction
     ///
     /// # Panics
     /// If `bytes.len()` > `u32::MAX`

--- a/crates/examples/combined/all.rs
+++ b/crates/examples/combined/all.rs
@@ -1,4 +1,4 @@
-//! A example program using both the web server and libp2p
+//! An example program using both the web server and libp2p
 /// types used for this example
 pub mod types;
 

--- a/crates/examples/infra/mod.rs
+++ b/crates/examples/infra/mod.rs
@@ -101,7 +101,7 @@ pub fn read_orchestrator_init_config<TYPES: NodeType>() -> (NetworkConfig<TYPES:
     // assign default setting
     let mut orchestrator_url = Url::parse("http://localhost:4444").unwrap();
     let mut args = ConfigArgs::default();
-    // start reading from command line
+    // start reading from the command line
     let matches = Command::new("orchestrator")
         .arg(
             Arg::new("config_file")

--- a/crates/examples/libp2p/all.rs
+++ b/crates/examples/libp2p/all.rs
@@ -1,4 +1,4 @@
-//! A example program using libp2p
+//! An example program using libp2p
 /// types used for this example
 pub mod types;
 


### PR DESCRIPTION
This PR addresses several typographical errors across various files in the project. The changes improve readability and maintain the professional standard of the documentation and code comments.

Justification
Typographical errors, while minor, can detract from the overall quality of the project. Correcting these errors ensures clarity and professionalism, making the project more accessible and understandable for current and future contributors.

Hope it helps.