### PR TITLE
Add Byzantine Test where we have a dishonest leader

### DIFF
--- a/crates/testing/src/consistency_task.rs
+++ b/crates/testing/src/consistency_task.rs
@@ -148,7 +148,7 @@ pub struct ConsistencyTask<TYPES: NodeType> {
     /// A map from node ids to (leaves keyed on view number)
     pub consensus_leaves: NetworkMap<TYPES>,
     /// safety task requirements
-    pub safety_properties: OverallSafetyPropertiesDescription,
+    pub safety_properties: OverallSafetyPropertiesDescription<TYPES>,
 }
 
 #[async_trait]

--- a/crates/testing/src/overall_safety_task.rs
+++ b/crates/testing/src/overall_safety_task.rs
@@ -550,6 +550,7 @@ impl<TYPES: NodeType> std::fmt::Debug for OverallSafetyPropertiesDescription<TYP
             .field("check_block", &self.check_block)
             .field("num_failed_rounds_total", &self.num_failed_views)
             .field("transaction_threshold", &self.transaction_threshold)
+            .field("expected views to fail", &self.expected_views_to_fail)
             .finish_non_exhaustive()
     }
 }

--- a/crates/testing/src/overall_safety_task.rs
+++ b/crates/testing/src/overall_safety_task.rs
@@ -106,7 +106,6 @@ impl<TYPES: NodeType, I: TestableNodeImplementation<TYPES>> OverallSafetyTask<TY
             match expected_view_to_fail.get(&view_number) {
                 Some(_) => {
                     expected_view_to_fail.insert(view_number, true);
-                    error!("{:?}", expected_view_to_fail);
                 }
                 None => {
                     let _ = self.test_sender.broadcast(TestEvent::Shutdown).await;

--- a/crates/testing/src/test_builder.rs
+++ b/crates/testing/src/test_builder.rs
@@ -1,10 +1,4 @@
-use std::{
-    collections::{HashMap, HashSet},
-    num::NonZeroUsize,
-    rc::Rc,
-    sync::Arc,
-    time::Duration,
-};
+use std::{collections::HashMap, num::NonZeroUsize, rc::Rc, sync::Arc, time::Duration};
 
 use hotshot::{
     tasks::EventTransformerState,
@@ -243,7 +237,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> TestDescription<TYPES, I> {
                 num_failed_views: 15,
                 transaction_threshold: 0,
                 threshold_calculator: Arc::new(|_active, total| (2 * total / 3 + 1)),
-                expected_views_to_fail: HashSet::new(),
+                expected_views_to_fail: HashMap::new(),
             },
             timing_data: TimingData {
                 next_view_timeout: 2000,
@@ -277,7 +271,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> TestDescription<TYPES, I> {
                 num_failed_views: 8,
                 transaction_threshold: 0,
                 threshold_calculator: Arc::new(|_active, total| (2 * total / 3 + 1)),
-                expected_views_to_fail: HashSet::new(),
+                expected_views_to_fail: HashMap::new(),
             },
             timing_data: TimingData {
                 start_delay: 120_000,

--- a/crates/testing/src/test_builder.rs
+++ b/crates/testing/src/test_builder.rs
@@ -1,4 +1,10 @@
-use std::{collections::HashMap, num::NonZeroUsize, rc::Rc, sync::Arc, time::Duration};
+use std::{
+    collections::{HashMap, HashSet},
+    num::NonZeroUsize,
+    rc::Rc,
+    sync::Arc,
+    time::Duration,
+};
 
 use hotshot::{
     tasks::EventTransformerState,
@@ -67,7 +73,7 @@ pub struct TestDescription<TYPES: NodeType, I: NodeImplementation<TYPES>> {
     /// Size of the non-staked DA committee for the test
     pub da_non_staked_committee_size: usize,
     /// overall safety property description
-    pub overall_safety_properties: OverallSafetyPropertiesDescription,
+    pub overall_safety_properties: OverallSafetyPropertiesDescription<TYPES>,
     /// spinning properties
     pub spinning_properties: SpinningTaskDescription,
     /// txns timing
@@ -230,13 +236,14 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> TestDescription<TYPES, I> {
             num_nodes_with_stake,
             num_nodes_without_stake,
             start_nodes: num_nodes_with_stake,
-            overall_safety_properties: OverallSafetyPropertiesDescription {
+            overall_safety_properties: OverallSafetyPropertiesDescription::<TYPES> {
                 num_successful_views: 50,
                 check_leaf: true,
                 check_block: true,
                 num_failed_views: 15,
                 transaction_threshold: 0,
                 threshold_calculator: Arc::new(|_active, total| (2 * total / 3 + 1)),
+                expected_views_to_fail: HashSet::new(),
             },
             timing_data: TimingData {
                 next_view_timeout: 2000,
@@ -263,13 +270,14 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> TestDescription<TYPES, I> {
             num_nodes_with_stake,
             num_nodes_without_stake,
             start_nodes: num_nodes_with_stake,
-            overall_safety_properties: OverallSafetyPropertiesDescription {
+            overall_safety_properties: OverallSafetyPropertiesDescription::<TYPES> {
                 num_successful_views: 20,
                 check_leaf: true,
                 check_block: true,
                 num_failed_views: 8,
                 transaction_threshold: 0,
                 threshold_calculator: Arc::new(|_active, total| (2 * total / 3 + 1)),
+                expected_views_to_fail: HashSet::new(),
             },
             timing_data: TimingData {
                 start_delay: 120_000,

--- a/crates/testing/tests/tests_1/test_with_failures_2.rs
+++ b/crates/testing/tests/tests_1/test_with_failures_2.rs
@@ -96,8 +96,7 @@ cross_tests!(
         metadata.num_nodes_with_stake = 5;
         metadata.overall_safety_properties.expected_views_to_fail = HashMap::from([
             (ViewNumber::new(7), false),
-            (ViewNumber::new(12), false),
-            (ViewNumber::new(20), false)
+            (ViewNumber::new(12), false)
         ]);
         metadata
     },

--- a/crates/testing/tests/tests_1/test_with_failures_2.rs
+++ b/crates/testing/tests/tests_1/test_with_failures_2.rs
@@ -68,7 +68,12 @@ cross_tests!(
     Ignore: false,
     Metadata: {
         let behaviour = Rc::new(|node_id| {
-                let dishonest_leader = DishonestLeader::<TestTypes, MemoryImpl>::default();
+                let dishonest_leader = DishonestLeader::<TestTypes, MemoryImpl> {
+                    dishonest_at_proposal_numbers: HashSet::from([2, 3]),
+                    validated_proposals: Vec::new(),
+                    total_proposals_from_node: 0,
+                    _phantom: std::marker::PhantomData
+                };
                 match node_id {
                     2 => Behaviour::Byzantine(Box::new(dishonest_leader)),
                     _ => Behaviour::Standard,
@@ -86,8 +91,10 @@ cross_tests!(
             ..TestDescription::default()
         };
 
-        metadata.overall_safety_properties.num_failed_views = 1;
-        metadata.overall_safety_properties.expected_views_to_fail = HashSet::from([ViewNumber::new(8)]);
+        metadata.overall_safety_properties.num_failed_views = 2;
+        metadata.num_nodes_with_stake = 5;
+        metadata.overall_safety_properties.expected_views_to_fail = 
+            HashSet::from([ViewNumber::new(7), ViewNumber::new(12)]);
         metadata
     },
 );

--- a/crates/testing/tests/tests_1/test_with_failures_2.rs
+++ b/crates/testing/tests/tests_1/test_with_failures_2.rs
@@ -13,7 +13,7 @@ use hotshot_testing::{
 };
 use hotshot_types::data::ViewNumber;
 use hotshot_types::traits::node_implementation::ConsensusTime;
-use std::time::Duration;
+use std::{collections::HashMap, time::Duration};
 use std::collections::HashSet;
 
 #[cfg(async_executor_impl = "async-std")]
@@ -94,8 +94,11 @@ cross_tests!(
 
         metadata.overall_safety_properties.num_failed_views = 2;
         metadata.num_nodes_with_stake = 5;
-        metadata.overall_safety_properties.expected_views_to_fail = 
-            HashSet::from([ViewNumber::new(7), ViewNumber::new(12)]);
+        metadata.overall_safety_properties.expected_views_to_fail = HashMap::from([
+            (ViewNumber::new(7), false),
+            (ViewNumber::new(12), false),
+            (ViewNumber::new(20), false)
+        ]);
         metadata
     },
 );

--- a/crates/testing/tests/tests_1/test_with_failures_2.rs
+++ b/crates/testing/tests/tests_1/test_with_failures_2.rs
@@ -72,6 +72,7 @@ cross_tests!(
                     dishonest_at_proposal_numbers: HashSet::from([2, 3]),
                     validated_proposals: Vec::new(),
                     total_proposals_from_node: 0,
+                    view_look_back: 1,
                     _phantom: std::marker::PhantomData
                 };
                 match node_id {

--- a/crates/testing/tests/tests_1/test_with_failures_2.rs
+++ b/crates/testing/tests/tests_1/test_with_failures_2.rs
@@ -11,7 +11,10 @@ use hotshot_testing::{
     spinning_task::{ChangeNode, SpinningTaskDescription, UpDown},
     test_builder::TestDescription,
 };
+use hotshot_types::data::ViewNumber;
+use hotshot_types::traits::node_implementation::ConsensusTime;
 use std::time::Duration;
+use std::collections::HashSet;
 
 #[cfg(async_executor_impl = "async-std")]
 use {hotshot::tasks::DishonestLeader, hotshot_testing::test_builder::Behaviour, std::rc::Rc};
@@ -84,6 +87,7 @@ cross_tests!(
         };
 
         metadata.overall_safety_properties.num_failed_views = 1;
+        metadata.overall_safety_properties.expected_views_to_fail = HashSet::from([ViewNumber::new(8)]);
         metadata
     },
 );


### PR DESCRIPTION
Closes #[3515](https://github.com/EspressoSystems/HotShot/issues/3515)
<!-- See here for keywords in Github -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

### This PR: 
<!-- Describe what this PR adds to HotSHot -->
<!-- E.g. -->
<!-- * Implements feature 1 -->
<!-- * Implements feature 2 -->
<!-- * Fixes bug 3 -->
Uses byzantine trait in testing framework to create a dishonest leader that will replace proposed QC with a QC from a previous view

### This PR does not: 
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->

### Key places to review: 
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->
`tests/tests_1/test_with_failures_2.rs` I added the integration test at the bottom to test dishonest leader

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
