### PR TITLE
Ungate dependency task modules

### DIFF
--- a/crates/hotshot/src/tasks/mod.rs
+++ b/crates/hotshot/src/tasks/mod.rs
@@ -9,15 +9,8 @@ use async_compatibility_layer::art::{async_sleep, async_spawn};
 use async_lock::RwLock;
 use async_trait::async_trait;
 use hotshot_task::task::Task;
-#[cfg(not(feature = "dependency-tasks"))]
-use hotshot_task_impls::consensus::ConsensusTaskState;
 #[cfg(feature = "rewind")]
 use hotshot_task_impls::rewind::RewindTaskState;
-#[cfg(feature = "dependency-tasks")]
-use hotshot_task_impls::{
-    consensus2::Consensus2TaskState, quorum_proposal::QuorumProposalTaskState,
-    quorum_proposal_recv::QuorumProposalRecvTaskState, quorum_vote::QuorumVoteTaskState,
-};
 use hotshot_task_impls::{
     da::DaTaskState,
     events::HotShotEvent,
@@ -191,10 +184,17 @@ pub async fn add_consensus_tasks<TYPES: NodeType, I: NodeImplementation<TYPES>>(
 
     {
         #![cfg(not(feature = "dependency-tasks"))]
+        use hotshot_task_impls::consensus::ConsensusTaskState;
+
         handle.add_task(ConsensusTaskState::<TYPES, I>::create_from(handle).await);
     }
     {
         #![cfg(feature = "dependency-tasks")]
+        use hotshot_task_impls::{
+            consensus2::Consensus2TaskState, quorum_proposal::QuorumProposalTaskState,
+            quorum_proposal_recv::QuorumProposalRecvTaskState, quorum_vote::QuorumVoteTaskState,
+        };
+
         handle.add_task(QuorumProposalTaskState::<TYPES, I>::create_from(handle).await);
         handle.add_task(QuorumVoteTaskState::<TYPES, I>::create_from(handle).await);
         handle.add_task(QuorumProposalRecvTaskState::<TYPES, I>::create_from(handle).await);

--- a/crates/hotshot/src/traits/election/static_committee.rs
+++ b/crates/hotshot/src/traits/election/static_committee.rs
@@ -1,12 +1,14 @@
 use std::{marker::PhantomData, num::NonZeroU64};
 
 use ethereum_types::U256;
-use hotshot_types::traits::network::Topic;
 // use ark_bls12_381::Parameters as Param381;
 use hotshot_types::traits::signature_key::StakeTableEntryType;
 use hotshot_types::{
     signature_key::BLSPubKey,
-    traits::{election::Membership, node_implementation::NodeType, signature_key::SignatureKey},
+    traits::{
+        election::Membership, network::Topic, node_implementation::NodeType,
+        signature_key::SignatureKey,
+    },
     PeerConfig,
 };
 #[cfg(feature = "randomized-leader-election")]

--- a/crates/hotshot/src/traits/election/static_committee_leader_two_views.rs
+++ b/crates/hotshot/src/traits/election/static_committee_leader_two_views.rs
@@ -1,12 +1,14 @@
 use std::{marker::PhantomData, num::NonZeroU64};
 
 use ethereum_types::U256;
-use hotshot_types::traits::network::Topic;
 // use ark_bls12_381::Parameters as Param381;
 use hotshot_types::traits::signature_key::StakeTableEntryType;
 use hotshot_types::{
     signature_key::BLSPubKey,
-    traits::{election::Membership, node_implementation::NodeType, signature_key::SignatureKey},
+    traits::{
+        election::Membership, network::Topic, node_implementation::NodeType,
+        signature_key::SignatureKey,
+    },
     PeerConfig,
 };
 use tracing::debug;

--- a/crates/task-impls/src/quorum_proposal/handlers.rs
+++ b/crates/task-impls/src/quorum_proposal/handlers.rs
@@ -1,8 +1,6 @@
 //! This module holds the dependency task for the QuorumProposalTask. It is spawned whenever an event that could
 //! initiate a proposal occurs.
 
-#![cfg(feature = "dependency-tasks")]
-
 use std::{marker::PhantomData, sync::Arc, time::Duration};
 
 use anyhow::{ensure, Context, Result};

--- a/crates/task-impls/src/quorum_proposal/mod.rs
+++ b/crates/task-impls/src/quorum_proposal/mod.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "dependency-tasks")]
-
 use std::{collections::HashMap, sync::Arc};
 
 use anyhow::Result;

--- a/crates/task-impls/src/quorum_proposal_recv/handlers.rs
+++ b/crates/task-impls/src/quorum_proposal_recv/handlers.rs
@@ -1,5 +1,4 @@
 #![allow(dead_code)]
-#![cfg(feature = "dependency-tasks")]
 
 use std::sync::Arc;
 

--- a/crates/task-impls/src/quorum_proposal_recv/mod.rs
+++ b/crates/task-impls/src/quorum_proposal_recv/mod.rs
@@ -1,5 +1,4 @@
 #![allow(unused_imports)]
-#![cfg(feature = "dependency-tasks")]
 
 use std::{collections::BTreeMap, sync::Arc};
 

--- a/crates/task-impls/src/quorum_vote/handlers.rs
+++ b/crates/task-impls/src/quorum_vote/handlers.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "dependency-tasks")]
-
 use std::sync::Arc;
 
 use anyhow::Result;

--- a/crates/task-impls/src/quorum_vote/mod.rs
+++ b/crates/task-impls/src/quorum_vote/mod.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "dependency-tasks")]
-
 use std::{collections::HashMap, sync::Arc};
 
 use anyhow::{bail, ensure, Context, Result};


### PR DESCRIPTION
### This PR: 
In a separate PR, I was mildly surprised to see that `just cargo check` did not produce any errors for the dependency task modules when making a type change.

I don't believe there's any reason to gate the dependency task modules themselves; the main thing we want to gate is whether the dependency tasks are spawned in HotShot (which is already gated). This PR removes the gating on the modules.

### This PR does not: 
Dependency tasks will still not run unless the feature is enabled; this PR just prevents having to run `cargo check` twice (with and without the feature).

### Key places to review: 
