### PR TITLE
Remove builder_clients_marketplace from txn task

### DIFF
--- a/crates/hotshot/src/tasks/task_state.rs
+++ b/crates/hotshot/src/tasks/task_state.rs
@@ -203,7 +203,6 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> CreateTaskState<TYPES, I>
                 .cloned()
                 .map(BuilderClient::new)
                 .collect(),
-            builder_clients_marketplace: Vec::new(),
             decided_upgrade_certificate: Arc::clone(&handle.hotshot.decided_upgrade_certificate),
             auction_results_provider: Arc::clone(&handle.hotshot.auction_results_provider),
         }

--- a/crates/task-impls/src/transactions.rs
+++ b/crates/task-impls/src/transactions.rs
@@ -91,9 +91,6 @@ pub struct TransactionTaskState<TYPES: NodeType, I: NodeImplementation<TYPES>> {
     /// Builder 0.1 API clients
     pub builder_clients: Vec<BuilderClientBase<TYPES>>,
 
-    /// Builder 0.3 API clients
-    pub builder_clients_marketplace: Vec<BuilderClientMarketplace<TYPES>>,
-
     /// This Nodes Public Key
     pub public_key: TYPES::SignatureKey,
     /// Our Private Key
@@ -283,7 +280,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> TransactionTaskState<TYPES, 
                     futures.push(async_timeout(
                         self.builder_timeout.saturating_sub(start.elapsed()),
                         async {
-                            let client = crate::builder::v0_3::BuilderClient::new(url);
+                            let client = BuilderClientMarketplace::new(url);
                             client.bundle(*block_view).await
                         },
                     ));


### PR DESCRIPTION
Closes #0000


### This PR: 
Removes `builder_clients_marketplace` URL from transaction task, as it is unused and we create clients as-needed based on auction results

### This PR does not: 
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->

### Key places to review: 
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
