### PR TITLE
[Libp2p] Adjust some parameters

### DIFF
--- a/crates/libp2p-networking/src/network/node.rs
+++ b/crates/libp2p-networking/src/network/node.rs
@@ -208,16 +208,15 @@ impl NetworkNode {
 
             // Create a custom gossipsub
             let gossipsub_config = GossipsubConfigBuilder::default()
-                .opportunistic_graft_ticks(3)
                 .heartbeat_interval(Duration::from_secs(1))
                 // Force all messages to have valid signatures
                 .validation_mode(ValidationMode::Strict)
-                .history_gossip(50)
+                .history_gossip(10)
                 .mesh_n_high(params.mesh_n_high)
                 .mesh_n_low(params.mesh_n_low)
                 .mesh_outbound_min(params.mesh_outbound_min)
                 .mesh_n(params.mesh_n)
-                .history_length(500)
+                .history_length(10)
                 .max_transmit_size(MAX_GOSSIP_MSG_SIZE)
                 // Use the (blake3) hash of a message as its ID
                 .message_id_fn(message_id_fn)


### PR DESCRIPTION
These values were way off the defaults, bringing them back down. It made sense to keep some of them a bit higher though

For context:
- `opportunistic_graft_ticks`: Number of heartbeat ticks that specify the interval in which opportunistic grafting is applied. Every opportunistic_graft_ticks we will attempt to select some high-scoring mesh peers to replace lower-scoring ones, if the median score of our mesh peers falls below a threshold. The default is 60.

This one was doing grafting much too often, maybe it is high for a reason?

- `history_gossip`: Number of past heartbeats to gossip about (default is 3).

I think we are better off gossiping about a lower number of heartbeats. By default every gossip round is 1s, this means we will be gossiping about the last 50 seconds of activity all the time. If we are going by our current Cappuccino layout, every node should see a broadcast message in 1-2 heartbeats.

- `history_length`: Number of heartbeats to keep in the memcache (default is 5).

500 also seems like too many rounds to keep in memory