### PR TITLE
Lower Libp2p logging levels

### DIFF
--- a/crates/libp2p-networking/src/network/node.rs
+++ b/crates/libp2p-networking/src/network/node.rs
@@ -40,7 +40,7 @@ use libp2p::{
 use libp2p_identity::PeerId;
 use rand::{prelude::SliceRandom, thread_rng};
 use snafu::ResultExt;
-use tracing::{debug, error, info, info_span, instrument, trace, warn, Instrument};
+use tracing::{debug, error, info, info_span, instrument, warn, Instrument};
 
 pub use self::{
     config::{
@@ -124,7 +124,7 @@ impl NetworkNode {
                 break address;
             }
         };
-        info!("peerid {:?} started on addr: {:?}", self.peer_id, addr);
+        info!("Libp2p listening on {:?}", addr);
         Ok(addr)
     }
 
@@ -134,7 +134,7 @@ impl NetworkNode {
     /// will start connecting to peers
     #[instrument(skip(self))]
     pub fn add_known_peers(&mut self, known_peers: &[(PeerId, Multiaddr)]) {
-        info!("Adding nodes {:?} to {:?}", known_peers, self.peer_id);
+        debug!("Adding {} known peers", known_peers.len());
         let behaviour = self.swarm.behaviour_mut();
         let mut bs_nodes = HashMap::<PeerId, HashSet<Multiaddr>>::new();
         let mut shuffled = known_peers.iter().collect::<Vec<_>>();
@@ -167,7 +167,7 @@ impl NetworkNode {
         let peer_id = PeerId::from(identity.public());
         debug!(?peer_id);
         let transport: BoxedTransport = gen_transport(identity.clone()).await?;
-        trace!("Launched network transport");
+        debug!("Launched network transport");
         // Generate the swarm
         let mut swarm: Swarm<NetworkDef> = {
             // Use the hash of the message's contents as the ID
@@ -364,7 +364,7 @@ impl NetworkNode {
                 error!("Error publishing to DHT: {e:?} for peer {:?}", self.peer_id);
             }
             Ok(qid) => {
-                info!("Success publishing {:?} to DHT", qid);
+                debug!("Published record to DHT with qid {:?}", qid);
                 let query = KadPutQuery {
                     progress: DHTProgress::InProgress(qid),
                     ..query
@@ -476,7 +476,7 @@ impl NetworkNode {
                         contents,
                         retry_count,
                     } => {
-                        info!("pid {:?} adding direct request", self.peer_id);
+                        debug!("Sending direct request to {:?}", pid);
                         let id = behaviour.add_direct_request(pid, contents.clone());
                         let req = DMRequest {
                             peer_id: pid,
@@ -503,7 +503,7 @@ impl NetworkNode {
                             .send_response(chan, response)
                             .is_err()
                         {
-                            info!("Data Response dropped because response peer disconnected");
+                            debug!("Data response dropped because client is no longer connected");
                         }
                     }
                     ClientRequest::AddKnownPeers(peers) => {
@@ -511,10 +511,7 @@ impl NetworkNode {
                     }
                     ClientRequest::Prune(pid) => {
                         if self.swarm.disconnect_peer_id(pid).is_err() {
-                            error!(
-                                "Peer {:?} could not disconnect from pid {:?}",
-                                self.peer_id, pid
-                            );
+                            warn!("Could not disconnect from {:?}", pid);
                         }
                     }
                 }
@@ -535,7 +532,7 @@ impl NetworkNode {
         send_to_client: &UnboundedSender<NetworkEvent>,
     ) -> Result<(), NetworkError> {
         // Make the match cleaner
-        info!("event observed {:?}", event);
+        debug!("Swarm event observed {:?}", event);
 
         #[allow(deprecated)]
         match event {
@@ -553,7 +550,10 @@ impl NetworkNode {
                         ESTABLISHED_LIMIT, num_established
                     );
                 } else {
-                    info!("peerid {:?} connection is established to {:?} with endpoint {:?} with concurrent dial errors {:?}. {:?} connections left", self.peer_id, peer_id, endpoint, concurrent_dial_errors, num_established);
+                    debug!(
+                        "Connection established with {:?} at {:?} with {:?} concurrent dial errors",
+                        peer_id, endpoint, concurrent_dial_errors
+                    );
                 }
 
                 // Send the number of connected peers to the client
@@ -575,7 +575,10 @@ impl NetworkNode {
                         ESTABLISHED_LIMIT, num_established
                     );
                 } else {
-                    info!("peerid {:?} connection is closed to {:?} with endpoint {:?}. {:?} connections left. Cause: {:?}", self.peer_id, peer_id, endpoint, num_established, cause);
+                    debug!(
+                        "Connection closed with {:?} at {:?} due to {:?}",
+                        peer_id, endpoint, cause
+                    );
                 }
 
                 // Send the number of connected peers to the client
@@ -588,7 +591,7 @@ impl NetworkNode {
                 peer_id,
                 connection_id: _,
             } => {
-                info!("{:?} is dialing {:?}", self.peer_id, peer_id);
+                debug!("Attempting to dial {:?}", peer_id);
             }
             SwarmEvent::ListenerClosed {
                 listener_id: _,
@@ -626,19 +629,12 @@ impl NetworkNode {
                                     public_key: _,
                                     protocol_version: _,
                                     agent_version: _,
-                                    observed_addr,
+                                    observed_addr: _,
                                 },
                         } = *e
                         {
                             let behaviour = self.swarm.behaviour_mut();
-                            // NOTE in practice, we will want to NOT include this. E.g. only DNS/non localhost IPs
-                            // NOTE I manually checked and peer_id corresponds to listen_addrs.
-                            // NOTE Once we've tested on DNS addresses, this should be swapped out to play nicely
-                            // with autonat
-                            info!(
-                                "local peer {:?} IDENTIFY ADDRS LISTEN: {:?} for peer {:?}, ADDRS OBSERVED: {:?} ",
-                                self.dht_handler.peer_id , peer_id, listen_addrs, observed_addr
-                                );
+
                             // into hashset to delete duplicates (I checked: there are duplicates)
                             for addr in listen_addrs.iter().collect::<HashSet<_>>() {
                                 behaviour.dht.add_address(&peer_id, addr.clone());
@@ -653,15 +649,15 @@ impl NetworkNode {
                             message,
                         } => Some(NetworkEvent::GossipMsg(message.data)),
                         GossipEvent::Subscribed { peer_id, topic } => {
-                            info!("Peer: {:?}, Subscribed to topic: {:?}", peer_id, topic);
+                            debug!("Peer {:?} subscribed to topic {:?}", peer_id, topic);
                             None
                         }
                         GossipEvent::Unsubscribed { peer_id, topic } => {
-                            info!("Peer: {:?}, Unsubscribed from topic: {:?}", peer_id, topic);
+                            debug!("Peer {:?} unsubscribed from topic {:?}", peer_id, topic);
                             None
                         }
                         GossipEvent::GossipsubNotSupported { peer_id } => {
-                            info!("Peer: {:?}, Does not support Gossip", peer_id);
+                            warn!("Peer {:?} does not support gossipsub", peer_id);
                             None
                         }
                     },
@@ -683,13 +679,13 @@ impl NetworkNode {
                                     error,
                                 } => {
                                     warn!(
-                                        "Autonat Probe failed to peer {:?}, with error: {:?}",
+                                        "AutoNAT Probe failed to peer {:?} with error: {:?}",
                                         peer, error
                                     );
                                 }
                             },
                             autonat::Event::StatusChanged { old, new } => {
-                                info!("autonat Status changed. Old: {:?}, New: {:?}", old, new);
+                                debug!("AutoNAT Status changed. Old: {:?}, New: {:?}", old, new);
                             }
                         };
                         None
@@ -706,24 +702,24 @@ impl NetworkNode {
             }
             SwarmEvent::OutgoingConnectionError {
                 connection_id: _,
-                peer_id: _,
+                peer_id,
                 error,
             } => {
-                info!(?error, "OUTGOING CONNECTION ERROR, {:?}", error);
+                warn!("Outgoing connection error to {:?}: {:?}", peer_id, error);
             }
             SwarmEvent::IncomingConnectionError {
                 connection_id: _,
-                local_addr,
-                send_back_addr,
+                local_addr: _,
+                send_back_addr: _,
                 error,
             } => {
-                info!(
-                    "INCOMING CONNECTION ERROR: {:?} {:?} {:?}",
-                    local_addr, send_back_addr, error
-                );
+                warn!("Incoming connection error: {:?}", error);
             }
-            SwarmEvent::ListenerError { listener_id, error } => {
-                info!("LISTENER ERROR {:?} {:?}", listener_id, error);
+            SwarmEvent::ListenerError {
+                listener_id: _,
+                error,
+            } => {
+                warn!("Listener error: {:?}", error);
             }
             SwarmEvent::ExternalAddrConfirmed { address } => {
                 let my_id = *self.swarm.local_peer_id();
@@ -733,10 +729,7 @@ impl NetworkNode {
                     .add_address(&my_id, address.clone());
             }
             _ => {
-                error!(
-                    "Unhandled swarm event {:?}. This should not be possible.",
-                    event
-                );
+                debug!("Unhandled swarm event {:?}", event);
             }
         }
         Ok(())

--- a/crates/libp2p-networking/src/network/node/handle.rs
+++ b/crates/libp2p-networking/src/network/node/handle.rs
@@ -97,8 +97,6 @@ pub async fn spawn_network_node(
         recv_kill: None,
     };
 
-    info!("LISTEN ADDRESS IS {:?}", listen_addr);
-
     let handle = NetworkNodeHandle {
         network_config: config,
         send_network: send_chan,
@@ -430,7 +428,7 @@ impl NetworkNodeHandle {
         &self,
         known_peers: Vec<(PeerId, Multiaddr)>,
     ) -> Result<(), NetworkNodeHandleError> {
-        info!("ADDING KNOWN PEERS TO {:?}", self.peer_id);
+        debug!("Adding {} known peers", known_peers.len());
         let req = ClientRequest::AddKnownPeers(known_peers);
         self.send_request(req).await
     }
@@ -440,7 +438,6 @@ impl NetworkNodeHandle {
     /// # Errors
     /// - Will return [`NetworkNodeHandleError::SendError`] when underlying `NetworkNode` has been killed
     async fn send_request(&self, req: ClientRequest) -> Result<(), NetworkNodeHandleError> {
-        debug!("peerid {:?}\t\tsending message {:?}", self.peer_id, req);
         self.send_network
             .send(req)
             .await


### PR DESCRIPTION
### This PR: 
<!-- Describe what this PR adds to HotSHot -->
<!-- E.g. -->
<!-- * Implements feature 1 -->
<!-- * Implements feature 2 -->
<!-- * Fixes bug 3 -->

Lowers Libp2p logging levels so we can turn on `INFO` or `WARN` logging for it in the sequencer.

### This PR does not: 
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->

Touch any logic

