### PR TITLE
Change upgrade log from warn to error

### DIFF
--- a/crates/task-impls/src/consensus/mod.rs
+++ b/crates/task-impls/src/consensus/mod.rs
@@ -485,7 +485,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> ConsensusTaskState<TYPES, I>
                 // been upgraded.
                 if let Some(cert) = self.decided_upgrade_certificate.read().await.clone() {
                     if new_view == cert.data.new_version_first_view {
-                        warn!(
+                        error!(
                             "Version upgraded based on a decided upgrade cert: {:?}",
                             cert
                         );

--- a/crates/task-impls/src/consensus2/handlers.rs
+++ b/crates/task-impls/src/consensus2/handlers.rs
@@ -14,7 +14,7 @@ use hotshot_types::{
     },
     vote::HasViewNumber,
 };
-use tracing::{debug, instrument, warn};
+use tracing::{debug, error, instrument};
 
 use super::Consensus2TaskState;
 use crate::{
@@ -139,7 +139,7 @@ pub(crate) async fn handle_view_change<TYPES: NodeType, I: NodeImplementation<TY
         task_state.decided_upgrade_certificate.read().await.clone();
     if let Some(cert) = decided_upgrade_certificate_read {
         if new_view_number == cert.data.new_version_first_view {
-            warn!(
+            error!(
                 "Version upgraded based on a decided upgrade cert: {:?}",
                 cert
             );


### PR DESCRIPTION
No linked issue.

### This PR: 
Changes the log for when an upgrade certificate is decided from warn to error.

### This PR does not: 

### Key places to review: 
