### PR TITLE
[AUDIT][LOW][CX_HARDENING] - Add Bespoke Tests For VoteDependencyHandle 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3342,6 +3342,7 @@ dependencies = [
  "hotshot-task",
  "hotshot-task-impls",
  "hotshot-types",
+ "itertools 0.13.0",
  "jf-signature",
  "jf-vid",
  "lru 0.12.3",
@@ -3900,6 +3901,15 @@ name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]

--- a/crates/hotshot/src/types/handle.rs
+++ b/crates/hotshot/src/types/handle.rs
@@ -83,7 +83,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static> SystemContextHandl
         self.output_event_stream.1.activate_cloned()
     }
 
-    /// HACK so we can seed dependency tasks during tests...
+    /// HACK so we can create dependency tasks when running tests
     #[must_use]
     pub fn internal_event_stream_sender(&self) -> Sender<Arc<HotShotEvent<TYPES>>> {
         self.internal_event_stream.0.clone()

--- a/crates/hotshot/src/types/handle.rs
+++ b/crates/hotshot/src/types/handle.rs
@@ -83,13 +83,19 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static> SystemContextHandl
         self.output_event_stream.1.activate_cloned()
     }
 
+    /// HACK so we can seed dependency tasks during tests...
+    #[must_use]
+    pub fn internal_event_stream_sender(&self) -> Sender<Arc<HotShotEvent<TYPES>>> {
+        self.internal_event_stream.0.clone()
+    }
+
     /// HACK so we can know the types when running tests...
     /// there are two cleaner solutions:
     /// - make the stream generic and in nodetypes or nodeimpelmentation
     /// - type wrapper
     /// NOTE: this is only used for sanity checks in our tests
     #[must_use]
-    pub fn internal_event_stream_known_impl(&self) -> Receiver<Arc<HotShotEvent<TYPES>>> {
+    pub fn internal_event_stream_receiver_known_impl(&self) -> Receiver<Arc<HotShotEvent<TYPES>>> {
         self.internal_event_stream.1.activate_cloned()
     }
 

--- a/crates/task-impls/src/quorum_vote/mod.rs
+++ b/crates/task-impls/src/quorum_vote/mod.rs
@@ -59,30 +59,29 @@ enum VoteDependency {
 }
 
 /// Handler for the vote dependency.
-#[allow(dead_code)]
-struct VoteDependencyHandle<TYPES: NodeType, I: NodeImplementation<TYPES>> {
+pub struct VoteDependencyHandle<TYPES: NodeType, I: NodeImplementation<TYPES>> {
     /// Public key.
     pub public_key: TYPES::SignatureKey,
     /// Private Key.
     pub private_key: <TYPES::SignatureKey as SignatureKey>::PrivateKey,
     /// Reference to consensus. The replica will require a write lock on this.
-    consensus: OuterConsensus<TYPES>,
+    pub consensus: OuterConsensus<TYPES>,
     /// Immutable instance state
-    instance_state: Arc<TYPES::InstanceState>,
+    pub instance_state: Arc<TYPES::InstanceState>,
     /// Membership for Quorum certs/votes.
-    quorum_membership: Arc<TYPES::Membership>,
+    pub quorum_membership: Arc<TYPES::Membership>,
     /// Reference to the storage.
     pub storage: Arc<RwLock<I::Storage>>,
     /// View number to vote on.
-    view_number: TYPES::Time,
+    pub view_number: TYPES::Time,
     /// Event sender.
-    sender: Sender<Arc<HotShotEvent<TYPES>>>,
+    pub sender: Sender<Arc<HotShotEvent<TYPES>>>,
     /// Event receiver.
-    receiver: Receiver<Arc<HotShotEvent<TYPES>>>,
+    pub receiver: Receiver<Arc<HotShotEvent<TYPES>>>,
     /// An upgrade certificate that has been decided on, if any.
     pub decided_upgrade_certificate: Arc<RwLock<Option<UpgradeCertificate<TYPES>>>>,
     /// The node's id
-    id: u64,
+    pub id: u64,
 }
 
 impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static> VoteDependencyHandle<TYPES, I> {

--- a/crates/testing/Cargo.toml
+++ b/crates/testing/Cargo.toml
@@ -50,6 +50,7 @@ tagged-base64.workspace = true
 vec1 = { workspace = true }
 reqwest = { workspace = true }
 url = { workspace = true }
+itertools = "0.13.0"
 
 [target.'cfg(all(async_executor_impl = "tokio"))'.dependencies]
 tokio = { workspace = true }

--- a/crates/testing/src/test_runner.rs
+++ b/crates/testing/src/test_runner.rs
@@ -109,7 +109,7 @@ where
             event_rxs.push(r);
         }
         for node in &self.nodes {
-            let r = node.handle.internal_event_stream_known_impl();
+            let r = node.handle.internal_event_stream_receiver_known_impl();
             internal_event_rxs.push(r);
         }
 

--- a/crates/testing/tests/tests_1/quorum_vote_task.rs
+++ b/crates/testing/tests/tests_1/quorum_vote_task.rs
@@ -276,3 +276,4 @@ async fn test_quorum_vote_task_incorrect_dependency() {
     };
     run_test![inputs, script].await;
 }
+

--- a/crates/testing/tests/tests_1/vote_dependency_handle.rs
+++ b/crates/testing/tests/tests_1/vote_dependency_handle.rs
@@ -1,0 +1,124 @@
+#![cfg(feature = "dependency-tasks")]
+
+use std::time::Duration;
+
+use async_compatibility_layer::art::async_timeout;
+use futures::StreamExt;
+use hotshot::tasks::task_state::CreateTaskState;
+use hotshot_example_types::node_types::{MemoryImpl, TestTypes};
+use hotshot_macros::{run_test, test_scripts};
+use hotshot_task_impls::{
+    events::HotShotEvent::*,
+    quorum_vote::{QuorumVoteTaskState, VoteDependencyHandle},
+};
+use hotshot_testing::{
+    all_predicates,
+    helpers::{build_fake_view_with_leaf, build_system_handle, vid_share},
+    predicates::{event::*, Predicate, PredicateResult},
+    random,
+    script::{Expectations, InputOrder, TaskScript},
+    serial,
+    view_generator::TestViewGenerator,
+};
+use hotshot_types::{
+    consensus::OuterConsensus, data::ViewNumber, traits::node_implementation::ConsensusTime,
+    vote::HasViewNumber,
+};
+
+const TIMEOUT: Duration = Duration::from_millis(35);
+
+#[cfg(test)]
+#[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
+#[cfg_attr(async_executor_impl = "async-std", async_std::test)]
+async fn test_vote_dependency_handle() {
+    use std::sync::Arc;
+
+    use hotshot_task_impls::helpers::broadcast_event;
+
+    async_compatibility_layer::logging::setup_logging();
+    async_compatibility_layer::logging::setup_backtrace();
+
+    let node_id = 2;
+    let handle = build_system_handle::<TestTypes, MemoryImpl>(node_id)
+        .await
+        .0;
+    let quorum_membership = handle.hotshot.memberships.quorum_membership.clone();
+    let da_membership = handle.hotshot.memberships.da_membership.clone();
+
+    let mut generator = TestViewGenerator::generate(quorum_membership.clone(), da_membership);
+
+    let mut proposals = Vec::new();
+    let mut leaves = Vec::new();
+    let mut dacs = Vec::new();
+    let mut vids = Vec::new();
+    let consensus = handle.hotshot.consensus().clone();
+    let mut consensus_writer = consensus.write().await;
+    for view in (&mut generator).take(2).collect::<Vec<_>>().await {
+        proposals.push(view.quorum_proposal.clone());
+        leaves.push(view.leaf.clone());
+        dacs.push(view.da_certificate.clone());
+        vids.push(view.vid_proposal.clone());
+        consensus_writer
+            .update_validated_state_map(
+                view.quorum_proposal.data.view_number(),
+                build_fake_view_with_leaf(view.leaf.clone()),
+            )
+            .unwrap();
+        consensus_writer.update_saved_leaves(view.leaf.clone());
+    }
+    drop(consensus_writer);
+
+    let inputs = vec![
+        QuorumProposalValidated(proposals[1].data.clone(), leaves[0].clone()),
+        DaCertificateValidated(dacs[1].clone()),
+        VidShareValidated(vids[1].0[0].clone()),
+    ];
+
+    let outputs = vec![
+        exact(QuorumVoteDependenciesValidated(ViewNumber::new(2))),
+        validated_state_updated(),
+        quorum_vote_send(),
+    ];
+
+    let qv = QuorumVoteTaskState::<TestTypes, MemoryImpl>::create_from(&handle).await;
+
+    let event_sender = handle.internal_event_stream_sender();
+    let mut event_receiver = handle.internal_event_stream_receiver_known_impl();
+    let view_number = ViewNumber::new(node_id);
+
+    let vote_dependency_handle_state = VoteDependencyHandle::<TestTypes, MemoryImpl> {
+        public_key: qv.public_key.clone(),
+        private_key: qv.private_key.clone(),
+        consensus: OuterConsensus::new(Arc::clone(&qv.consensus.inner_consensus)),
+        instance_state: Arc::clone(&qv.instance_state),
+        quorum_membership: Arc::clone(&qv.quorum_membership),
+        storage: Arc::clone(&qv.storage),
+        view_number,
+        sender: event_sender.clone(),
+        receiver: event_receiver.clone(),
+        decided_upgrade_certificate: Arc::clone(&qv.decided_upgrade_certificate),
+        id: qv.id,
+    };
+
+    let inputs_len = inputs.len();
+    for event in inputs.into_iter() {
+        broadcast_event(event.into(), &event_sender).await;
+    }
+
+    let mut i = 0;
+    let mut output_events = vec![];
+    while let Ok(Ok(received_output)) = async_timeout(TIMEOUT, event_receiver.recv_direct()).await {
+        if i < inputs_len {
+            i += 1;
+            continue;
+        }
+
+        output_events.push(received_output);
+    }
+
+    for (check, real) in outputs.into_iter().zip(output_events) {
+        if check.evaluate(&real).await == PredicateResult::Fail {
+            panic!("Output {real} did not match expected output {check:?}");
+        }
+    }
+}


### PR DESCRIPTION
Closes #3452 
<!-- See here for keywords in Github -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

### This PR: 
Currently our vote task tests are not invariant to all possible orderings

Quorum Vote Task has a problem during its units tests where no matter what order the events are received, `QuorumProposalValidated` is ALWAYS the first event processed when `handle_dep_result` is called within the dependency task:

Consider this list of events

```
Inputs
0: DaCertificateRecv(view_number=ViewNumber(2))
1: VIDShareRecv(view_number=ViewNumber(2))
2: QuorumProposalValidated(view_number=ViewNumber(2))

Re-Broadcasts
3: DaCertificateValidated(view_number=ViewNumber(2))
4: VIDShareValidated(view_number=ViewNumber(2))

Outputs
5: QuorumVoteDependenciesValidated(view_number=ViewNumber(2))
6: ValidatedStateUpdated(view_number=ViewNumber(2))
7: QuorumVoteSend(view_number=ViewNumber(2))
```

The `events` vec will always shuffle DaCertificateRecv and VIDShareRecv accordingly, but QuorumProposalValidated is ALWAYS first, even when it comes last in the inputs. This is due to how the events are processed in the unit test:

Starting [here](https://github.com/EspressoSystems/HotShot/blob/main/crates/task-impls/src/quorum_vote/mod.rs#L552), we begin processing events. If you [notice](https://github.com/EspressoSystems/HotShot/blob/main/crates/task-impls/src/quorum_vote/mod.rs#L459), however, we deviate our behavior slightly from the Quorum Proposal Task [here](https://github.com/EspressoSystems/HotShot/blob/main/crates/task-impls/src/quorum_proposal/mod.rs#L287). The event is optional because of these:
- [DaCertificateValidated](https://github.com/EspressoSystems/HotShot/blob/main/crates/task-impls/src/quorum_vote/mod.rs#L604)
- [VidShareValidated](https://github.com/EspressoSystems/HotShot/blob/main/crates/task-impls/src/quorum_vote/mod.rs#L665)

The proposal task has no use for validation, but voting does, which means its custom events incur a rebroadcast delay (however slight), but only for the above tasks, not `QuorumProposalValidated`, leading to it *always* being the first event received by the spawned dependency tasks. As a result, these events beget `None` in the above code block when creating the background task in the voting logic, but the value is ALWAYS `Some` and, hence, does not use `Option` in the same function for the proposal task.

Because of this, during the testing, the events are applied *instantly*, meaning that the infinitessimal delay in broadacast to create the *new* DaCertificate and VidShare events *always* results in QuorumProposalValidated getting there first, meaning that we cannot *ever* have a test where this does not happen first in the current logic. 

This PR adds a specific test to the vote dependency task with all permutations.

### This PR does not: 
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->

### Key places to review: 
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
