### PR TITLE
[DEPENDENCY_REFACTOR] - Fix the view number when canceling old dependency tasks

### DIFF
--- a/crates/task-impls/src/quorum_vote/mod.rs
+++ b/crates/task-impls/src/quorum_vote/mod.rs
@@ -528,7 +528,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> QuorumVoteTaskState<TYPES, I
             );
 
             // Cancel the old dependency tasks.
-            for view in (*self.latest_voted_view + 1)..(*new_view) {
+            for view in *self.latest_voted_view..(*new_view) {
                 if let Some(dependency) = self.vote_dependencies.remove(&TYPES::Time::new(view)) {
                     cancel_task(dependency).await;
                     debug!("Vote dependency removed for view {:?}", view);


### PR DESCRIPTION
Closes #3342.

### This PR: 
* Cancels old dependency tasks starting from `latest_voted_view`, to fix the issue that many dependency tasks are skipped when canceling.