### PR TITLE
[AUDIT][LOW SEVERITY] Fix no-op validation in vote accumulator

### DIFF
--- a/crates/task-impls/src/consensus/mod.rs
+++ b/crates/task-impls/src/consensus/mod.rs
@@ -314,7 +314,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> ConsensusTaskState<TYPES, I>
                         TYPES,
                         QuorumVote<TYPES>,
                         QuorumCertificate<TYPES>,
-                    >(&info, vote.clone(), event, &event_stream)
+                    >(&info, event, &event_stream)
                     .await;
                 } else {
                     let result = collector
@@ -353,7 +353,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> ConsensusTaskState<TYPES, I>
                         TYPES,
                         TimeoutVote<TYPES>,
                         TimeoutCertificate<TYPES>,
-                    >(&info, vote.clone(), event, &event_stream)
+                    >(&info, event, &event_stream)
                     .await;
                 } else {
                     let result = collector

--- a/crates/task-impls/src/consensus2/handlers.rs
+++ b/crates/task-impls/src/consensus2/handlers.rs
@@ -49,10 +49,7 @@ pub(crate) async fn handle_quorum_vote_recv<TYPES: NodeType, I: NodeImplementati
             id: task_state.id,
         };
         *collector = create_vote_accumulator::<TYPES, QuorumVote<TYPES>, QuorumCertificate<TYPES>>(
-            &info,
-            vote.clone(),
-            event,
-            sender,
+            &info, event, sender,
         )
         .await;
     } else {
@@ -96,10 +93,7 @@ pub(crate) async fn handle_timeout_vote_recv<TYPES: NodeType, I: NodeImplementat
         };
         *collector =
             create_vote_accumulator::<TYPES, TimeoutVote<TYPES>, TimeoutCertificate<TYPES>>(
-                &info,
-                vote.clone(),
-                event,
-                sender,
+                &info, event, sender,
             )
             .await;
     } else {

--- a/crates/task-impls/src/da.rs
+++ b/crates/task-impls/src/da.rs
@@ -268,7 +268,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> DaTaskState<TYPES, I> {
                         TYPES,
                         DaVote<TYPES>,
                         DaCertificate<TYPES>,
-                    >(&info, vote.clone(), event, &event_stream)
+                    >(&info, event, &event_stream)
                     .await;
                 } else {
                     let result = collector

--- a/crates/task-impls/src/upgrade.rs
+++ b/crates/task-impls/src/upgrade.rs
@@ -237,7 +237,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> UpgradeTaskState<TYPES, I> {
                         TYPES,
                         UpgradeVote<TYPES>,
                         UpgradeCertificate<TYPES>,
-                    >(&info, vote.clone(), event, &tx)
+                    >(&info, event, &tx)
                     .await;
                 } else {
                     let result = collector

--- a/crates/task-impls/src/view_sync.rs
+++ b/crates/task-impls/src/view_sync.rs
@@ -293,8 +293,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> ViewSyncTaskState<TYPES, I> 
                     view: vote_view,
                     id: self.id,
                 };
-                let vote_collector =
-                    create_vote_accumulator(&info, vote.clone(), event, &event_stream).await;
+                let vote_collector = create_vote_accumulator(&info, event, &event_stream).await;
                 if let Some(vote_task) = vote_collector {
                     relay_map.insert(relay, vote_task);
                 }
@@ -331,8 +330,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> ViewSyncTaskState<TYPES, I> 
                     view: vote_view,
                     id: self.id,
                 };
-                let vote_collector =
-                    create_vote_accumulator(&info, vote.clone(), event, &event_stream).await;
+                let vote_collector = create_vote_accumulator(&info, event, &event_stream).await;
                 if let Some(vote_task) = vote_collector {
                     relay_map.insert(relay, vote_task);
                 }
@@ -369,8 +367,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> ViewSyncTaskState<TYPES, I> 
                     view: vote_view,
                     id: self.id,
                 };
-                let vote_collector =
-                    create_vote_accumulator(&info, vote.clone(), event, &event_stream).await;
+                let vote_collector = create_vote_accumulator(&info, event, &event_stream).await;
                 if let Some(vote_task) = vote_collector {
                     relay_map.insert(relay, vote_task);
                 }

--- a/crates/task-impls/src/vote_collection.rs
+++ b/crates/task-impls/src/vote_collection.rs
@@ -140,7 +140,6 @@ pub struct AccumulatorInfo<TYPES: NodeType> {
 /// Calls unwrap but should never panic.
 pub async fn create_vote_accumulator<TYPES, VOTE, CERT>(
     info: &AccumulatorInfo<TYPES>,
-    vote: VOTE,
     event: Arc<HotShotEvent<TYPES>>,
     sender: &Sender<Arc<HotShotEvent<TYPES>>>,
 ) -> Option<VoteCollectionTaskState<TYPES, VOTE, CERT>>
@@ -158,14 +157,6 @@ where
         + 'static,
     VoteCollectionTaskState<TYPES, VOTE, CERT>: HandleVoteEvent<TYPES, VOTE, CERT>,
 {
-    if vote.view_number() != info.view {
-        error!(
-            "Vote view does not match! vote view is {} current view is {}",
-            *vote.view_number(),
-            *info.view
-        );
-        return None;
-    }
     let new_accumulator = VoteAccumulator {
         vote_outcomes: HashMap::new(),
         signers: HashMap::new(),


### PR DESCRIPTION
Closes #<ISSUE_NUMBER>
<!-- See here for keywords in Github -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

### This PR: 
When the leader of view is collecting votes to create, for example, a quorum certificate the leader will call `handle_quorum_vote_recv` each time it receives a vote, which will then handle the vote sent in until it have a threshold of votes.

When the first vote is received, the leader will create a vote accumulator task by calling `create_vote_accumulator`.

The problem is in the way we validate the first vote's view number. This is done by erroring if `vote.view_number() != info.view`. But this validation will not do anything since `info.view` will be set to `vote.view_number()`.

```rust
let info = AccumulatorInfo {
            public_key: task_state.public_key.clone(),
            membership: Arc::clone(&task_state.quorum_membership),
            view: vote.view_number(),
            id: task_state.id,
        };
```

This PR removes the redundant check since every code branch that executes this initializes the `info` view number with the view number from the vote.

### This PR does not: 
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->

### Key places to review: 
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
