### PR TITLE
Add `Bundle` struct and request bundles in transaction task

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3512,6 +3512,7 @@ dependencies = [
  "memoize",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
+ "reqwest",
  "serde",
  "serde_json",
  "sha2 0.10.8",

--- a/crates/hotshot/src/tasks/task_state.rs
+++ b/crates/hotshot/src/tasks/task_state.rs
@@ -205,6 +205,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> CreateTaskState<TYPES, I>
                 .collect(),
             builder_clients_marketplace: Vec::new(),
             decided_upgrade_certificate: Arc::clone(&handle.hotshot.decided_upgrade_certificate),
+            auction_results_provider: Arc::clone(&handle.hotshot.auction_results_provider),
         }
     }
 }

--- a/crates/task-impls/src/transactions.rs
+++ b/crates/task-impls/src/transactions.rs
@@ -233,6 +233,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> TransactionTaskState<TYPES, 
         return None;
     }
 
+    #[allow(clippy::too_many_lines)]
     /// marketplace view change handler
     pub async fn handle_view_change_marketplace(
         &mut self,
@@ -295,7 +296,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> TransactionTaskState<TYPES, 
                     TYPES::BlockPayload::from_transactions(
                         transactions,
                         &validated_state,
-                        &self.instance_state.clone(),
+                        &Arc::clone(&self.instance_state),
                     )
                     .await,
                 ) {
@@ -356,7 +357,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> TransactionTaskState<TYPES, 
         )
         .await;
 
-        return None;
+        None
     }
 
     /// main task event handler

--- a/crates/task-impls/src/transactions.rs
+++ b/crates/task-impls/src/transactions.rs
@@ -68,19 +68,6 @@ pub struct BuilderResponse<TYPES: NodeType> {
     pub precompute_data: Option<VidPrecomputeData>,
 }
 
-/// The Bundle for a portion of a block, provided by a downstream builder that exists in a bundle
-/// auction.
-pub struct Bundle<TYPES: NodeType> {
-    /// The bundle transactions sent by the builder.
-    pub transactions: Vec<<TYPES::BlockPayload as BlockPayload<TYPES>>::Transaction>,
-
-    /// The signature over the bundle.
-    pub signature: TYPES::SignatureKey,
-
-    /// The fee for sequencing
-    pub sequencing_fee: BuilderFee<TYPES>,
-}
-
 /// Tracks state of a Transaction task
 pub struct TransactionTaskState<TYPES: NodeType, I: NodeImplementation<TYPES>> {
     /// The state's api

--- a/crates/task-impls/src/transactions.rs
+++ b/crates/task-impls/src/transactions.rs
@@ -318,7 +318,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> TransactionTaskState<TYPES, 
             }
         }
 
-        // If we couldn't get any bundles, send an empty block
+        // If we couldn't get any bundles (due to either the builders or solver failing to return a result), send an empty block
         warn!(
             "Failed to get a block for view {:?}, proposing empty block",
             block_view

--- a/crates/testing/tests/tests_1/da_task.rs
+++ b/crates/testing/tests/tests_1/da_task.rs
@@ -84,11 +84,6 @@ async fn test_da_task() {
                     BaseVersion::version()
                 )
                 .unwrap()],
-                vec1::vec1![null_block::builder_fee(
-                    quorum_membership.total_nodes(),
-                    BaseVersion::version()
-                )
-                .unwrap()],
                 Some(precompute),
             )),
         ],
@@ -170,11 +165,6 @@ async fn test_da_task_storage_failure() {
                 encoded_transactions,
                 TestMetadata,
                 ViewNumber::new(2),
-                vec1::vec1![null_block::builder_fee(
-                    quorum_membership.total_nodes(),
-                    BaseVersion::version()
-                )
-                .unwrap()],
                 vec1::vec1![null_block::builder_fee(
                     quorum_membership.total_nodes(),
                     BaseVersion::version()

--- a/crates/testing/tests/tests_1/libp2p.rs
+++ b/crates/testing/tests/tests_1/libp2p.rs
@@ -1,11 +1,11 @@
 use std::time::Duration;
 
 use hotshot_example_types::node_types::{Libp2pImpl, TestTypes};
-use hotshot_testing::spinning_task::{ChangeNode, SpinningTaskDescription, UpDown};
 use hotshot_testing::{
     block_builder::SimpleBuilderImplementation,
     completion_task::{CompletionTaskDescription, TimeBasedCompletionTaskDescription},
     overall_safety_task::OverallSafetyPropertiesDescription,
+    spinning_task::{ChangeNode, SpinningTaskDescription, UpDown},
     test_builder::{TestDescription, TimingData},
 };
 use tracing::instrument;

--- a/crates/testing/tests/tests_1/quorum_proposal_recv_task.rs
+++ b/crates/testing/tests/tests_1/quorum_proposal_recv_task.rs
@@ -14,12 +14,15 @@ use hotshot_task_impls::{
 };
 use hotshot_testing::{
     helpers::{build_fake_view_with_leaf_and_state, build_system_handle},
-    predicates::event::{all_predicates, quorum_proposal_missing, exact, vote_now},
+    predicates::event::{all_predicates, exact, quorum_proposal_missing, vote_now},
     script::InputOrder,
     serial,
     view_generator::TestViewGenerator,
 };
-use hotshot_types::{data::ViewNumber, traits::{node_implementation::ConsensusTime,ValidatedState}};
+use hotshot_types::{
+    data::ViewNumber,
+    traits::{node_implementation::ConsensusTime, ValidatedState},
+};
 
 #[cfg(test)]
 #[cfg(feature = "dependency-tasks")]
@@ -62,10 +65,12 @@ async fn test_quorum_proposal_recv_task() {
         // to that, we'll just put them in here.
         consensus_writer
             .update_saved_leaves(Leaf::from_quorum_proposal(&view.quorum_proposal.data));
-        consensus_writer.update_validated_state_map(
-            view.quorum_proposal.data.view_number,
-            build_fake_view_with_leaf(view.leaf.clone()),
-        ).unwrap();
+        consensus_writer
+            .update_validated_state_map(
+                view.quorum_proposal.data.view_number,
+                build_fake_view_with_leaf(view.leaf.clone()),
+            )
+            .unwrap();
     }
     drop(consensus_writer);
 
@@ -152,10 +157,12 @@ async fn test_quorum_proposal_recv_task_liveness_check() {
         // we don't have access to that, we'll just put them in here. We
         // specifically ignore writing the saved leaves so that way
         // the parent lookup fails and we trigger a view liveness check.
-        consensus_writer.update_validated_state_map(
-            inserted_view_number,
-            build_fake_view_with_leaf(view.leaf.clone()),
-        ).unwrap();
+        consensus_writer
+            .update_validated_state_map(
+                inserted_view_number,
+                build_fake_view_with_leaf(view.leaf.clone()),
+            )
+            .unwrap();
 
         // The index here is important. Since we're proposing for view 4, we need the
         // value from entry 2 to align the public key from the shares map.

--- a/crates/testing/tests/tests_1/quorum_vote_task.rs
+++ b/crates/testing/tests/tests_1/quorum_vote_task.rs
@@ -1,6 +1,8 @@
 #![allow(clippy::panic)]
 #![cfg(feature = "dependency-tasks")]
 
+use std::time::Duration;
+
 use futures::StreamExt;
 use hotshot::tasks::task_state::CreateTaskState;
 use hotshot_example_types::node_types::{MemoryImpl, TestTypes};
@@ -16,8 +18,6 @@ use hotshot_testing::{
 use hotshot_types::{
     data::ViewNumber, traits::node_implementation::ConsensusTime, vote::HasViewNumber,
 };
-
-use std::time::Duration;
 
 const TIMEOUT: Duration = Duration::from_millis(35);
 
@@ -52,10 +52,12 @@ async fn test_quorum_vote_task_success() {
         leaves.push(view.leaf.clone());
         dacs.push(view.da_certificate.clone());
         vids.push(view.vid_proposal.clone());
-        consensus_writer.update_validated_state_map(
-            view.quorum_proposal.data.view_number(),
-            build_fake_view_with_leaf(view.leaf.clone()),
-        ).unwrap();
+        consensus_writer
+            .update_validated_state_map(
+                view.quorum_proposal.data.view_number(),
+                build_fake_view_with_leaf(view.leaf.clone()),
+            )
+            .unwrap();
         consensus_writer.update_saved_leaves(view.leaf.clone());
     }
     drop(consensus_writer);
@@ -172,10 +174,12 @@ async fn test_quorum_vote_task_miss_dependency() {
         vids.push(view.vid_proposal.clone());
         leaves.push(view.leaf.clone());
 
-        consensus_writer.update_validated_state_map(
-            view.quorum_proposal.data.view_number(),
-            build_fake_view_with_leaf(view.leaf.clone()),
-        ).unwrap();
+        consensus_writer
+            .update_validated_state_map(
+                view.quorum_proposal.data.view_number(),
+                build_fake_view_with_leaf(view.leaf.clone()),
+            )
+            .unwrap();
         consensus_writer.update_saved_leaves(view.leaf.clone());
     }
     drop(consensus_writer);
@@ -197,9 +201,9 @@ async fn test_quorum_vote_task_miss_dependency() {
     ];
 
     let expectations = vec![
-        Expectations::from_outputs(all_predicates![
-            exact(VidShareValidated(vids[1].0[0].clone()))
-        ]),
+        Expectations::from_outputs(all_predicates![exact(VidShareValidated(
+            vids[1].0[0].clone()
+        ))]),
         Expectations::from_outputs(all_predicates![
             exact(LockedViewUpdated(ViewNumber::new(1))),
             exact(DaCertificateValidated(dacs[2].clone()))

--- a/crates/testing/tests/tests_1/upgrade_task_with_vote.rs
+++ b/crates/testing/tests/tests_1/upgrade_task_with_vote.rs
@@ -1,5 +1,4 @@
 #![cfg(feature = "dependency-tasks")]
-
 // TODO: Remove after integration of dependency-tasks
 #![allow(unused_imports)]
 
@@ -14,14 +13,16 @@ use hotshot_example_types::{
 };
 use hotshot_macros::{run_test, test_scripts};
 use hotshot_task_impls::{
-    consensus2::Consensus2TaskState, events::HotShotEvent::*, quorum_vote::QuorumVoteTaskState, upgrade::UpgradeTaskState
+    consensus2::Consensus2TaskState, events::HotShotEvent::*, quorum_vote::QuorumVoteTaskState,
+    upgrade::UpgradeTaskState,
 };
 use hotshot_testing::{
+    all_predicates,
     helpers::{build_fake_view_with_leaf, vid_share},
     predicates::{event::*, upgrade_with_vote::*},
-    script::{Expectations, TaskScript, InputOrder},
+    random,
+    script::{Expectations, InputOrder, TaskScript},
     view_generator::TestViewGenerator,
-    random, all_predicates
 };
 use hotshot_types::{
     data::{null_block, ViewNumber},
@@ -77,10 +78,12 @@ async fn test_upgrade_task_with_vote() {
         vids.push(view.vid_proposal.clone());
         leaders.push(view.leader_public_key);
         leaves.push(view.leaf.clone());
-        consensus_writer.update_validated_state_map(
-            view.quorum_proposal.data.view_number(),
-            build_fake_view_with_leaf(view.leaf.clone()),
-        ).unwrap();
+        consensus_writer
+            .update_validated_state_map(
+                view.quorum_proposal.data.view_number(),
+                build_fake_view_with_leaf(view.leaf.clone()),
+            )
+            .unwrap();
         consensus_writer.update_saved_leaves(view.leaf.clone());
     }
     drop(consensus_writer);
@@ -117,9 +120,10 @@ async fn test_upgrade_task_with_vote() {
             DaCertificateRecv(dacs[4].clone()),
             VidShareRecv(vids[4].0[0].clone()),
         ],
-        random![
-            QuorumProposalValidated(proposals[5].data.clone(), leaves[5].clone()),
-        ],
+        random![QuorumProposalValidated(
+            proposals[5].data.clone(),
+            leaves[5].clone()
+        ),],
     ];
 
     let expectations = vec![
@@ -184,7 +188,6 @@ async fn test_upgrade_task_with_vote() {
         state: vote_state,
         expectations,
     };
-
 
     run_test![inputs, vote_script].await;
 }

--- a/crates/testing/tests/tests_1/vid_task.rs
+++ b/crates/testing/tests/tests_1/vid_task.rs
@@ -96,11 +96,6 @@ async fn test_vid_task() {
                     BaseVersion::version()
                 )
                 .unwrap()],
-                vec1::vec1![null_block::builder_fee(
-                    quorum_membership.total_nodes(),
-                    BaseVersion::version()
-                )
-                .unwrap()],
                 Some(vid_precompute),
             )),
         ],

--- a/crates/testing/tests/tests_3/memory_network.rs
+++ b/crates/testing/tests/tests_3/memory_network.rs
@@ -11,10 +11,10 @@ use hotshot::{
     types::SignatureKey,
 };
 use hotshot_example_types::{
+    auction_results_provider_types::TestAuctionResultsProvider,
     block_types::{TestBlockHeader, TestBlockPayload, TestTransaction},
     state_types::{TestInstanceState, TestValidatedState},
     storage_types::TestStorage,
-    auction_results_provider_types::TestAuctionResultsProvider,
 };
 use hotshot_types::{
     data::ViewNumber,
@@ -48,7 +48,10 @@ pub struct Test;
 impl NodeType for Test {
     type Base = StaticVersion<0, 1>;
     type Upgrade = StaticVersion<0, 2>;
-    const UPGRADE_HASH: [u8; 32] = [1, 0, 1, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0,];
+    const UPGRADE_HASH: [u8; 32] = [
+        1, 0, 1, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0,
+        0, 0,
+    ];
     type Time = ViewNumber;
     type BlockHeader = TestBlockHeader;
     type BlockPayload = TestBlockPayload;

--- a/crates/testing/tests/tests_5/fake_solver.rs
+++ b/crates/testing/tests/tests_5/fake_solver.rs
@@ -1,10 +1,10 @@
 use async_compatibility_layer::art::async_spawn;
+use hotshot_example_types::{
+    auction_results_provider_types::TestAuctionResult, node_types::TestTypes,
+};
 use hotshot_fakeapi::fake_solver::FakeSolverState;
-use hotshot_types::traits::{node_implementation::NodeType, signature_key::SignatureKey};
-
-use hotshot_example_types::node_types::TestTypes;
-use hotshot_example_types::auction_results_provider_types::TestAuctionResult;
 use hotshot_testing::helpers::key_pair_for_id;
+use hotshot_types::traits::{node_implementation::NodeType, signature_key::SignatureKey};
 use tracing::instrument;
 use url::Url;
 
@@ -13,7 +13,6 @@ use url::Url;
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 #[instrument]
 async fn test_fake_solver_fetch_non_permissioned_no_error() {
-
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
 
@@ -65,7 +64,6 @@ async fn test_fake_solver_fetch_non_permissioned_no_error() {
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 #[instrument]
 async fn test_fake_solver_fetch_non_permissioned_with_errors() {
-
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
 
@@ -141,7 +139,10 @@ async fn test_fake_solver_fetch_non_permissioned_with_errors() {
 
     // Assert over the payloads with a 50% error rate.
     for payload in payloads {
-        assert_eq!(payload.urls[0], Url::parse("http://localhost:1111/").unwrap());
+        assert_eq!(
+            payload.urls[0],
+            Url::parse("http://localhost:1111/").unwrap()
+        );
     }
 }
 
@@ -150,7 +151,6 @@ async fn test_fake_solver_fetch_non_permissioned_with_errors() {
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 #[instrument]
 async fn test_fake_solver_fetch_permissioned_no_error() {
-
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
 
@@ -213,7 +213,6 @@ async fn test_fake_solver_fetch_permissioned_no_error() {
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 #[instrument]
 async fn test_fake_solver_fetch_permissioned_with_errors() {
-
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
 
@@ -296,6 +295,9 @@ async fn test_fake_solver_fetch_permissioned_with_errors() {
 
     // Assert over the payloads with a 50% error rate.
     for payload in payloads {
-        assert_eq!(payload.urls[0], Url::parse("http://localhost:1111/").unwrap());
+        assert_eq!(
+            payload.urls[0],
+            Url::parse("http://localhost:1111/").unwrap()
+        );
     }
 }

--- a/crates/testing/tests/tests_5/timeout.rs
+++ b/crates/testing/tests/tests_5/timeout.rs
@@ -21,7 +21,7 @@ async fn test_timeout() {
         ..Default::default()
     };
 
-    let mut metadata: TestDescription<TestTypes,MemoryImpl> = TestDescription {
+    let mut metadata: TestDescription<TestTypes, MemoryImpl> = TestDescription {
         num_nodes_with_stake: 10,
         start_nodes: 10,
         ..Default::default()

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -29,6 +29,7 @@ espresso-systems-common = { workspace = true }
 ethereum-types = { workspace = true }
 futures = { workspace = true }
 cdn-proto = { workspace = true }
+reqwest = { workspace = true }
 
 generic-array = { workspace = true }
 

--- a/crates/types/src/bundle.rs
+++ b/crates/types/src/bundle.rs
@@ -1,4 +1,4 @@
-//! This module provides the `Bundle` type that the HotShot leader will use to construct its block
+//! This module provides the `Bundle` type
 
 use serde::{Deserialize, Serialize};
 

--- a/crates/types/src/bundle.rs
+++ b/crates/types/src/bundle.rs
@@ -1,0 +1,17 @@
+//! This module provides the `Bundle` type that the HotShot leader will use to construct its block
+
+use crate::traits::{block_contents::BuilderFee, node_implementation::NodeType, BlockPayload};
+
+/// The Bundle for a portion of a block, provided by a downstream
+/// builder that exists in a bundle auction.
+/// This type is maintained by HotShot
+pub struct Bundle<TYPES: NodeType> {
+    /// The bundle transactions sent by the builder.
+    pub transactions: Vec<<TYPES::BlockPayload as BlockPayload<TYPES>>::Transaction>,
+
+    /// The signature over the bundle.
+    pub signature: TYPES::SignatureKey,
+
+    /// The fee for sequencing
+    pub sequencing_fee: BuilderFee<TYPES>,
+}

--- a/crates/types/src/bundle.rs
+++ b/crates/types/src/bundle.rs
@@ -1,7 +1,11 @@
 //! This module provides the `Bundle` type that the HotShot leader will use to construct its block
 
+use serde::{Deserialize, Serialize};
+
 use crate::traits::{block_contents::BuilderFee, node_implementation::NodeType, BlockPayload};
 
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(bound = "TYPES: NodeType")]
 /// The Bundle for a portion of a block, provided by a downstream
 /// builder that exists in a bundle auction.
 /// This type is maintained by HotShot

--- a/crates/types/src/constants.rs
+++ b/crates/types/src/constants.rs
@@ -44,8 +44,6 @@ pub const WEB_SERVER_VERSION: WebServerVersion = StaticVersion {};
 
 /// Type for semver representation of "Base" version
 pub type BaseVersion = StaticVersion<0, 1>;
-/// Constant for semver representation of "Base" version
-pub const BASE_VERSION: BaseVersion = StaticVersion {};
 
 /// Type for semver representation of "Marketplace" version
 pub type MarketplaceVersion = StaticVersion<0, 3>;

--- a/crates/types/src/constants.rs
+++ b/crates/types/src/constants.rs
@@ -1,6 +1,14 @@
 //! configurable constants for hotshot
 
+use std::time::Duration;
+
 use vbs::version::StaticVersion;
+
+/// timeout for fetching auction results from the solver
+pub const AUCTION_RESULTS_FETCH_TIMEOUT: Duration = Duration::from_millis(500);
+
+/// timeout for fetching bundles from builders
+pub const BUNDLE_FETCH_TIMEOUT: Duration = Duration::from_millis(500);
 
 /// the number of views to gather information for ahead of time
 pub const LOOK_AHEAD: u64 = 5;

--- a/crates/types/src/data.rs
+++ b/crates/types/src/data.rs
@@ -876,9 +876,6 @@ pub struct PackedBundle<TYPES: NodeType> {
     /// The view number that this block is associated with.
     pub view_number: TYPES::Time,
 
-    /// The bid fees for submitting the block.
-    pub bid_fees: Vec1<BuilderFee<TYPES>>,
-
     /// The sequencing fee for submitting bundles.
     pub sequencing_fees: Vec1<BuilderFee<TYPES>>,
 
@@ -892,7 +889,6 @@ impl<TYPES: NodeType> PackedBundle<TYPES> {
         encoded_transactions: Arc<[u8]>,
         metadata: <TYPES::BlockPayload as BlockPayload<TYPES>>::Metadata,
         view_number: TYPES::Time,
-        bid_fees: Vec1<BuilderFee<TYPES>>,
         sequencing_fees: Vec1<BuilderFee<TYPES>>,
         vid_precompute: Option<VidPrecomputeData>,
     ) -> Self {
@@ -900,7 +896,6 @@ impl<TYPES: NodeType> PackedBundle<TYPES> {
             encoded_transactions,
             metadata,
             view_number,
-            bid_fees,
             sequencing_fees,
             vid_precompute,
         }

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -11,6 +11,7 @@ use url::Url;
 use vec1::Vec1;
 
 use crate::utils::bincode_opts;
+pub mod bundle;
 pub mod consensus;
 pub mod constants;
 pub mod data;

--- a/crates/types/src/traits/auction_results_provider.rs
+++ b/crates/types/src/traits/auction_results_provider.rs
@@ -2,11 +2,16 @@
 //! which handles connecting to, and fetching the allocation results from, the Solver.
 
 use anyhow::Result;
+use async_compatibility_layer::art::async_timeout;
 use async_trait::async_trait;
+use futures::future::join_all;
 use url::Url;
 
 use super::node_implementation::NodeType;
-use crate::bundle::Bundle;
+use crate::{
+    bundle::Bundle,
+    constants::{AUCTION_RESULTS_FETCH_TIMEOUT, BUNDLE_FETCH_TIMEOUT},
+};
 
 /// This trait guarantees that a particular type has urls that can be extracted from it. This trait
 /// essentially ensures that the results returned by the [`AuctionResultsProvider`] trait includes a
@@ -32,21 +37,30 @@ pub trait AuctionResultsProvider<TYPES: NodeType>: Send + Sync + Clone {
 
     /// Fetches the bundles for a view.
     async fn fetch_bundles(&self, view_number: TYPES::Time) -> Result<Vec<Bundle<TYPES>>> {
-        let result = self.fetch_auction_result(view_number).await?;
+        let result = async_timeout(
+            AUCTION_RESULTS_FETCH_TIMEOUT,
+            self.fetch_auction_result(view_number),
+        )
+        .await??;
 
-        let mut bundles = Vec::new();
         let client = reqwest::Client::new();
 
-        for url in result.urls() {
-            // Then, hit the API
-            let bundle: Bundle<TYPES> = client
-                .get(url)
-                .send()
-                .await?
-                .json::<Bundle<TYPES>>()
-                .await?;
+        let mut futures = Vec::new();
 
-            bundles.push(bundle);
+        for url in result.urls() {
+            futures.push(async_timeout(
+                BUNDLE_FETCH_TIMEOUT,
+                client.get(url).send().await?.json::<Bundle<TYPES>>(),
+            ));
+        }
+
+        let mut bundles = Vec::new();
+
+        for bundle in join_all(futures).await {
+            match bundle {
+                Ok(Ok(b)) => bundles.push(b),
+                _ => continue,
+            }
         }
 
         Ok(bundles)

--- a/crates/types/src/traits/block_contents.rs
+++ b/crates/types/src/traits/block_contents.rs
@@ -65,7 +65,7 @@ pub trait BlockPayload<TYPES: NodeType>:
     /// The type of the instance-level state this state is associated with
     type Instance: InstanceState;
     /// The type of the transitions we are applying
-    type Transaction: Transaction;
+    type Transaction: Transaction + Serialize + DeserializeOwned;
     /// Validated State
     type ValidatedState: ValidatedState<TYPES>;
     /// Data created during block building which feeds into the block header


### PR DESCRIPTION
Closes #3381 
Closes #3375 

### This PR: 
- Adds the `Bundle` struct
- Adds a `fetch_bundles` method to the `AuctionResultsProvider` trait that retrieves a `Bundle` from all builders that win a given auction.
- Adds logic in the transactions task to call `fetch_bundles` and construct a `PackedBundle` from multiple builders depending on the version of HotShot in effect.
- Removes the `bid_fees` field from `PackedBundle`.

### This PR does not: 

### Key places to review: 
- `task-impls/src/transactions.rs`
- `types/src/traits/auction_results_provider.rs`