### PR TITLE
Update codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,5 @@
 # Default owners and repository maintainers:
-* @elliedavidson @bfish713
+* @bfish713
 
 # Owner of `constants` crate
 /constants/ @shenkeyao
@@ -17,19 +17,19 @@
 /hotshot-state-prover/ @dailinsubjam
 
 # Owner of `libp2p-networking` crate
-/libp2p-networking/ @rob-maron @DieracDelta
+/libp2p-networking/ @rob-maron 
 
 # Owner of `orchestrator` crate
 /orchestrator/ @rob-maron @elliedavidson
 
 # Owner of `task` crate
-/task/ @rob-maron @DieracDelta
+/task/ @rob-maron 
 
 # Owner of `task-impls` crate
-/task-impls/ @elliedavidson @bfish713 @jparr721 @shenkeyao
+/task-impls/  @bfish713 @jparr721 @shenkeyao
 
 # Owner of `testing` crate
-/testing/ @DieracDelta @bfish713
+/testing/  @bfish713
 
 # Owner of `types` crate
 /types/ @shenkeyao


### PR DESCRIPTION
Closes #<ISSUE_NUMBER>
<!-- See here for keywords in Github -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

### This PR: 
This PR updates the Codeowners file to remove myself and DieracDelta from most crates since the two of us are not regularly maintaining those crates anymore.  

### This PR does not: 
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->

### Key places to review: 
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
