### PR TITLE
Add helper function to calculate version

### DIFF
--- a/crates/types/src/message.rs
+++ b/crates/types/src/message.rs
@@ -34,6 +34,31 @@ use crate::{
     vote::HasViewNumber,
 };
 
+/// Calculate the version applied in a view, based on the provided upgrade certificate.
+pub fn version<TYPES: NodeType>(
+    view: TYPES::Time,
+    upgrade_certificate: &Option<UpgradeCertificate<TYPES>>,
+) -> Result<Version> {
+    let version = match upgrade_certificate {
+        Some(ref cert) => {
+            if view >= cert.data.new_version_first_view
+                && cert.data.new_version == TYPES::Upgrade::VERSION
+            {
+                TYPES::Upgrade::VERSION
+            } else if view >= cert.data.new_version_first_view
+                && cert.data.new_version != TYPES::Upgrade::VERSION
+            {
+                bail!("The network has upgraded to a new version that we do not support!");
+            } else {
+                TYPES::Base::VERSION
+            }
+        }
+        None => TYPES::Base::VERSION,
+    };
+
+    Ok(version)
+}
+
 /// Incoming message
 #[derive(Serialize, Deserialize, Clone, Derivative, PartialEq, Eq, Hash)]
 #[serde(bound(deserialize = "", serialize = ""))]
@@ -62,22 +87,7 @@ where
     ) -> Result<Vec<u8>> {
         let view = self.view_number();
 
-        let version = match upgrade_certificate {
-            Some(ref cert) => {
-                if view >= cert.data.new_version_first_view
-                    && cert.data.new_version == TYPES::Upgrade::VERSION
-                {
-                    TYPES::Upgrade::VERSION
-                } else if view >= cert.data.new_version_first_view
-                    && cert.data.new_version != TYPES::Upgrade::VERSION
-                {
-                    bail!("The network has upgraded to a new version that we do not support!");
-                } else {
-                    TYPES::Base::VERSION
-                }
-            }
-            None => TYPES::Base::VERSION,
-        };
+        let version = version(view, upgrade_certificate)?;
 
         let serialized_message = match version {
             // Associated constants cannot be used in pattern matches, so we do this trick instead.
@@ -100,11 +110,11 @@ where
         message: &'a [u8],
         upgrade_certificate: &Option<UpgradeCertificate<TYPES>>,
     ) -> Result<Self> {
-        let version = Version::deserialize(message)
+        let actual_version = Version::deserialize(message)
             .context("Failed to read message version!")?
             .0;
 
-        let deserialized_message: Self = match version {
+        let deserialized_message: Self = match actual_version {
             v if v == TYPES::Base::VERSION => Serializer::<TYPES::Base>::deserialize(message),
             v if v == TYPES::Upgrade::VERSION => Serializer::<TYPES::Upgrade>::deserialize(message),
             _ => {
@@ -115,26 +125,11 @@ where
 
         let view = deserialized_message.view_number();
 
-        let expected_version = match upgrade_certificate {
-            Some(ref cert) => {
-                if view >= cert.data.new_version_first_view
-                    && cert.data.new_version == TYPES::Upgrade::VERSION
-                {
-                    TYPES::Upgrade::VERSION
-                } else if view >= cert.data.new_version_first_view
-                    && cert.data.new_version != TYPES::Upgrade::VERSION
-                {
-                    bail!("The network has upgraded to a new version that we do not support!");
-                } else {
-                    TYPES::Base::VERSION
-                }
-            }
-            None => TYPES::Base::VERSION,
-        };
+        let expected_version = version(view, upgrade_certificate)?;
 
         ensure!(
-            version == expected_version,
-            "Message has invalid version number for its view. Expected: {expected_version}, Actual: {version}, View: {view:?}"
+            actual_version == expected_version,
+            "Message has invalid version number for its view. Expected: {expected_version}, Actual: {actual_version}, View: {view:?}"
         );
 
         Ok(deserialized_message)

--- a/crates/types/src/message.rs
+++ b/crates/types/src/message.rs
@@ -35,6 +35,9 @@ use crate::{
 };
 
 /// Calculate the version applied in a view, based on the provided upgrade certificate.
+///
+/// # Errors
+/// Returns an error if we do not support the version required by the upgrade certificate.
 pub fn version<TYPES: NodeType>(
     view: TYPES::Time,
     upgrade_certificate: &Option<UpgradeCertificate<TYPES>>,

--- a/crates/types/src/traits/auction_results_provider.rs
+++ b/crates/types/src/traits/auction_results_provider.rs
@@ -1,10 +1,11 @@
 //! This module defines the interaction layer with the Solver via the [`AuctionResultsProvider`] trait,
 //! which handles connecting to, and fetching the allocation results from, the Solver.
 
-use super::node_implementation::NodeType;
 use anyhow::Result;
 use async_trait::async_trait;
 use url::Url;
+
+use super::node_implementation::NodeType;
 
 /// This trait guarantees that a particular type has a url associated with it. This trait
 /// essentially ensures that the results returned by the [`AuctionResultsProvider`] trait includes a URL


### PR DESCRIPTION
No linked issue.

### This PR: 
Adds a helper `version(view, upgrade_certificate)` function to calculate the version number in effect for a view.

### This PR does not: 

### Key places to review: 
