### PR TITLE
Minor change to AuctionResults trait to allow multiple URLs

### DIFF
--- a/crates/example-types/src/auction_results_provider_types.rs
+++ b/crates/example-types/src/auction_results_provider_types.rs
@@ -1,22 +1,26 @@
+use std::collections::HashSet;
+
 use anyhow::{bail, Result};
 use async_trait::async_trait;
 use hotshot_types::traits::{
-    auction_results_provider::{AuctionResultsProvider, HasUrl},
+    auction_results_provider::{AuctionResultsProvider, HasUrls},
     node_implementation::NodeType,
 };
 use serde::{Deserialize, Serialize};
 use url::Url;
 
 /// A mock result for the auction solver. This type is just a pointer to a URL.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct TestAuctionResult {
     /// The URL of the builder to reach out to.
-    pub url: Url,
+    pub urls: HashSet<Url>,
 }
 
-impl HasUrl for TestAuctionResult {
-    fn url(&self) -> Url {
-        self.url.clone()
+
+
+impl HasUrls for TestAuctionResult {
+    fn urls(&self) -> HashSet<Url> {
+        self.urls.clone()
     }
 }
 
@@ -25,7 +29,7 @@ impl HasUrl for TestAuctionResult {
 pub struct TestAuctionResultsProvider {
     /// We intentionally allow for the results to be pre-cooked for the unit test to gurantee a
     /// particular outcome is met.
-    pub solver_results: Vec<TestAuctionResult>,
+    pub solver_results: TestAuctionResult,
 
     /// A canned type to ensure that an error is thrown in absence of a true fault-injectible
     /// system for logical tests. This will guarantee that `fetch_auction_result` always throws an
@@ -44,15 +48,12 @@ impl<TYPES: NodeType> AuctionResultsProvider<TYPES> for TestAuctionResultsProvid
 
     /// Mock fetching the auction results, with optional error injection to simulate failure cases
     /// in the solver.
-    async fn fetch_auction_result(
-        &self,
-        view_number: TYPES::Time,
-    ) -> Result<Vec<Self::AuctionResult>> {
+    async fn fetch_auction_result(&self, view_number: TYPES::Time) -> Result<Self::AuctionResult> {
         if let Some(url) = &self.broadcast_url {
             let resp =
                 reqwest::get(url.join(&format!("/v0/api/auction_results/{}", *view_number))?)
                     .await?
-                    .json::<Vec<TestAuctionResult>>()
+                    .json::<TestAuctionResult>()
                     .await?;
 
             Ok(resp)

--- a/crates/example-types/src/auction_results_provider_types.rs
+++ b/crates/example-types/src/auction_results_provider_types.rs
@@ -1,5 +1,3 @@
-use std::collections::HashSet;
-
 use anyhow::{bail, Result};
 use async_trait::async_trait;
 use hotshot_types::traits::{
@@ -13,13 +11,13 @@ use url::Url;
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct TestAuctionResult {
     /// The URL of the builder to reach out to.
-    pub urls: HashSet<Url>,
+    pub urls: Vec<Url>,
 }
 
 
 
 impl HasUrls for TestAuctionResult {
-    fn urls(&self) -> HashSet<Url> {
+    fn urls(&self) -> Vec<Url> {
         self.urls.clone()
     }
 }

--- a/crates/example-types/src/auction_results_provider_types.rs
+++ b/crates/example-types/src/auction_results_provider_types.rs
@@ -14,8 +14,6 @@ pub struct TestAuctionResult {
     pub urls: Vec<Url>,
 }
 
-
-
 impl HasUrls for TestAuctionResult {
     fn urls(&self) -> Vec<Url> {
         self.urls.clone()

--- a/crates/fakeapi/src/fake_solver.rs
+++ b/crates/fakeapi/src/fake_solver.rs
@@ -99,13 +99,9 @@ impl FakeSolverState {
             }
         }
 
-        let mut auction_results = TestAuctionResult::default();
-        // Now just send the builder urls
-        let _ = self
-            .available_builders
-            .iter()
-            .map(|url| auction_results.urls.push(url.clone()));
-        Ok(auction_results)
+        Ok(TestAuctionResult {
+            urls: self.available_builders.clone(),
+        })
     }
 }
 

--- a/crates/fakeapi/src/fake_solver.rs
+++ b/crates/fakeapi/src/fake_solver.rs
@@ -104,7 +104,7 @@ impl FakeSolverState {
         let _ = self
             .available_builders
             .iter()
-            .map(|url|  auction_results.urls.insert(url.clone()) );
+            .map(|url|  auction_results.urls.push(url.clone()) );
         Ok(auction_results)
         
     }

--- a/crates/fakeapi/src/fake_solver.rs
+++ b/crates/fakeapi/src/fake_solver.rs
@@ -83,7 +83,7 @@ impl FakeSolverState {
     ///
     /// # Errors
     /// Returns an error if the `should_fault` method is `Some`.
-    fn dump_builders(&self) -> Result<Vec<TestAuctionResult>, ServerError> {
+    fn dump_builders(&self) -> Result<TestAuctionResult, ServerError> {
         if let Some(fault) = self.should_fault() {
             match fault {
                 FakeSolverFaultType::InternalServerFault => {
@@ -99,12 +99,14 @@ impl FakeSolverState {
             }
         }
 
+        let mut auction_results = TestAuctionResult::default(); 
         // Now just send the builder urls
-        Ok(self
+        let _ = self
             .available_builders
             .iter()
-            .map(|url| TestAuctionResult { url: url.clone() })
-            .collect())
+            .map(|url|  auction_results.urls.insert(url.clone()) );
+        Ok(auction_results)
+        
     }
 }
 
@@ -116,14 +118,14 @@ pub trait FakeSolverApi<TYPES: NodeType> {
     async fn get_auction_results_non_permissioned(
         &self,
         _view_number: u64,
-    ) -> Result<Vec<TestAuctionResult>, ServerError>;
+    ) -> Result<TestAuctionResult, ServerError>;
 
     /// Get the auction results with a valid signature.
     async fn get_auction_results_permissioned(
         &self,
         _view_number: u64,
         _signature: &<TYPES::SignatureKey as SignatureKey>::PureAssembledSignatureType,
-    ) -> Result<Vec<TestAuctionResult>, ServerError>;
+    ) -> Result<TestAuctionResult, ServerError>;
 }
 
 #[async_trait::async_trait]
@@ -132,7 +134,7 @@ impl<TYPES: NodeType> FakeSolverApi<TYPES> for FakeSolverState {
     async fn get_auction_results_non_permissioned(
         &self,
         _view_number: u64,
-    ) -> Result<Vec<TestAuctionResult>, ServerError> {
+    ) -> Result<TestAuctionResult, ServerError> {
         self.dump_builders()
     }
 
@@ -141,7 +143,7 @@ impl<TYPES: NodeType> FakeSolverApi<TYPES> for FakeSolverState {
         &self,
         _view_number: u64,
         _signature: &<TYPES::SignatureKey as SignatureKey>::PureAssembledSignatureType,
-    ) -> Result<Vec<TestAuctionResult>, ServerError> {
+    ) -> Result<TestAuctionResult, ServerError> {
         self.dump_builders()
     }
 }

--- a/crates/fakeapi/src/fake_solver.rs
+++ b/crates/fakeapi/src/fake_solver.rs
@@ -99,14 +99,13 @@ impl FakeSolverState {
             }
         }
 
-        let mut auction_results = TestAuctionResult::default(); 
+        let mut auction_results = TestAuctionResult::default();
         // Now just send the builder urls
         let _ = self
             .available_builders
             .iter()
-            .map(|url|  auction_results.urls.push(url.clone()) );
+            .map(|url| auction_results.urls.push(url.clone()));
         Ok(auction_results)
-        
     }
 }
 

--- a/crates/task-impls/src/transactions.rs
+++ b/crates/task-impls/src/transactions.rs
@@ -164,7 +164,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> TransactionTaskState<TYPES, 
                 }
                 let block_view = if make_block { view } else { view + 1 };
 
-                let version = match hotshot_types::message::version(
+                let version = match hotshot_types::simple_certificate::version(
                     block_view,
                     &self
                         .decided_upgrade_certificate

--- a/crates/testing/tests/tests_5/fake_solver.rs
+++ b/crates/testing/tests/tests_5/fake_solver.rs
@@ -3,8 +3,8 @@ use hotshot_fakeapi::fake_solver::FakeSolverState;
 use hotshot_types::traits::{node_implementation::NodeType, signature_key::SignatureKey};
 
 use hotshot_example_types::node_types::TestTypes;
+use hotshot_example_types::auction_results_provider_types::TestAuctionResult;
 use hotshot_testing::helpers::key_pair_for_id;
-use std::collections::HashMap;
 use tracing::instrument;
 use url::Url;
 
@@ -13,6 +13,7 @@ use url::Url;
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 #[instrument]
 async fn test_fake_solver_fetch_non_permissioned_no_error() {
+
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
 
@@ -45,7 +46,7 @@ async fn test_fake_solver_fetch_non_permissioned_no_error() {
         .send()
         .await
         .unwrap()
-        .json::<Vec<HashMap<String, String>>>()
+        .json::<TestAuctionResult>()
         .await
         .unwrap();
 
@@ -54,9 +55,9 @@ async fn test_fake_solver_fetch_non_permissioned_no_error() {
     #[cfg(async_executor_impl = "tokio")]
     solver_handle.abort();
 
-    assert_eq!(resp[0]["url"], "http://localhost:1111/");
-    assert_eq!(resp[1]["url"], "http://localhost:1112/");
-    assert_eq!(resp[2]["url"], "http://localhost:1113/");
+    assert_eq!(resp.urls[0], Url::parse("http://localhost:1111/").unwrap());
+    assert_eq!(resp.urls[1], Url::parse("http://localhost:1112/").unwrap());
+    assert_eq!(resp.urls[2], Url::parse("http://localhost:1113/").unwrap());
 }
 
 #[cfg(test)]
@@ -64,6 +65,7 @@ async fn test_fake_solver_fetch_non_permissioned_no_error() {
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 #[instrument]
 async fn test_fake_solver_fetch_non_permissioned_with_errors() {
+
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
 
@@ -127,7 +129,7 @@ async fn test_fake_solver_fetch_non_permissioned_with_errors() {
                 return;
             }
 
-            let payload = resp.json::<Vec<HashMap<String, String>>>().await.unwrap();
+            let payload = resp.json::<TestAuctionResult>().await.unwrap();
             payloads.push(payload);
         }
     }
@@ -139,7 +141,7 @@ async fn test_fake_solver_fetch_non_permissioned_with_errors() {
 
     // Assert over the payloads with a 50% error rate.
     for payload in payloads {
-        assert_eq!(payload[0]["url"], "http://localhost:1111/");
+        assert_eq!(payload.urls[0], Url::parse("http://localhost:1111/").unwrap());
     }
 }
 
@@ -148,6 +150,7 @@ async fn test_fake_solver_fetch_non_permissioned_with_errors() {
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 #[instrument]
 async fn test_fake_solver_fetch_permissioned_no_error() {
+
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
 
@@ -191,7 +194,7 @@ async fn test_fake_solver_fetch_permissioned_no_error() {
         .send()
         .await
         .unwrap()
-        .json::<Vec<HashMap<String, String>>>()
+        .json::<TestAuctionResult>()
         .await
         .unwrap();
 
@@ -200,9 +203,9 @@ async fn test_fake_solver_fetch_permissioned_no_error() {
     #[cfg(async_executor_impl = "tokio")]
     solver_handle.abort();
 
-    assert_eq!(resp[0]["url"], "http://localhost:1111/");
-    assert_eq!(resp[1]["url"], "http://localhost:1112/");
-    assert_eq!(resp[2]["url"], "http://localhost:1113/");
+    assert_eq!(resp.urls[0], Url::parse("http://localhost:1111/").unwrap());
+    assert_eq!(resp.urls[1], Url::parse("http://localhost:1112/").unwrap());
+    assert_eq!(resp.urls[2], Url::parse("http://localhost:1113/").unwrap());
 }
 
 #[cfg(test)]
@@ -210,6 +213,7 @@ async fn test_fake_solver_fetch_permissioned_no_error() {
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 #[instrument]
 async fn test_fake_solver_fetch_permissioned_with_errors() {
+
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
 
@@ -280,7 +284,7 @@ async fn test_fake_solver_fetch_permissioned_with_errors() {
                 return;
             }
 
-            let payload = resp.json::<Vec<HashMap<String, String>>>().await.unwrap();
+            let payload = resp.json::<TestAuctionResult>().await.unwrap();
             payloads.push(payload);
         }
     }
@@ -292,6 +296,6 @@ async fn test_fake_solver_fetch_permissioned_with_errors() {
 
     // Assert over the payloads with a 50% error rate.
     for payload in payloads {
-        assert_eq!(payload[0]["url"], "http://localhost:1111/");
+        assert_eq!(payload.urls[0], Url::parse("http://localhost:1111/").unwrap());
     }
 }

--- a/crates/types/src/traits/auction_results_provider.rs
+++ b/crates/types/src/traits/auction_results_provider.rs
@@ -1,18 +1,19 @@
 //! This module defines the interaction layer with the Solver via the [`AuctionResultsProvider`] trait,
 //! which handles connecting to, and fetching the allocation results from, the Solver.
 
+use std::collections::HashSet;
 use anyhow::Result;
 use async_trait::async_trait;
 use url::Url;
 
 use super::node_implementation::NodeType;
 
-/// This trait guarantees that a particular type has a url associated with it. This trait
-/// essentially ensures that the results returned by the [`AuctionResultsProvider`] trait includes a URL
-/// for the builder that HotShot must request from.
-pub trait HasUrl {
+/// This trait guarantees that a particular type has urls that can be extracted from it. This trait
+/// essentially ensures that the results returned by the [`AuctionResultsProvider`] trait includes a
+/// list of urls for the builders that HotShot must request from.
+pub trait HasUrls {
     /// Returns the builer url associated with the datatype
-    fn url(&self) -> Url;
+    fn urls(&self) -> HashSet<Url>;
 }
 
 /// The AuctionResultsProvider trait is the sole source of Solver-originated state and interaction,
@@ -23,12 +24,12 @@ pub trait HasUrl {
 pub trait AuctionResultsProvider<TYPES: NodeType>: Send + Sync + Clone {
     /// The AuctionSolverResult is a type that holds the data associated with a particular solver
     /// run, for a particular view.
-    type AuctionResult: HasUrl;
+    type AuctionResult: HasUrls;
 
     /// Fetches the auction result for a view. Does not cache the result,
     /// subsequent calls will invoke additional wasted calls.
     async fn fetch_auction_result(
         &self,
         view_number: TYPES::Time,
-    ) -> Result<Vec<Self::AuctionResult>>;
+    ) -> Result<Self::AuctionResult>;
 }

--- a/crates/types/src/traits/auction_results_provider.rs
+++ b/crates/types/src/traits/auction_results_provider.rs
@@ -17,7 +17,7 @@ pub trait HasUrls {
 
 /// The AuctionResultsProvider trait is the sole source of Solver-originated state and interaction,
 /// and returns the results of the Solver's allocation via the associated type. The associated type,
-/// `AuctionResult`, also implements the [`HasUrl`] trait, which requires that the output
+/// `AuctionResult`, also implements the [`HasUrls`] trait, which requires that the output
 /// type has the requisite fields available.
 #[async_trait]
 pub trait AuctionResultsProvider<TYPES: NodeType>: Send + Sync + Clone {

--- a/crates/types/src/traits/auction_results_provider.rs
+++ b/crates/types/src/traits/auction_results_provider.rs
@@ -1,7 +1,6 @@
 //! This module defines the interaction layer with the Solver via the [`AuctionResultsProvider`] trait,
 //! which handles connecting to, and fetching the allocation results from, the Solver.
 
-use std::collections::HashSet;
 use anyhow::Result;
 use async_trait::async_trait;
 use url::Url;
@@ -13,7 +12,7 @@ use super::node_implementation::NodeType;
 /// list of urls for the builders that HotShot must request from.
 pub trait HasUrls {
     /// Returns the builer url associated with the datatype
-    fn urls(&self) -> HashSet<Url>;
+    fn urls(&self) -> Vec<Url>;
 }
 
 /// The AuctionResultsProvider trait is the sole source of Solver-originated state and interaction,

--- a/crates/types/src/traits/auction_results_provider.rs
+++ b/crates/types/src/traits/auction_results_provider.rs
@@ -27,8 +27,5 @@ pub trait AuctionResultsProvider<TYPES: NodeType>: Send + Sync + Clone {
 
     /// Fetches the auction result for a view. Does not cache the result,
     /// subsequent calls will invoke additional wasted calls.
-    async fn fetch_auction_result(
-        &self,
-        view_number: TYPES::Time,
-    ) -> Result<Self::AuctionResult>;
+    async fn fetch_auction_result(&self, view_number: TYPES::Time) -> Result<Self::AuctionResult>;
 }


### PR DESCRIPTION
Closes #<ISSUE_NUMBER>
<!-- See here for keywords in Github -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

### This PR: 
This PR updates the `AuctionResults` trait to support a Vec of URLs instead of just one URL.  

### This PR does not: 
Implement logic for the HotShot leader to fetch AuctionResults

### Key places to review: 
`auction_results.rs`

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->

I'm assigning this PR to @jparr721 since he wrote this code initially. 
