### PR TITLE
Add `Libp2p` connection limits

### DIFF
--- a/crates/libp2p-networking/src/network/mod.rs
+++ b/crates/libp2p-networking/src/network/mod.rs
@@ -191,6 +191,8 @@ pub enum NetworkEventInternal {
     RequestResponseEvent(libp2p::request_response::Event<Request, Response>),
     /// a autonat event
     AutonatEvent(libp2p::autonat::Event),
+    /// A null event
+    Void(void::Void),
 }
 
 /// Bind all interfaces on port `port`


### PR DESCRIPTION
No linked issue.

### This PR: 
<!-- Describe what this PR adds to HotSHot -->
<!-- E.g. -->
<!-- * Implements feature 1 -->
<!-- * Implements feature 2 -->
<!-- * Fixes bug 3 -->

Limits the number of simultaneous [pending/established] connections that Libp2p can use.

### This PR does not: 
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->

Break anything at the protocol level. This is all client-side so it should be backwards compatible.

### Key places to review: 
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->

The configured values at `node.rs`