### PR TITLE
[CATCHUP] Test all nodes restarting

### DIFF
--- a/crates/example-types/src/storage_types.rs
+++ b/crates/example-types/src/storage_types.rs
@@ -10,8 +10,10 @@ use hotshot_types::{
     consensus::CommitmentMap,
     data::{DaProposal, Leaf, QuorumProposal, VidDisperseShare},
     message::Proposal,
+    simple_certificate::QuorumCertificate,
     traits::{node_implementation::NodeType, storage::Storage},
     utils::View,
+    vote::HasViewNumber,
 };
 
 type VidShares<TYPES> = HashMap<
@@ -23,7 +25,8 @@ type VidShares<TYPES> = HashMap<
 pub struct TestStorageState<TYPES: NodeType> {
     vids: VidShares<TYPES>,
     das: HashMap<TYPES::Time, Proposal<TYPES, DaProposal<TYPES>>>,
-    proposals: HashMap<TYPES::Time, Proposal<TYPES, QuorumProposal<TYPES>>>,
+    proposals: BTreeMap<TYPES::Time, Proposal<TYPES, QuorumProposal<TYPES>>>,
+    high_qc: Option<hotshot_types::simple_certificate::QuorumCertificate<TYPES>>,
 }
 
 impl<TYPES: NodeType> Default for TestStorageState<TYPES> {
@@ -31,7 +34,8 @@ impl<TYPES: NodeType> Default for TestStorageState<TYPES> {
         Self {
             vids: HashMap::new(),
             das: HashMap::new(),
-            proposals: HashMap::new(),
+            proposals: BTreeMap::new(),
+            high_qc: None,
         }
     }
 }
@@ -49,6 +53,17 @@ impl<TYPES: NodeType> Default for TestStorage<TYPES> {
             inner: Arc::new(RwLock::new(TestStorageState::default())),
             should_return_err: false,
         }
+    }
+}
+
+impl<TYPES: NodeType> TestStorage<TYPES> {
+    pub async fn proposals_cloned(
+        &self,
+    ) -> BTreeMap<TYPES::Time, Proposal<TYPES, QuorumProposal<TYPES>>> {
+        self.inner.read().await.proposals.clone()
+    }
+    pub async fn high_qc(&self) -> Option<QuorumCertificate<TYPES>> {
+        self.inner.read().await.high_qc.clone()
     }
 }
 
@@ -104,10 +119,18 @@ impl<TYPES: NodeType> Storage<TYPES> for TestStorage<TYPES> {
 
     async fn update_high_qc(
         &self,
-        _high_qc: hotshot_types::simple_certificate::QuorumCertificate<TYPES>,
+        new_high_qc: hotshot_types::simple_certificate::QuorumCertificate<TYPES>,
     ) -> Result<()> {
         if self.should_return_err {
             bail!("Failed to update high qc to storage");
+        }
+        let mut inner = self.inner.write().await;
+        if let Some(ref current_high_qc) = inner.high_qc {
+            if new_high_qc.view_number() > current_high_qc.view_number() {
+                inner.high_qc = Some(new_high_qc);
+            }
+        } else {
+            inner.high_qc = Some(new_high_qc);
         }
         Ok(())
     }

--- a/crates/testing/tests/tests_2/catchup.rs
+++ b/crates/testing/tests/tests_2/catchup.rs
@@ -286,3 +286,64 @@ async fn test_catchup_reload() {
         .run_test::<SimpleBuilderImplementation>()
         .await;
 }
+
+#[cfg(test)]
+#[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
+#[cfg_attr(async_executor_impl = "async-std", async_std::test)]
+async fn test_all_restart() {
+    use std::time::Duration;
+
+    use hotshot_example_types::node_types::{CombinedImpl, TestTypes};
+    use hotshot_testing::{
+        block_builder::SimpleBuilderImplementation,
+        completion_task::{CompletionTaskDescription, TimeBasedCompletionTaskDescription},
+        overall_safety_task::OverallSafetyPropertiesDescription,
+        spinning_task::{ChangeNode, SpinningTaskDescription, UpDown},
+        test_builder::{TestDescription, TimingData},
+    };
+
+    async_compatibility_layer::logging::setup_logging();
+    async_compatibility_layer::logging::setup_backtrace();
+    let timing_data = TimingData {
+        next_view_timeout: 2000,
+        ..Default::default()
+    };
+    let mut metadata: TestDescription<TestTypes, CombinedImpl> = TestDescription::default();
+    let mut catchup_nodes = vec![];
+    for i in 1..20 {
+        catchup_nodes.push(ChangeNode {
+        idx: i,
+        updown: UpDown::Restart,
+    })};
+
+    metadata.timing_data = timing_data;
+    metadata.start_nodes = 20;
+    metadata.num_nodes_with_stake = 20;
+
+    metadata.view_sync_properties =
+        hotshot_testing::view_sync_task::ViewSyncTaskDescription::Threshold(0, 20);
+
+    metadata.spinning_properties = SpinningTaskDescription {
+        // Start the nodes before their leadership.
+        node_changes: vec![(13, catchup_nodes)],
+    };
+
+    metadata.completion_task_description =
+        CompletionTaskDescription::TimeBasedCompletionTaskBuilder(
+            TimeBasedCompletionTaskDescription {
+                duration: Duration::from_secs(60),
+            },
+        );
+    metadata.overall_safety_properties = OverallSafetyPropertiesDescription {
+        // Make sure we keep committing rounds after the catchup, but not the full 50.
+        num_successful_views: 22,
+        num_failed_views: 0,
+        ..Default::default()
+    };
+
+    metadata
+        .gen_launcher(0)
+        .launch()
+        .run_test::<SimpleBuilderImplementation>()
+        .await;
+}


### PR DESCRIPTION
Closes #<ISSUE_NUMBER>
<!-- See here for keywords in Github -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

### This PR: 

Should test that all nodes can go down and come back up without keeping their in memory state

### This PR does not: 
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->

### Key places to review: 
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
