### PR TITLE
Remove combined fail increment

### DIFF
--- a/crates/hotshot/src/traits/networking/combined_network.rs
+++ b/crates/hotshot/src/traits/networking/combined_network.rs
@@ -199,7 +199,6 @@ impl<TYPES: NodeType> CombinedNetworks<TYPES> {
                 // The task hasn't been cancelled, the primary probably failed.
                 // Increment the primary fail counter and send the message.
                 debug!("Sending on secondary after delay, message possibly has not reached recipient on primary");
-                primary_fail_counter.fetch_add(1, Ordering::Relaxed);
                 secondary_future.await
             });
             Ok(())


### PR DESCRIPTION
This removes a spot where we increment the primary network's failure counter when it's not clear if it failed or not. Right now if a view doesn't update for any reason within a specified amount of time, we treat this as a primary network failure. This would force nodes to use Libp2p if something else happens, like we are running into some timeouts