### PR TITLE
CI: Use buildjet arm builder instead of self-hosted

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -187,7 +187,7 @@ jobs:
           - async-std
           - tokio
       fail-fast: false
-    runs-on: [self-hosted, arm64]
+    runs-on: buildjet-4vcpu-ubuntu-2204-arm
     if: ${{ github.ref == 'refs/heads/main' }}
     container: ghcr.io/espressosystems/devops-rust:stable
     steps:


### PR DESCRIPTION
Swapping from self hosted ARM runner to BuildJet. Already trialed in espresso-sequencer for the past couple months.