### PR TITLE
Minor Libp2p changes

### DIFF
--- a/crates/hotshot/src/traits/networking/libp2p_network.rs
+++ b/crates/hotshot/src/traits/networking/libp2p_network.rs
@@ -4,6 +4,7 @@
 #[cfg(feature = "hotshot-testing")]
 use std::str::FromStr;
 use std::{
+    cmp::min,
     collections::{BTreeSet, HashSet},
     fmt::Debug,
     net::SocketAddr,
@@ -15,7 +16,7 @@ use std::{
     time::Duration,
 };
 
-use anyhow::anyhow;
+use anyhow::{anyhow, Context};
 use async_compatibility_layer::{
     art::{async_sleep, async_spawn},
     channel::{
@@ -60,7 +61,7 @@ use libp2p_networking::{
         spawn_network_node, MeshParams,
         NetworkEvent::{self, DirectRequest, DirectResponse, GossipMsg},
         NetworkNodeConfig, NetworkNodeConfigBuilder, NetworkNodeHandle, NetworkNodeHandleError,
-        NetworkNodeReceiver, NetworkNodeType,
+        NetworkNodeReceiver, NetworkNodeType, DEFAULT_REPLICATION_FACTOR,
     },
     reexport::{Multiaddr, ResponseChannel},
 };
@@ -397,11 +398,19 @@ impl<K: SignatureKey + 'static> Libp2pNetwork<K> {
         .parse()?;
 
         // Build our libp2p configuration from our global, network configuration
-        let mut config_builder = NetworkNodeConfigBuilder::default();
+        let mut config_builder: NetworkNodeConfigBuilder = NetworkNodeConfigBuilder::default();
+
+        // The replication factor is the minimum of [the default and 2/3 the number of nodes]
+        let replication_factor = NonZeroUsize::new(min(
+            DEFAULT_REPLICATION_FACTOR,
+            config.config.num_nodes_with_stake.get() * 2 / 3,
+        ))
+        .with_context(|| "Failed to calculate replication factor")?;
 
         config_builder
             .server_mode(libp2p_config.server_mode)
             .identity(keypair)
+            .replication_factor(replication_factor)
             .bound_addr(Some(bind_address.clone()))
             .mesh_params(Some(MeshParams {
                 mesh_n_high: libp2p_config.mesh_n_high,

--- a/crates/libp2p-networking/src/network/node.rs
+++ b/crates/libp2p-networking/src/network/node.rs
@@ -355,7 +355,10 @@ impl NetworkNode {
         let record = Record::new(query.key.clone(), query.value.clone());
         match self.swarm.behaviour_mut().dht.put_record(
             record,
-            libp2p::kad::Quorum::N(self.dht_handler.replication_factor()),
+            libp2p::kad::Quorum::N(
+                NonZeroUsize::try_from(self.dht_handler.replication_factor().get() / 2)
+                    .expect("replication factor should be bigger than 0"),
+            ),
         ) {
             Err(e) => {
                 // failed try again later


### PR DESCRIPTION
No linked issue.

# This PR
- Changes the Libp2p replication factor to the minimum of 2/3 the number of nodes or 20. This fixes smaller runs.
- Lowers the DHT ready quorum to half of the replication factor. We should be able to start when not all nodes have seen our key yet; everyone will ask for it eventually. This is what's currently running in Cappuccino