### PR TITLE
Ignore random block builder test

### DIFF
--- a/crates/testing/tests/tests_1/block_builder.rs
+++ b/crates/testing/tests/tests_1/block_builder.rs
@@ -28,6 +28,7 @@ use tide_disco::Url;
     tokio::test(flavor = "multi_thread", worker_threads = 2)
 )]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
+#[ignore]
 async fn test_random_block_builder() {
     let port = portpicker::pick_unused_port().expect("No free ports");
     let api_url = Url::parse(&format!("http://localhost:{port}")).expect("Valid URL");

--- a/crates/types/src/traits/auction_results_provider.rs
+++ b/crates/types/src/traits/auction_results_provider.rs
@@ -1,10 +1,11 @@
 //! This module defines the interaction layer with the Solver via the [`AuctionResultsProvider`] trait,
 //! which handles connecting to, and fetching the allocation results from, the Solver.
 
-use super::node_implementation::NodeType;
 use anyhow::Result;
 use async_trait::async_trait;
 use url::Url;
+
+use super::node_implementation::NodeType;
 
 /// This trait guarantees that a particular type has a url associated with it. This trait
 /// essentially ensures that the results returned by the [`AuctionResultsProvider`] trait includes a URL


### PR DESCRIPTION
No linked issue.

### This PR: 
The random block builder test is failing sporadically with some frequency, with the builder not producing a block in time. This PR disables that test.

### This PR does not: 

### Key places to review: 
