### PR TITLE
Add byzantine integration tests

### DIFF
--- a/crates/fakeapi/src/fake_solver.rs
+++ b/crates/fakeapi/src/fake_solver.rs
@@ -1,12 +1,13 @@
+use std::{
+    io::{self, ErrorKind},
+    thread, time,
+};
+
 use anyhow::Result;
 use async_lock::RwLock;
 use futures::FutureExt;
 use hotshot_example_types::auction_results_provider_types::TestAuctionResult;
 use hotshot_types::traits::{node_implementation::NodeType, signature_key::SignatureKey};
-use std::{
-    io::{self, ErrorKind},
-    thread, time,
-};
 use tide_disco::{
     api::ApiError,
     error::ServerError,

--- a/crates/hotshot/src/lib.rs
+++ b/crates/hotshot/src/lib.rs
@@ -635,11 +635,7 @@ where
                 let mut result = state.recv_handler(&msg).await;
 
                 while let Some(event) = result.pop() {
-
-                let _ = result_sender
-                    .broadcast(event.into())
-                    .await;
-
+                    let _ = result_sender.broadcast(event.into()).await;
                 }
             }
         });
@@ -834,7 +830,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> TwinsHandlerState<TYPES, I>
         &mut self,
         event: &HotShotEvent<TYPES>,
     ) -> Vec<Either<HotShotEvent<TYPES>, HotShotEvent<TYPES>>> {
-            vec![Either::Left(event.clone()),Either::Right(event.clone())]
+        vec![Either::Left(event.clone()), Either::Right(event.clone())]
     }
 
     async fn recv_handler(

--- a/crates/hotshot/src/lib.rs
+++ b/crates/hotshot/src/lib.rs
@@ -622,7 +622,7 @@ where
         let (right_sender, mut right_receiver) = (right.0, right.1);
 
         // channel to the network task
-        let (sender_to_network, mut network_task_receiver) = broadcast(EVENT_CHANNEL_SIZE);
+        let (sender_to_network, network_task_receiver) = broadcast(EVENT_CHANNEL_SIZE);
         // channel from the network task
         let (network_task_sender, mut receiver_from_network): Channel<HotShotEvent<TYPES>> =
             broadcast(EVENT_CHANNEL_SIZE);

--- a/crates/hotshot/src/lib.rs
+++ b/crates/hotshot/src/lib.rs
@@ -582,12 +582,89 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> SystemContext<TYPES, I> {
 
         handle
     }
+}
+
+/// An async broadcast channel
+type Channel<S> = (Sender<Arc<S>>, Receiver<Arc<S>>);
+
+#[async_trait]
+/// Trait for handling messages for a node with a twin copy of consensus
+pub trait TwinsHandlerState<TYPES, I>
+where
+    Self: std::fmt::Debug + Send + Sync,
+    TYPES: NodeType,
+    I: NodeImplementation<TYPES>,
+{
+    /// Handle a message sent to the twin from the outside, forwarding it to one of the two twins.
+    async fn send_handler(
+        &mut self,
+        event: &HotShotEvent<TYPES>,
+    ) -> Either<HotShotEvent<TYPES>, HotShotEvent<TYPES>>;
+
+    /// Handle a message from either twin, forwarding it to the outside
+    async fn recv_handler(
+        &mut self,
+        event: &Either<HotShotEvent<TYPES>, HotShotEvent<TYPES>>,
+    ) -> HotShotEvent<TYPES>;
+
+    /// Fuse two channels into a single channel
+    ///
+    /// Note: the channels are fused using two async loops, whose `JoinHandle`s are dropped.
+    fn fuse_channels(
+        &'static mut self,
+        left: Channel<HotShotEvent<TYPES>>,
+        right: Channel<HotShotEvent<TYPES>>,
+    ) -> Channel<HotShotEvent<TYPES>> {
+        let send_state = Arc::new(RwLock::new(self));
+        let recv_state = Arc::clone(&send_state);
+
+        let (left_sender, mut left_receiver) = (left.0, left.1);
+        let (right_sender, mut right_receiver) = (right.0, right.1);
+
+        let result: Channel<HotShotEvent<TYPES>> = broadcast(EVENT_CHANNEL_SIZE);
+        let (result_sender, mut result_receiver) = (result.0.clone(), result.1.clone());
+
+        let _recv_loop_handle = async_spawn(async move {
+            loop {
+                let msg = match select(left_receiver.recv(), right_receiver.recv()).await {
+                    Either::Left(msg) => Either::Left(msg.0.unwrap().as_ref().clone()),
+                    Either::Right(msg) => Either::Right(msg.0.unwrap().as_ref().clone()),
+                };
+
+                let mut state = recv_state.write().await;
+
+                let _ = result_sender
+                    .broadcast(state.recv_handler(&msg).await.into())
+                    .await;
+            }
+        });
+
+        let _send_loop_handle = async_spawn(async move {
+            loop {
+                if let Ok(msg) = result_receiver.recv().await {
+                    let mut state = send_state.write().await;
+
+                    match state.send_handler(&msg).await {
+                        Either::Left(msg) => {
+                            let _ = left_sender.broadcast(msg.into()).await;
+                        }
+                        Either::Right(msg) => {
+                            let _ = right_sender.broadcast(msg.into()).await;
+                        }
+                    }
+                }
+            }
+        });
+
+        result
+    }
 
     #[allow(clippy::too_many_arguments)]
     /// Spawn all tasks that operate on [`SystemContextHandle`].
     ///
     /// For a list of which tasks are being spawned, see this module's documentation.
-    pub async fn spawn_twin_handles(
+    async fn spawn_twin_handles(
+        &'static mut self,
         public_key: TYPES::SignatureKey,
         private_key: <TYPES::SignatureKey as SignatureKey>::PrivateKey,
         nonce: u64,
@@ -599,7 +676,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> SystemContext<TYPES, I> {
         storage: I::Storage,
         auction_results_provider: I::AuctionResultsProvider,
     ) -> (SystemContextHandle<TYPES, I>, SystemContextHandle<TYPES, I>) {
-        let left_system_context = Self::new(
+        let left_system_context = SystemContext::new(
             public_key.clone(),
             private_key.clone(),
             nonce,
@@ -611,7 +688,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> SystemContext<TYPES, I> {
             storage.clone(),
             auction_results_provider.clone(),
         );
-        let right_system_context = Self::new(
+        let right_system_context = SystemContext::new(
             public_key,
             private_key,
             nonce,
@@ -682,7 +759,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> SystemContext<TYPES, I> {
         add_consensus_tasks::<TYPES, I>(&mut right_handle).await;
 
         // fuse the event streams from both handles before initializing the network tasks
-        let fused_internal_event_stream = fuse_channels::<HotShotEvent<TYPES>, RandomTwinsHandler>(
+        let fused_internal_event_stream = self.fuse_channels(
             (left_internal_sender, left_internal_receiver),
             (right_internal_sender, right_internal_receiver),
         );
@@ -703,56 +780,19 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> SystemContext<TYPES, I> {
     }
 }
 
-/// An async broadcast channel
-type Channel<S> = (Sender<Arc<S>>, Receiver<Arc<S>>);
-
-#[async_trait]
-/// Trait for handling messages for a node with a twin copy of consensus
-pub trait TwinsHandlerState<MESSAGE>
-where
-    Self: Sync,
-    MESSAGE: Send + Sync,
-{
-    /// Initialize the state
-    fn new() -> Self;
-
-    /// Handle a message sent to the twin from the outside, forwarding it to one of the two twins.
-    async fn send_handler(&mut self, event: &MESSAGE) -> Either<MESSAGE, MESSAGE>;
-
-    /// Wrapper for `send_handler`.
-    async fn send_handler_arc(
-        lock: &Arc<RwLock<Self>>,
-        event: &MESSAGE,
-    ) -> Either<MESSAGE, MESSAGE> {
-        let mut state = lock.write().await;
-
-        state.send_handler(event).await
-    }
-
-    /// Handle a message from either twin, forwarding it to the outside
-    async fn recv_handler(&mut self, event: &Either<MESSAGE, MESSAGE>) -> MESSAGE;
-
-    /// Wrapper for `recv_handler`.
-    async fn recv_handler_arc(
-        lock: &Arc<RwLock<Self>>,
-        event: &Either<MESSAGE, MESSAGE>,
-    ) -> MESSAGE {
-        let mut state = lock.write().await;
-
-        state.recv_handler(event).await
-    }
-}
-
+#[derive(Debug)]
 /// A `TwinsHandlerState` that randomly forwards a message to either twin,
 /// and returns messages from both.
 pub struct RandomTwinsHandler;
 
 #[async_trait]
-impl<MESSAGE: Send + Sync + Clone> TwinsHandlerState<MESSAGE> for RandomTwinsHandler {
-    fn new() -> Self {
-        RandomTwinsHandler
-    }
-    async fn send_handler(&mut self, event: &MESSAGE) -> Either<MESSAGE, MESSAGE> {
+impl<TYPES: NodeType, I: NodeImplementation<TYPES>> TwinsHandlerState<TYPES, I>
+    for RandomTwinsHandler
+{
+    async fn send_handler(
+        &mut self,
+        event: &HotShotEvent<TYPES>,
+    ) -> Either<HotShotEvent<TYPES>, HotShotEvent<TYPES>> {
         let random: bool = rand::thread_rng().gen();
 
         #[allow(clippy::match_bool)]
@@ -762,62 +802,14 @@ impl<MESSAGE: Send + Sync + Clone> TwinsHandlerState<MESSAGE> for RandomTwinsHan
         }
     }
 
-    async fn recv_handler(&mut self, event: &Either<MESSAGE, MESSAGE>) -> MESSAGE {
+    async fn recv_handler(
+        &mut self,
+        event: &Either<HotShotEvent<TYPES>, HotShotEvent<TYPES>>,
+    ) -> HotShotEvent<TYPES> {
         match event {
             Either::Left(msg) | Either::Right(msg) => msg.clone(),
         }
     }
-}
-
-/// Fuse two channels into a single channel, using handlers provided by the `STATE` type.
-///
-/// Note: the channels are fused using two async loops, whose `JoinHandle`s are dropped.
-fn fuse_channels<MESSAGE, STATE>(
-    left: Channel<MESSAGE>,
-    right: Channel<MESSAGE>,
-) -> Channel<MESSAGE>
-where
-    MESSAGE: Clone + std::marker::Send + std::marker::Sync + 'static,
-    STATE: TwinsHandlerState<MESSAGE> + Send + 'static,
-{
-    let send_state = Arc::new(RwLock::new(STATE::new()));
-    let recv_state = Arc::clone(&send_state);
-
-    let (left_sender, mut left_receiver) = (left.0, left.1);
-    let (right_sender, mut right_receiver) = (right.0, right.1);
-
-    let result: Channel<MESSAGE> = broadcast(EVENT_CHANNEL_SIZE);
-    let (result_sender, mut result_receiver) = (result.0.clone(), result.1.clone());
-
-    let _recv_loop_handle = async_spawn(async move {
-        loop {
-            let msg = match select(left_receiver.recv(), right_receiver.recv()).await {
-                Either::Left(msg) => Either::Left(msg.0.unwrap().as_ref().clone()),
-                Either::Right(msg) => Either::Right(msg.0.unwrap().as_ref().clone()),
-            };
-
-            let _ = result_sender
-                .broadcast(STATE::recv_handler_arc(&recv_state, &msg).await.into())
-                .await;
-        }
-    });
-
-    let _send_loop_handle = async_spawn(async move {
-        loop {
-            if let Ok(msg) = result_receiver.recv().await {
-                match STATE::send_handler_arc(&send_state, &msg).await {
-                    Either::Left(msg) => {
-                        let _ = left_sender.broadcast(msg.into()).await;
-                    }
-                    Either::Right(msg) => {
-                        let _ = right_sender.broadcast(msg.into()).await;
-                    }
-                }
-            }
-        }
-    });
-
-    result
 }
 
 #[async_trait]

--- a/crates/hotshot/src/tasks/mod.rs
+++ b/crates/hotshot/src/tasks/mod.rs
@@ -309,6 +309,11 @@ where
         let send_handle = async_spawn(async move {
             loop {
                 if let Ok(msg) = original_receiver.recv().await {
+                    if matches!(msg.as_ref(), HotShotEvent::Shutdown) {
+                        let _ = sender_to_network.broadcast(msg.clone().into()).await;
+                        break;
+                    }
+
                     let mut state = state_out.write().await;
 
                     let mut results = state.send_handler(&msg).await;
@@ -325,6 +330,11 @@ where
         let recv_handle = async_spawn(async move {
             loop {
                 if let Ok(msg) = receiver_from_network.recv().await {
+                    if matches!(msg.as_ref(), HotShotEvent::Shutdown) {
+                        let _ = original_sender.broadcast(msg.clone().into()).await;
+                        break;
+                    }
+
                     let mut state = state_in.write().await;
 
                     let mut results = state.recv_handler(&msg).await;

--- a/crates/hotshot/src/tasks/mod.rs
+++ b/crates/hotshot/src/tasks/mod.rs
@@ -309,11 +309,6 @@ where
         let send_handle = async_spawn(async move {
             loop {
                 if let Ok(msg) = original_receiver.recv().await {
-                    if matches!(msg.as_ref(), HotShotEvent::Shutdown) {
-                        let _ = sender_to_network.broadcast(msg.clone().into()).await;
-                        break;
-                    }
-
                     let mut state = state_out.write().await;
 
                     let mut results = state.send_handler(&msg).await;
@@ -330,11 +325,6 @@ where
         let recv_handle = async_spawn(async move {
             loop {
                 if let Ok(msg) = receiver_from_network.recv().await {
-                    if matches!(msg.as_ref(), HotShotEvent::Shutdown) {
-                        let _ = original_sender.broadcast(msg.clone().into()).await;
-                        break;
-                    }
-
                     let mut state = state_in.write().await;
 
                     let mut results = state.recv_handler(&msg).await;

--- a/crates/hotshot/src/tasks/mod.rs
+++ b/crates/hotshot/src/tasks/mod.rs
@@ -218,6 +218,7 @@ where
     /// modify outgoing messages from the network
     async fn send_handler(&mut self, event: &HotShotEvent<TYPES>) -> Vec<HotShotEvent<TYPES>>;
 
+    #[allow(clippy::too_many_arguments)]
     /// Creates a `SystemContextHandle` with the given even transformer
     async fn spawn_handle(
         &'static mut self,
@@ -255,7 +256,7 @@ where
             network_registry,
             output_event_stream: output_event_stream.clone(),
             internal_event_stream: internal_event_stream.clone(),
-            hotshot: hotshot.clone().into(),
+            hotshot: Arc::clone(&hotshot),
             storage: Arc::clone(&hotshot.storage),
             network: Arc::clone(&hotshot.network),
             memberships: Arc::clone(&hotshot.memberships),
@@ -275,7 +276,7 @@ where
         // with this, we can control exactly what events the network tasks see.
 
         // channel to the network task
-        let (sender_to_network, mut network_task_receiver) = broadcast(EVENT_CHANNEL_SIZE);
+        let (sender_to_network, network_task_receiver) = broadcast(EVENT_CHANNEL_SIZE);
         // channel from the network task
         let (network_task_sender, mut receiver_from_network) = broadcast(EVENT_CHANNEL_SIZE);
         // create a copy of the original receiver

--- a/crates/macros/src/lib.rs
+++ b/crates/macros/src/lib.rs
@@ -118,7 +118,8 @@ impl TestData {
             async fn #test_name() {
                 async_compatibility_layer::logging::setup_logging();
                 async_compatibility_layer::logging::setup_backtrace();
-                (#metadata).gen_launcher::<#ty, #imply>(0).launch().run_test::<SimpleBuilderImplementation>().await;
+                let metadata: TestDescription<#ty, #imply> = (#metadata);
+                metadata.gen_launcher(0).launch().run_test::<SimpleBuilderImplementation>().await;
             }
         }
     }

--- a/crates/macros/src/lib.rs
+++ b/crates/macros/src/lib.rs
@@ -118,8 +118,7 @@ impl TestData {
             async fn #test_name() {
                 async_compatibility_layer::logging::setup_logging();
                 async_compatibility_layer::logging::setup_backtrace();
-                let metadata: TestDescription<#ty, #imply> = (#metadata);
-                metadata.gen_launcher(0).launch().run_test::<SimpleBuilderImplementation>().await;
+                TestDescription::<#ty, #imply>::gen_launcher((#metadata), 0).launch().run_test::<SimpleBuilderImplementation>().await;
             }
         }
     }

--- a/crates/testing/src/helpers.rs
+++ b/crates/testing/src/helpers.rs
@@ -46,9 +46,10 @@ pub async fn build_system_handle(
     Sender<Arc<HotShotEvent<TestTypes>>>,
     Receiver<Arc<HotShotEvent<TestTypes>>>,
 ) {
-    let builder = TestDescription::default_multiple_rounds();
+    let builder: TestDescription<TestTypes, MemoryImpl> =
+        TestDescription::default_multiple_rounds();
 
-    let launcher = builder.gen_launcher::<TestTypes, MemoryImpl>(node_id);
+    let launcher = builder.gen_launcher(node_id);
 
     let network = (launcher.resource_generator.channel_generator)(node_id).await;
     let storage = (launcher.resource_generator.storage)(node_id);

--- a/crates/testing/src/test_builder.rs
+++ b/crates/testing/src/test_builder.rs
@@ -223,7 +223,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> TestDescription<TYPES, I> {
         let num_nodes_with_stake = 100;
         let num_nodes_without_stake = 0;
 
-        TestDescription::<TYPES, I> {
+        Self {
             num_bootstrap_nodes: num_nodes_with_stake,
             num_nodes_with_stake,
             num_nodes_without_stake,
@@ -244,7 +244,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> TestDescription<TYPES, I> {
                 ..TimingData::default()
             },
             view_sync_properties: ViewSyncTaskDescription::Threshold(0, num_nodes_with_stake),
-            ..TestDescription::<TYPES, I>::default()
+            ..Self::default()
         }
     }
 
@@ -285,7 +285,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> TestDescription<TYPES, I> {
     pub fn default_more_nodes() -> Self {
         let num_nodes_with_stake = 20;
         let num_nodes_without_stake = 0;
-        TestDescription::<TYPES, I> {
+        Self {
             num_nodes_with_stake,
             num_nodes_without_stake,
             start_nodes: num_nodes_with_stake,
@@ -310,7 +310,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> TestDescription<TYPES, I> {
                 ..TimingData::default()
             },
             view_sync_properties: ViewSyncTaskDescription::Threshold(0, num_nodes_with_stake),
-            ..TestDescription::<TYPES, I>::default()
+            ..Self::default()
         }
     }
 }

--- a/crates/testing/src/test_builder.rs
+++ b/crates/testing/src/test_builder.rs
@@ -90,8 +90,8 @@ pub struct TestDescription<TYPES: NodeType, I: NodeImplementation<TYPES>> {
 
 #[derive(Debug)]
 pub enum Behaviour<TYPES: NodeType, I: NodeImplementation<TYPES>> {
-    ByzantineTwins(&'static mut Box<dyn TwinsHandlerState<TYPES, I>>),
-    Byzantine(&'static mut Box<dyn EventTransformerState<TYPES, I>>),
+    ByzantineTwins(Box<dyn TwinsHandlerState<TYPES, I>>),
+    Byzantine(Box<dyn EventTransformerState<TYPES, I>>),
     Standard,
 }
 
@@ -123,6 +123,7 @@ pub async fn create_test_handle<
 
     match behaviour {
         Behaviour::ByzantineTwins(state) => {
+            let state = Box::leak(state);
             let (left_handle, _right_handle) = state
                 .spawn_twin_handles(
                     public_key,
@@ -141,6 +142,7 @@ pub async fn create_test_handle<
             left_handle
         }
         Behaviour::Byzantine(state) => {
+            let state = Box::leak(state);
             state
                 .spawn_handle(
                     public_key,

--- a/crates/testing/src/test_builder.rs
+++ b/crates/testing/src/test_builder.rs
@@ -123,7 +123,7 @@ pub async fn create_test_handle<
 
     match behaviour {
         Behaviour::Twins(state) => {
-            let (left_handle, right_handle) = state
+            let (left_handle, _right_handle) = state
                 .spawn_twin_handles(
                     public_key,
                     private_key,

--- a/crates/testing/src/test_builder.rs
+++ b/crates/testing/src/test_builder.rs
@@ -82,7 +82,15 @@ pub struct TestDescription<TYPES: NodeType, I: NodeImplementation<TYPES>> {
     /// description of the solver to run
     pub solver: FakeSolverApiDescription,
     /// nodes with byzantine behaviour
-    pub byzantine_nodes: Vec<(u64, Rc<Box<dyn EventTransformerState<TYPES, I>>>)>,
+    pub byzantine_nodes: fn(u64) -> ByzantineBehaviour<TYPES, I>,
+}
+
+#[derive(Clone, Debug)]
+pub enum ByzantineBehaviour<TYPES: NodeType, I: NodeImplementation<TYPES>> {
+    TwinsRandom,
+    TwinsBoth,
+    InterceptNetwork(Rc<Box<dyn EventTransformerState<TYPES, I>>>),
+    None,
 }
 
 /// Describes a possible change to builder status during test
@@ -266,7 +274,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> Default for TestDescription<
                 // Default to a 10% error rate.
                 error_pct: 0.1,
             },
-            byzantine_nodes: vec![],
+            byzantine_nodes: |_| ByzantineBehaviour::None,
         }
     }
 }

--- a/crates/testing/src/test_builder.rs
+++ b/crates/testing/src/test_builder.rs
@@ -103,9 +103,7 @@ pub async fn create_test_handle<
     node_id: u64,
     network: Network<TYPES, I>,
     memberships: Memberships<TYPES>,
-    initializer: HotShotInitializer<TYPES>,
     config: HotShotConfig<TYPES::SignatureKey>,
-    validator_config: ValidatorConfig<TYPES::SignatureKey>,
     storage: I::Storage,
     auction_results_provider: I::AuctionResultsProvider,
 ) -> SystemContextHandle<TYPES, I> {

--- a/crates/testing/src/test_builder.rs
+++ b/crates/testing/src/test_builder.rs
@@ -90,9 +90,9 @@ pub struct TestDescription<TYPES: NodeType, I: NodeImplementation<TYPES>> {
 
 #[derive(Debug)]
 pub enum Behaviour<TYPES: NodeType, I: NodeImplementation<TYPES>> {
-    Twins(&'static mut Box<dyn TwinsHandlerState<TYPES, I>>),
-    Single(&'static mut Box<dyn EventTransformerState<TYPES, I>>),
-    None,
+    ByzantineTwins(&'static mut Box<dyn TwinsHandlerState<TYPES, I>>),
+    Byzantine(&'static mut Box<dyn EventTransformerState<TYPES, I>>),
+    Standard,
 }
 
 pub async fn create_test_handle<
@@ -122,7 +122,7 @@ pub async fn create_test_handle<
     let public_key = validator_config.public_key.clone();
 
     match behaviour {
-        Behaviour::Twins(state) => {
+        Behaviour::ByzantineTwins(state) => {
             let (left_handle, _right_handle) = state
                 .spawn_twin_handles(
                     public_key,
@@ -140,7 +140,7 @@ pub async fn create_test_handle<
 
             left_handle
         }
-        Behaviour::Single(state) => {
+        Behaviour::Byzantine(state) => {
             state
                 .spawn_handle(
                     public_key,
@@ -156,7 +156,7 @@ pub async fn create_test_handle<
                 )
                 .await
         }
-        Behaviour::None => {
+        Behaviour::Standard => {
             let hotshot = SystemContext::<TYPES, I>::new(
                 public_key,
                 private_key,
@@ -356,7 +356,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> Default for TestDescription<
                 // Default to a 10% error rate.
                 error_pct: 0.1,
             },
-            behaviour: Rc::new(|_| Behaviour::None),
+            behaviour: Rc::new(|_| Behaviour::Standard),
         }
     }
 }

--- a/crates/testing/src/test_builder.rs
+++ b/crates/testing/src/test_builder.rs
@@ -49,7 +49,7 @@ pub struct TimingData {
 }
 
 /// metadata describing a test
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct TestDescription<TYPES: NodeType, I: NodeImplementation<TYPES>> {
     /// Total number of staked nodes in the test
     pub num_nodes_with_stake: usize,
@@ -85,7 +85,7 @@ pub struct TestDescription<TYPES: NodeType, I: NodeImplementation<TYPES>> {
     /// description of the solver to run
     pub solver: FakeSolverApiDescription,
     /// nodes with byzantine behaviour
-    pub behaviour: Rc<fn(u64) -> Behaviour<TYPES, I>>,
+    pub behaviour: Rc<dyn Fn(u64) -> Behaviour<TYPES, I>>,
 }
 
 #[derive(Debug)]

--- a/crates/testing/src/test_launcher.rs
+++ b/crates/testing/src/test_launcher.rs
@@ -37,7 +37,7 @@ pub struct TestLauncher<TYPES: NodeType, I: TestableNodeImplementation<TYPES>> {
     /// generator for resources
     pub resource_generator: ResourceGenerators<TYPES, I>,
     /// metadata used for tasks
-    pub metadata: TestDescription,
+    pub metadata: TestDescription<TYPES, I>,
 }
 
 impl<TYPES: NodeType, I: TestableNodeImplementation<TYPES>> TestLauncher<TYPES, I> {

--- a/crates/testing/src/test_runner.rs
+++ b/crates/testing/src/test_runner.rs
@@ -1,17 +1,15 @@
 #![allow(clippy::panic)]
-#[cfg(async_executor_impl = "async-std")]
-use async_std::task::JoinHandle;
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
     marker::PhantomData,
     sync::Arc,
 };
-#[cfg(async_executor_impl = "tokio")]
-use tokio::task::JoinHandle;
 
 use async_broadcast::broadcast;
 use async_compatibility_layer::art::async_spawn;
 use async_lock::RwLock;
+#[cfg(async_executor_impl = "async-std")]
+use async_std::task::JoinHandle;
 use futures::future::join_all;
 use hotshot::{
     traits::TestableNodeImplementation, types::SystemContextHandle, HotShotInitializer,
@@ -36,6 +34,8 @@ use hotshot_types::{
     HotShotConfig, ValidatorConfig,
 };
 use tide_disco::Url;
+#[cfg(async_executor_impl = "tokio")]
+use tokio::task::JoinHandle;
 #[allow(deprecated)]
 use tracing::info;
 

--- a/crates/testing/src/test_runner.rs
+++ b/crates/testing/src/test_runner.rs
@@ -497,7 +497,7 @@ where
         for (node_id, network, memberships, storage, auction_results_provider) in
             uninitialized_nodes
         {
-            let behaviour = (self.launcher.metadata.byzantine_nodes)(node_id);
+            let behaviour = (self.launcher.metadata.behaviour)(node_id);
             let handle = create_test_handle(
                 behaviour,
                 node_id,

--- a/crates/testing/src/test_runner.rs
+++ b/crates/testing/src/test_runner.rs
@@ -482,6 +482,7 @@ where
                     node_id,
                     network,
                     memberships,
+                    config,
                     storage,
                     auction_results_provider,
                 ));
@@ -494,7 +495,7 @@ where
         join_all(networks_ready).await;
 
         // Then start the necessary tasks
-        for (node_id, network, memberships, storage, auction_results_provider) in
+        for (node_id, network, memberships, config, storage, auction_results_provider) in
             uninitialized_nodes
         {
             let behaviour = (self.launcher.metadata.behaviour)(node_id);

--- a/crates/testing/src/test_runner.rs
+++ b/crates/testing/src/test_runner.rs
@@ -49,6 +49,7 @@ use crate::{
     block_builder::{BuilderTask, TestBuilderImplementation},
     completion_task::CompletionTaskDescription,
     spinning_task::{ChangeNode, SpinningTask, UpDown},
+    test_builder::create_test_handle,
     test_launcher::{Network, TestLauncher},
     test_task::{TestResult, TestTask},
     txn_task::TxnTaskDescription,
@@ -477,28 +478,13 @@ where
                     );
                 }
             } else {
-                let initializer = HotShotInitializer::<TYPES>::from_genesis(TestInstanceState {})
-                    .await
-                    .unwrap();
-
-                // See whether or not we should be DA
-                let is_da = node_id < config.da_staked_committee_size as u64;
-
-                // We assign node's public key and stake value rather than read from config file since it's a test
-                let validator_config =
-                    ValidatorConfig::generated_from_seed_indexed([0u8; 32], node_id, 1, is_da);
-                let hotshot = Self::add_node_with_config(
+                uninitialized_nodes.push((
                     node_id,
-                    network.clone(),
+                    network,
                     memberships,
-                    initializer,
-                    config,
-                    validator_config,
                     storage,
                     auction_results_provider,
-                )
-                .await;
-                uninitialized_nodes.push((node_id, network, hotshot));
+                ));
             }
 
             results.push(node_id);
@@ -508,8 +494,20 @@ where
         join_all(networks_ready).await;
 
         // Then start the necessary tasks
-        for (node_id, network, hotshot) in uninitialized_nodes {
-            let handle = hotshot.run_tasks().await;
+        for (node_id, network, memberships, storage, auction_results_provider) in
+            uninitialized_nodes
+        {
+            let behaviour = (self.launcher.metadata.byzantine_nodes)(node_id);
+            let handle = create_test_handle(
+                behaviour,
+                node_id,
+                network.clone(),
+                memberships,
+                config.clone(),
+                storage,
+                auction_results_provider,
+            )
+            .await;
 
             match node_id.cmp(&(config.da_staked_committee_size as u64 - 1)) {
                 std::cmp::Ordering::Less => {

--- a/crates/testing/tests/tests_1/libp2p.rs
+++ b/crates/testing/tests/tests_1/libp2p.rs
@@ -17,7 +17,7 @@ use tracing::instrument;
 async fn libp2p_network() {
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
-    let metadata = TestDescription {
+    let metadata: TestDescription<TestTypes, Libp2pImpl> = TestDescription {
         overall_safety_properties: OverallSafetyPropertiesDescription {
             check_leaf: true,
             ..Default::default()
@@ -35,7 +35,7 @@ async fn libp2p_network() {
     };
 
     metadata
-        .gen_launcher::<TestTypes, Libp2pImpl>(0)
+        .gen_launcher(0)
         .launch()
         .run_test::<SimpleBuilderImplementation>()
         .await;
@@ -48,7 +48,7 @@ async fn libp2p_network() {
 async fn libp2p_network_failures_2() {
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
-    let mut metadata = TestDescription {
+    let mut metadata: TestDescription<TestTypes, Libp2pImpl> = TestDescription {
         overall_safety_properties: OverallSafetyPropertiesDescription {
             check_leaf: true,
             ..Default::default()
@@ -82,7 +82,7 @@ async fn libp2p_network_failures_2() {
     metadata.overall_safety_properties.num_successful_views = 15;
 
     metadata
-        .gen_launcher::<TestTypes, Libp2pImpl>(0)
+        .gen_launcher(0)
         .launch()
         .run_test::<SimpleBuilderImplementation>()
         .await;
@@ -96,9 +96,9 @@ async fn libp2p_network_failures_2() {
 async fn test_stress_libp2p_network() {
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
-    let metadata = TestDescription::default_stress();
+    let metadata: TestDescription<TestTypes, Libp2pImpl> = TestDescription::default_stress();
     metadata
-        .gen_launcher::<TestTypes, Libp2pImpl>(0)
+        .gen_launcher(0)
         .launch()
         .run_test::<SimpleBuilderImplementation>()
         .await;

--- a/crates/testing/tests/tests_1/network_task.rs
+++ b/crates/testing/tests/tests_1/network_task.rs
@@ -34,10 +34,10 @@ async fn test_network_task() {
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
 
-    let builder = TestDescription::default_multiple_rounds();
+    let builder: TestDescription<TestTypes, MemoryImpl> = TestDescription::default_multiple_rounds();
     let node_id = 1;
 
-    let launcher = builder.gen_launcher::<TestTypes, MemoryImpl>(node_id);
+    let launcher = builder.gen_launcher(node_id);
 
     let network = (launcher.resource_generator.channel_generator)(node_id).await;
 
@@ -98,10 +98,10 @@ async fn test_network_storage_fail() {
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
 
-    let builder = TestDescription::default_multiple_rounds();
+    let builder: TestDescription<TestTypes, MemoryImpl> = TestDescription::default_multiple_rounds();
     let node_id = 1;
 
-    let launcher = builder.gen_launcher::<TestTypes, MemoryImpl>(node_id);
+    let launcher = builder.gen_launcher(node_id);
 
     let network = (launcher.resource_generator.channel_generator)(node_id).await;
 

--- a/crates/testing/tests/tests_1/test_success.rs
+++ b/crates/testing/tests/tests_1/test_success.rs
@@ -39,8 +39,8 @@ cross_tests!(
     Ignore: false,
     Metadata: {
         let behaviour = Rc::new(|node_id| { match node_id {
-          1 => Behaviour::Single(Box::leak(Box::new(Box::new(DoubleProposeVote)))),
-          _ => Behaviour::None,
+          1 => Behaviour::Byzantine(Box::leak(Box::new(Box::new(DoubleProposeVote)))),
+          _ => Behaviour::Standard,
           } });
 
         TestDescription {

--- a/crates/testing/tests/tests_1/test_success.rs
+++ b/crates/testing/tests/tests_1/test_success.rs
@@ -39,7 +39,7 @@ cross_tests!(
     Ignore: false,
     Metadata: {
         let behaviour = Rc::new(|node_id| { match node_id {
-          1 => Behaviour::Byzantine(Box::leak(Box::new(Box::new(DoubleProposeVote)))),
+          1 => Behaviour::Byzantine(Box::new(DoubleProposeVote)),
           _ => Behaviour::Standard,
           } });
 

--- a/crates/testing/tests/tests_1/test_success.rs
+++ b/crates/testing/tests/tests_1/test_success.rs
@@ -29,6 +29,7 @@ cross_tests!(
     },
 );
 
+#[cfg(async_executor_impl = "async-std")]
 cross_tests!(
     TestName: twins_test_success,
     Impls: [MemoryImpl],

--- a/crates/testing/tests/tests_1/test_success.rs
+++ b/crates/testing/tests/tests_1/test_success.rs
@@ -1,6 +1,6 @@
 use std::{rc::Rc, time::Duration};
 
-use hotshot::{DoubleTwinsHandler, TwinsHandlerState};
+use hotshot::tasks::DoubleProposeVote;
 use hotshot_example_types::{
     node_types::{Libp2pImpl, MemoryImpl, PushCdnImpl},
     state_types::TestTypes,
@@ -36,7 +36,7 @@ cross_tests!(
     Ignore: false,
     Metadata: {
         let behaviour = Rc::new(|node_id| { match node_id {
-          1 => Behaviour::Twins(Box::leak(Box::new(Box::new(DoubleTwinsHandler)))),
+          1 => Behaviour::Single(Box::leak(Box::new(Box::new(DoubleProposeVote)))),
           _ => Behaviour::None,
           } });
 

--- a/crates/testing/tests/tests_1/test_success.rs
+++ b/crates/testing/tests/tests_1/test_success.rs
@@ -1,6 +1,5 @@
-use std::{rc::Rc, time::Duration};
+use std::time::Duration;
 
-use hotshot::tasks::DoubleProposeVote;
 use hotshot_example_types::{
     node_types::{Libp2pImpl, MemoryImpl, PushCdnImpl},
     state_types::TestTypes,
@@ -9,8 +8,11 @@ use hotshot_macros::cross_tests;
 use hotshot_testing::{
     block_builder::SimpleBuilderImplementation,
     completion_task::{CompletionTaskDescription, TimeBasedCompletionTaskDescription},
-    test_builder::{Behaviour, TestDescription},
+    test_builder::TestDescription,
 };
+#[cfg(async_executor_impl = "async-std")]
+use {hotshot::tasks::DoubleProposeVote, hotshot_testing::test_builder::Behaviour, std::rc::Rc};
+
 cross_tests!(
     TestName: test_success,
     Impls: [MemoryImpl, Libp2pImpl, PushCdnImpl],

--- a/crates/testing/tests/tests_2/catchup.rs
+++ b/crates/testing/tests/tests_2/catchup.rs
@@ -19,7 +19,7 @@ async fn test_catchup() {
         next_view_timeout: 2000,
         ..Default::default()
     };
-    let mut metadata = TestDescription::default();
+    let mut metadata: TestDescription<TestTypes, MemoryImpl> = TestDescription::default();
     let catchup_node = vec![ChangeNode {
         idx: 19,
         updown: UpDown::Up,
@@ -51,7 +51,7 @@ async fn test_catchup() {
     };
 
     metadata
-        .gen_launcher::<TestTypes, MemoryImpl>(0)
+        .gen_launcher(0)
         .launch()
         .run_test::<SimpleBuilderImplementation>()
         .await;
@@ -78,7 +78,7 @@ async fn test_catchup_cdn() {
         next_view_timeout: 2000,
         ..Default::default()
     };
-    let mut metadata = TestDescription::default();
+    let mut metadata: TestDescription<TestTypes, PushCdnImpl> = TestDescription::default();
     let catchup_nodes = vec![ChangeNode {
         idx: 18,
         updown: UpDown::Up,
@@ -104,7 +104,7 @@ async fn test_catchup_cdn() {
     };
 
     metadata
-        .gen_launcher::<TestTypes, PushCdnImpl>(0)
+        .gen_launcher(0)
         .launch()
         .run_test::<SimpleBuilderImplementation>()
         .await;
@@ -131,7 +131,7 @@ async fn test_catchup_one_node() {
         next_view_timeout: 2000,
         ..Default::default()
     };
-    let mut metadata = TestDescription::default();
+    let mut metadata: TestDescription<TestTypes, MemoryImpl> = TestDescription::default();
     let catchup_nodes = vec![ChangeNode {
         idx: 18,
         updown: UpDown::Up,
@@ -159,7 +159,7 @@ async fn test_catchup_one_node() {
     };
 
     metadata
-        .gen_launcher::<TestTypes, MemoryImpl>(0)
+        .gen_launcher(0)
         .launch()
         .run_test::<SimpleBuilderImplementation>()
         .await;
@@ -186,7 +186,7 @@ async fn test_catchup_in_view_sync() {
         next_view_timeout: 2000,
         ..Default::default()
     };
-    let mut metadata = TestDescription::default();
+    let mut metadata: TestDescription<TestTypes, MemoryImpl> = TestDescription::default();
     let catchup_nodes = vec![
         ChangeNode {
             idx: 18,
@@ -220,7 +220,7 @@ async fn test_catchup_in_view_sync() {
     };
 
     metadata
-        .gen_launcher::<TestTypes, MemoryImpl>(0)
+        .gen_launcher(0)
         .launch()
         .run_test::<SimpleBuilderImplementation>()
         .await;
@@ -249,7 +249,7 @@ async fn test_catchup_reload() {
         next_view_timeout: 2000,
         ..Default::default()
     };
-    let mut metadata = TestDescription::default();
+    let mut metadata: TestDescription<TestTypes, MemoryImpl> = TestDescription::default();
     let catchup_node = vec![ChangeNode {
         idx: 19,
         updown: UpDown::Up,
@@ -281,7 +281,7 @@ async fn test_catchup_reload() {
     };
 
     metadata
-        .gen_launcher::<TestTypes, MemoryImpl>(0)
+        .gen_launcher(0)
         .launch()
         .run_test::<SimpleBuilderImplementation>()
         .await;

--- a/crates/testing/tests/tests_2/push_cdn.rs
+++ b/crates/testing/tests/tests_2/push_cdn.rs
@@ -17,7 +17,7 @@ use tracing::instrument;
 async fn push_cdn_network() {
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
-    let metadata = TestDescription {
+    let metadata: TestDescription<TestTypes, PushCdnImpl> = TestDescription {
         timing_data: TimingData {
             round_start_delay: 25,
             next_view_timeout: 10_000,
@@ -38,7 +38,7 @@ async fn push_cdn_network() {
         ..TestDescription::default()
     };
     metadata
-        .gen_launcher::<TestTypes, PushCdnImpl>(0)
+        .gen_launcher(0)
         .launch()
         .run_test::<SimpleBuilderImplementation>()
         .await;

--- a/crates/testing/tests/tests_5/combined_network.rs
+++ b/crates/testing/tests/tests_5/combined_network.rs
@@ -21,7 +21,7 @@ async fn test_combined_network() {
 
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
-    let metadata: TestDescription = TestDescription {
+    let metadata: TestDescription<TestTypes, CombinedImpl> = TestDescription {
         timing_data: TimingData {
             round_start_delay: 25,
             next_view_timeout: 10_000,
@@ -43,7 +43,7 @@ async fn test_combined_network() {
     };
 
     metadata
-        .gen_launcher::<TestTypes, CombinedImpl>(0)
+        .gen_launcher(0)
         .launch()
         .run_test::<SimpleBuilderImplementation>()
         .await;
@@ -56,7 +56,7 @@ async fn test_combined_network() {
 async fn test_combined_network_cdn_crash() {
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
-    let mut metadata: TestDescription = TestDescription {
+    let mut metadata: TestDescription<TestTypes, CombinedImpl> = TestDescription {
         timing_data: TimingData {
             round_start_delay: 25,
             next_view_timeout: 10_000,
@@ -89,7 +89,7 @@ async fn test_combined_network_cdn_crash() {
     };
 
     metadata
-        .gen_launcher::<TestTypes, CombinedImpl>(0)
+        .gen_launcher(0)
         .launch()
         .run_test::<SimpleBuilderImplementation>()
         .await;
@@ -103,7 +103,7 @@ async fn test_combined_network_cdn_crash() {
 async fn test_combined_network_reup() {
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
-    let mut metadata: TestDescription = TestDescription {
+    let mut metadata: TestDescription<TestTypes, CombinedImpl> = TestDescription {
         timing_data: TimingData {
             round_start_delay: 25,
             next_view_timeout: 10_000,
@@ -143,7 +143,7 @@ async fn test_combined_network_reup() {
     };
 
     metadata
-        .gen_launcher::<TestTypes, CombinedImpl>(0)
+        .gen_launcher(0)
         .launch()
         .run_test::<SimpleBuilderImplementation>()
         .await;
@@ -156,7 +156,7 @@ async fn test_combined_network_reup() {
 async fn test_combined_network_half_dc() {
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
-    let mut metadata: TestDescription = TestDescription {
+    let mut metadata: TestDescription<TestTypes, CombinedImpl> = TestDescription {
         timing_data: TimingData {
             round_start_delay: 25,
             next_view_timeout: 10_000,
@@ -191,7 +191,7 @@ async fn test_combined_network_half_dc() {
     };
 
     metadata
-        .gen_launcher::<TestTypes, CombinedImpl>(0)
+        .gen_launcher(0)
         .launch()
         .run_test::<SimpleBuilderImplementation>()
         .await;
@@ -232,7 +232,7 @@ fn generate_random_node_changes(
 async fn test_stress_combined_network_fuzzy() {
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
-    let mut metadata = TestDescription {
+    let mut metadata: TestDescription<TestTypes, CombinedImpl> = TestDescription {
         num_bootstrap_nodes: 10,
         num_nodes_with_stake: 20,
         start_nodes: 20,
@@ -261,7 +261,7 @@ async fn test_stress_combined_network_fuzzy() {
     };
 
     metadata
-        .gen_launcher::<TestTypes, CombinedImpl>(0)
+        .gen_launcher(0)
         .launch()
         .run_test::<SimpleBuilderImplementation>()
         .await;

--- a/crates/testing/tests/tests_5/timeout.rs
+++ b/crates/testing/tests/tests_5/timeout.rs
@@ -21,7 +21,7 @@ async fn test_timeout() {
         ..Default::default()
     };
 
-    let mut metadata = TestDescription {
+    let mut metadata: TestDescription<TestTypes,MemoryImpl> = TestDescription {
         num_nodes_with_stake: 10,
         start_nodes: 10,
         ..Default::default()
@@ -53,7 +53,7 @@ async fn test_timeout() {
     // TODO ED Test with memory network once issue is resolved
     // https://github.com/EspressoSystems/HotShot/issues/1790
     metadata
-        .gen_launcher::<TestTypes, MemoryImpl>(0)
+        .gen_launcher(0)
         .launch()
         .run_test::<SimpleBuilderImplementation>()
         .await;
@@ -84,7 +84,7 @@ async fn test_timeout_libp2p() {
         ..Default::default()
     };
 
-    let mut metadata = TestDescription {
+    let mut metadata: TestDescription<TestTypes, Libp2pImpl> = TestDescription {
         num_nodes_with_stake: 10,
         start_nodes: 10,
         num_bootstrap_nodes: 10,
@@ -117,7 +117,7 @@ async fn test_timeout_libp2p() {
     // TODO ED Test with memory network once issue is resolved
     // https://github.com/EspressoSystems/HotShot/issues/1790
     metadata
-        .gen_launcher::<TestTypes, Libp2pImpl>(0)
+        .gen_launcher(0)
         .launch()
         .run_test::<SimpleBuilderImplementation>()
         .await;

--- a/crates/testing/tests/tests_5/unreliable_network.rs
+++ b/crates/testing/tests/tests_5/unreliable_network.rs
@@ -18,7 +18,7 @@ use tracing::instrument;
 async fn libp2p_network_sync() {
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
-    let metadata = TestDescription {
+    let metadata: TestDescription<TestTypes, Libp2pImpl> = TestDescription {
         overall_safety_properties: OverallSafetyPropertiesDescription {
             check_leaf: true,
             ..Default::default()
@@ -36,7 +36,7 @@ async fn libp2p_network_sync() {
     };
 
     metadata
-        .gen_launcher::<TestTypes, Libp2pImpl>(0)
+        .gen_launcher(0)
         .launch()
         .run_test::<SimpleBuilderImplementation>()
         .await;
@@ -56,7 +56,7 @@ async fn test_memory_network_sync() {
 
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
-    let metadata = TestDescription {
+    let metadata: TestDescription<TestTypes, MemoryImpl> = TestDescription {
         // allow more time to pass in CI
         completion_task_description: CompletionTaskDescription::TimeBasedCompletionTaskBuilder(
             TimeBasedCompletionTaskDescription {
@@ -70,7 +70,7 @@ async fn test_memory_network_sync() {
         ..TestDescription::default()
     };
     metadata
-        .gen_launcher::<TestTypes, MemoryImpl>(0)
+        .gen_launcher(0)
         .launch()
         .run_test::<SimpleBuilderImplementation>()
         .await;
@@ -83,7 +83,7 @@ async fn test_memory_network_sync() {
 async fn libp2p_network_async() {
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
-    let metadata = TestDescription {
+    let metadata: TestDescription<TestTypes, Libp2pImpl> = TestDescription {
         overall_safety_properties: OverallSafetyPropertiesDescription {
             check_leaf: true,
             num_failed_views: 50,
@@ -97,7 +97,7 @@ async fn libp2p_network_async() {
         timing_data: TimingData {
             timeout_ratio: (1, 1),
             next_view_timeout: 25000,
-            ..TestDescription::default_multiple_rounds().timing_data
+            ..TestDescription::<TestTypes, Libp2pImpl>::default_multiple_rounds().timing_data
         },
         unreliable_network: Some(Box::new(AsynchronousNetwork {
             keep_numerator: 9,
@@ -109,7 +109,7 @@ async fn libp2p_network_async() {
     };
 
     metadata
-        .gen_launcher::<TestTypes, Libp2pImpl>(0)
+        .gen_launcher(0)
         .launch()
         .run_test::<SimpleBuilderImplementation>()
         .await;
@@ -130,7 +130,7 @@ async fn test_memory_network_async() {
 
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
-    let metadata = TestDescription {
+    let metadata: TestDescription<TestTypes, MemoryImpl> = TestDescription {
         overall_safety_properties: OverallSafetyPropertiesDescription {
             check_leaf: true,
             num_failed_views: 5000,
@@ -145,7 +145,7 @@ async fn test_memory_network_async() {
         timing_data: TimingData {
             timeout_ratio: (1, 1),
             next_view_timeout: 1000,
-            ..TestDescription::default_multiple_rounds().timing_data
+            ..TestDescription::<TestTypes, MemoryImpl>::default_multiple_rounds().timing_data
         },
         unreliable_network: Some(Box::new(AsynchronousNetwork {
             keep_numerator: 95,
@@ -156,7 +156,7 @@ async fn test_memory_network_async() {
         ..TestDescription::default()
     };
     metadata
-        .gen_launcher::<TestTypes, MemoryImpl>(0)
+        .gen_launcher(0)
         .launch()
         .run_test::<SimpleBuilderImplementation>()
         .await;
@@ -176,7 +176,7 @@ async fn test_memory_network_partially_sync() {
 
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
-    let metadata = TestDescription {
+    let metadata: TestDescription<TestTypes, MemoryImpl> = TestDescription {
         overall_safety_properties: OverallSafetyPropertiesDescription {
             num_failed_views: 0,
             ..Default::default()
@@ -208,7 +208,7 @@ async fn test_memory_network_partially_sync() {
         ..TestDescription::default()
     };
     metadata
-        .gen_launcher::<TestTypes, MemoryImpl>(0)
+        .gen_launcher(0)
         .launch()
         .run_test::<SimpleBuilderImplementation>()
         .await;
@@ -220,7 +220,7 @@ async fn test_memory_network_partially_sync() {
 async fn libp2p_network_partially_sync() {
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
-    let metadata = TestDescription {
+    let metadata: TestDescription<TestTypes, Libp2pImpl> = TestDescription {
         overall_safety_properties: OverallSafetyPropertiesDescription {
             num_failed_views: 0,
             ..Default::default()
@@ -248,7 +248,7 @@ async fn libp2p_network_partially_sync() {
     };
 
     metadata
-        .gen_launcher::<TestTypes, Libp2pImpl>(0)
+        .gen_launcher(0)
         .launch()
         .run_test::<SimpleBuilderImplementation>()
         .await;
@@ -269,7 +269,7 @@ async fn test_memory_network_chaos() {
 
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
-    let metadata = TestDescription {
+    let metadata: TestDescription<TestTypes, MemoryImpl> = TestDescription {
         // allow more time to pass in CI
         completion_task_description: CompletionTaskDescription::TimeBasedCompletionTaskBuilder(
             TimeBasedCompletionTaskDescription {
@@ -287,7 +287,7 @@ async fn test_memory_network_chaos() {
         ..TestDescription::default()
     };
     metadata
-        .gen_launcher::<TestTypes, MemoryImpl>(0)
+        .gen_launcher(0)
         .launch()
         .run_test::<SimpleBuilderImplementation>()
         .await;
@@ -300,7 +300,7 @@ async fn test_memory_network_chaos() {
 async fn libp2p_network_chaos() {
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
-    let metadata = TestDescription {
+    let metadata: TestDescription<TestTypes, Libp2pImpl> = TestDescription {
         overall_safety_properties: OverallSafetyPropertiesDescription {
             check_leaf: true,
             ..Default::default()
@@ -322,7 +322,7 @@ async fn libp2p_network_chaos() {
     };
 
     metadata
-        .gen_launcher::<TestTypes, Libp2pImpl>(0)
+        .gen_launcher(0)
         .launch()
         .run_test::<SimpleBuilderImplementation>()
         .await;

--- a/crates/types/src/consensus.rs
+++ b/crates/types/src/consensus.rs
@@ -10,7 +10,7 @@ use std::{
 use anyhow::{bail, ensure, Result};
 use async_lock::{RwLock, RwLockReadGuard, RwLockUpgradableReadGuard, RwLockWriteGuard};
 use committable::{Commitment, Committable};
-use tracing::{debug, error, instrument};
+use tracing::{debug, error, instrument, trace};
 
 pub use crate::utils::{View, ViewInner};
 use crate::{
@@ -60,31 +60,31 @@ impl<TYPES: NodeType> OuterConsensus<TYPES> {
     /// Locks inner consensus for reading and leaves debug traces
     #[instrument(skip_all, target = "OuterConsensus")]
     pub async fn read(&self) -> ConsensusReadLockGuard<'_, TYPES> {
-        debug!("Trying to acquire read lock on consensus");
+        trace!("Trying to acquire read lock on consensus");
         let ret = self.inner_consensus.read().await;
-        debug!("Acquired read lock on consensus");
+        trace!("Acquired read lock on consensus");
         ConsensusReadLockGuard::new(ret)
     }
 
     /// Locks inner consensus for writing and leaves debug traces
     #[instrument(skip_all, target = "OuterConsensus")]
     pub async fn write(&self) -> ConsensusWriteLockGuard<'_, TYPES> {
-        debug!("Trying to acquire write lock on consensus");
+        trace!("Trying to acquire write lock on consensus");
         let ret = self.inner_consensus.write().await;
-        debug!("Acquired write lock on consensus");
+        trace!("Acquired write lock on consensus");
         ConsensusWriteLockGuard::new(ret)
     }
 
     /// Tries to acquire write lock on inner consensus and leaves debug traces
     #[instrument(skip_all, target = "OuterConsensus")]
     pub fn try_write(&self) -> Option<ConsensusWriteLockGuard<'_, TYPES>> {
-        debug!("Trying to acquire write lock on consensus");
+        trace!("Trying to acquire write lock on consensus");
         let ret = self.inner_consensus.try_write();
         if let Some(guard) = ret {
-            debug!("Acquired write lock on consensus");
+            trace!("Acquired write lock on consensus");
             Some(ConsensusWriteLockGuard::new(guard))
         } else {
-            debug!("Failed to acquire write lock");
+            trace!("Failed to acquire write lock");
             None
         }
     }
@@ -92,22 +92,22 @@ impl<TYPES: NodeType> OuterConsensus<TYPES> {
     /// Acquires upgradable read lock on inner consensus and leaves debug traces
     #[instrument(skip_all, target = "OuterConsensus")]
     pub async fn upgradable_read(&self) -> ConsensusUpgradableReadLockGuard<'_, TYPES> {
-        debug!("Trying to acquire upgradable read lock on consensus");
+        trace!("Trying to acquire upgradable read lock on consensus");
         let ret = self.inner_consensus.upgradable_read().await;
-        debug!("Acquired upgradable read lock on consensus");
+        trace!("Acquired upgradable read lock on consensus");
         ConsensusUpgradableReadLockGuard::new(ret)
     }
 
     /// Tries to acquire read lock on inner consensus and leaves debug traces
     #[instrument(skip_all, target = "OuterConsensus")]
     pub fn try_read(&self) -> Option<ConsensusReadLockGuard<'_, TYPES>> {
-        debug!("Trying to acquire read lock on consensus");
+        trace!("Trying to acquire read lock on consensus");
         let ret = self.inner_consensus.try_read();
         if let Some(guard) = ret {
-            debug!("Acquired read lock on consensus");
+            trace!("Acquired read lock on consensus");
             Some(ConsensusReadLockGuard::new(guard))
         } else {
-            debug!("Failed to acquire read lock");
+            trace!("Failed to acquire read lock");
             None
         }
     }
@@ -137,7 +137,7 @@ impl<'a, TYPES: NodeType> Deref for ConsensusReadLockGuard<'a, TYPES> {
 impl<'a, TYPES: NodeType> Drop for ConsensusReadLockGuard<'a, TYPES> {
     #[instrument(skip_all, target = "ConsensusReadLockGuard")]
     fn drop(&mut self) {
-        debug!("Read lock on consensus dropped");
+        trace!("Read lock on consensus dropped");
     }
 }
 


### PR DESCRIPTION
Closes #3435 

### This PR: 
Integrates the byzantine trait into the existing integration test framework, configurable via the test metadata. In addition, `test_success` is replicated with nodes that double-vote and double-propose

### This PR does not: 
The twin handle implementation has some issues; this PR does not fix that. There are also some shutdown issues with byzantine nodes in `tokio`, so the test is gated for `async-std`.

### Key places to review: 
`testing/tests/tests_1/test_success.rs` for the extra double vote/propose test.