### PR TITLE
[DEPENDENCY_REFACTOR] - Integrate upgradability into dependency tasks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -568,7 +568,7 @@ checksum = "7378575ff571966e99a744addeff0bff98b8ada0dedf1956d59e634db95eaac1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.66",
  "synstructure 0.13.1",
 ]
 
@@ -591,7 +591,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -926,7 +926,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -956,7 +956,7 @@ checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -1041,7 +1041,7 @@ checksum = "edf3ee19dbc0a46d740f6f0926bde8c50f02bdbc7b536842da28f6ac56513a8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -1168,7 +1168,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.68",
+ "syn 2.0.66",
  "which",
 ]
 
@@ -1559,7 +1559,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -2040,7 +2040,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -2084,7 +2084,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.68",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -2095,7 +2095,7 @@ checksum = "733cabb43482b1a1b53eee8583c2b9e8684d592215ea83efd305dd31bc2f0178"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -2219,7 +2219,7 @@ checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -2240,7 +2240,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -2250,7 +2250,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "206868b8242f27cecce124c19fd88157fbd0dd334df2587f36417bafbc85097b"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.68",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -2263,7 +2263,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version 0.4.0",
- "syn 2.0.68",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -2331,7 +2331,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -2436,7 +2436,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -2753,7 +2753,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -3319,7 +3319,7 @@ dependencies = [
  "derive_builder",
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -4281,11 +4281,11 @@ dependencies = [
 
 [[package]]
 name = "lazy_static"
-version = "1.5.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 dependencies = [
- "spin 0.9.8",
+ "spin 0.5.2",
 ]
 
 [[package]]
@@ -4858,7 +4858,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -5157,7 +5157,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -5560,7 +5560,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -5625,7 +5625,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -5797,7 +5797,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -5828,7 +5828,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -5986,7 +5986,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
 dependencies = [
  "proc-macro2",
- "syn 2.0.68",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -6042,9 +6042,9 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.86"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+checksum = "22244ce15aa966053a896d1accb3a6e68469b97c7f33f284b99f0d576879fc23"
 dependencies = [
  "unicode-ident",
 ]
@@ -6084,7 +6084,7 @@ checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -6107,7 +6107,7 @@ dependencies = [
  "itertools 0.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -7036,7 +7036,7 @@ checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -7118,7 +7118,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -7335,7 +7335,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -7721,7 +7721,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.68",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -7840,9 +7840,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.68"
+version = "2.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "901fa70d88b9d6c98022e23b4136f9f3e54e4662c3bc1bd1d84a42a9a0f0c1e9"
+checksum = "c42f3f41a2de00b01c0aaad383c5a45241efc8b2d1eda5661812fda5f3cdcff5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7875,7 +7875,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -7960,7 +7960,7 @@ checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -8205,7 +8205,7 @@ checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -8415,7 +8415,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -8888,7 +8888,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.66",
  "wasm-bindgen-shared",
 ]
 
@@ -8922,7 +8922,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.66",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -9360,7 +9360,7 @@ checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -9380,5 +9380,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.66",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3170,7 +3170,7 @@ dependencies = [
 
 [[package]]
 name = "hotshot"
-version = "0.5.58"
+version = "0.5.59"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -3235,7 +3235,7 @@ dependencies = [
 
 [[package]]
 name = "hotshot-example-types"
-version = "0.5.58"
+version = "0.5.59"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -3265,7 +3265,7 @@ dependencies = [
 
 [[package]]
 name = "hotshot-examples"
-version = "0.5.58"
+version = "0.5.59"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -3314,7 +3314,7 @@ dependencies = [
 
 [[package]]
 name = "hotshot-macros"
-version = "0.5.58"
+version = "0.5.59"
 dependencies = [
  "derive_builder",
  "proc-macro2",
@@ -3324,7 +3324,7 @@ dependencies = [
 
 [[package]]
 name = "hotshot-orchestrator"
-version = "0.5.58"
+version = "0.5.59"
 dependencies = [
  "anyhow",
  "async-compatibility-layer",
@@ -3353,7 +3353,7 @@ dependencies = [
 
 [[package]]
 name = "hotshot-stake-table"
-version = "0.5.58"
+version = "0.5.59"
 dependencies = [
  "ark-bn254",
  "ark-ed-on-bn254",
@@ -3374,7 +3374,7 @@ dependencies = [
 
 [[package]]
 name = "hotshot-task"
-version = "0.5.58"
+version = "0.5.59"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -3388,7 +3388,7 @@ dependencies = [
 
 [[package]]
 name = "hotshot-task-impls"
-version = "0.5.58"
+version = "0.5.59"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -3422,7 +3422,7 @@ dependencies = [
 
 [[package]]
 name = "hotshot-testing"
-version = "0.5.58"
+version = "0.5.59"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -4624,7 +4624,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-networking"
-version = "0.5.58"
+version = "0.5.59"
 dependencies = [
  "anyhow",
  "async-compatibility-layer",

--- a/crates/examples/infra/mod.rs
+++ b/crates/examples/infra/mod.rs
@@ -153,7 +153,7 @@ pub fn read_orchestrator_init_config<TYPES: NodeType>() -> (NetworkConfig<TYPES:
         )
         .arg(
             Arg::new("commit_sha")
-                .short('h')
+                .short('o')
                 .long("commit_sha")
                 .value_name("SHA")
                 .help("Sets the commit sha to output in the results")

--- a/crates/hotshot/src/tasks/task_state.rs
+++ b/crates/hotshot/src/tasks/task_state.rs
@@ -255,6 +255,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> CreateTaskState<TYPES, I>
             id: handle.hotshot.id,
             storage: Arc::clone(&handle.storage),
             version: *handle.hotshot.version.read().await,
+            decided_upgrade_certificate: Arc::clone(&handle.hotshot.decided_upgrade_certificate),
         }
     }
 }
@@ -287,6 +288,8 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> CreateTaskState<TYPES, I>
             round_start_delay: handle.hotshot.config.round_start_delay,
             id: handle.hotshot.id,
             version: *handle.hotshot.version.read().await,
+            formed_upgrade_certificate: None,
+            decided_upgrade_certificate: Arc::clone(&handle.hotshot.decided_upgrade_certificate),
         }
     }
 }
@@ -315,13 +318,12 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> CreateTaskState<TYPES, I>
             round_start_delay: handle.hotshot.config.round_start_delay,
             output_event_stream: handle.hotshot.external_event_stream.0.clone(),
             storage: Arc::clone(&handle.storage),
-            formed_upgrade_certificate: None,
             proposal_cert: None,
-            decided_upgrade_cert: None,
             spawned_tasks: BTreeMap::new(),
             instance_state: handle.hotshot.instance_state(),
             id: handle.hotshot.id,
             version: *handle.hotshot.version.read().await,
+            decided_upgrade_certificate: Arc::clone(&handle.hotshot.decided_upgrade_certificate),
         }
     }
 }

--- a/crates/hotshot/src/tasks/task_state.rs
+++ b/crates/hotshot/src/tasks/task_state.rs
@@ -254,7 +254,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> CreateTaskState<TYPES, I>
             output_event_stream: handle.hotshot.external_event_stream.0.clone(),
             id: handle.hotshot.id,
             storage: Arc::clone(&handle.storage),
-            version: *handle.hotshot.version.read().await,
+            version: Arc::clone(&handle.hotshot.version),
             decided_upgrade_certificate: Arc::clone(&handle.hotshot.decided_upgrade_certificate),
         }
     }
@@ -287,7 +287,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> CreateTaskState<TYPES, I>
             timeout_task,
             round_start_delay: handle.hotshot.config.round_start_delay,
             id: handle.hotshot.id,
-            version: *handle.hotshot.version.read().await,
+            version: Arc::clone(&handle.hotshot.version),
             formed_upgrade_certificate: None,
             decided_upgrade_certificate: Arc::clone(&handle.hotshot.decided_upgrade_certificate),
         }
@@ -322,7 +322,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> CreateTaskState<TYPES, I>
             spawned_tasks: BTreeMap::new(),
             instance_state: handle.hotshot.instance_state(),
             id: handle.hotshot.id,
-            version: *handle.hotshot.version.read().await,
+            version: Arc::clone(&handle.hotshot.version),
             decided_upgrade_certificate: Arc::clone(&handle.hotshot.decided_upgrade_certificate),
         }
     }
@@ -356,6 +356,8 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> CreateTaskState<TYPES, I>
             consensus,
             last_decided_view: handle.cur_view().await,
             id: handle.hotshot.id,
+            version: Arc::clone(&handle.hotshot.version),
+            decided_upgrade_certificate: Arc::clone(&handle.hotshot.decided_upgrade_certificate),
         }
     }
 }

--- a/crates/task-impls/src/consensus/helpers.rs
+++ b/crates/task-impls/src/consensus/helpers.rs
@@ -3,13 +3,12 @@ use std::{
     sync::Arc,
 };
 
-use crate::{events::ProposalMissing, request::REQUEST_TIMEOUT};
-use anyhow::bail;
-use anyhow::{ensure, Context, Result};
+use anyhow::{bail, ensure, Context, Result};
 use async_broadcast::{broadcast, Sender};
 use async_compatibility_layer::art::async_timeout;
 use async_lock::RwLock;
 #[cfg(async_executor_impl = "async-std")]
+#[cfg(not(feature = "dependency-tasks"))]
 use async_std::task::JoinHandle;
 use committable::{Commitment, Committable};
 use hotshot_types::{
@@ -52,8 +51,15 @@ use {
     vbs::version::Version,
 };
 
-use crate::{events::HotShotEvent, helpers::broadcast_event};
+use crate::{
+    events::{HotShotEvent, ProposalMissing},
+    helpers::broadcast_event,
+    request::REQUEST_TIMEOUT,
+};
 
+// TODO: Replace this function with `validate_proposal_safety_and_liveness` after the following
+// issue is done:
+// https://github.com/EspressoSystems/HotShot/issues/3357.
 /// Validate the state and safety and liveness of a proposal then emit
 /// a `QuorumProposalValidated` event.
 ///
@@ -61,7 +67,8 @@ use crate::{events::HotShotEvent, helpers::broadcast_event};
 /// we merge the dependency tasks.
 #[allow(clippy::too_many_arguments)]
 #[allow(clippy::too_many_lines)]
-pub async fn validate_proposal_safety_and_liveness<TYPES: NodeType>(
+#[cfg(not(feature = "dependency-tasks"))]
+pub async fn temp_validate_proposal_safety_and_liveness<TYPES: NodeType>(
     proposal: Proposal<TYPES, QuorumProposal<TYPES>>,
     parent_leaf: Leaf<TYPES>,
     consensus: Arc<RwLock<Consensus<TYPES>>>,
@@ -125,7 +132,145 @@ pub async fn validate_proposal_safety_and_liveness<TYPES: NodeType>(
     UpgradeCertificate::validate(&proposal.data.upgrade_certificate, &quorum_membership)?;
 
     // Validate that the upgrade certificate is re-attached, if we saw one on the parent
-    proposed_leaf.extends_upgrade(&parent_leaf, &decided_upgrade_certificate)?;
+    proposed_leaf.temp_extends_upgrade(&parent_leaf, &decided_upgrade_certificate)?;
+
+    let justify_qc = proposal.data.justify_qc.clone();
+    // Create a positive vote if either liveness or safety check
+    // passes.
+
+    // Liveness check.
+    let read_consensus = consensus.read().await;
+    let liveness_check = justify_qc.view_number() > read_consensus.locked_view();
+
+    // Safety check.
+    // Check if proposal extends from the locked leaf.
+    let outcome = read_consensus.visit_leaf_ancestors(
+        justify_qc.view_number(),
+        Terminator::Inclusive(read_consensus.locked_view()),
+        false,
+        |leaf, _, _| {
+            // if leaf view no == locked view no then we're done, report success by
+            // returning true
+            leaf.view_number() != read_consensus.locked_view()
+        },
+    );
+    let safety_check = outcome.is_ok();
+
+    ensure!(safety_check || liveness_check, {
+        if let Err(e) = outcome {
+            broadcast_event(
+                Event {
+                    view_number,
+                    event: EventType::Error { error: Arc::new(e) },
+                },
+                &event_sender,
+            )
+            .await;
+        }
+
+        format!("Failed safety and liveness check \n High QC is {:?}  Proposal QC is {:?}  Locked view is {:?}", read_consensus.high_qc(), proposal.data.clone(), read_consensus.locked_view())
+    });
+
+    // We accept the proposal, notify the application layer
+
+    broadcast_event(
+        Event {
+            view_number,
+            event: EventType::QuorumProposal {
+                proposal: proposal.clone(),
+                sender,
+            },
+        },
+        &event_sender,
+    )
+    .await;
+    // Notify other tasks
+    broadcast_event(
+        Arc::new(HotShotEvent::QuorumProposalValidated(
+            proposal.data.clone(),
+            parent_leaf,
+        )),
+        &event_stream,
+    )
+    .await;
+
+    Ok(())
+}
+
+/// Validate the state and safety and liveness of a proposal then emit
+/// a `QuorumProposalValidated` event.
+///
+/// TODO - This should just take the QuorumProposalRecv task state after
+/// we merge the dependency tasks.
+#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_lines)]
+pub async fn validate_proposal_safety_and_liveness<TYPES: NodeType>(
+    proposal: Proposal<TYPES, QuorumProposal<TYPES>>,
+    parent_leaf: Leaf<TYPES>,
+    consensus: Arc<RwLock<Consensus<TYPES>>>,
+    decided_upgrade_certificate: Arc<RwLock<Option<UpgradeCertificate<TYPES>>>>,
+    quorum_membership: Arc<TYPES::Membership>,
+    view_leader_key: TYPES::SignatureKey,
+    event_stream: Sender<Arc<HotShotEvent<TYPES>>>,
+    sender: TYPES::SignatureKey,
+    event_sender: Sender<Event<TYPES>>,
+) -> Result<()> {
+    let view_number = proposal.data.view_number();
+
+    let proposed_leaf = Leaf::from_quorum_proposal(&proposal.data);
+    ensure!(
+        proposed_leaf.parent_commitment() == parent_leaf.commit(),
+        "Proposed leaf does not extend the parent leaf."
+    );
+
+    let state = Arc::new(
+        <TYPES::ValidatedState as ValidatedState<TYPES>>::from_header(&proposal.data.block_header),
+    );
+    let view = View {
+        view_inner: ViewInner::Leaf {
+            leaf: proposed_leaf.commit(),
+            state,
+            delta: None, // May be updated to `Some` in the vote task.
+        },
+    };
+
+    if let Err(e) = consensus
+        .write()
+        .await
+        .update_validated_state_map(view_number, view.clone())
+    {
+        tracing::trace!("{e:?}");
+    }
+    consensus
+        .write()
+        .await
+        .update_saved_leaves(proposed_leaf.clone());
+
+    // Broadcast that we've updated our consensus state so that other tasks know it's safe to grab.
+    broadcast_event(
+        Arc::new(HotShotEvent::ValidatedStateUpdated(view_number, view)),
+        &event_stream,
+    )
+    .await;
+
+    // Validate the proposal's signature. This should also catch if the leaf_commitment does not equal our calculated parent commitment
+    //
+    // There is a mistake here originating in the genesis leaf/qc commit. This should be replaced by:
+    //
+    //    proposal.validate_signature(&quorum_membership)?;
+    //
+    // in a future PR.
+    ensure!(
+        view_leader_key.validate(&proposal.signature, proposed_leaf.commit().as_ref()),
+        "Could not verify proposal."
+    );
+
+    UpgradeCertificate::validate(&proposal.data.upgrade_certificate, &quorum_membership)?;
+
+    // Validate that the upgrade certificate is re-attached, if we saw one on the parent
+    proposed_leaf
+        .extends_upgrade(&parent_leaf, &decided_upgrade_certificate)
+        .await?;
 
     let justify_qc = proposal.data.justify_qc.clone();
     // Create a positive vote if either liveness or safety check
@@ -452,7 +597,7 @@ pub async fn publish_proposal_from_commitment_and_metadata<TYPES: NodeType>(
 
     if !proposal_upgrade_certificate
         .clone()
-        .is_some_and(|cert| cert.is_relevant(view, decided_upgrade_cert).is_ok())
+        .is_some_and(|cert| cert.temp_is_relevant(view, decided_upgrade_cert).is_ok())
     {
         proposal_upgrade_certificate = None;
     }
@@ -803,7 +948,7 @@ pub(crate) async fn handle_quorum_proposal_recv<TYPES: NodeType, I: NodeImplemen
         .entry(proposal.data.view_number())
         .or_default()
         .push(async_spawn(
-            validate_proposal_safety_and_liveness(
+            temp_validate_proposal_safety_and_liveness(
                 proposal.clone(),
                 parent_leaf,
                 Arc::clone(&task_state.consensus),
@@ -841,7 +986,7 @@ pub struct LeafChainTraversalOutcome<TYPES: NodeType> {
     pub included_txns: Option<HashSet<Commitment<<TYPES as NodeType>::Transaction>>>,
 
     /// The most recent upgrade certificate from one of the leaves.
-    pub decided_upgrade_cert: Option<UpgradeCertificate<TYPES>>,
+    pub decided_upgrade_certificate: Option<UpgradeCertificate<TYPES>>,
 }
 
 /// We need Default to be implemented because the leaf ascension has very few failure branches,
@@ -857,7 +1002,7 @@ impl<TYPES: NodeType + Default> Default for LeafChainTraversalOutcome<TYPES> {
             leaf_views: Vec::new(),
             leaves_decided: Vec::new(),
             included_txns: None,
-            decided_upgrade_cert: None,
+            decided_upgrade_certificate: None,
         }
     }
 }
@@ -955,7 +1100,7 @@ pub async fn decide_from_proposal<TYPES: NodeType>(
                             warn!("Failed to decide an upgrade certificate in time. Ignoring.");
                         } else {
                             info!("Reached decide on upgrade certificate: {:?}", cert);
-                            res.decided_upgrade_cert = Some(cert.clone());
+                            res.decided_upgrade_certificate = Some(cert.clone());
                         }
                     }
                 }
@@ -1028,7 +1173,7 @@ pub async fn handle_quorum_proposal_validated<TYPES: NodeType, I: NodeImplementa
     )
     .await;
 
-    if let Some(cert) = res.decided_upgrade_cert {
+    if let Some(cert) = res.decided_upgrade_certificate {
         task_state.decided_upgrade_cert = Some(cert.clone());
 
         let mut decided_certificate_lock = task_state.decided_upgrade_certificate.write().await;

--- a/crates/task-impls/src/consensus/mod.rs
+++ b/crates/task-impls/src/consensus/mod.rs
@@ -435,6 +435,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> ConsensusTaskState<TYPES, I>
                     };
                 }
             },
+            #[cfg(not(feature = "dependency-tasks"))]
             HotShotEvent::UpgradeCertificateFormed(cert) => {
                 debug!(
                     "Upgrade certificate received for view {}!",

--- a/crates/task-impls/src/consensus2/handlers.rs
+++ b/crates/task-impls/src/consensus2/handlers.rs
@@ -14,7 +14,7 @@ use hotshot_types::{
     },
     vote::HasViewNumber,
 };
-use tracing::debug;
+use tracing::{debug, warn};
 
 use super::Consensus2TaskState;
 use crate::{
@@ -132,6 +132,23 @@ pub(crate) async fn handle_view_change<TYPES: NodeType, I: NodeImplementation<TY
 
     // Move this node to the next view
     task_state.cur_view = new_view_number;
+
+    // If we have a decided upgrade certificate, we may need to upgrade the protocol version on a
+    // view change.
+    let decided_upgrade_certificate_read =
+        task_state.decided_upgrade_certificate.read().await.clone();
+    if let Some(cert) = decided_upgrade_certificate_read {
+        if new_view_number == cert.data.new_version_first_view {
+            warn!(
+                "Updating version based on a decided upgrade cert: {:?}",
+                cert
+            );
+            let mut version = task_state.version.write().await;
+            let new_version = cert.data.new_version;
+            *version = new_version;
+            broadcast_event(Arc::new(HotShotEvent::VersionUpgrade(new_version)), sender).await;
+        }
+    }
 
     // Spawn a timeout task if we did actually update view
     let timeout = task_state.timeout;

--- a/crates/task-impls/src/consensus2/mod.rs
+++ b/crates/task-impls/src/consensus2/mod.rs
@@ -10,7 +10,7 @@ use hotshot_task::task::TaskState;
 use hotshot_types::{
     consensus::Consensus,
     event::Event,
-    simple_certificate::{QuorumCertificate, TimeoutCertificate},
+    simple_certificate::{QuorumCertificate, TimeoutCertificate, UpgradeCertificate},
     simple_vote::{QuorumVote, TimeoutVote},
     traits::{
         node_implementation::{NodeImplementation, NodeType},
@@ -20,6 +20,7 @@ use hotshot_types::{
 #[cfg(async_executor_impl = "tokio")]
 use tokio::task::JoinHandle;
 use tracing::instrument;
+use vbs::version::Version;
 
 use self::handlers::{
     handle_quorum_vote_recv, handle_timeout, handle_timeout_vote_recv, handle_view_change,
@@ -92,6 +93,12 @@ pub struct Consensus2TaskState<TYPES: NodeType, I: NodeImplementation<TYPES>> {
 
     /// The node's id
     pub id: u64,
+
+    /// Globally shared reference to the current network version.
+    pub version: Arc<RwLock<Version>>,
+
+    /// An upgrade certificate that has been decided on, if any.
+    pub decided_upgrade_certificate: Arc<RwLock<Option<UpgradeCertificate<TYPES>>>>,
 }
 impl<TYPES: NodeType, I: NodeImplementation<TYPES>> Consensus2TaskState<TYPES, I> {
     /// Handles a consensus event received on the event stream

--- a/crates/task-impls/src/quorum_proposal/dependency_handle.rs
+++ b/crates/task-impls/src/quorum_proposal/dependency_handle.rs
@@ -16,6 +16,7 @@ use hotshot_types::{
     consensus::{CommitmentAndMetadata, Consensus},
     data::{Leaf, QuorumProposal, VidDisperse, ViewChangeEvidence},
     message::Proposal,
+    simple_certificate::UpgradeCertificate,
     traits::{
         block_contents::BlockHeader, node_implementation::NodeType, signature_key::SignatureKey,
     },
@@ -85,6 +86,17 @@ pub struct ProposalDependencyHandle<TYPES: NodeType> {
 
     /// The current version of consensus
     pub version: Version,
+
+    /// The most recent upgrade certificate this node formed.
+    /// Note: this is ONLY for certificates that have been formed internally,
+    /// so that we can propose with them.
+    ///
+    /// Certificates received from other nodes will get reattached regardless of this fields,
+    /// since they will be present in the leaf we propose off of.
+    pub formed_upgrade_certificate: Option<UpgradeCertificate<TYPES>>,
+
+    /// An upgrade certificate that has been decided on, if any.
+    pub decided_upgrade_certificate: Arc<RwLock<Option<UpgradeCertificate<TYPES>>>>,
 }
 
 impl<TYPES: NodeType> ProposalDependencyHandle<TYPES> {
@@ -96,6 +108,8 @@ impl<TYPES: NodeType> ProposalDependencyHandle<TYPES> {
         commitment_and_metadata: CommitmentAndMetadata<TYPES>,
         vid_share: Proposal<TYPES, VidDisperse<TYPES>>,
         view_change_evidence: Option<ViewChangeEvidence<TYPES>>,
+        formed_upgrade_certificate: Option<UpgradeCertificate<TYPES>>,
+        decided_upgrade_certificate: Arc<RwLock<Option<UpgradeCertificate<TYPES>>>>,
     ) -> Result<()> {
         let (parent_leaf, state) = parent_leaf_and_state(
             self.view_number,
@@ -104,6 +118,34 @@ impl<TYPES: NodeType> ProposalDependencyHandle<TYPES> {
             Arc::clone(&self.consensus),
         )
         .await?;
+
+        // In order of priority, we should try to attach:
+        //   - the parent certificate if it exists, or
+        //   - our own certificate that we formed.
+        // In either case, we need to ensure that the certificate is still relevant.
+        //
+        // Note: once we reach a point of potentially propose with our formed upgrade certificate,
+        // we will ALWAYS drop it. If we cannot immediately use it for whatever reason, we choose
+        // to discard it.
+        //
+        // It is possible that multiple nodes form separate upgrade certificates for the some
+        // upgrade if we are not careful about voting. But this shouldn't bother us: the first
+        // leader to propose is the one whose certificate will be used. And if that fails to reach
+        // a decide for whatever reason, we may lose our own certificate, but something will likely
+        // have gone wrong there anyway.
+        let mut upgrade_certificate = parent_leaf
+            .upgrade_certificate()
+            .or(formed_upgrade_certificate);
+
+        if let Some(cert) = upgrade_certificate.clone() {
+            if cert
+                .is_relevant(self.view_number, Arc::clone(&decided_upgrade_certificate))
+                .await
+                .is_err()
+            {
+                upgrade_certificate = None;
+            }
+        }
 
         let proposal_certificate = view_change_evidence
             .as_ref()
@@ -134,7 +176,7 @@ impl<TYPES: NodeType> ProposalDependencyHandle<TYPES> {
             view_number: self.view_number,
             justify_qc: self.consensus.read().await.high_qc().clone(),
             proposal_certificate,
-            upgrade_certificate: None,
+            upgrade_certificate,
         };
 
         let proposed_leaf = Leaf::from_quorum_proposal(&proposal);
@@ -272,6 +314,8 @@ impl<TYPES: NodeType> HandleDepOutput for ProposalDependencyHandle<TYPES> {
                 commit_and_metadata.unwrap(),
                 vid_share.unwrap(),
                 proposal_cert,
+                self.formed_upgrade_certificate.clone(),
+                Arc::clone(&self.decided_upgrade_certificate),
             )
             .await
         {

--- a/crates/task-impls/src/quorum_proposal/dependency_handle.rs
+++ b/crates/task-impls/src/quorum_proposal/dependency_handle.rs
@@ -84,8 +84,8 @@ pub struct ProposalDependencyHandle<TYPES: NodeType> {
     /// Shared consensus task state
     pub consensus: Arc<RwLock<Consensus<TYPES>>>,
 
-    /// The current version of consensus
-    pub version: Version,
+    /// Globally shared reference to the current network version.
+    pub version: Arc<RwLock<Version>>,
 
     /// The most recent upgrade certificate this node formed.
     /// Note: this is ONLY for certificates that have been formed internally,
@@ -166,7 +166,7 @@ impl<TYPES: NodeType> ProposalDependencyHandle<TYPES> {
             commitment_and_metadata.metadata,
             commitment_and_metadata.fee,
             vid_share.data.common.clone(),
-            self.version,
+            *self.version.read().await,
         )
         .await
         .context("Failed to construct block header")?;

--- a/crates/task-impls/src/quorum_proposal/mod.rs
+++ b/crates/task-impls/src/quorum_proposal/mod.rs
@@ -87,8 +87,8 @@ pub struct QuorumProposalTaskState<TYPES: NodeType, I: NodeImplementation<TYPES>
     /// The node's id
     pub id: u64,
 
-    /// Current version of consensus
-    pub version: Version,
+    /// Globally shared reference to the current network version.
+    pub version: Arc<RwLock<Version>>,
 
     /// The most recent upgrade certificate this node formed.
     /// Note: this is ONLY for certificates that have been formed internally,
@@ -321,7 +321,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> QuorumProposalTaskState<TYPE
                 round_start_delay: self.round_start_delay,
                 instance_state: Arc::clone(&self.instance_state),
                 consensus: Arc::clone(&self.consensus),
-                version: self.version,
+                version: Arc::clone(&self.version),
                 formed_upgrade_certificate: self.formed_upgrade_certificate.clone(),
                 decided_upgrade_certificate: Arc::clone(&self.decided_upgrade_certificate),
             },
@@ -363,9 +363,6 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> QuorumProposalTaskState<TYPE
         event_sender: Sender<Arc<HotShotEvent<TYPES>>>,
     ) {
         match event.as_ref() {
-            HotShotEvent::VersionUpgrade(version) => {
-                self.version = *version;
-            }
             HotShotEvent::UpgradeCertificateFormed(cert) => {
                 debug!(
                     "Upgrade certificate received for view {}!",

--- a/crates/task-impls/src/quorum_proposal_recv/handlers.rs
+++ b/crates/task-impls/src/quorum_proposal_recv/handlers.rs
@@ -227,7 +227,7 @@ pub(crate) async fn handle_quorum_proposal_recv<TYPES: NodeType, I: NodeImplemen
         proposal.clone(),
         parent_leaf,
         Arc::clone(&task_state.consensus),
-        None,
+        Arc::clone(&task_state.decided_upgrade_certificate),
         Arc::clone(&task_state.quorum_membership),
         view_leader_key,
         event_sender.clone(),

--- a/crates/task-impls/src/quorum_proposal_recv/mod.rs
+++ b/crates/task-impls/src/quorum_proposal_recv/mod.rs
@@ -79,19 +79,8 @@ pub struct QuorumProposalRecvTaskState<TYPES: NodeType, I: NodeImplementation<TY
     /// This node's storage ref
     pub storage: Arc<RwLock<I::Storage>>,
 
-    /// The most recent upgrade certificate this node formed.
-    /// Note: this is ONLY for certificates that have been formed internally,
-    /// so that we can propose with them.
-    ///
-    /// Certificates received from other nodes will get reattached regardless of this fields,
-    /// since they will be present in the leaf we propose off of.
-    pub formed_upgrade_certificate: Option<UpgradeCertificate<TYPES>>,
-
     /// last View Sync Certificate or Timeout Certificate this node formed.
     pub proposal_cert: Option<ViewChangeEvidence<TYPES>>,
-
-    /// most recent decided upgrade certificate
-    pub decided_upgrade_cert: Option<UpgradeCertificate<TYPES>>,
 
     /// Spawned tasks related to a specific view, so we can cancel them when
     /// they are stale
@@ -105,6 +94,9 @@ pub struct QuorumProposalRecvTaskState<TYPES: NodeType, I: NodeImplementation<TY
 
     /// Current version of consensus
     pub version: Version,
+
+    /// An upgrade certificate that has been decided on, if any.
+    pub decided_upgrade_certificate: Arc<RwLock<Option<UpgradeCertificate<TYPES>>>>,
 }
 
 impl<TYPES: NodeType, I: NodeImplementation<TYPES>> QuorumProposalRecvTaskState<TYPES, I> {

--- a/crates/task-impls/src/quorum_proposal_recv/mod.rs
+++ b/crates/task-impls/src/quorum_proposal_recv/mod.rs
@@ -92,8 +92,8 @@ pub struct QuorumProposalRecvTaskState<TYPES: NodeType, I: NodeImplementation<TY
     /// The node's id
     pub id: u64,
 
-    /// Current version of consensus
-    pub version: Version,
+    /// Globally shared reference to the current network version.
+    pub version: Arc<RwLock<Version>>,
 
     /// An upgrade certificate that has been decided on, if any.
     pub decided_upgrade_certificate: Arc<RwLock<Option<UpgradeCertificate<TYPES>>>>,

--- a/crates/task-impls/src/quorum_vote/handlers.rs
+++ b/crates/task-impls/src/quorum_vote/handlers.rs
@@ -66,8 +66,6 @@ pub(crate) async fn handle_quorum_proposal_validated<
         consensus_writer.update_locked_view(locked_view_number)?;
     }
 
-    // TODO - update decided upgrade cert
-
     #[allow(clippy::cast_precision_loss)]
     if let Some(decided_view_number) = new_decided_view_number {
         // Bring in the cleanup crew. When a new decide is indeed valid, we need to clear out old memory.

--- a/crates/task-impls/src/quorum_vote/handlers.rs
+++ b/crates/task-impls/src/quorum_vote/handlers.rs
@@ -27,6 +27,7 @@ pub(crate) async fn handle_quorum_proposal_validated<
     sender: &Sender<Arc<HotShotEvent<TYPES>>>,
     task_state: &mut QuorumVoteTaskState<TYPES, I>,
 ) -> Result<()> {
+    let decided_upgrade_certificate_read = task_state.decided_upgrade_certificate.read().await;
     let LeafChainTraversalOutcome {
         new_locked_view_number,
         new_decided_view_number,
@@ -34,14 +35,24 @@ pub(crate) async fn handle_quorum_proposal_validated<
         leaf_views,
         leaves_decided,
         included_txns,
-        ..
+        decided_upgrade_certificate,
     } = decide_from_proposal(
         proposal,
         Arc::clone(&task_state.consensus),
-        &None,
+        &decided_upgrade_certificate_read,
         &task_state.public_key,
     )
     .await;
+    drop(decided_upgrade_certificate_read);
+
+    if let Some(cert) = decided_upgrade_certificate.clone() {
+        let mut decided_certificate_lock = task_state.decided_upgrade_certificate.write().await;
+        *decided_certificate_lock = Some(cert.clone());
+        drop(decided_certificate_lock);
+        let _ = sender
+            .broadcast(Arc::new(HotShotEvent::UpgradeDecided(cert.clone())))
+            .await;
+    }
 
     let mut consensus_writer = task_state.consensus.write().await;
     if let Some(locked_view_number) = new_locked_view_number {

--- a/crates/task-impls/src/quorum_vote/mod.rs
+++ b/crates/task-impls/src/quorum_vote/mod.rs
@@ -17,6 +17,7 @@ use hotshot_types::{
     data::{Leaf, VidDisperseShare},
     event::Event,
     message::Proposal,
+    simple_certificate::UpgradeCertificate,
     simple_vote::{QuorumData, QuorumVote},
     traits::{
         block_contents::BlockHeader,
@@ -389,6 +390,9 @@ pub struct QuorumVoteTaskState<TYPES: NodeType, I: NodeImplementation<TYPES>> {
 
     /// The curent version of HotShot
     pub version: Version,
+
+    /// An upgrade certificate that has been decided on, if any.
+    pub decided_upgrade_certificate: Arc<RwLock<Option<UpgradeCertificate<TYPES>>>>,
 }
 
 impl<TYPES: NodeType, I: NodeImplementation<TYPES>> QuorumVoteTaskState<TYPES, I> {

--- a/crates/task-impls/src/quorum_vote/mod.rs
+++ b/crates/task-impls/src/quorum_vote/mod.rs
@@ -14,7 +14,7 @@ use hotshot_task::{
 };
 use hotshot_types::{
     consensus::Consensus,
-    data::{Leaf, VidDisperseShare},
+    data::{Leaf, VidDisperseShare, ViewNumber},
     event::Event,
     message::Proposal,
     simple_certificate::UpgradeCertificate,
@@ -232,12 +232,14 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static> HandleDepOutput
     #[allow(clippy::too_many_lines)]
     async fn handle_dep_result(self, res: Self::Output) {
         let high_qc_view_number = self.consensus.read().await.high_qc().view_number;
-        if !self
-            .consensus
-            .read()
-            .await
-            .validated_state_map()
-            .contains_key(&high_qc_view_number)
+        // The validated state of a non-genesis high QC should exist in the state map.
+        if *high_qc_view_number != *ViewNumber::genesis()
+            && !self
+                .consensus
+                .read()
+                .await
+                .validated_state_map()
+                .contains_key(&high_qc_view_number)
         {
             // Block on receiving the event from the event stream.
             EventDependency::new(

--- a/crates/testing/src/helpers.rs
+++ b/crates/testing/src/helpers.rs
@@ -240,6 +240,17 @@ pub fn da_payload_commitment(
     vid_commitment(&encoded_transactions, quorum_membership.total_nodes())
 }
 
+pub fn build_payload_commitment(
+    membership: &<TestTypes as NodeType>::Membership,
+    view: ViewNumber,
+) -> <VidSchemeType as VidScheme>::Commit {
+    // Make some empty encoded transactions, we just care about having a commitment handy for the
+    // later calls. We need the VID commitment to be able to propose later.
+    let mut vid = vid_scheme_from_view_number::<TestTypes>(membership, view);
+    let encoded_transactions = Vec::new();
+    vid.commit_only(&encoded_transactions).unwrap()
+}
+
 /// TODO: <https://github.com/EspressoSystems/HotShot/issues/2821>
 #[allow(clippy::type_complexity)]
 pub fn build_vid_proposal(

--- a/crates/testing/src/predicates/mod.rs
+++ b/crates/testing/src/predicates/mod.rs
@@ -1,5 +1,10 @@
 pub mod event;
-pub mod upgrade;
+#[cfg(not(feature = "dependency-tasks"))]
+pub mod upgrade_with_consensus;
+#[cfg(feature = "dependency-tasks")]
+pub mod upgrade_with_proposal;
+#[cfg(feature = "dependency-tasks")]
+pub mod upgrade_with_vote;
 
 use async_trait::async_trait;
 

--- a/crates/testing/src/predicates/upgrade_with_consensus.rs
+++ b/crates/testing/src/predicates/upgrade_with_consensus.rs
@@ -1,0 +1,50 @@
+#![cfg(not(feature = "dependency-tasks"))]
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use hotshot_example_types::node_types::{MemoryImpl, TestTypes};
+use hotshot_task_impls::consensus::ConsensusTaskState;
+use hotshot_types::simple_certificate::UpgradeCertificate;
+
+use crate::predicates::{Predicate, PredicateResult};
+
+type ConsensusTaskTestState = ConsensusTaskState<TestTypes, MemoryImpl>;
+
+type UpgradeCertCallback =
+    Arc<dyn Fn(Arc<Option<UpgradeCertificate<TestTypes>>>) -> bool + Send + Sync>;
+
+pub struct UpgradeCertPredicate {
+    check: UpgradeCertCallback,
+    info: String,
+}
+
+impl std::fmt::Debug for UpgradeCertPredicate {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.info)
+    }
+}
+
+#[async_trait]
+impl Predicate<ConsensusTaskTestState> for UpgradeCertPredicate {
+    async fn evaluate(&self, input: &ConsensusTaskTestState) -> PredicateResult {
+        let upgrade_cert = input.decided_upgrade_cert.clone();
+        PredicateResult::from((self.check)(upgrade_cert.into()))
+    }
+
+    async fn info(&self) -> String {
+        self.info.clone()
+    }
+}
+
+pub fn no_decided_upgrade_cert() -> Box<UpgradeCertPredicate> {
+    let info = "expected decided_upgrade_cert to be None".to_string();
+    let check: UpgradeCertCallback = Arc::new(move |s| s.is_none());
+    Box::new(UpgradeCertPredicate { info, check })
+}
+
+pub fn decided_upgrade_cert() -> Box<UpgradeCertPredicate> {
+    let info = "expected decided_upgrade_cert to be Some(_)".to_string();
+    let check: UpgradeCertCallback = Arc::new(move |s| s.is_some());
+    Box::new(UpgradeCertPredicate { info, check })
+}

--- a/crates/testing/src/predicates/upgrade_with_proposal.rs
+++ b/crates/testing/src/predicates/upgrade_with_proposal.rs
@@ -1,0 +1,50 @@
+#![cfg(feature = "dependency-tasks")]
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use hotshot_example_types::node_types::{MemoryImpl, TestTypes};
+use hotshot_task_impls::quorum_proposal::QuorumProposalTaskState;
+use hotshot_types::simple_certificate::UpgradeCertificate;
+
+use crate::predicates::{Predicate, PredicateResult};
+
+type QuorumProposalTaskTestState = QuorumProposalTaskState<TestTypes, MemoryImpl>;
+
+type UpgradeCertCallback =
+    Arc<dyn Fn(Arc<Option<UpgradeCertificate<TestTypes>>>) -> bool + Send + Sync>;
+
+pub struct UpgradeCertPredicate {
+    check: UpgradeCertCallback,
+    info: String,
+}
+
+impl std::fmt::Debug for UpgradeCertPredicate {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.info)
+    }
+}
+
+#[async_trait]
+impl Predicate<QuorumProposalTaskTestState> for UpgradeCertPredicate {
+    async fn evaluate(&self, input: &QuorumProposalTaskTestState) -> PredicateResult {
+        let upgrade_cert = input.decided_upgrade_certificate.read().await.clone();
+        PredicateResult::from((self.check)(upgrade_cert.into()))
+    }
+
+    async fn info(&self) -> String {
+        self.info.clone()
+    }
+}
+
+pub fn no_decided_upgrade_cert() -> Box<UpgradeCertPredicate> {
+    let info = "expected decided_upgrade_cert to be None".to_string();
+    let check: UpgradeCertCallback = Arc::new(move |s| s.is_none());
+    Box::new(UpgradeCertPredicate { info, check })
+}
+
+pub fn decided_upgrade_cert() -> Box<UpgradeCertPredicate> {
+    let info = "expected decided_upgrade_cert to be Some(_)".to_string();
+    let check: UpgradeCertCallback = Arc::new(move |s| s.is_some());
+    Box::new(UpgradeCertPredicate { info, check })
+}

--- a/crates/testing/src/predicates/upgrade_with_vote.rs
+++ b/crates/testing/src/predicates/upgrade_with_vote.rs
@@ -1,13 +1,14 @@
+#![cfg(feature = "dependency-tasks")]
+
 use std::sync::Arc;
 
 use async_trait::async_trait;
 use hotshot_example_types::node_types::{MemoryImpl, TestTypes};
-use hotshot_task_impls::consensus::ConsensusTaskState;
+use hotshot_task_impls::quorum_vote::QuorumVoteTaskState;
 use hotshot_types::simple_certificate::UpgradeCertificate;
 
 use crate::predicates::{Predicate, PredicateResult};
-
-type ConsensusTaskTestState = ConsensusTaskState<TestTypes, MemoryImpl>;
+type QuorumVoteTaskTestState = QuorumVoteTaskState<TestTypes, MemoryImpl>;
 
 type UpgradeCertCallback =
     Arc<dyn Fn(Arc<Option<UpgradeCertificate<TestTypes>>>) -> bool + Send + Sync>;
@@ -23,10 +24,11 @@ impl std::fmt::Debug for UpgradeCertPredicate {
     }
 }
 
+#[cfg(feature = "dependency-tasks")]
 #[async_trait]
-impl Predicate<ConsensusTaskTestState> for UpgradeCertPredicate {
-    async fn evaluate(&self, input: &ConsensusTaskTestState) -> PredicateResult {
-        let upgrade_cert = input.decided_upgrade_cert.clone();
+impl Predicate<QuorumVoteTaskTestState> for UpgradeCertPredicate {
+    async fn evaluate(&self, input: &QuorumVoteTaskTestState) -> PredicateResult {
+        let upgrade_cert = input.decided_upgrade_certificate.read().await.clone();
         PredicateResult::from((self.check)(upgrade_cert.into()))
     }
 

--- a/crates/testing/src/script.rs
+++ b/crates/testing/src/script.rs
@@ -49,6 +49,15 @@ impl<TYPES: NodeType, S> Expectations<TYPES, S> {
             task_state_asserts: vec![],
         }
     }
+    pub fn from_outputs_and_task_states(
+        output_asserts: Vec<Box<dyn Predicate<Arc<HotShotEvent<TYPES>>>>>,
+        task_state_asserts: Vec<Box<dyn Predicate<S>>>,
+    ) -> Self {
+        Self {
+            output_asserts,
+            task_state_asserts,
+        }
+    }
 }
 
 pub fn panic_extra_output_in_script<S>(stage_number: usize, script_name: String, output: &S)

--- a/crates/testing/tests/tests_1/quorum_proposal_task.rs
+++ b/crates/testing/tests/tests_1/quorum_proposal_task.rs
@@ -19,7 +19,7 @@ use hotshot_testing::{
     all_predicates,
     helpers::{
         build_fake_view_with_leaf, build_system_handle,
-        vid_scheme_from_view_number,
+        build_payload_commitment
     },
     predicates::{
         event::{all_predicates, exact, quorum_proposal_send},
@@ -34,27 +34,14 @@ use hotshot_types::{
     simple_vote::{TimeoutData, ViewSyncFinalizeData},
     traits::{
         election::Membership,
-        node_implementation::{ConsensusTime, NodeType},
+        node_implementation::{ConsensusTime},
     },
     utils::BuilderCommitment,
-    vid::VidSchemeType,
     vote::HasViewNumber,
 };
-use jf_vid::VidScheme;
 use sha2::Digest;
 
 const TIMEOUT: Duration = Duration::from_millis(35);
-
-fn make_payload_commitment(
-    membership: &<TestTypes as NodeType>::Membership,
-    view: ViewNumber,
-) -> <VidSchemeType as VidScheme>::Commit {
-    // Make some empty encoded transactions, we just care about having a commitment handy for the
-    // later calls. We need the VID commitment to be able to propose later.
-    let mut vid = vid_scheme_from_view_number::<TestTypes>(membership, view);
-    let encoded_transactions = Vec::new();
-    vid.commit_only(&encoded_transactions).unwrap()
-}
 
 #[cfg(test)]
 #[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
@@ -70,7 +57,7 @@ async fn test_quorum_proposal_task_quorum_proposal_view_1() {
     let quorum_membership = handle.hotshot.memberships.quorum_membership.clone();
     let da_membership = handle.hotshot.memberships.da_membership.clone();
 
-    let payload_commitment = make_payload_commitment(&quorum_membership, ViewNumber::new(node_id));
+    let payload_commitment = build_payload_commitment(&quorum_membership, ViewNumber::new(node_id));
 
     let mut generator = TestViewGenerator::generate(quorum_membership.clone(), da_membership);
 
@@ -195,7 +182,7 @@ async fn test_quorum_proposal_task_quorum_proposal_view_gt_1() {
         random![
             QcFormed(either::Left(genesis_cert.clone())),
             SendPayloadCommitmentAndMetadata(
-                make_payload_commitment(&quorum_membership, ViewNumber::new(1)),
+                build_payload_commitment(&quorum_membership, ViewNumber::new(1)),
                 builder_commitment.clone(),
                 TestMetadata,
                 ViewNumber::new(1),
@@ -211,7 +198,7 @@ async fn test_quorum_proposal_task_quorum_proposal_view_gt_1() {
             QuorumProposalRecv(proposals[0].clone(), leaders[0]),
             QcFormed(either::Left(proposals[1].data.justify_qc.clone())),
             SendPayloadCommitmentAndMetadata(
-                make_payload_commitment(&quorum_membership, ViewNumber::new(2)),
+                build_payload_commitment(&quorum_membership, ViewNumber::new(2)),
                 builder_commitment.clone(),
                 TestMetadata,
                 ViewNumber::new(2),
@@ -227,7 +214,7 @@ async fn test_quorum_proposal_task_quorum_proposal_view_gt_1() {
             QuorumProposalRecv(proposals[1].clone(), leaders[1]),
             QcFormed(either::Left(proposals[2].data.justify_qc.clone())),
             SendPayloadCommitmentAndMetadata(
-                make_payload_commitment(&quorum_membership, ViewNumber::new(3)),
+                build_payload_commitment(&quorum_membership, ViewNumber::new(3)),
                 builder_commitment.clone(),
                 TestMetadata,
                 ViewNumber::new(3),
@@ -243,7 +230,7 @@ async fn test_quorum_proposal_task_quorum_proposal_view_gt_1() {
             QuorumProposalRecv(proposals[2].clone(), leaders[2]),
             QcFormed(either::Left(proposals[3].data.justify_qc.clone())),
             SendPayloadCommitmentAndMetadata(
-                make_payload_commitment(&quorum_membership, ViewNumber::new(4)),
+                build_payload_commitment(&quorum_membership, ViewNumber::new(4)),
                 builder_commitment.clone(),
                 TestMetadata,
                 ViewNumber::new(4),
@@ -259,7 +246,7 @@ async fn test_quorum_proposal_task_quorum_proposal_view_gt_1() {
             QuorumProposalRecv(proposals[3].clone(), leaders[3]),
             QcFormed(either::Left(proposals[4].data.justify_qc.clone())),
             SendPayloadCommitmentAndMetadata(
-                make_payload_commitment(&quorum_membership, ViewNumber::new(5)),
+                build_payload_commitment(&quorum_membership, ViewNumber::new(5)),
                 builder_commitment,
                 TestMetadata,
                 ViewNumber::new(5),
@@ -321,7 +308,7 @@ async fn test_quorum_proposal_task_qc_timeout() {
     let quorum_membership = handle.hotshot.memberships.quorum_membership.clone();
     let da_membership = handle.hotshot.memberships.da_membership.clone();
 
-    let payload_commitment = make_payload_commitment(&quorum_membership, ViewNumber::new(node_id));
+    let payload_commitment = build_payload_commitment(&quorum_membership, ViewNumber::new(node_id));
     let builder_commitment = BuilderCommitment::from_raw_digest(sha2::Sha256::new().finalize());
 
     let mut generator = TestViewGenerator::generate(quorum_membership.clone(), da_membership);
@@ -400,7 +387,7 @@ async fn test_quorum_proposal_task_view_sync() {
     let quorum_membership = handle.hotshot.memberships.quorum_membership.clone();
     let da_membership = handle.hotshot.memberships.da_membership.clone();
 
-    let payload_commitment = make_payload_commitment(&quorum_membership, ViewNumber::new(node_id));
+    let payload_commitment = build_payload_commitment(&quorum_membership, ViewNumber::new(node_id));
     let builder_commitment = BuilderCommitment::from_raw_digest(sha2::Sha256::new().finalize());
 
     let mut generator = TestViewGenerator::generate(quorum_membership.clone(), da_membership);
@@ -521,7 +508,7 @@ async fn test_quorum_proposal_task_liveness_check() {
         random![
             QcFormed(either::Left(genesis_cert.clone())),
             SendPayloadCommitmentAndMetadata(
-                make_payload_commitment(&quorum_membership, ViewNumber::new(1)),
+                build_payload_commitment(&quorum_membership, ViewNumber::new(1)),
                 builder_commitment.clone(),
                 TestMetadata,
                 ViewNumber::new(1),
@@ -537,7 +524,7 @@ async fn test_quorum_proposal_task_liveness_check() {
             QuorumProposalRecv(proposals[0].clone(), leaders[0]),
             QcFormed(either::Left(proposals[1].data.justify_qc.clone())),
             SendPayloadCommitmentAndMetadata(
-                make_payload_commitment(&quorum_membership, ViewNumber::new(2)),
+                build_payload_commitment(&quorum_membership, ViewNumber::new(2)),
                 builder_commitment.clone(),
                 TestMetadata,
                 ViewNumber::new(2),
@@ -553,7 +540,7 @@ async fn test_quorum_proposal_task_liveness_check() {
             QuorumProposalRecv(proposals[1].clone(), leaders[1]),
             QcFormed(either::Left(proposals[2].data.justify_qc.clone())),
             SendPayloadCommitmentAndMetadata(
-                make_payload_commitment(&quorum_membership, ViewNumber::new(3)),
+                build_payload_commitment(&quorum_membership, ViewNumber::new(3)),
                 builder_commitment.clone(),
                 TestMetadata,
                 ViewNumber::new(3),
@@ -570,7 +557,7 @@ async fn test_quorum_proposal_task_liveness_check() {
             QuorumProposalRecv(proposals[2].clone(), leaders[2]),
             QcFormed(either::Left(proposals[3].data.justify_qc.clone())),
             SendPayloadCommitmentAndMetadata(
-                make_payload_commitment(&quorum_membership, ViewNumber::new(4)),
+                build_payload_commitment(&quorum_membership, ViewNumber::new(4)),
                 builder_commitment.clone(),
                 TestMetadata,
                 ViewNumber::new(4),
@@ -586,7 +573,7 @@ async fn test_quorum_proposal_task_liveness_check() {
             QuorumProposalRecv(proposals[3].clone(), leaders[3]),
             QcFormed(either::Left(proposals[4].data.justify_qc.clone())),
             SendPayloadCommitmentAndMetadata(
-                make_payload_commitment(&quorum_membership, ViewNumber::new(5)),
+                build_payload_commitment(&quorum_membership, ViewNumber::new(5)),
                 builder_commitment,
                 TestMetadata,
                 ViewNumber::new(5),

--- a/crates/testing/tests/tests_1/upgrade_task_with_consensus.rs
+++ b/crates/testing/tests/tests_1/upgrade_task_with_consensus.rs
@@ -1,3 +1,5 @@
+#![cfg(not(feature = "dependency-tasks"))]
+
 // TODO: Remove after integration of dependency-tasks
 #![allow(unused_imports)]
 
@@ -12,11 +14,11 @@ use hotshot_example_types::{
 };
 use hotshot_macros::test_scripts;
 use hotshot_task_impls::{
-    consensus::ConsensusTaskState, events::HotShotEvent::*, upgrade::UpgradeTaskState,
+    consensus::ConsensusTaskState, events::HotShotEvent::*, upgrade::UpgradeTaskState
 };
 use hotshot_testing::{
     helpers::{build_fake_view_with_leaf, vid_share},
-    predicates::{event::*, upgrade::*},
+    predicates::{event::*, upgrade_with_consensus::*},
     script::{Expectations, TaskScript},
     view_generator::TestViewGenerator,
 };
@@ -28,11 +30,10 @@ use hotshot_types::{
 };
 use vbs::version::Version;
 
-#[cfg(not(feature = "dependency-tasks"))]
 #[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 /// Tests that we correctly update our internal consensus state when reaching a decided upgrade certificate.
-async fn test_consensus_task_upgrade() {
+async fn test_upgrade_task_vote() {
     use hotshot_testing::helpers::build_system_handle;
 
     async_compatibility_layer::logging::setup_logging();
@@ -181,14 +182,13 @@ async fn test_consensus_task_upgrade() {
     test_scripts![inputs, consensus_script].await;
 }
 
-#[cfg(not(feature = "dependency-tasks"))]
 #[cfg_attr(
     async_executor_impl = "tokio",
     tokio::test(flavor = "multi_thread", worker_threads = 2)
 )]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 /// Test that we correctly form and include an `UpgradeCertificate` when receiving votes.
-async fn test_upgrade_and_consensus_task() {
+async fn test_upgrade_task_propose() {
     use std::sync::Arc;
 
     use hotshot_testing::helpers::build_system_handle;
@@ -336,7 +336,6 @@ async fn test_upgrade_and_consensus_task() {
     test_scripts![inputs, consensus_script, upgrade_script].await;
 }
 
-#[cfg(not(feature = "dependency-tasks"))]
 #[cfg_attr(
     async_executor_impl = "tokio",
     tokio::test(flavor = "multi_thread", worker_threads = 2)
@@ -348,7 +347,7 @@ async fn test_upgrade_and_consensus_task() {
 ///   - we correctly vote affirmatively on a QuorumProposal with a null block payload in view 5
 ///   - we correctly propose with a null block payload in view 6, even if we have indications to do otherwise (via SendPayloadCommitmentAndMetadata, VID etc).
 ///   - we correctly reject a QuorumProposal with a non-null block payload in view 7.
-async fn test_upgrade_and_consensus_task_blank_blocks() {
+async fn test_upgrade_task_blank_blocks() {
     use hotshot_testing::helpers::build_system_handle;
 
     async_compatibility_layer::logging::setup_logging();

--- a/crates/testing/tests/tests_1/upgrade_task_with_proposal.rs
+++ b/crates/testing/tests/tests_1/upgrade_task_with_proposal.rs
@@ -1,0 +1,238 @@
+#![cfg(feature = "dependency-tasks")]
+
+// TODO: Remove after integration of dependency-tasks
+#![allow(unused_imports)]
+
+use std::time::Duration;
+
+use futures::StreamExt;
+use hotshot::{tasks::task_state::CreateTaskState, types::SystemContextHandle};
+use hotshot_example_types::{
+    block_types::{TestMetadata, TestTransaction},
+    node_types::{MemoryImpl, TestTypes},
+    state_types::TestInstanceState,
+};
+use sha2::Digest;
+use hotshot_macros::test_scripts;
+use hotshot_task_impls::{
+    quorum_proposal::QuorumProposalTaskState,
+    consensus::ConsensusTaskState, consensus2::Consensus2TaskState, events::HotShotEvent::*, upgrade::UpgradeTaskState
+};
+use hotshot_testing::{
+    helpers::{build_fake_view_with_leaf, vid_share,build_payload_commitment},
+    predicates::{event::*, upgrade_with_proposal::*},
+    script::{Expectations, TaskScript},
+    view_generator::TestViewGenerator,
+};
+use hotshot_types::{
+    data::{null_block,Leaf, ViewNumber},
+    simple_vote::UpgradeProposalData,
+    traits::{election::Membership,ValidatedState, node_implementation::ConsensusTime},
+    vote::HasViewNumber,
+    utils::BuilderCommitment
+};
+use hotshot_example_types::state_types::TestValidatedState;
+use vbs::version::Version;
+
+#[cfg_attr(
+    async_executor_impl = "tokio",
+    tokio::test(flavor = "multi_thread", worker_threads = 2)
+)]
+#[cfg_attr(async_executor_impl = "async-std", async_std::test)]
+/// Test that we correctly form and include an `UpgradeCertificate` when receiving votes.
+async fn test_upgrade_task_with_proposal() {
+    use std::sync::Arc;
+
+    use hotshot_testing::helpers::build_system_handle;
+
+    async_compatibility_layer::logging::setup_logging();
+    async_compatibility_layer::logging::setup_backtrace();
+
+    let handle = build_system_handle(3).await.0;
+    let quorum_membership = handle.hotshot.memberships.quorum_membership.clone();
+    let da_membership = handle.hotshot.memberships.da_membership.clone();
+
+    let other_handles = futures::future::join_all((0..=9).map(build_system_handle)).await;
+
+    let old_version = Version { major: 0, minor: 1 };
+    let new_version = Version { major: 0, minor: 2 };
+
+    let upgrade_data: UpgradeProposalData<TestTypes> = UpgradeProposalData {
+        old_version,
+        new_version,
+        decide_by: ViewNumber::new(4),
+        new_version_hash: [0u8; 12].to_vec(),
+        old_version_last_view: ViewNumber::new(5),
+        new_version_first_view: ViewNumber::new(7),
+    };
+
+    let mut proposals = Vec::new();
+    let mut votes = Vec::new();
+    let mut dacs = Vec::new();
+    let mut vid_dispersals = Vec::new();
+    let mut leaders = Vec::new();
+    let mut leaves = Vec::new();
+    let mut views = Vec::new();
+    let consensus = handle.hotshot.consensus();
+    let mut consensus_writer = consensus.write().await;
+
+    let mut generator = TestViewGenerator::generate(quorum_membership.clone(), da_membership);
+
+    for view in (&mut generator).take(1).collect::<Vec<_>>().await {
+        proposals.push(view.quorum_proposal.clone());
+        votes.push(view.create_quorum_vote(&handle));
+        dacs.push(view.da_certificate.clone());
+        vid_dispersals.push(view.vid_disperse.clone());
+        leaders.push(view.leader_public_key);
+        views.push(view.clone());
+        consensus_writer
+            .update_saved_leaves(Leaf::from_quorum_proposal(&view.quorum_proposal.data));
+        consensus_writer
+            .update_validated_state_map(
+                view.quorum_proposal.data.view_number(),
+                build_fake_view_with_leaf(view.leaf.clone()),
+            ).unwrap();
+    }
+
+    generator.add_upgrade(upgrade_data.clone());
+
+    for view in generator.take(4).collect::<Vec<_>>().await {
+        proposals.push(view.quorum_proposal.clone());
+        votes.push(view.create_quorum_vote(&handle));
+        dacs.push(view.da_certificate.clone());
+        vid_dispersals.push(view.vid_disperse.clone());
+        leaders.push(view.leader_public_key);
+        leaves.push(view.leaf.clone());
+        views.push(view.clone());
+        consensus_writer
+            .update_saved_leaves(Leaf::from_quorum_proposal(&view.quorum_proposal.data));
+        consensus_writer
+            .update_validated_state_map(
+                view.quorum_proposal.data.view_number(),
+                build_fake_view_with_leaf(view.leaf.clone()),
+            ).unwrap();
+    }
+    drop(consensus_writer);
+
+    let (validated_state, _ /* state delta */) = <TestValidatedState as ValidatedState<TestTypes>>::genesis(&*handle.hotshot.instance_state());
+    let genesis_cert = proposals[0].data.justify_qc.clone();
+    let genesis_leaf = Leaf::genesis(&validated_state, &*handle.hotshot.instance_state()).await;
+    let builder_commitment = BuilderCommitment::from_raw_digest(sha2::Sha256::new().finalize());
+    let upgrade_votes = other_handles
+        .iter()
+        .map(|h| views[2].create_upgrade_vote(upgrade_data.clone(), &h.0));
+
+    let proposal_state = QuorumProposalTaskState::<TestTypes, MemoryImpl>::create_from(&handle).await;
+    let upgrade_state = UpgradeTaskState::<TestTypes, MemoryImpl>::create_from(&handle).await;
+
+    let upgrade_vote_recvs: Vec<_> = upgrade_votes.map(UpgradeVoteRecv).collect();
+
+    let inputs = vec![
+        vec![
+            QcFormed(either::Left(genesis_cert.clone())),
+            SendPayloadCommitmentAndMetadata(
+                build_payload_commitment(&quorum_membership, ViewNumber::new(1)),
+                builder_commitment.clone(),
+                TestMetadata,
+                ViewNumber::new(1),
+                null_block::builder_fee(quorum_membership.total_nodes()).unwrap(),
+            ),
+            VidDisperseSend(vid_dispersals[0].clone(), handle.public_key()),
+            ValidatedStateUpdated(
+                genesis_cert.view_number(),
+                build_fake_view_with_leaf(genesis_leaf.clone()),
+            ),
+        ],
+        vec![
+            QuorumProposalRecv(proposals[0].clone(), leaders[0]),
+            QcFormed(either::Left(proposals[1].data.justify_qc.clone())),
+            SendPayloadCommitmentAndMetadata(
+                build_payload_commitment(&quorum_membership, ViewNumber::new(2)),
+                builder_commitment.clone(),
+                TestMetadata,
+                ViewNumber::new(2),
+                null_block::builder_fee(quorum_membership.total_nodes()).unwrap(),
+            ),
+            VidDisperseSend(vid_dispersals[1].clone(), handle.public_key()),
+            ValidatedStateUpdated(
+                proposals[0].data.view_number(),
+                build_fake_view_with_leaf(leaves[0].clone()),
+            ),
+        ],
+        upgrade_vote_recvs,
+        vec![
+            QuorumProposalRecv(proposals[1].clone(), leaders[1]),
+            QcFormed(either::Left(proposals[2].data.justify_qc.clone())),
+            SendPayloadCommitmentAndMetadata(
+                build_payload_commitment(&quorum_membership, ViewNumber::new(3)),
+                builder_commitment.clone(),
+                TestMetadata,
+                ViewNumber::new(3),
+                null_block::builder_fee(quorum_membership.total_nodes()).unwrap(),
+            ),
+            VidDisperseSend(vid_dispersals[2].clone(), handle.public_key()),
+            ValidatedStateUpdated(
+                proposals[1].data.view_number(),
+                build_fake_view_with_leaf(leaves[1].clone()),
+            ),
+        ],
+    ];
+
+    let mut proposal_script = TaskScript {
+        timeout: Duration::from_millis(35),
+        state: proposal_state,
+        expectations: vec![
+            Expectations {
+                output_asserts: vec![
+                    exact(UpdateHighQc(genesis_cert.clone())),
+                    exact(HighQcUpdated(genesis_cert.clone())),        
+                ],
+                task_state_asserts: vec![],
+            },
+            Expectations {
+                output_asserts: vec![
+                    exact(UpdateHighQc(proposals[1].data.justify_qc.clone())),
+                    exact(HighQcUpdated(proposals[1].data.justify_qc.clone())),   
+                ],
+                task_state_asserts: vec![],
+            },
+            Expectations {
+                output_asserts: vec![],
+                task_state_asserts: vec![],
+            },
+            Expectations {
+                output_asserts: vec![
+                    exact(UpdateHighQc(proposals[2].data.justify_qc.clone())),
+                    exact(HighQcUpdated(proposals[2].data.justify_qc.clone())),
+                    quorum_proposal_send_with_upgrade_certificate::<TestTypes>()
+                ],
+                task_state_asserts: vec![],
+            },
+        ],
+    };
+
+    let mut upgrade_script = TaskScript {
+        timeout: Duration::from_millis(35),
+        state: upgrade_state,
+        expectations: vec![
+            Expectations {
+                output_asserts: vec![],
+                task_state_asserts: vec![],
+            },
+            Expectations {
+                output_asserts: vec![],
+                task_state_asserts: vec![],
+            },
+            Expectations {
+                output_asserts: vec![upgrade_certificate_formed::<TestTypes>()],
+                task_state_asserts: vec![],
+            },
+            Expectations {
+                output_asserts: vec![],
+                task_state_asserts: vec![],
+            },
+        ],
+    };
+
+    test_scripts![inputs, proposal_script, upgrade_script].await;
+}

--- a/crates/testing/tests/tests_1/upgrade_task_with_vote.rs
+++ b/crates/testing/tests/tests_1/upgrade_task_with_vote.rs
@@ -1,0 +1,190 @@
+#![cfg(feature = "dependency-tasks")]
+
+// TODO: Remove after integration of dependency-tasks
+#![allow(unused_imports)]
+
+use std::time::Duration;
+
+use futures::StreamExt;
+use hotshot::{tasks::task_state::CreateTaskState, types::SystemContextHandle};
+use hotshot_example_types::{
+    block_types::{TestMetadata, TestTransaction},
+    node_types::{MemoryImpl, TestTypes},
+    state_types::TestInstanceState,
+};
+use hotshot_macros::test_scripts;
+use hotshot_task_impls::{
+    consensus::ConsensusTaskState, consensus2::Consensus2TaskState, events::HotShotEvent::*, quorum_vote::QuorumVoteTaskState, upgrade::UpgradeTaskState
+};
+use hotshot_testing::{
+    helpers::{build_fake_view_with_leaf, vid_share},
+    predicates::{event::*, upgrade_with_vote::*},
+    script::{Expectations, TaskScript},
+    view_generator::TestViewGenerator,
+};
+use hotshot_types::{
+    data::{null_block, ViewNumber},
+    simple_vote::UpgradeProposalData,
+    traits::{election::Membership, node_implementation::ConsensusTime},
+    vote::HasViewNumber,
+};
+use vbs::version::Version;
+
+#[cfg(feature = "dependency-tasks")]
+#[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
+#[cfg_attr(async_executor_impl = "async-std", async_std::test)]
+/// Tests that we correctly update our internal quorum vote state when reaching a decided upgrade
+/// certificate.
+async fn test_upgrade_task_with_vote() {
+    use hotshot_testing::helpers::build_system_handle;
+
+    async_compatibility_layer::logging::setup_logging();
+    async_compatibility_layer::logging::setup_backtrace();
+
+    let handle = build_system_handle(2).await.0;
+    let quorum_membership = handle.hotshot.memberships.quorum_membership.clone();
+    let da_membership = handle.hotshot.memberships.da_membership.clone();
+
+    let old_version = Version { major: 0, minor: 1 };
+    let new_version = Version { major: 0, minor: 2 };
+
+    let upgrade_data: UpgradeProposalData<TestTypes> = UpgradeProposalData {
+        old_version,
+        new_version,
+        decide_by: ViewNumber::new(6),
+        new_version_hash: [0u8; 12].to_vec(),
+        old_version_last_view: ViewNumber::new(6),
+        new_version_first_view: ViewNumber::new(7),
+    };
+
+    let mut proposals = Vec::new();
+    let mut votes = Vec::new();
+    let mut dacs = Vec::new();
+    let mut vids = Vec::new();
+    let mut leaders = Vec::new();
+    let mut leaves = Vec::new();
+    let consensus = handle.hotshot.consensus().clone();
+    let mut consensus_writer = consensus.write().await;
+
+    let mut generator = TestViewGenerator::generate(quorum_membership.clone(), da_membership);
+    for view in (&mut generator).take(2).collect::<Vec<_>>().await {
+        proposals.push(view.quorum_proposal.clone());
+        votes.push(view.create_quorum_vote(&handle));
+        dacs.push(view.da_certificate.clone());
+        vids.push(view.vid_proposal.clone());
+        leaders.push(view.leader_public_key);
+        leaves.push(view.leaf.clone());
+        consensus_writer.update_validated_state_map(
+            view.quorum_proposal.data.view_number(),
+            build_fake_view_with_leaf(view.leaf.clone()),
+        ).unwrap();
+        consensus_writer.update_saved_leaves(view.leaf.clone());
+    }
+    drop(consensus_writer);
+
+    generator.add_upgrade(upgrade_data);
+
+    for view in generator.take(4).collect::<Vec<_>>().await {
+        proposals.push(view.quorum_proposal.clone());
+        votes.push(view.create_quorum_vote(&handle));
+        dacs.push(view.da_certificate.clone());
+        vids.push(view.vid_proposal.clone());
+        leaders.push(view.leader_public_key);
+        leaves.push(view.leaf.clone());
+    }
+
+    let inputs = vec![
+        vec![
+            QuorumProposalValidated(proposals[1].data.clone(), leaves[0].clone()),
+            DaCertificateRecv(dacs[1].clone()),
+            VidShareRecv(vids[1].0[0].clone()),
+        ],
+        vec![
+            QuorumProposalValidated(proposals[2].data.clone(), leaves[1].clone()),
+            DaCertificateRecv(dacs[2].clone()),
+            VidShareRecv(vids[2].0[0].clone()),
+        ],
+        vec![
+            QuorumProposalValidated(proposals[3].data.clone(), leaves[2].clone()),
+            DaCertificateRecv(dacs[3].clone()),
+            VidShareRecv(vids[3].0[0].clone()),
+        ],
+        vec![
+            QuorumProposalValidated(proposals[4].data.clone(), leaves[3].clone()),
+            DaCertificateRecv(dacs[4].clone()),
+            VidShareRecv(vids[4].0[0].clone()),
+        ],
+        vec![
+            QuorumProposalValidated(proposals[5].data.clone(), leaves[5].clone()),
+        ],
+    ];
+
+    let expectations = vec![
+        Expectations {
+            output_asserts: vec![
+                exact(DaCertificateValidated(dacs[1].clone())),
+                exact(VidShareValidated(vids[1].0[0].clone())),
+                exact(QuorumVoteDependenciesValidated(ViewNumber::new(2))),
+                validated_state_updated(),
+                quorum_vote_send(),
+            ],
+            task_state_asserts: vec![],
+        },
+        Expectations {
+            output_asserts: vec![
+                exact(LockedViewUpdated(ViewNumber::new(1))),
+                exact(DaCertificateValidated(dacs[2].clone())),
+                exact(VidShareValidated(vids[2].0[0].clone())),
+                exact(QuorumVoteDependenciesValidated(ViewNumber::new(3))),
+                validated_state_updated(),
+                quorum_vote_send(),
+            ],
+            task_state_asserts: vec![no_decided_upgrade_cert()],
+        },
+        Expectations {
+            output_asserts: vec![
+                exact(LockedViewUpdated(ViewNumber::new(2))),
+                exact(LastDecidedViewUpdated(ViewNumber::new(1))),
+                leaf_decided(),
+                exact(DaCertificateValidated(dacs[3].clone())),
+                exact(VidShareValidated(vids[3].0[0].clone())),
+                exact(QuorumVoteDependenciesValidated(ViewNumber::new(4))),
+                validated_state_updated(),
+                quorum_vote_send(),
+            ],
+            task_state_asserts: vec![no_decided_upgrade_cert()],
+        },
+        Expectations {
+            output_asserts: vec![
+                exact(LockedViewUpdated(ViewNumber::new(3))),
+                exact(LastDecidedViewUpdated(ViewNumber::new(2))),
+                leaf_decided(),
+                exact(DaCertificateValidated(dacs[4].clone())),
+                exact(VidShareValidated(vids[4].0[0].clone())),
+                exact(QuorumVoteDependenciesValidated(ViewNumber::new(5))),
+                validated_state_updated(),
+                quorum_vote_send(),
+            ],
+            task_state_asserts: vec![no_decided_upgrade_cert()],
+        },
+        Expectations {
+            output_asserts: vec![
+                upgrade_decided(),
+                exact(LockedViewUpdated(ViewNumber::new(4))),
+                exact(LastDecidedViewUpdated(ViewNumber::new(3))),
+                leaf_decided(),
+            ],
+            task_state_asserts: vec![decided_upgrade_cert()],
+        },
+    ];
+
+    let vote_state = QuorumVoteTaskState::<TestTypes, MemoryImpl>::create_from(&handle).await;
+    let mut vote_script = TaskScript {
+        timeout: Duration::from_millis(65),
+        state: vote_state,
+        expectations,
+    };
+
+
+    test_scripts![inputs, vote_script].await;
+}

--- a/crates/types/src/consensus.rs
+++ b/crates/types/src/consensus.rs
@@ -15,7 +15,7 @@ use crate::{
     data::{Leaf, QuorumProposal, VidDisperse, VidDisperseShare},
     error::HotShotError,
     message::Proposal,
-    simple_certificate::{DaCertificate, QuorumCertificate, UpgradeCertificate},
+    simple_certificate::{DaCertificate, QuorumCertificate},
     traits::{
         block_contents::BuilderFee,
         metrics::{Counter, Gauge, Histogram, Metrics, NoMetrics},
@@ -83,17 +83,6 @@ pub struct Consensus<TYPES: NodeType> {
 
     /// A reference to the metrics trait
     pub metrics: Arc<ConsensusMetricsValue>,
-
-    /// The most recent upgrade certificate this node formed.
-    /// Note: this is ONLY for certificates that have been formed internally,
-    /// so that we can propose with them.
-    ///
-    /// Certificates received from other nodes will get reattached regardless of this fields,
-    /// since they will be present in the leaf we propose off of.
-    dontuse_formed_upgrade_certificate: Option<UpgradeCertificate<TYPES>>,
-
-    /// most recent decided upgrade certificate
-    dontuse_decided_upgrade_cert: Option<UpgradeCertificate<TYPES>>,
 }
 
 /// Contains several `ConsensusMetrics` that we're interested in from the consensus interfaces
@@ -189,8 +178,6 @@ impl<TYPES: NodeType> Consensus<TYPES> {
             saved_payloads,
             high_qc,
             metrics,
-            dontuse_decided_upgrade_cert: None,
-            dontuse_formed_upgrade_certificate: None,
         }
     }
 
@@ -383,11 +370,6 @@ impl<TYPES: NodeType> Consensus<TYPES> {
     /// Add a new entry to the da_certs map.
     pub fn update_saved_da_certs(&mut self, view_number: TYPES::Time, cert: DaCertificate<TYPES>) {
         self.saved_da_certs.insert(view_number, cert);
-    }
-
-    /// Update the most recent decided upgrade certificate.
-    pub fn update_dontuse_decided_upgrade_cert(&mut self, cert: Option<UpgradeCertificate<TYPES>>) {
-        self.dontuse_decided_upgrade_cert = cert;
     }
 
     /// gather information from the parent chain of leaves

--- a/crates/types/src/data.rs
+++ b/crates/types/src/data.rs
@@ -13,6 +13,7 @@ use std::{
 
 use anyhow::{ensure, Result};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
+use async_lock::RwLock;
 #[cfg(async_executor_impl = "async-std")]
 use async_std::task::spawn_blocking;
 use bincode::Options;
@@ -605,6 +606,8 @@ impl<TYPES: NodeType> Leaf<TYPES> {
         self.block_header().payload_commitment()
     }
 
+    // TODO: Replace this function with `extends_upgrade` after the following issue is done:
+    // https://github.com/EspressoSystems/HotShot/issues/3357.
     /// Validate that a leaf has the right upgrade certificate to be the immediate child of another leaf
     ///
     /// This may not be a complete function. Please double-check that it performs the checks you expect before subtituting validation logic with it.
@@ -612,7 +615,7 @@ impl<TYPES: NodeType> Leaf<TYPES> {
     /// # Errors
     /// Returns an error if the certificates are not identical, or that when we no longer see a
     /// cert, it's for the right reason.
-    pub fn extends_upgrade(
+    pub fn temp_extends_upgrade(
         &self,
         parent: &Self,
         decided_upgrade_certificate: &Option<UpgradeCertificate<TYPES>>,
@@ -628,6 +631,47 @@ impl<TYPES: NodeType> Leaf<TYPES> {
             (None, Some(parent_cert)) => {
                 ensure!(self.view_number() > parent_cert.data.new_version_first_view
                     || (self.view_number() > parent_cert.data.decide_by && decided_upgrade_certificate.is_none()),
+                       "The new leaf is missing an upgrade certificate that was present in its parent, and should still be live."
+                );
+            }
+            // If we both have a certificate, they should be identical.
+            // Technically, this prevents us from initiating a new upgrade in the view immediately following an upgrade.
+            // I think this is a fairly lax restriction.
+            (Some(cert), Some(parent_cert)) => {
+                ensure!(cert == parent_cert, "The new leaf does not extend the parent leaf, because it has attached a different upgrade certificate.");
+            }
+        }
+
+        // This check should be added once we sort out the genesis leaf/justify_qc issue.
+        // ensure!(self.parent_commitment() == parent_leaf.commit(), "The commitment of the parent leaf does not match the specified parent commitment.");
+
+        Ok(())
+    }
+
+    /// Validate that a leaf has the right upgrade certificate to be the immediate child of another leaf
+    ///
+    /// This may not be a complete function. Please double-check that it performs the checks you expect before subtituting validation logic with it.
+    ///
+    /// # Errors
+    /// Returns an error if the certificates are not identical, or that when we no longer see a
+    /// cert, it's for the right reason.
+    pub async fn extends_upgrade(
+        &self,
+        parent: &Self,
+        decided_upgrade_certificate: &Arc<RwLock<Option<UpgradeCertificate<TYPES>>>>,
+    ) -> Result<()> {
+        match (self.upgrade_certificate(), parent.upgrade_certificate()) {
+            // Easiest cases are:
+            //   - no upgrade certificate on either: this is the most common case, and is always fine.
+            //   - if the parent didn't have a certificate, but we see one now, it just means that we have begun an upgrade: again, this is always fine.
+            (None | Some(_), None) => {}
+            // If we no longer see a cert, we have to make sure that we either:
+            //    - no longer care because we have passed new_version_first_view, or
+            //    - no longer care because we have passed `decide_by` without deciding the certificate.
+            (None, Some(parent_cert)) => {
+                let decided_upgrade_certificate_read = decided_upgrade_certificate.read().await;
+                ensure!(self.view_number() > parent_cert.data.new_version_first_view
+                    || (self.view_number() > parent_cert.data.decide_by && decided_upgrade_certificate_read.is_none()),
                        "The new leaf is missing an upgrade certificate that was present in its parent, and should still be live."
                 );
             }

--- a/justfile
+++ b/justfile
@@ -113,7 +113,7 @@ test_with_failures:
   cargo test  --lib --bins --tests --benches --workspace --no-fail-fast test_with_failures -- --test-threads=1 --nocapture
 
 test_with_failures_dependency_tasks:
-  echo Testing nodes leaving the network
+  echo Testing nodes leaving the network with dependency tasks
   cargo test  --lib --bins --tests --benches --workspace --no-fail-fast --features "dependency-tasks" test_with_failures -- --test-threads=1 --nocapture
 
 test_network_task:
@@ -149,8 +149,12 @@ test_view_sync_task:
   cargo test --lib --bins --tests --benches --workspace --no-fail-fast test_view_sync_task -- --test-threads=1 --nocapture
 
 test_quorum_proposal_recv_task:
-  echo Testing the view sync task
+  echo Testing the quorum proposal recv task
   cargo test --lib --bins --tests --benches --workspace --no-fail-fast --features "dependency-tasks" test_quorum_proposal_recv_task -- --test-threads=1 --nocapture
+
+test_upgrade_task:
+  echo Testing the upgrade task without dependency tasks
+  cargo test --lib --bins --tests --benches --workspace --no-fail-fast test_upgrade_task -- --test-threads=1 --nocapture
 
 test_pkg := "hotshot"
 

--- a/justfile
+++ b/justfile
@@ -156,6 +156,10 @@ test_upgrade_task:
   echo Testing the upgrade task without dependency tasks
   cargo test --lib --bins --tests --benches --workspace --no-fail-fast test_upgrade_task -- --test-threads=1 --nocapture
 
+test_upgrade_task_dependency_tasks:
+  echo Testing the upgrade task without dependency tasks
+  cargo test --lib --bins --tests --benches --workspace --no-fail-fast --features "dependency-tasks" test_upgrade_task -- --test-threads=1 --nocapture
+
 test_pkg := "hotshot"
 
 default_test := ""


### PR DESCRIPTION
Closes #3356.

### This PR: 
* Integrates the formed and decided upgrade certificates into dependency tasks.
* Renames functions that take non-`Arc<RwLock<...>>` decided upgrade cert as parameter to `temp_*`, and adds new functions that take `Arc<RwLock<...>>`.
  * The dependency tasks now all use the new functions, but the old consensus task uses `temp_*` functions that will be replaced in a separate PR.

### This PR does not: 
* Make improvements to the existing upgradability code, which will be done later. Relevant issues:
  * #3378
  * #3357

### Key places to review: 
* Whether upgrade certificates are added correctly in the dependency tasks.
* Whether any update is missed.
* (`temp_*` functions may be ignored since they only have the name change.)

### How to test this PR:
* Run `RUST_LOG=error,hotshot_task_impls=info just cargo run --example all-push-cdn --features example-upgrade --features dependency-tasks -- --config_file ./crates/orchestrator/run-config.toml`.
  * Note the `dependency-tasks` feature.
* The upgrade should occur for view 25.

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
