### PR TITLE
[Audit] - Fetch Blocks Properly when Leader Consecutively

### DIFF
--- a/crates/example-types/src/node_types.rs
+++ b/crates/example-types/src/node_types.rs
@@ -1,5 +1,5 @@
 use hotshot::traits::{
-    election::static_committee::{GeneralStaticCommittee, StaticCommittee},
+    election::{static_committee::StaticCommittee, static_committee_leader_two_views::StaticCommitteeLeaderForTwoViews},
     implementations::{CombinedNetworks, Libp2pNetwork, MemoryNetwork, PushCdnNetwork},
     NodeImplementation,
 };
@@ -48,7 +48,7 @@ impl NodeType for TestTypes {
     type Transaction = TestTransaction;
     type ValidatedState = TestValidatedState;
     type InstanceState = TestInstanceState;
-    type Membership = GeneralStaticCommittee<TestTypes, Self::SignatureKey>;
+    type Membership = StaticCommitteeLeaderForTwoViews<TestTypes, Self::SignatureKey>;
     type BuilderSignatureKey = BuilderKey;
 }
 

--- a/crates/example-types/src/node_types.rs
+++ b/crates/example-types/src/node_types.rs
@@ -1,5 +1,8 @@
 use hotshot::traits::{
-    election::{static_committee::{GeneralStaticCommittee, StaticCommittee}, static_committee_leader_two_views::StaticCommitteeLeaderForTwoViews},
+    election::{
+        static_committee::{GeneralStaticCommittee, StaticCommittee},
+        static_committee_leader_two_views::StaticCommitteeLeaderForTwoViews,
+    },
     implementations::{CombinedNetworks, Libp2pNetwork, MemoryNetwork, PushCdnNetwork},
     NodeImplementation,
 };
@@ -82,7 +85,8 @@ impl NodeType for TestConsecutiveLeaderTypes {
     type Transaction = TestTransaction;
     type ValidatedState = TestValidatedState;
     type InstanceState = TestInstanceState;
-    type Membership = StaticCommitteeLeaderForTwoViews<TestConsecutiveLeaderTypes, Self::SignatureKey>;
+    type Membership =
+        StaticCommitteeLeaderForTwoViews<TestConsecutiveLeaderTypes, Self::SignatureKey>;
     type BuilderSignatureKey = BuilderKey;
 }
 

--- a/crates/example-types/src/node_types.rs
+++ b/crates/example-types/src/node_types.rs
@@ -1,5 +1,5 @@
 use hotshot::traits::{
-    election::{static_committee::StaticCommittee, static_committee_leader_two_views::StaticCommitteeLeaderForTwoViews},
+    election::{static_committee::{GeneralStaticCommittee, StaticCommittee}, static_committee_leader_two_views::StaticCommitteeLeaderForTwoViews},
     implementations::{CombinedNetworks, Libp2pNetwork, MemoryNetwork, PushCdnNetwork},
     NodeImplementation,
 };
@@ -48,7 +48,41 @@ impl NodeType for TestTypes {
     type Transaction = TestTransaction;
     type ValidatedState = TestValidatedState;
     type InstanceState = TestInstanceState;
-    type Membership = StaticCommitteeLeaderForTwoViews<TestTypes, Self::SignatureKey>;
+    type Membership = GeneralStaticCommittee<TestTypes, Self::SignatureKey>;
+    type BuilderSignatureKey = BuilderKey;
+}
+
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    Hash,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    serde::Serialize,
+    serde::Deserialize,
+)]
+/// filler struct to implement node type and allow us
+/// to select our traits
+pub struct TestConsecutiveLeaderTypes;
+impl NodeType for TestConsecutiveLeaderTypes {
+    type Base = StaticVersion<0, 1>;
+    type Upgrade = StaticVersion<0, 2>;
+    const UPGRADE_HASH: [u8; 32] = [
+        1, 0, 1, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0,
+        0, 0,
+    ];
+    type Time = ViewNumber;
+    type BlockHeader = TestBlockHeader;
+    type BlockPayload = TestBlockPayload;
+    type SignatureKey = BLSPubKey;
+    type Transaction = TestTransaction;
+    type ValidatedState = TestValidatedState;
+    type InstanceState = TestInstanceState;
+    type Membership = StaticCommitteeLeaderForTwoViews<TestConsecutiveLeaderTypes, Self::SignatureKey>;
     type BuilderSignatureKey = BuilderKey;
 }
 

--- a/crates/hotshot/src/traits/election.rs
+++ b/crates/hotshot/src/traits/election.rs
@@ -2,3 +2,5 @@
 
 /// static (round robin) committee election
 pub mod static_committee;
+/// static (round robin leader for 2 consecutive views) committee election
+pub mod static_committee_leader_two_views;

--- a/crates/hotshot/src/traits/election/static_committee_leader_two_views.rs
+++ b/crates/hotshot/src/traits/election/static_committee_leader_two_views.rs
@@ -66,7 +66,8 @@ where
     )))]
     /// Index the vector of public keys with the current view number
     fn leader(&self, view_number: TYPES::Time) -> PUBKEY {
-        // this will break other test cases
+        // two connsecutive views will have same index starting with even number.
+        // eg 0->1, 2->3 ... 10->11 etc
         let index = usize::try_from((*view_number / 2) % self.all_nodes_with_stake.len() as u64).unwrap();
         let res = self.all_nodes_with_stake[index].clone();
         TYPES::SignatureKey::public_key(&res)

--- a/crates/hotshot/src/traits/election/static_committee_leader_two_views.rs
+++ b/crates/hotshot/src/traits/election/static_committee_leader_two_views.rs
@@ -1,0 +1,215 @@
+use std::{marker::PhantomData, num::NonZeroU64};
+
+use ethereum_types::U256;
+// use ark_bls12_381::Parameters as Param381;
+use hotshot_types::traits::signature_key::StakeTableEntryType;
+use hotshot_types::{
+    signature_key::BLSPubKey,
+    traits::{election::Membership, node_implementation::NodeType, signature_key::SignatureKey},
+    PeerConfig,
+};
+#[cfg(feature = "randomized-leader-election")]
+use rand::{rngs::StdRng, Rng};
+use tracing::debug;
+
+/// Dummy implementation of [`Membership`]
+
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+pub struct StaticCommitteeLeaderForTwoViews<T, PUBKEY: SignatureKey> {
+    /// All the nodes participating and their stake
+    all_nodes_with_stake: Vec<PUBKEY::StakeTableEntry>,
+    /// The nodes on the static committee and their stake
+    committee_nodes_with_stake: Vec<PUBKEY::StakeTableEntry>,
+    /// builder nodes
+    committee_nodes_without_stake: Vec<PUBKEY>,
+    /// the number of fixed leader for gpuvid
+    fixed_leader_for_gpuvid: usize,
+    /// Node type phantom
+    _type_phantom: PhantomData<T>,
+}
+
+/// static committee using a vrf kp
+pub type StaticCommittee<T> = StaticCommitteeLeaderForTwoViews<T, BLSPubKey>;
+
+impl<T, PUBKEY: SignatureKey> StaticCommitteeLeaderForTwoViews<T, PUBKEY> {
+    /// Creates a new dummy elector
+    #[must_use]
+    pub fn new(
+        _nodes: &[PUBKEY],
+        nodes_with_stake: Vec<PUBKEY::StakeTableEntry>,
+        nodes_without_stake: Vec<PUBKEY>,
+        fixed_leader_for_gpuvid: usize,
+    ) -> Self {
+        Self {
+            all_nodes_with_stake: nodes_with_stake.clone(),
+            committee_nodes_with_stake: nodes_with_stake,
+            committee_nodes_without_stake: nodes_without_stake,
+            fixed_leader_for_gpuvid,
+            _type_phantom: PhantomData,
+        }
+    }
+}
+
+impl<TYPES, PUBKEY: SignatureKey + 'static> Membership<TYPES>
+    for StaticCommitteeLeaderForTwoViews<TYPES, PUBKEY>
+where
+    TYPES: NodeType<SignatureKey = PUBKEY>,
+{
+    /// Clone the public key and corresponding stake table for current elected committee
+    fn committee_qc_stake_table(&self) -> Vec<PUBKEY::StakeTableEntry> {
+        self.committee_nodes_with_stake.clone()
+    }
+
+    #[cfg(not(any(
+        feature = "randomized-leader-election",
+        feature = "fixed-leader-election"
+    )))]
+    /// Index the vector of public keys with the current view number
+    fn leader(&self, view_number: TYPES::Time) -> PUBKEY {
+        // this will break other test cases
+        let index = usize::try_from((*view_number / 2) % self.all_nodes_with_stake.len() as u64).unwrap();
+        let res = self.all_nodes_with_stake[index].clone();
+        TYPES::SignatureKey::public_key(&res)
+    }
+
+    #[cfg(feature = "fixed-leader-election")]
+    /// Only get leader in fixed set
+    /// Index the fixed vector (first fixed_leader_for_gpuvid element) of public keys with the current view number
+    fn leader(&self, view_number: TYPES::Time) -> PUBKEY {
+        if self.fixed_leader_for_gpuvid <= 0
+            || self.fixed_leader_for_gpuvid > self.all_nodes_with_stake.len()
+        {
+            panic!("fixed_leader_for_gpuvid is not set correctly.");
+        }
+        let index = usize::try_from(*view_number % self.fixed_leader_for_gpuvid as u64).unwrap();
+        let res = self.all_nodes_with_stake[index].clone();
+        TYPES::SignatureKey::public_key(&res)
+    }
+
+    #[cfg(feature = "randomized-leader-election")]
+    /// Index the vector of public keys with a random number generated using the current view number as a seed
+    fn leader(&self, view_number: TYPES::Time) -> PUBKEY {
+        let mut rng: StdRng = rand::SeedableRng::seed_from_u64(*view_number);
+        let randomized_view_number: usize = rng.gen();
+        let index = randomized_view_number % self.nodes_with_stake.len();
+        let res = self.all_nodes_with_stake[index].clone();
+        TYPES::SignatureKey::public_key(&res)
+    }
+
+    fn has_stake(&self, pub_key: &PUBKEY) -> bool {
+        let entry = pub_key.stake_table_entry(1u64);
+        self.committee_nodes_with_stake.contains(&entry)
+    }
+
+    fn stake(
+        &self,
+        pub_key: &<TYPES as NodeType>::SignatureKey,
+    ) -> Option<<TYPES::SignatureKey as SignatureKey>::StakeTableEntry> {
+        let entry = pub_key.stake_table_entry(1u64);
+        if self.committee_nodes_with_stake.contains(&entry) {
+            Some(entry)
+        } else {
+            None
+        }
+    }
+
+    fn create_election(
+        mut all_nodes: Vec<PeerConfig<PUBKEY>>,
+        committee_members: Vec<PeerConfig<PUBKEY>>,
+        fixed_leader_for_gpuvid: usize,
+    ) -> Self {
+        let mut committee_nodes_with_stake = Vec::new();
+        let mut committee_nodes_without_stake = Vec::new();
+
+        // Iterate over committee members
+        for entry in committee_members
+            .iter()
+            .map(|entry| entry.stake_table_entry.clone())
+        {
+            if entry.stake() > U256::from(0) {
+                // Positive stake
+                committee_nodes_with_stake.push(entry);
+            } else {
+                // Zero stake
+                committee_nodes_without_stake.push(PUBKEY::public_key(&entry));
+            }
+        }
+
+        // Retain all nodes with stake
+        all_nodes.retain(|entry| entry.stake_table_entry.stake() > U256::from(0));
+
+        debug!(
+            "Election Membership Size: {}",
+            committee_nodes_with_stake.len()
+        );
+
+        Self {
+            all_nodes_with_stake: all_nodes
+                .into_iter()
+                .map(|entry| entry.stake_table_entry)
+                .collect(),
+            committee_nodes_with_stake,
+            committee_nodes_without_stake,
+            fixed_leader_for_gpuvid,
+            _type_phantom: PhantomData,
+        }
+    }
+
+    fn total_nodes(&self) -> usize {
+        self.committee_nodes_with_stake.len()
+    }
+
+    fn success_threshold(&self) -> NonZeroU64 {
+        NonZeroU64::new(((self.committee_nodes_with_stake.len() as u64 * 2) / 3) + 1).unwrap()
+    }
+
+    fn failure_threshold(&self) -> NonZeroU64 {
+        NonZeroU64::new(((self.committee_nodes_with_stake.len() as u64) / 3) + 1).unwrap()
+    }
+
+    fn upgrade_threshold(&self) -> NonZeroU64 {
+        NonZeroU64::new(((self.committee_nodes_with_stake.len() as u64 * 9) / 10) + 1).unwrap()
+    }
+
+    fn staked_committee(
+        &self,
+        _view_number: <TYPES as NodeType>::Time,
+    ) -> std::collections::BTreeSet<<TYPES as NodeType>::SignatureKey> {
+        self.committee_nodes_with_stake
+            .iter()
+            .map(|node| <TYPES as NodeType>::SignatureKey::public_key(node))
+            .collect()
+    }
+
+    fn non_staked_committee(
+        &self,
+        _view_number: <TYPES as NodeType>::Time,
+    ) -> std::collections::BTreeSet<<TYPES as NodeType>::SignatureKey> {
+        self.committee_nodes_without_stake.iter().cloned().collect()
+    }
+
+    fn whole_committee(
+        &self,
+        view_number: <TYPES as NodeType>::Time,
+    ) -> std::collections::BTreeSet<<TYPES as NodeType>::SignatureKey> {
+        let mut committee = self.staked_committee(view_number);
+        committee.extend(self.non_staked_committee(view_number));
+        committee
+    }
+}
+
+impl<TYPES, PUBKEY: SignatureKey + 'static> StaticCommitteeLeaderForTwoViews<TYPES, PUBKEY>
+where
+    TYPES: NodeType<SignatureKey = PUBKEY>,
+{
+    #[allow(clippy::must_use_candidate)]
+    /// get the non-staked builder nodes
+    pub fn non_staked_nodes_count(&self) -> usize {
+        self.committee_nodes_without_stake.len()
+    }
+    #[allow(clippy::must_use_candidate)]
+    /// get all the non-staked nodes
+    pub fn non_staked_nodes(&self) -> Vec<PUBKEY> {
+        self.committee_nodes_without_stake.clone()
+    }
+}

--- a/crates/hotshot/src/traits/election/static_committee_leader_two_views.rs
+++ b/crates/hotshot/src/traits/election/static_committee_leader_two_views.rs
@@ -68,7 +68,8 @@ where
     fn leader(&self, view_number: TYPES::Time) -> PUBKEY {
         // two connsecutive views will have same index starting with even number.
         // eg 0->1, 2->3 ... 10->11 etc
-        let index = usize::try_from((*view_number / 2) % self.all_nodes_with_stake.len() as u64).unwrap();
+        let index =
+            usize::try_from((*view_number / 2) % self.all_nodes_with_stake.len() as u64).unwrap();
         let res = self.all_nodes_with_stake[index].clone();
         TYPES::SignatureKey::public_key(&res)
     }

--- a/crates/task-impls/src/transactions.rs
+++ b/crates/task-impls/src/transactions.rs
@@ -113,7 +113,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> TransactionTaskState<TYPES, 
     #[instrument(skip_all, fields(id = self.id, view = *self.cur_view), name = "Transaction task", level = "error", target = "TransactionTaskState")]
     pub async fn handle_view_change_legacy(
         &mut self,
-        event_stream: Sender<Arc<HotShotEvent<TYPES>>>,
+        event_stream: &Sender<Arc<HotShotEvent<TYPES>>>,
         block_view: TYPES::Time,
     ) -> Option<HotShotTaskCompleted> {
         let version = match hotshot_types::simple_certificate::version(
@@ -162,7 +162,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> TransactionTaskState<TYPES, 
                     vec1::vec1![fee],
                     precompute_data,
                 ))),
-                &event_stream,
+                event_stream,
             )
             .await;
         } else {
@@ -201,7 +201,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> TransactionTaskState<TYPES, 
                     vec1::vec1![null_fee],
                     Some(precompute_data),
                 ))),
-                &event_stream,
+                event_stream,
             )
             .await;
         };
@@ -213,7 +213,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> TransactionTaskState<TYPES, 
     /// marketplace view change handler
     pub async fn handle_view_change_marketplace(
         &mut self,
-        event_stream: Sender<Arc<HotShotEvent<TYPES>>>,
+        event_stream: &Sender<Arc<HotShotEvent<TYPES>>>,
         block_view: TYPES::Time,
     ) -> Option<HotShotTaskCompleted> {
         let version = match hotshot_types::simple_certificate::version(
@@ -274,7 +274,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> TransactionTaskState<TYPES, 
                             sequencing_fees,
                             None,
                         ))),
-                        &event_stream,
+                        event_stream,
                     )
                     .await;
 
@@ -317,7 +317,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> TransactionTaskState<TYPES, 
                 vec1::vec1![null_fee],
                 Some(precompute_data),
             ))),
-            &event_stream,
+            event_stream,
         )
         .await;
 
@@ -360,30 +360,41 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> TransactionTaskState<TYPES, 
                 }
                 self.cur_view = view;
 
-                // return if we aren't the next leader or we skipped last view and aren't the current leader.
-                if !make_block && self.membership.leader(self.cur_view + 1) != self.public_key {
-                    debug!("Not next leader for view {:?}", self.cur_view);
-                    return None;
-                }
-                let block_view = if make_block { view } else { view + 1 };
-
-                let version = match version(
-                    block_view,
-                    &self.decided_upgrade_certificate.read().await.clone(),
-                ) {
-                    Ok(v) => v,
-                    Err(e) => {
-                        tracing::error!("Failed to calculate version: {:?}", e);
+                let next_view = self.cur_view + 1;
+                let next_leader = self.membership.leader(next_view) == self.public_key;
+                let block_views = match (make_block, next_leader) {
+                    // case where we are next leader and current leader
+                    (true, true) => vec![self.cur_view, next_view],
+                    // current view leader
+                    (true, false) => vec![self.cur_view],
+                    // next view leader
+                    (false, true) => vec![next_view],
+                    (false, false) => {
+                        // return if we aren't the next leader or we skipped last view and aren't the current leader.
+                        debug!("Not next leader for view {:?}", self.cur_view);
                         return None;
                     }
                 };
 
-                if version < MarketplaceVersion::VERSION {
-                    self.handle_view_change_legacy(event_stream, block_view)
-                        .await;
-                } else {
-                    self.handle_view_change_marketplace(event_stream, block_view)
-                        .await;
+                for block_view in block_views {
+                    let version = match version(
+                        block_view,
+                        &self.decided_upgrade_certificate.read().await.clone(),
+                    ) {
+                        Ok(v) => v,
+                        Err(e) => {
+                            tracing::error!("Failed to calculate version: {:?}", e);
+                            return None;
+                        }
+                    };
+
+                    if version < MarketplaceVersion::VERSION {
+                        self.handle_view_change_legacy(&event_stream, block_view)
+                            .await;
+                    } else {
+                        self.handle_view_change_marketplace(&event_stream, block_view)
+                            .await;
+                    }
                 }
             }
             HotShotEvent::Shutdown => {

--- a/crates/task-impls/src/transactions.rs
+++ b/crates/task-impls/src/transactions.rs
@@ -127,10 +127,10 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> TransactionTaskState<TYPES, 
         };
 
         if version < MarketplaceVersion::VERSION {
-            self.handle_view_change_legacy(&event_stream, block_view)
+            self.handle_view_change_legacy(event_stream, block_view)
                 .await
         } else {
-            self.handle_view_change_marketplace(&event_stream, block_view)
+            self.handle_view_change_marketplace(event_stream, block_view)
                 .await
         }
     }

--- a/crates/testing/src/helpers.rs
+++ b/crates/testing/src/helpers.rs
@@ -8,13 +8,14 @@ use ethereum_types::U256;
 use hotshot::{
     traits::{NodeImplementation, TestableNodeImplementation},
     types::{BLSPubKey, SignatureKey, SystemContextHandle},
-    HotShotInitializer, Memberships, SystemContext
+    HotShotInitializer, Memberships, SystemContext,
 };
 use hotshot_example_types::{
     auction_results_provider_types::TestAuctionResultsProvider,
-    block_types::TestTransaction, node_types::{MemoryImpl, TestTypes},
+    block_types::TestTransaction,
+    node_types::{MemoryImpl, TestTypes},
     state_types::{TestInstanceState, TestValidatedState},
-    storage_types::TestStorage
+    storage_types::TestStorage,
 };
 use hotshot_task_impls::events::HotShotEvent;
 use hotshot_types::{
@@ -41,15 +42,21 @@ use crate::test_builder::TestDescription;
 /// create the [`SystemContextHandle`] from a node id
 /// # Panics
 /// if cannot create a [`HotShotInitializer`]
-pub async fn build_system_handle<TYPES: NodeType<InstanceState = TestInstanceState>, I: NodeImplementation<TYPES, Storage = TestStorage<TYPES>, AuctionResultsProvider = TestAuctionResultsProvider> + TestableNodeImplementation<TYPES>>(
+pub async fn build_system_handle<
+    TYPES: NodeType<InstanceState = TestInstanceState>,
+    I: NodeImplementation<
+            TYPES,
+            Storage = TestStorage<TYPES>,
+            AuctionResultsProvider = TestAuctionResultsProvider,
+        > + TestableNodeImplementation<TYPES>,
+>(
     node_id: u64,
 ) -> (
     SystemContextHandle<TYPES, I>,
     Sender<Arc<HotShotEvent<TYPES>>>,
     Receiver<Arc<HotShotEvent<TYPES>>>,
 ) {
-    let builder: TestDescription<TYPES, I> =
-        TestDescription::default_multiple_rounds();
+    let builder: TestDescription<TYPES, I> = TestDescription::default_multiple_rounds();
 
     let launcher = builder.gen_launcher(node_id);
 
@@ -100,7 +107,7 @@ pub async fn build_system_handle<TYPES: NodeType<InstanceState = TestInstanceSta
         network,
         initializer,
         ConsensusMetricsValue::default(),
-        storage, 
+        storage,
         auction_results_provider,
     )
     .await

--- a/crates/testing/src/helpers.rs
+++ b/crates/testing/src/helpers.rs
@@ -6,13 +6,15 @@ use bitvec::bitvec;
 use committable::Committable;
 use ethereum_types::U256;
 use hotshot::{
+    traits::{NodeImplementation, TestableNodeImplementation},
     types::{BLSPubKey, SignatureKey, SystemContextHandle},
-    HotShotInitializer, Memberships, SystemContext,
+    HotShotInitializer, Memberships, SystemContext
 };
 use hotshot_example_types::{
-    block_types::TestTransaction,
-    node_types::{MemoryImpl, TestTypes},
+    auction_results_provider_types::TestAuctionResultsProvider,
+    block_types::TestTransaction, node_types::{MemoryImpl, TestTypes},
     state_types::{TestInstanceState, TestValidatedState},
+    storage_types::TestStorage
 };
 use hotshot_task_impls::events::HotShotEvent;
 use hotshot_types::{
@@ -39,14 +41,14 @@ use crate::test_builder::TestDescription;
 /// create the [`SystemContextHandle`] from a node id
 /// # Panics
 /// if cannot create a [`HotShotInitializer`]
-pub async fn build_system_handle(
+pub async fn build_system_handle<TYPES: NodeType<InstanceState = TestInstanceState>, I: NodeImplementation<TYPES, Storage = TestStorage<TYPES>, AuctionResultsProvider = TestAuctionResultsProvider> + TestableNodeImplementation<TYPES>>(
     node_id: u64,
 ) -> (
-    SystemContextHandle<TestTypes, MemoryImpl>,
-    Sender<Arc<HotShotEvent<TestTypes>>>,
-    Receiver<Arc<HotShotEvent<TestTypes>>>,
+    SystemContextHandle<TYPES, I>,
+    Sender<Arc<HotShotEvent<TYPES>>>,
+    Receiver<Arc<HotShotEvent<TYPES>>>,
 ) {
-    let builder: TestDescription<TestTypes, MemoryImpl> =
+    let builder: TestDescription<TYPES, I> =
         TestDescription::default_multiple_rounds();
 
     let launcher = builder.gen_launcher(node_id);
@@ -56,33 +58,33 @@ pub async fn build_system_handle(
     let auction_results_provider = (launcher.resource_generator.auction_results_provider)(node_id);
     let config = launcher.resource_generator.config.clone();
 
-    let initializer = HotShotInitializer::<TestTypes>::from_genesis(TestInstanceState {})
+    let initializer = HotShotInitializer::<TYPES>::from_genesis(TestInstanceState {})
         .await
         .unwrap();
 
     let known_nodes_with_stake = config.known_nodes_with_stake.clone();
     let private_key = config.my_own_validator_config.private_key.clone();
-    let public_key = config.my_own_validator_config.public_key;
+    let public_key = config.my_own_validator_config.public_key.clone();
 
     let _known_nodes_without_stake = config.known_nodes_without_stake.clone();
 
     let memberships = Memberships {
-        quorum_membership: <TestTypes as NodeType>::Membership::create_election(
+        quorum_membership: <TYPES as NodeType>::Membership::create_election(
             known_nodes_with_stake.clone(),
             known_nodes_with_stake.clone(),
             config.fixed_leader_for_gpuvid,
         ),
-        da_membership: <TestTypes as NodeType>::Membership::create_election(
+        da_membership: <TYPES as NodeType>::Membership::create_election(
             known_nodes_with_stake.clone(),
             config.known_da_nodes.clone(),
             config.fixed_leader_for_gpuvid,
         ),
-        vid_membership: <TestTypes as NodeType>::Membership::create_election(
+        vid_membership: <TYPES as NodeType>::Membership::create_election(
             known_nodes_with_stake.clone(),
             known_nodes_with_stake.clone(),
             config.fixed_leader_for_gpuvid,
         ),
-        view_sync_membership: <TestTypes as NodeType>::Membership::create_election(
+        view_sync_membership: <TYPES as NodeType>::Membership::create_election(
             known_nodes_with_stake.clone(),
             known_nodes_with_stake,
             config.fixed_leader_for_gpuvid,
@@ -98,7 +100,7 @@ pub async fn build_system_handle(
         network,
         initializer,
         ConsensusMetricsValue::default(),
-        storage,
+        storage, 
         auction_results_provider,
     )
     .await

--- a/crates/testing/src/helpers.rs
+++ b/crates/testing/src/helpers.rs
@@ -76,22 +76,22 @@ pub async fn build_system_handle<
     let _known_nodes_without_stake = config.known_nodes_without_stake.clone();
 
     let memberships = Memberships {
-        quorum_membership: <TYPES as NodeType>::Membership::create_election(
+        quorum_membership: TYPES::Membership::create_election(
             known_nodes_with_stake.clone(),
             known_nodes_with_stake.clone(),
             config.fixed_leader_for_gpuvid,
         ),
-        da_membership: <TYPES as NodeType>::Membership::create_election(
+        da_membership: TYPES::Membership::create_election(
             known_nodes_with_stake.clone(),
             config.known_da_nodes.clone(),
             config.fixed_leader_for_gpuvid,
         ),
-        vid_membership: <TYPES as NodeType>::Membership::create_election(
+        vid_membership: TYPES::Membership::create_election(
             known_nodes_with_stake.clone(),
             known_nodes_with_stake.clone(),
             config.fixed_leader_for_gpuvid,
         ),
-        view_sync_membership: <TYPES as NodeType>::Membership::create_election(
+        view_sync_membership: TYPES::Membership::create_election(
             known_nodes_with_stake.clone(),
             known_nodes_with_stake,
             config.fixed_leader_for_gpuvid,

--- a/crates/testing/tests/tests_1/consensus_task.rs
+++ b/crates/testing/tests/tests_1/consensus_task.rs
@@ -50,7 +50,7 @@ async fn test_consensus_task() {
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
 
-    let handle = build_system_handle(2).await.0;
+    let handle = build_system_handle::<TestTypes, MemoryImpl>(2).await.0;
     let quorum_membership = handle.hotshot.memberships.quorum_membership.clone();
     let da_membership = handle.hotshot.memberships.da_membership.clone();
 
@@ -135,7 +135,7 @@ async fn test_consensus_vote() {
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
 
-    let handle = build_system_handle(2).await.0;
+    let handle = build_system_handle::<TestTypes, MemoryImpl>(2).await.0;
     let quorum_membership = handle.hotshot.memberships.quorum_membership.clone();
     let da_membership = handle.hotshot.memberships.da_membership.clone();
 
@@ -193,7 +193,7 @@ async fn test_view_sync_finalize_propose() {
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
 
-    let handle = build_system_handle(4).await.0;
+    let handle = build_system_handle::<TestTypes, MemoryImpl>(4).await.0;
     let (priv_key, pub_key) = key_pair_for_id(4);
     let quorum_membership = handle.hotshot.memberships.quorum_membership.clone();
     let da_membership = handle.hotshot.memberships.da_membership.clone();
@@ -327,7 +327,7 @@ async fn test_view_sync_finalize_vote() {
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
 
-    let handle = build_system_handle(5).await.0;
+    let handle = build_system_handle::<TestTypes, MemoryImpl>(5).await.0;
     let quorum_membership = handle.hotshot.memberships.quorum_membership.clone();
     let da_membership = handle.hotshot.memberships.da_membership.clone();
 
@@ -422,7 +422,7 @@ async fn test_view_sync_finalize_vote_fail_view_number() {
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
 
-    let handle = build_system_handle(5).await.0;
+    let handle = build_system_handle::<TestTypes, MemoryImpl>(5).await.0;
     let quorum_membership = handle.hotshot.memberships.quorum_membership.clone();
     let da_membership = handle.hotshot.memberships.da_membership.clone();
 
@@ -522,7 +522,7 @@ async fn test_vid_disperse_storage_failure() {
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
 
-    let handle = build_system_handle(2).await.0;
+    let handle = build_system_handle::<TestTypes, MemoryImpl>(2).await.0;
 
     // Set the error flag here for the system handle. This causes it to emit an error on append.
     handle.storage().write().await.should_return_err = true;

--- a/crates/testing/tests/tests_1/da_task.rs
+++ b/crates/testing/tests/tests_1/da_task.rs
@@ -32,7 +32,7 @@ async fn test_da_task() {
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
 
-    let handle = build_system_handle(2).await.0;
+    let handle = build_system_handle::<TestTypes, MemoryImpl>(2).await.0;
     let quorum_membership = handle.hotshot.memberships.quorum_membership.clone();
     let da_membership = handle.hotshot.memberships.da_membership.clone();
 
@@ -115,7 +115,7 @@ async fn test_da_task_storage_failure() {
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
 
-    let handle = build_system_handle(2).await.0;
+    let handle = build_system_handle::<TestTypes, MemoryImpl>(2).await.0;
 
     // Set the error flag here for the system handle. This causes it to emit an error on append.
     handle.storage().write().await.should_return_err = true;

--- a/crates/testing/tests/tests_1/quorum_proposal_recv_task.rs
+++ b/crates/testing/tests/tests_1/quorum_proposal_recv_task.rs
@@ -40,7 +40,7 @@ async fn test_quorum_proposal_recv_task() {
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
 
-    let handle = build_system_handle(2).await.0;
+    let handle = build_system_handle::<TestTypes, MemoryImpl>(2).await.0;
     let quorum_membership = handle.hotshot.memberships.quorum_membership.clone();
     let da_membership = handle.hotshot.memberships.da_membership.clone();
     let consensus = handle.hotshot.consensus();
@@ -128,7 +128,7 @@ async fn test_quorum_proposal_recv_task_liveness_check() {
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
 
-    let handle = build_system_handle(4).await.0;
+    let handle = build_system_handle::<TestTypes, MemoryImpl>(4).await.0;
     let quorum_membership = handle.hotshot.memberships.quorum_membership.clone();
     let da_membership = handle.hotshot.memberships.da_membership.clone();
     let consensus = handle.hotshot.consensus();

--- a/crates/testing/tests/tests_1/quorum_proposal_task.rs
+++ b/crates/testing/tests/tests_1/quorum_proposal_task.rs
@@ -43,7 +43,7 @@ async fn test_quorum_proposal_task_quorum_proposal_view_1() {
     async_compatibility_layer::logging::setup_backtrace();
 
     let node_id = 1;
-    let handle = build_system_handle(node_id).await.0;
+    let handle = build_system_handle::<TestTypes, MemoryImpl>(node_id).await.0;
     let quorum_membership = handle.hotshot.memberships.quorum_membership.clone();
     let da_membership = handle.hotshot.memberships.da_membership.clone();
 
@@ -130,7 +130,7 @@ async fn test_quorum_proposal_task_quorum_proposal_view_gt_1() {
     async_compatibility_layer::logging::setup_backtrace();
 
     let node_id = 3;
-    let handle = build_system_handle(node_id).await.0;
+    let handle = build_system_handle::<TestTypes, MemoryImpl>(node_id).await.0;
     let quorum_membership = handle.hotshot.memberships.quorum_membership.clone();
     let da_membership = handle.hotshot.memberships.da_membership.clone();
 
@@ -307,7 +307,7 @@ async fn test_quorum_proposal_task_qc_timeout() {
     async_compatibility_layer::logging::setup_backtrace();
 
     let node_id = 3;
-    let handle = build_system_handle(node_id).await.0;
+    let handle = build_system_handle::<TestTypes, MemoryImpl>(node_id).await.0;
     let quorum_membership = handle.hotshot.memberships.quorum_membership.clone();
     let da_membership = handle.hotshot.memberships.da_membership.clone();
 
@@ -388,7 +388,7 @@ async fn test_quorum_proposal_task_view_sync() {
     async_compatibility_layer::logging::setup_backtrace();
 
     let node_id = 2;
-    let handle = build_system_handle(node_id).await.0;
+    let handle = build_system_handle::<TestTypes, MemoryImpl>(node_id).await.0;
     let quorum_membership = handle.hotshot.memberships.quorum_membership.clone();
     let da_membership = handle.hotshot.memberships.da_membership.clone();
 
@@ -470,7 +470,7 @@ async fn test_quorum_proposal_task_liveness_check() {
     async_compatibility_layer::logging::setup_backtrace();
 
     let node_id = 3;
-    let handle = build_system_handle(node_id).await.0;
+    let handle = build_system_handle::<TestTypes, MemoryImpl>(node_id).await.0;
     let quorum_membership = handle.hotshot.memberships.quorum_membership.clone();
     let da_membership = handle.hotshot.memberships.da_membership.clone();
 
@@ -640,7 +640,7 @@ async fn test_quorum_proposal_task_with_incomplete_events() {
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
 
-    let handle = build_system_handle(2).await.0;
+    let handle = build_system_handle::<TestTypes, MemoryImpl>(2).await.0;
     let quorum_membership = handle.hotshot.memberships.quorum_membership.clone();
     let da_membership = handle.hotshot.memberships.da_membership.clone();
 

--- a/crates/testing/tests/tests_1/quorum_vote_task.rs
+++ b/crates/testing/tests/tests_1/quorum_vote_task.rs
@@ -35,7 +35,7 @@ async fn test_quorum_vote_task_success() {
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
 
-    let handle = build_system_handle(2).await.0;
+    let handle = build_system_handle::<TestTypes, MemoryImpl>(2).await.0;
     let quorum_membership = handle.hotshot.memberships.quorum_membership.clone();
     let da_membership = handle.hotshot.memberships.da_membership.clone();
 
@@ -104,7 +104,7 @@ async fn test_quorum_vote_task_vote_now() {
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
 
-    let handle = build_system_handle(2).await.0;
+    let handle = build_system_handle::<TestTypes, MemoryImpl>(2).await.0;
     let quorum_membership = handle.hotshot.memberships.quorum_membership.clone();
     let da_membership = handle.hotshot.memberships.da_membership.clone();
 
@@ -152,7 +152,7 @@ async fn test_quorum_vote_task_miss_dependency() {
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
 
-    let handle = build_system_handle(2).await.0;
+    let handle = build_system_handle::<TestTypes, MemoryImpl>(2).await.0;
     let quorum_membership = handle.hotshot.memberships.quorum_membership.clone();
     let da_membership = handle.hotshot.memberships.da_membership.clone();
 
@@ -237,7 +237,7 @@ async fn test_quorum_vote_task_incorrect_dependency() {
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
 
-    let handle = build_system_handle(2).await.0;
+    let handle = build_system_handle::<TestTypes, MemoryImpl>(2).await.0;
     let quorum_membership = handle.hotshot.memberships.quorum_membership.clone();
     let da_membership = handle.hotshot.memberships.da_membership.clone();
 

--- a/crates/testing/tests/tests_1/transaction_task.rs
+++ b/crates/testing/tests/tests_1/transaction_task.rs
@@ -17,7 +17,7 @@ use vbs::version::StaticVersionType;
 #[cfg(test)]
 #[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
-async fn test_transaction_task_double_election_leader() {
+async fn test_transaction_task_leader_two_views_in_a_row() {
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
 

--- a/crates/testing/tests/tests_1/transaction_task.rs
+++ b/crates/testing/tests/tests_1/transaction_task.rs
@@ -21,8 +21,9 @@ async fn test_transaction_task_leader_two_views_in_a_row() {
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
 
-    // Build the API for node 5.
-    let handle = build_system_handle::<TestConsecutiveLeaderTypes, MemoryImpl>(2).await.0;
+    // Build the API for node 2.
+    let node_id = 2;
+    let handle = build_system_handle::<TestConsecutiveLeaderTypes, MemoryImpl>(node_id).await.0;
 
     let mut input = Vec::new();
     let mut output = Vec::new();

--- a/crates/testing/tests/tests_1/trasnsaction_task.rs
+++ b/crates/testing/tests/tests_1/trasnsaction_task.rs
@@ -1,0 +1,59 @@
+use hotshot::tasks::task_state::CreateTaskState;
+use hotshot_example_types::{
+    node_types::{MemoryImpl, TestTypes},
+    block_types::TestMetadata
+};
+use hotshot_task_impls::{
+    events::HotShotEvent, harness::run_harness, transactions::TransactionTaskState
+};
+use hotshot_testing::helpers::build_system_handle;
+use hotshot_types::{
+    data::{ViewNumber, null_block, PackedBundle},
+    traits::{node_implementation::ConsensusTime, election::Membership, block_contents::precompute_vid_commitment},
+    constants::BaseVersion
+};
+use vbs::version::StaticVersionType;
+
+#[cfg(test)]
+#[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
+#[cfg_attr(async_executor_impl = "async-std", async_std::test)]
+async fn test_transaction_task_double_election_leader() {
+
+    async_compatibility_layer::logging::setup_logging();
+    async_compatibility_layer::logging::setup_backtrace();
+
+    // Build the API for node 5.
+    let handle = build_system_handle(2).await.0;
+
+    let mut input = Vec::new();
+    let mut output = Vec::new();
+
+    let current_view = ViewNumber::new(4);
+    input.push(HotShotEvent::ViewChange(current_view));
+    input.push(HotShotEvent::Shutdown);
+    let quorum_membership = handle.hotshot.memberships.view_sync_membership.clone();
+    
+    let (_, precompute_data) =
+        precompute_vid_commitment(&[], quorum_membership.total_nodes());
+
+    // current view
+    let mut exp_packed_bundle = PackedBundle::new(
+        vec![].into(),
+        TestMetadata,
+        current_view,
+        vec1::vec1![null_block::builder_fee(
+            quorum_membership.total_nodes(),
+            BaseVersion::version()
+        )
+        .unwrap()],
+        Some(precompute_data.clone()),
+    );
+    output.push(HotShotEvent::BlockRecv(exp_packed_bundle.clone()));
+
+    // next view
+    exp_packed_bundle.view_number = current_view + 1;
+    output.push(HotShotEvent::BlockRecv(exp_packed_bundle));
+
+    let transaction_state = TransactionTaskState::<TestTypes, MemoryImpl>::create_from(&handle).await;
+    run_harness(input, output, transaction_state, false).await;
+}

--- a/crates/testing/tests/tests_1/upgrade_task_with_consensus.rs
+++ b/crates/testing/tests/tests_1/upgrade_task_with_consensus.rs
@@ -40,7 +40,7 @@ async fn test_upgrade_task_vote() {
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
 
-    let handle = build_system_handle(1).await.0;
+    let handle = build_system_handle::<TestTypes, MemoryImpl>(1).await.0;
     let quorum_membership = handle.hotshot.memberships.quorum_membership.clone();
     let da_membership = handle.hotshot.memberships.da_membership.clone();
 
@@ -197,7 +197,7 @@ async fn test_upgrade_task_propose() {
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
 
-    let handle = build_system_handle(3).await.0;
+    let handle = build_system_handle::<TestTypes, MemoryImpl>(3).await.0;
     let quorum_membership = handle.hotshot.memberships.quorum_membership.clone();
     let da_membership = handle.hotshot.memberships.da_membership.clone();
 
@@ -355,7 +355,7 @@ async fn test_upgrade_task_blank_blocks() {
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
 
-    let handle = build_system_handle(6).await.0;
+    let handle = build_system_handle::<TestTypes, MemoryImpl>(6).await.0;
     let quorum_membership = handle.hotshot.memberships.quorum_membership.clone();
     let da_membership = handle.hotshot.memberships.da_membership.clone();
 

--- a/crates/testing/tests/tests_1/upgrade_task_with_proposal.rs
+++ b/crates/testing/tests/tests_1/upgrade_task_with_proposal.rs
@@ -52,7 +52,7 @@ async fn test_upgrade_task_with_proposal() {
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
 
-    let handle = build_system_handle(3).await.0;
+    let handle = build_system_handle::<TestTypes, MemoryImpl>(3).await.0;
     let quorum_membership = handle.hotshot.memberships.quorum_membership.clone();
     let da_membership = handle.hotshot.memberships.da_membership.clone();
 

--- a/crates/testing/tests/tests_1/upgrade_task_with_vote.rs
+++ b/crates/testing/tests/tests_1/upgrade_task_with_vote.rs
@@ -45,7 +45,7 @@ async fn test_upgrade_task_with_vote() {
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
 
-    let handle = build_system_handle(2).await.0;
+    let handle = build_system_handle::<TestTypes, MemoryImpl>(2).await.0;
     let quorum_membership = handle.hotshot.memberships.quorum_membership.clone();
     let da_membership = handle.hotshot.memberships.da_membership.clone();
 

--- a/crates/testing/tests/tests_1/vid_task.rs
+++ b/crates/testing/tests/tests_1/vid_task.rs
@@ -36,7 +36,7 @@ async fn test_vid_task() {
     async_compatibility_layer::logging::setup_backtrace();
 
     // Build the API for node 2.
-    let handle = build_system_handle(2).await.0;
+    let handle = build_system_handle::<TestTypes, MemoryImpl>(2).await.0;
     let pub_key = handle.public_key();
 
     // quorum membership for VID share distribution

--- a/crates/testing/tests/tests_1/view_sync_task.rs
+++ b/crates/testing/tests/tests_1/view_sync_task.rs
@@ -17,7 +17,7 @@ async fn test_view_sync_task() {
     async_compatibility_layer::logging::setup_backtrace();
 
     // Build the API for node 5.
-    let handle = build_system_handle(5).await.0;
+    let handle = build_system_handle::<TestTypes, MemoryImpl>(5).await.0;
 
     let vote_data = ViewSyncPreCommitData {
         relay: 0,


### PR DESCRIPTION
Closes #[3462](https://github.com/EspressoSystems/HotShot/issues/3462)
<!-- See here for keywords in Github -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

### This PR: 
<!-- Describe what this PR adds to HotSHot -->
<!-- E.g. -->
<!-- * Implements feature 1 -->
<!-- * Implements feature 2 -->
<!-- * Fixes bug 3 -->
Fixes a bug where a node could be the leader for the current and next view. Currently we only propose block for current view.
### This PR does not: 
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->

### Key places to review: 
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
