### PR TITLE
[AUDIT][Med/Low Severity] Fix race condition in state update for block building

### DIFF
--- a/crates/task-impls/src/quorum_proposal_recv/handlers.rs
+++ b/crates/task-impls/src/quorum_proposal_recv/handlers.rs
@@ -95,8 +95,26 @@ async fn validate_proposal_liveness<TYPES: NodeType, I: NodeImplementation<TYPES
     )
     .await;
 
+    let cur_view = task_state.cur_view;
+    if let Err(e) = update_view::<TYPES>(
+        view_number,
+        event_sender,
+        task_state.timeout,
+        OuterConsensus::new(Arc::clone(&task_state.consensus.inner_consensus)),
+        &mut task_state.cur_view,
+        &mut task_state.cur_view_time,
+        &mut task_state.timeout_task,
+        &task_state.output_event_stream,
+        SEND_VIEW_CHANGE_EVENT,
+        task_state.quorum_membership.leader(cur_view) == task_state.public_key,
+    )
+    .await
+    {
+        debug!("Liveness Branch - Failed to update view; error = {e:#}");
+    }
+
     if !liveness_check {
-        bail!("Liveness invalid.");
+        bail!("Quorum Proposal failed the liveness check");
     }
 
     Ok(QuorumProposalValidity::Liveness)
@@ -137,24 +155,6 @@ pub(crate) async fn handle_quorum_proposal_recv<TYPES: NodeType, I: NodeImplemen
         let consensus = task_state.consensus.read().await;
         consensus.metrics.invalid_qc.update(1);
         bail!("Invalid justify_qc in proposal for view {}", *view_number);
-    }
-
-    // NOTE: We could update our view with a valid TC but invalid QC, but that is not what we do here
-    if let Err(e) = update_view::<TYPES>(
-        view_number,
-        event_sender,
-        task_state.timeout,
-        OuterConsensus::new(Arc::clone(&task_state.consensus.inner_consensus)),
-        &mut task_state.cur_view,
-        &mut task_state.cur_view_time,
-        &mut task_state.timeout_task,
-        &task_state.output_event_stream,
-        SEND_VIEW_CHANGE_EVENT,
-        task_state.quorum_membership.leader(cur_view) == task_state.public_key,
-    )
-    .await
-    {
-        debug!("Failed to update view; error = {e:#}");
     }
 
     // Get the parent leaf and state.
@@ -237,6 +237,24 @@ pub(crate) async fn handle_quorum_proposal_recv<TYPES: NodeType, I: NodeImplemen
         task_state.id,
     )
     .await?;
+
+    // NOTE: We could update our view with a valid TC but invalid QC, but that is not what we do here
+    if let Err(e) = update_view::<TYPES>(
+        view_number,
+        event_sender,
+        task_state.timeout,
+        OuterConsensus::new(Arc::clone(&task_state.consensus.inner_consensus)),
+        &mut task_state.cur_view,
+        &mut task_state.cur_view_time,
+        &mut task_state.timeout_task,
+        &task_state.output_event_stream,
+        SEND_VIEW_CHANGE_EVENT,
+        task_state.quorum_membership.leader(cur_view) == task_state.public_key,
+    )
+    .await
+    {
+        debug!("Full Branch - Failed to update view; error = {e:#}");
+    }
 
     Ok(QuorumProposalValidity::Fully)
 }

--- a/crates/testing/tests/tests_1/quorum_proposal_recv_task.rs
+++ b/crates/testing/tests/tests_1/quorum_proposal_recv_task.rs
@@ -80,7 +80,6 @@ async fn test_quorum_proposal_recv_task() {
     )]];
 
     let expectations = vec![Expectations::from_outputs(vec![
-        exact(ViewChange(ViewNumber::new(2))),
         exact(UpdateHighQc(proposals[1].data.justify_qc.clone())),
         exact(ValidatedStateUpdated(
             ViewNumber::new(2),
@@ -95,6 +94,7 @@ async fn test_quorum_proposal_recv_task() {
             proposals[1].data.clone(),
             leaves[0].clone(),
         )),
+        exact(ViewChange(ViewNumber::new(2))),
     ])];
 
     let state = QuorumProposalRecvTaskState::<TestTypes, MemoryImpl>::create_from(&handle).await;


### PR DESCRIPTION
Closes #<ISSUE_NUMBER>
<!-- See here for keywords in Github -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

### This PR: 
Hotshot initiates a block build request when a node is the leader of the next view. This process is handled via the `wait_for_block` function call. However, a race condition exists concerning the timing of reads and writes to the `validated_state_map`.

When `validate_proposal_safety_and_liveness` is called, it can update the `validated_state_map` after the `ViewChange` from the `update_view` function is processed. This results in `wait_for_block` reading stale state as the parent during the while loop lookup. 

This PR fixes the issue by moving the `update_view` call to happen *after* the validated state update has occurred and it also adds another call site to the liveness branch.

### This PR does not: 
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->

### Key places to review: 
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
