### PR TITLE
[CX-Marketplace] - Add the `Bundle` Complementary Builder Type 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3418,6 +3418,7 @@ dependencies = [
  "tokio",
  "tracing",
  "vbs",
+ "vec1",
 ]
 
 [[package]]

--- a/crates/task-impls/Cargo.toml
+++ b/crates/task-impls/Cargo.toml
@@ -38,6 +38,7 @@ tagged-base64 = { workspace = true }
 time = { workspace = true }
 tracing = { workspace = true }
 vbs = { workspace = true }
+vec1 = { workspace = true }
 
 [target.'cfg(all(async_executor_impl = "tokio"))'.dependencies]
 tokio = { workspace = true }

--- a/crates/task-impls/src/da.rs
+++ b/crates/task-impls/src/da.rs
@@ -10,7 +10,7 @@ use async_trait::async_trait;
 use hotshot_task::task::TaskState;
 use hotshot_types::{
     consensus::{Consensus, LockedConsensusState, View},
-    data::DaProposal,
+    data::{DaProposal, PackedBundle},
     event::{Event, EventType},
     message::Proposal,
     simple_certificate::DaCertificate,
@@ -287,8 +287,14 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> DaTaskState<TYPES, I> {
 
                 return None;
             }
-            HotShotEvent::BlockRecv(encoded_transactions, metadata, view, _fee, _vid_precomp) => {
-                let view = *view;
+            HotShotEvent::BlockRecv(packed_bundle) => {
+                let PackedBundle::<TYPES> {
+                    encoded_transactions,
+                    metadata,
+                    view_number,
+                    ..
+                } = packed_bundle;
+                let view_number = *view_number;
 
                 // quick hash the encoded txns with sha256
                 let encoded_transactions_hash = Sha256::digest(encoded_transactions);
@@ -305,7 +311,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> DaTaskState<TYPES, I> {
                     encoded_transactions: Arc::clone(encoded_transactions),
                     metadata: metadata.clone(),
                     // Upon entering a new view we want to send a DA Proposal for the next view -> Is it always the case that this is cur_view + 1?
-                    view_number: view,
+                    view_number,
                 };
 
                 let message = Proposal {

--- a/crates/task-impls/src/vid.rs
+++ b/crates/task-impls/src/vid.rs
@@ -7,7 +7,7 @@ use async_trait::async_trait;
 use hotshot_task::task::TaskState;
 use hotshot_types::{
     consensus::Consensus,
-    data::{VidDisperse, VidDisperseShare},
+    data::{PackedBundle, VidDisperse, VidDisperseShare},
     message::Proposal,
     traits::{
         election::Membership,
@@ -52,13 +52,15 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> VidTaskState<TYPES, I> {
         event_stream: Sender<Arc<HotShotEvent<TYPES>>>,
     ) -> Option<HotShotTaskCompleted> {
         match event.as_ref() {
-            HotShotEvent::BlockRecv(
-                encoded_transactions,
-                metadata,
-                view_number,
-                fee,
-                precompute_data,
-            ) => {
+            HotShotEvent::BlockRecv(packed_bundle) => {
+                let PackedBundle::<TYPES> {
+                    encoded_transactions,
+                    metadata,
+                    view_number,
+                    bid_fees,
+                    vid_precompute,
+                    ..
+                } = packed_bundle;
                 let payload =
                     <TYPES as NodeType>::BlockPayload::from_bytes(encoded_transactions, metadata);
                 let builder_commitment = payload.builder_commitment(metadata);
@@ -66,7 +68,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> VidTaskState<TYPES, I> {
                     Arc::clone(encoded_transactions),
                     &Arc::clone(&self.membership),
                     *view_number,
-                    Some(precompute_data.clone()),
+                    Some(vid_precompute.clone()),
                 )
                 .await;
                 let payload_commitment = vid_disperse.payload_commitment;
@@ -86,7 +88,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> VidTaskState<TYPES, I> {
                         builder_commitment,
                         metadata.clone(),
                         *view_number,
-                        fee.clone(),
+                        bid_fees[0].clone(),
                     )),
                     &event_stream,
                 )

--- a/crates/testing/tests/tests_1/da_task.rs
+++ b/crates/testing/tests/tests_1/da_task.rs
@@ -16,7 +16,7 @@ use hotshot_testing::{
     view_generator::TestViewGenerator,
 };
 use hotshot_types::{
-    data::{null_block, ViewNumber},
+    data::{null_block, ViewNumber, PackedBundle},
     simple_vote::DaData,
     traits::{
         block_contents::precompute_vid_commitment, election::Membership,
@@ -74,11 +74,14 @@ async fn test_da_task() {
             ViewChange(ViewNumber::new(1)),
             ViewChange(ViewNumber::new(2)),
             BlockRecv(
+                PackedBundle::new(
                 encoded_transactions,
                 TestMetadata,
                 ViewNumber::new(2),
-                null_block::builder_fee(quorum_membership.total_nodes()).unwrap(),
+                vec1::vec1![null_block::builder_fee(quorum_membership.total_nodes()).unwrap()],
+                vec1::vec1![null_block::builder_fee(quorum_membership.total_nodes()).unwrap()],
                 precompute,
+                )
             ),
         ],
         serial![DaProposalRecv(proposals[1].clone(), leaders[1])],
@@ -156,11 +159,14 @@ async fn test_da_task_storage_failure() {
             ViewChange(ViewNumber::new(1)),
             ViewChange(ViewNumber::new(2)),
             BlockRecv(
+                PackedBundle::new(
                 encoded_transactions,
                 TestMetadata,
                 ViewNumber::new(2),
-                null_block::builder_fee(quorum_membership.total_nodes()).unwrap(),
+                vec1::vec1![null_block::builder_fee(quorum_membership.total_nodes()).unwrap()],
+                vec1::vec1![null_block::builder_fee(quorum_membership.total_nodes()).unwrap()],
                 precompute,
+                ),
             ),
         ],
         serial![DaProposalRecv(proposals[1].clone(), leaders[1])],

--- a/crates/testing/tests/tests_1/vid_task.rs
+++ b/crates/testing/tests/tests_1/vid_task.rs
@@ -15,7 +15,7 @@ use hotshot_testing::{
     serial,
 };
 use hotshot_types::{
-    data::{null_block, DaProposal, VidDisperse, ViewNumber},
+    data::{null_block, DaProposal, VidDisperse, ViewNumber,PackedBundle},
     traits::{
         consensus_api::ConsensusApi,
         election::Membership,
@@ -86,12 +86,16 @@ async fn test_vid_task() {
         serial![
             ViewChange(ViewNumber::new(2)),
             BlockRecv(
-                encoded_transactions,
-                TestMetadata,
-                ViewNumber::new(2),
-                null_block::builder_fee(quorum_membership.total_nodes()).unwrap(),
-                vid_precompute,
+                PackedBundle::new(
+                    encoded_transactions,
+                    TestMetadata,
+                    ViewNumber::new(2),
+                    vec1::vec1![null_block::builder_fee(quorum_membership.total_nodes()).unwrap()],
+                    vec1::vec1![null_block::builder_fee(quorum_membership.total_nodes()).unwrap()],
+                    vid_precompute,
+                )
             ),
+
         ],
     ];
 

--- a/crates/types/src/data.rs
+++ b/crates/types/src/data.rs
@@ -25,6 +25,7 @@ use snafu::Snafu;
 #[cfg(async_executor_impl = "tokio")]
 use tokio::task::spawn_blocking;
 use tracing::error;
+use vec1::Vec1;
 
 use crate::{
     message::Proposal,
@@ -34,7 +35,8 @@ use crate::{
     simple_vote::{QuorumData, UpgradeProposalData},
     traits::{
         block_contents::{
-            vid_commitment, BlockHeader, EncodeBytes, TestableBlock, GENESIS_VID_NUM_STORAGE_NODES,
+            vid_commitment, BlockHeader, BuilderFee, EncodeBytes, TestableBlock,
+            GENESIS_VID_NUM_STORAGE_NODES,
         },
         election::Membership,
         node_implementation::{ConsensusTime, NodeType},
@@ -800,4 +802,26 @@ pub mod null_block {
             Err(_) => None,
         }
     }
+}
+
+/// A packed bundle constructed from a sequence of bundles.
+#[derive(Debug, Eq, PartialEq, Clone)]
+pub struct PackedBundle<TYPES: NodeType> {
+    /// The combined transactions as bytes.
+    pub encoded_transactions: Arc<[u8]>,
+
+    /// The metadata of the block.
+    pub metadata: <TYPES::BlockPayload as BlockPayload<TYPES>>::Metadata,
+
+    /// The view number that this block is associated with.
+    pub view_number: TYPES::Time,
+
+    /// The bid fees for submitting the block.
+    pub bid_fees: Vec1<BuilderFee<TYPES>>,
+
+    /// The sequencing fee for submitting bundles.
+    pub sequencing_fees: Vec1<BuilderFee<TYPES>>,
+
+    /// The Vid precompute for the block.
+    pub vid_precompute: VidPrecomputeData,
 }

--- a/crates/types/src/data.rs
+++ b/crates/types/src/data.rs
@@ -825,3 +825,24 @@ pub struct PackedBundle<TYPES: NodeType> {
     /// The Vid precompute for the block.
     pub vid_precompute: VidPrecomputeData,
 }
+
+impl<TYPES: NodeType> PackedBundle<TYPES> {
+    /// Create a new [`PackedBundle`].
+    pub fn new(
+        encoded_transactions: Arc<[u8]>,
+        metadata: <TYPES::BlockPayload as BlockPayload<TYPES>>::Metadata,
+        view_number: TYPES::Time,
+        bid_fees: Vec1<BuilderFee<TYPES>>,
+        sequencing_fees: Vec1<BuilderFee<TYPES>>,
+        vid_precompute: VidPrecomputeData,
+    ) -> Self {
+        Self {
+            encoded_transactions,
+            metadata,
+            view_number,
+            bid_fees,
+            sequencing_fees,
+            vid_precompute,
+        }
+    }
+}


### PR DESCRIPTION
Closes #3372 
<!-- See here for keywords in Github -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

### This PR: 
Starts the groundwork for multiple fees in HotShot. HotShot needs to be able to accept multiple fees for a block to allow for multiple builders to submit bundles with requisite fees as a result of the Solver’s allocation result. Because of this, we start by creating a complementary type to the existing `BuilderResponses` type, and then also refactor the `BlockRecv` type to support the new `PackedBundle` type, which solves two issues:
1. The BlockRecv event tuple is large, and it would have been hard to disambiguate bid fees from sequencing fees.
2. We eventually want to support multiple fees, and the new type supports the `vec1` type to allow for a guarantee that index 0 will always have a value, so there's no need to bounds check on access for the legacy behavior.

We also will need to augment the contract to how blocks are formed, this will eventually replace the existing type:

```rust
/// Builder Provided Responses
pub struct BuilderResponses<TYPES: NodeType> {
    /// Initial API response
    /// It contains information about the available blocks
    pub blocks_initial_info: AvailableBlockInfo<TYPES>,
    /// Second API response
    /// It contains information about the chosen blocks
    pub block_data: AvailableBlockData<TYPES>,
    /// Third API response
    /// It contains the final block information
    pub block_header: AvailableBlockHeaderInput<TYPES>,
}
```

To the new type added to the code:
```rust
/// The Bundle for a portion of a block, provided by a downstream builder that exists in a bundle
/// auction.
pub struct Bundle<TYPES: NodeType> {
    /// The bundle transactions sent by the builder.
    pub transactions: Vec<<TYPES::BlockPayload as BlockPayload<TYPES>>::Transaction>,

    /// The signature over the bundle.
    pub signature: TYPES::SignatureKey,

    /// The fee for submitting a bid.
    pub bid_fee: BuilderFee<TYPES>,

    /// The fee for sequencing
    pub sequencing_fee: BuilderFee<TYPES>,
}
```

This type will eventually replace the `BuilderResponses` type entirely but, right now, we leave it to maintain backwards compatibility in expectation that this change will be complete in a subsequent PR. This PR would have been extremely large if not broken up so, right now, this type does not change the existing logic.

### This PR does not: 
Change any logic, we simply wrap all existing `builder_fee`s into `bid_fees`, and add an always-null `sequencing_fee` to every event.

### Key places to review: 
- `data.rs`
- `transactions.rs`

<!-- ### How to test this PR:  -->
Existing tests should all pass.

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
