### PR TITLE
Benchmark script adjust and ORCHESTRATOR_DEFAULT_NUM_ROUNDS adjust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3170,7 +3170,7 @@ dependencies = [
 
 [[package]]
 name = "hotshot"
-version = "0.5.58"
+version = "0.5.59"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -3235,7 +3235,7 @@ dependencies = [
 
 [[package]]
 name = "hotshot-example-types"
-version = "0.5.58"
+version = "0.5.59"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -3265,7 +3265,7 @@ dependencies = [
 
 [[package]]
 name = "hotshot-examples"
-version = "0.5.58"
+version = "0.5.59"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -3314,7 +3314,7 @@ dependencies = [
 
 [[package]]
 name = "hotshot-macros"
-version = "0.5.58"
+version = "0.5.59"
 dependencies = [
  "derive_builder",
  "proc-macro2",
@@ -3324,7 +3324,7 @@ dependencies = [
 
 [[package]]
 name = "hotshot-orchestrator"
-version = "0.5.58"
+version = "0.5.59"
 dependencies = [
  "anyhow",
  "async-compatibility-layer",
@@ -3353,7 +3353,7 @@ dependencies = [
 
 [[package]]
 name = "hotshot-stake-table"
-version = "0.5.58"
+version = "0.5.59"
 dependencies = [
  "ark-bn254",
  "ark-ed-on-bn254",
@@ -3374,7 +3374,7 @@ dependencies = [
 
 [[package]]
 name = "hotshot-task"
-version = "0.5.58"
+version = "0.5.59"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -3388,7 +3388,7 @@ dependencies = [
 
 [[package]]
 name = "hotshot-task-impls"
-version = "0.5.58"
+version = "0.5.59"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -3422,7 +3422,7 @@ dependencies = [
 
 [[package]]
 name = "hotshot-testing"
-version = "0.5.58"
+version = "0.5.59"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -4624,7 +4624,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-networking"
-version = "0.5.58"
+version = "0.5.59"
 dependencies = [
  "anyhow",
  "async-compatibility-layer",

--- a/crates/examples/infra/mod.rs
+++ b/crates/examples/infra/mod.rs
@@ -168,22 +168,6 @@ pub fn read_orchestrator_init_config<TYPES: NodeType>() -> (NetworkConfig<TYPES:
                 .required(false),
         )
         .arg(
-            Arg::new("webserver_url")
-                .short('w')
-                .long("webserver_url")
-                .value_name("URL")
-                .help("Sets the url of the webserver")
-                .required(false),
-        )
-        .arg(
-            Arg::new("da_webserver_url")
-                .short('a')
-                .long("da_webserver_url")
-                .value_name("URL")
-                .help("Sets the url of the da webserver")
-                .required(false),
-        )
-        .arg(
             Arg::new("fixed_leader_for_gpuvid")
                 .short('f')
                 .long("fixed_leader_for_gpuvid")
@@ -253,20 +237,6 @@ pub fn read_orchestrator_init_config<TYPES: NodeType>() -> (NetworkConfig<TYPES:
     }
     if let Some(orchestrator_url_string) = matches.get_one::<String>("orchestrator_url") {
         orchestrator_url = Url::parse(orchestrator_url_string).unwrap();
-    }
-    if let Some(webserver_url_string) = matches.get_one::<String>("webserver_url") {
-        let updated_web_server_config = WebServerConfig {
-            url: Url::parse(webserver_url_string).unwrap(),
-            wait_between_polls: config.web_server_config.unwrap().wait_between_polls,
-        };
-        config.web_server_config = Some(updated_web_server_config);
-    }
-    if let Some(da_webserver_url_string) = matches.get_one::<String>("da_webserver_url") {
-        let updated_da_web_server_config = WebServerConfig {
-            url: Url::parse(da_webserver_url_string).unwrap(),
-            wait_between_polls: config.da_web_server_config.unwrap().wait_between_polls,
-        };
-        config.da_web_server_config = Some(updated_da_web_server_config);
     }
     if let Some(builder_type) = matches.get_one::<BuilderType>("builder") {
         config.builder = *builder_type;

--- a/crates/examples/infra/mod.rs
+++ b/crates/examples/infra/mod.rs
@@ -40,7 +40,6 @@ use hotshot_orchestrator::{
     client::{BenchResults, OrchestratorClient, ValidatorArgs},
     config::{
         BuilderType, CombinedNetworkConfig, NetworkConfig, NetworkConfigFile, NetworkConfigSource,
-        WebServerConfig,
     },
 };
 use hotshot_testing::block_builder::{

--- a/crates/orchestrator/run-config.toml
+++ b/crates/orchestrator/run-config.toml
@@ -76,24 +76,9 @@ txn_in_block = 100
 blocks_per_second = 1
 txn_size = { start = 20, end = 100 }
 
-[web_server_config]
-url = "http://localhost:9000"
-
-[da_web_server_config]
-url = "http://localhost:9001"
-
 [combined_network_config.delay_duration]
 secs = 1
 nanos = 0
-
-[web_server_config.wait_between_polls]
-secs = 0
-nanos = 10_000_000
-
-[da_web_server_config.wait_between_polls]
-secs = 0
-nanos = 10_000_000
-
 
 [config.view_sync_timeout]
 secs = 2
@@ -103,8 +88,6 @@ nanos = 0
 secs = 0
 nanos = 200_000_000
 
-# TODO (Keyao) Clean up configuration parameters.
-# <https://github.com/EspressoSystems/HotShot/issues/1823>
 [config.builder_timeout]
 secs = 10
 nanos = 0

--- a/crates/orchestrator/src/config.rs
+++ b/crates/orchestrator/src/config.rs
@@ -713,7 +713,7 @@ impl<KEY: SignatureKey> From<HotShotConfigFile<KEY>> for HotShotConfig<KEY> {
     }
 }
 /// default number of rounds to run
-pub const ORCHESTRATOR_DEFAULT_NUM_ROUNDS: usize = 10;
+pub const ORCHESTRATOR_DEFAULT_NUM_ROUNDS: usize = 100;
 /// default number of transactions per round
 pub const ORCHESTRATOR_DEFAULT_TRANSACTIONS_PER_ROUND: usize = 10;
 /// default size of transactions

--- a/crates/orchestrator/src/config.rs
+++ b/crates/orchestrator/src/config.rs
@@ -191,10 +191,6 @@ pub struct NetworkConfig<KEY: SignatureKey> {
     pub libp2p_config: Option<Libp2pConfig>,
     /// the hotshot config
     pub config: HotShotConfig<KEY>,
-    /// the webserver config
-    pub web_server_config: Option<WebServerConfig>,
-    /// the data availability web server config
-    pub da_web_server_config: Option<WebServerConfig>,
     /// The address for the Push CDN's "marshal", A.K.A. load balancer
     pub cdn_marshal_address: Option<String>,
     /// combined network config
@@ -426,8 +422,6 @@ impl<K: SignatureKey> Default for NetworkConfig<K> {
             config: HotShotConfigFile::default().into(),
             start_delay_seconds: 60,
             key_type_name: std::any::type_name::<K>().to_string(),
-            web_server_config: None,
-            da_web_server_config: None,
             cdn_marshal_address: None,
             combined_network_config: None,
             next_view_timeout: 10,
@@ -481,12 +475,6 @@ pub struct NetworkConfigFile<KEY: SignatureKey> {
     /// The address of the Push CDN's "marshal", A.K.A. load balancer
     #[serde(default)]
     pub cdn_marshal_address: Option<String>,
-    /// the webserver config
-    #[serde(default)]
-    pub web_server_config: Option<WebServerConfig>,
-    /// the data availability web server config
-    #[serde(default)]
-    pub da_web_server_config: Option<WebServerConfig>,
     /// combined network config
     #[serde(default)]
     pub combined_network_config: Option<CombinedNetworkConfig>,
@@ -534,8 +522,6 @@ impl<K: SignatureKey> From<NetworkConfigFile<K>> for NetworkConfig<K> {
             key_type_name: std::any::type_name::<K>().to_string(),
             start_delay_seconds: val.start_delay_seconds,
             cdn_marshal_address: val.cdn_marshal_address,
-            web_server_config: val.web_server_config,
-            da_web_server_config: val.da_web_server_config,
             combined_network_config: val.combined_network_config,
             commit_sha: String::new(),
             builder: val.builder,

--- a/scripts/benchmark_scripts/aws_ecs_benchmarks_cdn.sh
+++ b/scripts/benchmark_scripts/aws_ecs_benchmarks_cdn.sh
@@ -26,11 +26,11 @@ ulimit -n 65536
 # for pid in $(ps -ef | grep "validator" | awk '{print $2}'); do kill -9 $pid; done
 
 # docker build and push
-docker build . -f ./docker/validator-cdn-local.Dockerfile -t ghcr.io/espressosystems/hotshot/validator-webserver:main-async-std
-docker push ghcr.io/espressosystems/hotshot/validator-webserver:main-async-std
+docker build . -f ./docker/validator-cdn-local.Dockerfile -t ghcr.io/espressosystems/hotshot/validator-push-cdn:main-tokio
+docker push ghcr.io/espressosystems/hotshot/validator-push-cdn:main-tokio
 
 # ecs deploy
-ecs deploy --region us-east-2 hotshot hotshot_centralized -i centralized ghcr.io/espressosystems/hotshot/validator-webserver:main-async-std
+ecs deploy --region us-east-2 hotshot hotshot_centralized -i centralized ghcr.io/espressosystems/hotshot/validator-push-cdn:main-tokio
 ecs deploy --region us-east-2 hotshot hotshot_centralized -c centralized ${orchestrator_url}
 
 # runstart keydb

--- a/scripts/benchmark_scripts/aws_ecs_benchmarks_cdn_gpu.sh
+++ b/scripts/benchmark_scripts/aws_ecs_benchmarks_cdn_gpu.sh
@@ -28,11 +28,11 @@ sleep 3m
 for pid in $(ps -ef | grep "validator" | awk '{print $2}'); do kill -9 $pid; done
 
 # docker build and push
-docker build . -f ./docker/validator-cdn-local.Dockerfile -t ghcr.io/espressosystems/hotshot/validator-webserver:main-async-std
-docker push ghcr.io/espressosystems/hotshot/validator-webserver:main-async-std
+docker build . -f ./docker/validator-cdn-local.Dockerfile -t ghcr.io/espressosystems/hotshot/validator-push-cdn:main-tokio
+docker push ghcr.io/espressosystems/hotshot/validator-push-cdn:main-tokio
 
 # ecs deploy
-ecs deploy --region us-east-2 hotshot hotshot_centralized -i centralized ghcr.io/espressosystems/hotshot/validator-webserver:main-async-std
+ecs deploy --region us-east-2 hotshot hotshot_centralized -i centralized ghcr.io/espressosystems/hotshot/validator-push-cdn:main-tokio
 ecs deploy --region us-east-2 hotshot hotshot_centralized -c centralized ${orchestrator_url}
 
 # runstart keydb


### PR DESCRIPTION
<!-- See here for keywords in Github -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

### This PR: 
- Changes `ORCHESTRATOR_DEFAULT_NUM_ROUNDS` default value from 10 to 100 so that I can use it for benchmarking with sequencer.
-  Removes `da_webserver_url` and `webserver_url` as arguments when running examples.
- Changes docker name in the script.
- Removes comments in `run-config.toml` as https://github.com/EspressoSystems/HotShot/issues/1823 is closed.
<!-- Describe what this PR adds to HotSHot -->
<!-- E.g. -->
<!-- * Implements feature 1 -->
<!-- * Implements feature 2 -->
<!-- * Fixes bug 3 -->

### This PR does not: 
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->

### Key places to review: 
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
