### PR TITLE
Node lookup `try_send`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -647,9 +647,9 @@ dependencies = [
 
 [[package]]
 name = "async-compatibility-layer"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c928880329566b45c159fca61fbc2a1d301a7e5fd2a0e94c17476bb1a3ea526"
+checksum = "32dd1dfd4a05a197583e51036d9615f04a4d851089dc119ee965d440d0bcaa39"
 dependencies = [
  "async-lock 3.4.0",
  "async-std",
@@ -4348,7 +4348,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -7374,7 +7374,7 @@ version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38d1e02fca405f6280643174a50c942219f0bbf4dbf7d480f1dd864d6f211ae5"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.70",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,8 @@ members = [
   "crates/examples",
   "crates/example-types",
   "crates/types",
-  "crates/builder-api", "crates/fakeapi",
+  "crates/builder-api",
+  "crates/fakeapi",
 ]
 resolver = "2"
 
@@ -35,7 +36,7 @@ ark-ff = "0.4"
 ark-serialize = "0.4"
 ark-std = { version = "0.4", default-features = false }
 async-broadcast = "0.7"
-async-compatibility-layer = { version = "1.2", default-features = false, features = [
+async-compatibility-layer = { version = "1.2.1", default-features = false, features = [
   "logging-utils",
 ] }
 task = { git = "https://github.com/EspressoSystems/HotShotTasks.git" }

--- a/crates/hotshot/src/traits/networking/combined_network.rs
+++ b/crates/hotshot/src/traits/networking/combined_network.rs
@@ -493,8 +493,7 @@ impl<TYPES: NodeType> ConnectedNetwork<TYPES::SignatureKey> for CombinedNetworks
         view_number: ViewNumber,
         pk: TYPES::SignatureKey,
     ) -> Result<(), TrySendError<Option<(ViewNumber, TYPES::SignatureKey)>>> {
-        self.primary()
-            .queue_node_lookup(view_number, pk.clone())?;
+        self.primary().queue_node_lookup(view_number, pk.clone())?;
         self.secondary().queue_node_lookup(view_number, pk)
     }
 

--- a/crates/hotshot/src/traits/networking/combined_network.rs
+++ b/crates/hotshot/src/traits/networking/combined_network.rs
@@ -15,7 +15,7 @@ use std::{
 use async_broadcast::{broadcast, InactiveReceiver, Sender};
 use async_compatibility_layer::{
     art::{async_sleep, async_spawn},
-    channel::UnboundedSendError,
+    channel::TrySendError,
 };
 use async_lock::RwLock;
 use async_trait::async_trait;
@@ -488,15 +488,14 @@ impl<TYPES: NodeType> ConnectedNetwork<TYPES::SignatureKey> for CombinedNetworks
         Ok(filtered_msgs)
     }
 
-    async fn queue_node_lookup(
+    fn queue_node_lookup(
         &self,
         view_number: ViewNumber,
         pk: TYPES::SignatureKey,
-    ) -> Result<(), UnboundedSendError<Option<(ViewNumber, TYPES::SignatureKey)>>> {
+    ) -> Result<(), TrySendError<Option<(ViewNumber, TYPES::SignatureKey)>>> {
         self.primary()
-            .queue_node_lookup(view_number, pk.clone())
-            .await?;
-        self.secondary().queue_node_lookup(view_number, pk).await
+            .queue_node_lookup(view_number, pk.clone())?;
+        self.secondary().queue_node_lookup(view_number, pk)
     }
 
     async fn update_view<'a, T>(&'a self, view: u64, membership: &T::Membership)

--- a/crates/hotshot/src/traits/networking/libp2p_network.rs
+++ b/crates/hotshot/src/traits/networking/libp2p_network.rs
@@ -18,7 +18,7 @@ use std::{
 use anyhow::anyhow;
 use async_compatibility_layer::{
     art::{async_sleep, async_spawn},
-    channel::{self, bounded, unbounded, UnboundedReceiver, UnboundedSendError, UnboundedSender},
+    channel::{self, bounded, unbounded, TrySendError, UnboundedReceiver, UnboundedSender, Sender as BoundedSender, Receiver as BoundedReceiver},
 };
 use async_lock::{Mutex, RwLock};
 use async_trait::async_trait;
@@ -147,7 +147,7 @@ struct Libp2pNetworkInner<K: SignatureKey + 'static> {
     /// Sender for broadcast messages
     sender: UnboundedSender<Vec<u8>>,
     /// Sender for node lookup (relevant view number, key of node) (None for shutdown)
-    node_lookup_send: UnboundedSender<Option<(ViewNumber, K)>>,
+    node_lookup_send: BoundedSender<Option<(ViewNumber, K)>>,
     /// this is really cheating to enable local tests
     /// hashset of (bootstrap_addr, peer_id)
     bootstrap_addrs: PeerInfoVec,
@@ -517,7 +517,7 @@ impl<K: SignatureKey + 'static> Libp2pNetwork<K> {
         // if bounded figure out a way to log dropped msgs
         let (sender, receiver) = unbounded();
         let (requests_tx, requests_rx) = channel(100);
-        let (node_lookup_send, node_lookup_recv) = unbounded();
+        let (node_lookup_send, node_lookup_recv) = bounded(10);
         let (kill_tx, kill_rx) = bounded(1);
         rx.set_kill_switch(kill_rx);
 
@@ -557,7 +557,7 @@ impl<K: SignatureKey + 'static> Libp2pNetwork<K> {
 
     /// Spawns task for looking up nodes pre-emptively
     #[allow(clippy::cast_sign_loss, clippy::cast_precision_loss)]
-    fn spawn_node_lookup(&self, node_lookup_recv: UnboundedReceiver<Option<(ViewNumber, K)>>) {
+    fn spawn_node_lookup(&self, mut node_lookup_recv: BoundedReceiver<Option<(ViewNumber, K)>>) {
         let handle = Arc::clone(&self.inner.handle);
         let dht_timeout = self.inner.dht_timeout;
         let latest_seen_view = Arc::clone(&self.inner.latest_seen_view);
@@ -1075,15 +1075,14 @@ impl<K: SignatureKey + 'static> ConnectedNetwork<K> for Libp2pNetwork<K> {
     }
 
     #[instrument(name = "Libp2pNetwork::queue_node_lookup", skip_all)]
-    async fn queue_node_lookup(
+    fn queue_node_lookup(
         &self,
         view_number: ViewNumber,
         pk: K,
-    ) -> Result<(), UnboundedSendError<Option<(ViewNumber, K)>>> {
+    ) -> Result<(), TrySendError<Option<(ViewNumber, K)>>> {
         self.inner
             .node_lookup_send
-            .send(Some((view_number, pk)))
-            .await
+            .try_send(Some((view_number, pk)))
     }
 
     /// handles view update
@@ -1096,7 +1095,6 @@ impl<K: SignatureKey + 'static> ConnectedNetwork<K> for Libp2pNetwork<K> {
 
         let _ = self
             .queue_node_lookup(ViewNumber::new(*future_view), future_leader)
-            .await
             .map_err(|err| tracing::warn!("failed to process node lookup request: {err}"));
     }
 }

--- a/crates/hotshot/src/traits/networking/libp2p_network.rs
+++ b/crates/hotshot/src/traits/networking/libp2p_network.rs
@@ -18,7 +18,10 @@ use std::{
 use anyhow::anyhow;
 use async_compatibility_layer::{
     art::{async_sleep, async_spawn},
-    channel::{self, bounded, unbounded, TrySendError, UnboundedReceiver, UnboundedSender, Sender as BoundedSender, Receiver as BoundedReceiver},
+    channel::{
+        self, bounded, unbounded, Receiver as BoundedReceiver, Sender as BoundedSender,
+        TrySendError, UnboundedReceiver, UnboundedSender,
+    },
 };
 use async_lock::{Mutex, RwLock};
 use async_trait::async_trait;

--- a/crates/hotshot/src/traits/networking/push_cdn_network.rs
+++ b/crates/hotshot/src/traits/networking/push_cdn_network.rs
@@ -4,7 +4,7 @@ use std::{collections::BTreeSet, marker::PhantomData, sync::Arc};
 #[cfg(feature = "hotshot-testing")]
 use std::{path::Path, time::Duration};
 
-use async_compatibility_layer::channel::UnboundedSendError;
+use async_compatibility_layer::channel::TrySendError;
 #[cfg(feature = "hotshot-testing")]
 use async_compatibility_layer::{art::async_sleep, art::async_spawn};
 use async_trait::async_trait;
@@ -557,11 +557,11 @@ impl<TYPES: NodeType> ConnectedNetwork<TYPES::SignatureKey> for PushCdnNetwork<T
     }
 
     /// Do nothing here, as we don't need to look up nodes.
-    async fn queue_node_lookup(
+    fn queue_node_lookup(
         &self,
         _view_number: ViewNumber,
         _pk: TYPES::SignatureKey,
-    ) -> Result<(), UnboundedSendError<Option<(ViewNumber, TYPES::SignatureKey)>>> {
+    ) -> Result<(), TrySendError<Option<(ViewNumber, TYPES::SignatureKey)>>> {
         Ok(())
     }
 }

--- a/crates/types/src/traits/network.rs
+++ b/crates/types/src/traits/network.rs
@@ -344,7 +344,7 @@ pub trait ConnectedNetwork<K: SignatureKey + 'static>: Clone + Send + Sync + 'st
     }
 
     /// queues lookup of a node
-    /// 
+    ///
     /// # Errors
     /// Does not error.
     fn queue_node_lookup(

--- a/crates/types/src/traits/network.rs
+++ b/crates/types/src/traits/network.rs
@@ -25,7 +25,7 @@ use std::{
     time::Duration,
 };
 
-use async_compatibility_layer::channel::UnboundedSendError;
+use async_compatibility_layer::channel::TrySendError;
 use async_trait::async_trait;
 use futures::future::join_all;
 use rand::{
@@ -344,11 +344,14 @@ pub trait ConnectedNetwork<K: SignatureKey + 'static>: Clone + Send + Sync + 'st
     }
 
     /// queues lookup of a node
-    async fn queue_node_lookup(
+    /// 
+    /// # Errors
+    /// Does not error.
+    fn queue_node_lookup(
         &self,
         _view_number: ViewNumber,
         _pk: K,
-    ) -> Result<(), UnboundedSendError<Option<(ViewNumber, K)>>> {
+    ) -> Result<(), TrySendError<Option<(ViewNumber, K)>>> {
         Ok(())
     }
 


### PR DESCRIPTION
May close #3425 

Since we process node lookups serially and the timeout is rather long (2m), if not all nodes are on Libp2p, `node_lookup` can get rather large (infinitely so).

This uses `try_send` instead so that overflows just get ignored.