### PR TITLE
Add `MarketplaceConfig` to `SystemContext::new/init`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3088,6 +3088,7 @@ dependencies = [
  "tokio",
  "toml",
  "tracing",
+ "url",
  "vbs",
 ]
 
@@ -3186,6 +3187,7 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-subscriber 0.3.18",
+ "url",
  "vbs",
  "vec1",
 ]
@@ -3313,6 +3315,7 @@ dependencies = [
  "time 0.3.36",
  "tokio",
  "tracing",
+ "url",
  "vbs",
  "vec1",
 ]

--- a/crates/examples/Cargo.toml
+++ b/crates/examples/Cargo.toml
@@ -115,6 +115,7 @@ vbs = { workspace = true }
 sha2.workspace = true
 local-ip-address = "0.6"
 vec1 = { workspace = true }
+url = { workspace = true }
 
 tracing = { workspace = true }
 

--- a/crates/examples/infra/mod.rs
+++ b/crates/examples/infra/mod.rs
@@ -27,7 +27,7 @@ use hotshot::{
         BlockPayload, NodeImplementation,
     },
     types::SystemContextHandle,
-    Memberships, SystemContext,
+    MarketplaceConfig, Memberships, SystemContext,
 };
 use hotshot_example_types::{
     auction_results_provider_types::TestAuctionResultsProvider,
@@ -396,6 +396,11 @@ pub trait RunDa<
             view_sync_membership: quorum_membership,
         };
 
+        let marketplace_config = MarketplaceConfig {
+            auction_results_provider: TestAuctionResultsProvider::<TYPES>::default().into(),
+            generic_builder_url: url::Url::parse("localhost").unwrap(),
+        };
+
         SystemContext::init(
             pk,
             sk,
@@ -406,7 +411,7 @@ pub trait RunDa<
             initializer,
             ConsensusMetricsValue::default(),
             TestStorage::<TYPES>::default(),
-            TestAuctionResultsProvider::<TYPES>::default(),
+            marketplace_config,
         )
         .await
         .expect("Could not init hotshot")

--- a/crates/hotshot/Cargo.toml
+++ b/crates/hotshot/Cargo.toml
@@ -59,6 +59,7 @@ jf-signature.workspace = true
 hotshot-orchestrator = { path = "../orchestrator" }
 blake3.workspace = true
 sha2 = { workspace = true }
+url = { workspace = true }
 num_enum = "0.7"
 
 [target.'cfg(all(async_executor_impl = "tokio"))'.dependencies]

--- a/crates/hotshot/src/tasks/mod.rs
+++ b/crates/hotshot/src/tasks/mod.rs
@@ -35,8 +35,8 @@ use vbs::version::StaticVersionType;
 
 use crate::{
     tasks::task_state::CreateTaskState, types::SystemContextHandle, ConsensusApi,
-    ConsensusMetricsValue, ConsensusTaskRegistry, HotShotConfig, HotShotInitializer, Memberships,
-    NetworkTaskRegistry, SignatureKey, SystemContext,
+    ConsensusMetricsValue, ConsensusTaskRegistry, HotShotConfig, HotShotInitializer,
+    MarketplaceConfig, Memberships, NetworkTaskRegistry, SignatureKey, SystemContext,
 };
 
 /// event for global event stream
@@ -232,7 +232,7 @@ where
         initializer: HotShotInitializer<TYPES>,
         metrics: ConsensusMetricsValue,
         storage: I::Storage,
-        auction_results_provider: I::AuctionResultsProvider,
+        marketplace_config: MarketplaceConfig<TYPES, I>,
     ) -> SystemContextHandle<TYPES, I> {
         let hotshot = SystemContext::new(
             public_key,
@@ -244,7 +244,7 @@ where
             initializer,
             metrics,
             storage,
-            auction_results_provider,
+            marketplace_config,
         );
         let consensus_registry = ConsensusTaskRegistry::new();
         let network_registry = NetworkTaskRegistry::new();

--- a/crates/hotshot/src/tasks/task_state.rs
+++ b/crates/hotshot/src/tasks/task_state.rs
@@ -205,7 +205,14 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> CreateTaskState<TYPES, I>
                 .collect(),
             builder_clients_marketplace: Vec::new(),
             decided_upgrade_certificate: Arc::clone(&handle.hotshot.decided_upgrade_certificate),
-            auction_results_provider: Arc::clone(&handle.hotshot.auction_results_provider),
+            auction_results_provider: Arc::clone(
+                &handle.hotshot.marketplace_config.auction_results_provider,
+            ),
+            generic_builder_url: handle
+                .hotshot
+                .marketplace_config
+                .generic_builder_url
+                .clone(),
         }
     }
 }

--- a/crates/task-impls/Cargo.toml
+++ b/crates/task-impls/Cargo.toml
@@ -37,6 +37,7 @@ surf-disco = { workspace = true }
 tagged-base64 = { workspace = true }
 time = { workspace = true }
 tracing = { workspace = true }
+url = { workspace = true }
 vbs = { workspace = true }
 vec1 = { workspace = true }
 

--- a/crates/task-impls/src/transactions.rs
+++ b/crates/task-impls/src/transactions.rs
@@ -29,6 +29,7 @@ use hotshot_types::{
     vid::{VidCommitment, VidPrecomputeData},
 };
 use tracing::{debug, error, instrument, warn};
+use url::Url;
 use vbs::version::StaticVersionType;
 use vec1::Vec1;
 
@@ -106,6 +107,8 @@ pub struct TransactionTaskState<TYPES: NodeType, I: NodeImplementation<TYPES>> {
     pub decided_upgrade_certificate: Arc<RwLock<Option<UpgradeCertificate<TYPES>>>>,
     /// auction results provider
     pub auction_results_provider: Arc<I::AuctionResultsProvider>,
+    /// generic builder url
+    pub generic_builder_url: Url,
 }
 
 impl<TYPES: NodeType, I: NodeImplementation<TYPES>> TransactionTaskState<TYPES, I> {
@@ -270,7 +273,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> TransactionTaskState<TYPES, 
         {
             let start = Instant::now();
 
-            if let Ok(Ok(urls)) = async_timeout(
+            if let Ok(Ok(auction_result)) = async_timeout(
                 self.builder_timeout,
                 self.auction_results_provider
                     .fetch_auction_result(block_view),
@@ -279,7 +282,10 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> TransactionTaskState<TYPES, 
             {
                 let mut futures = Vec::new();
 
-                for url in urls.clone().urls() {
+                let mut builder_urls = auction_result.clone().urls();
+                builder_urls.push(self.generic_builder_url.clone());
+
+                for url in builder_urls {
                     futures.push(async_timeout(
                         self.builder_timeout.saturating_sub(start.elapsed()),
                         async {
@@ -326,7 +332,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> TransactionTaskState<TYPES, 
                             block_view,
                             sequencing_fees,
                             None,
-                            Some(urls),
+                            Some(auction_result),
                         ))),
                         event_stream,
                     )

--- a/crates/testing/src/helpers.rs
+++ b/crates/testing/src/helpers.rs
@@ -63,7 +63,7 @@ pub async fn build_system_handle<
 
     let network = (launcher.resource_generator.channel_generator)(node_id).await;
     let storage = (launcher.resource_generator.storage)(node_id);
-    let auction_results_provider = (launcher.resource_generator.auction_results_provider)(node_id);
+    let marketplace_config = (launcher.resource_generator.marketplace_config)(node_id);
     let config = launcher.resource_generator.config.clone();
 
     let initializer = HotShotInitializer::<TYPES>::from_genesis(TestInstanceState {})
@@ -113,7 +113,7 @@ pub async fn build_system_handle<
         initializer,
         ConsensusMetricsValue::default(),
         storage,
-        auction_results_provider,
+        marketplace_config,
     )
     .await
     .expect("Could not init hotshot")

--- a/crates/testing/src/spinning_task.rs
+++ b/crates/testing/src/spinning_task.rs
@@ -114,7 +114,7 @@ where
                                             storage,
                                             memberships,
                                             config,
-                                            auction_results_provider,
+                                            marketplace_config,
                                         } = late_context_params;
 
                                         let initializer = HotShotInitializer::<TYPES>::from_reload(
@@ -144,7 +144,7 @@ where
                                             config,
                                             validator_config,
                                             storage,
-                                            auction_results_provider,
+                                            marketplace_config,
                                         )
                                         .await
                                     }

--- a/crates/testing/src/test_builder.rs
+++ b/crates/testing/src/test_builder.rs
@@ -4,7 +4,7 @@ use hotshot::{
     tasks::EventTransformerState,
     traits::{NetworkReliability, NodeImplementation, TestableNodeImplementation},
     types::SystemContextHandle,
-    HotShotInitializer, Memberships, SystemContext, TwinsHandlerState,
+    HotShotInitializer, MarketplaceConfig, Memberships, SystemContext, TwinsHandlerState,
 };
 use hotshot_example_types::{
     auction_results_provider_types::TestAuctionResultsProvider, state_types::TestInstanceState,
@@ -105,7 +105,7 @@ pub async fn create_test_handle<
     memberships: Memberships<TYPES>,
     config: HotShotConfig<TYPES::SignatureKey>,
     storage: I::Storage,
-    auction_results_provider: I::AuctionResultsProvider,
+    marketplace_config: MarketplaceConfig<TYPES, I>,
 ) -> SystemContextHandle<TYPES, I> {
     let initializer = HotShotInitializer::<TYPES>::from_genesis(TestInstanceState {})
         .await
@@ -135,7 +135,7 @@ pub async fn create_test_handle<
                     initializer,
                     ConsensusMetricsValue::default(),
                     storage,
-                    auction_results_provider,
+                    marketplace_config,
                 )
                 .await;
 
@@ -154,7 +154,7 @@ pub async fn create_test_handle<
                     initializer,
                     ConsensusMetricsValue::default(),
                     storage,
-                    auction_results_provider,
+                    marketplace_config,
                 )
                 .await
         }
@@ -169,7 +169,7 @@ pub async fn create_test_handle<
                 initializer,
                 ConsensusMetricsValue::default(),
                 storage,
-                auction_results_provider,
+                marketplace_config,
             );
 
             hotshot.run_tasks().await
@@ -365,6 +365,8 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> Default for TestDescription<
 
 impl<TYPES: NodeType<InstanceState = TestInstanceState>, I: TestableNodeImplementation<TYPES>>
     TestDescription<TYPES, I>
+where
+    I: NodeImplementation<TYPES, AuctionResultsProvider = TestAuctionResultsProvider<TYPES>>,
 {
     /// turn a description of a test (e.g. a [`TestDescription`]) into
     /// a [`TestLauncher`] that can be used to launch the test.
@@ -478,8 +480,9 @@ impl<TYPES: NodeType<InstanceState = TestInstanceState>, I: TestableNodeImplemen
                 ),
                 storage: Box::new(|_| TestStorage::<TYPES>::default()),
                 config,
-                auction_results_provider: Box::new(|_| {
-                    TestAuctionResultsProvider::<TYPES>::default()
+                marketplace_config: Box::new(|_| MarketplaceConfig::<TYPES, I> {
+                    auction_results_provider: TestAuctionResultsProvider::<TYPES>::default().into(),
+                    generic_builder_url: Url::parse("localhost").unwrap(),
                 }),
             },
             metadata: self,

--- a/crates/testing/src/test_launcher.rs
+++ b/crates/testing/src/test_launcher.rs
@@ -1,9 +1,10 @@
 use std::{collections::HashMap, marker::PhantomData, sync::Arc};
 
-use hotshot::traits::{NodeImplementation, TestableNodeImplementation};
-use hotshot_example_types::{
-    auction_results_provider_types::TestAuctionResultsProvider, storage_types::TestStorage,
+use hotshot::{
+    traits::{NodeImplementation, TestableNodeImplementation},
+    MarketplaceConfig,
 };
+use hotshot_example_types::storage_types::TestStorage;
 use hotshot_types::{
     traits::{
         network::{AsyncGenerator, ConnectedNetwork},
@@ -28,8 +29,8 @@ pub struct ResourceGenerators<TYPES: NodeType, I: TestableNodeImplementation<TYP
     pub storage: Generator<TestStorage<TYPES>>,
     /// configuration used to generate each hotshot node
     pub config: HotShotConfig<TYPES::SignatureKey>,
-    /// generate a new auction results connector for each node
-    pub auction_results_provider: Generator<TestAuctionResultsProvider<TYPES>>,
+    /// generate a new marketplace config for each node
+    pub marketplace_config: Generator<MarketplaceConfig<TYPES, I>>,
 }
 
 /// test launcher

--- a/crates/testing/tests/tests_1/transaction_task.rs
+++ b/crates/testing/tests/tests_1/transaction_task.rs
@@ -1,16 +1,19 @@
 use hotshot::tasks::task_state::CreateTaskState;
 use hotshot_example_types::{
+    block_types::TestMetadata,
     node_types::{MemoryImpl, TestConsecutiveLeaderTypes},
-    block_types::TestMetadata
 };
 use hotshot_task_impls::{
-    events::HotShotEvent, harness::run_harness, transactions::TransactionTaskState
+    events::HotShotEvent, harness::run_harness, transactions::TransactionTaskState,
 };
 use hotshot_testing::helpers::build_system_handle;
 use hotshot_types::{
-    data::{ViewNumber, null_block, PackedBundle},
-    traits::{node_implementation::ConsensusTime, election::Membership, block_contents::precompute_vid_commitment},
-    constants::BaseVersion
+    constants::BaseVersion,
+    data::{null_block, PackedBundle, ViewNumber},
+    traits::{
+        block_contents::precompute_vid_commitment, election::Membership,
+        node_implementation::ConsensusTime,
+    },
 };
 use vbs::version::StaticVersionType;
 
@@ -23,7 +26,9 @@ async fn test_transaction_task_leader_two_views_in_a_row() {
 
     // Build the API for node 2.
     let node_id = 2;
-    let handle = build_system_handle::<TestConsecutiveLeaderTypes, MemoryImpl>(node_id).await.0;
+    let handle = build_system_handle::<TestConsecutiveLeaderTypes, MemoryImpl>(node_id)
+        .await
+        .0;
 
     let mut input = Vec::new();
     let mut output = Vec::new();
@@ -32,9 +37,8 @@ async fn test_transaction_task_leader_two_views_in_a_row() {
     input.push(HotShotEvent::ViewChange(current_view));
     input.push(HotShotEvent::Shutdown);
     let quorum_membership = handle.hotshot.memberships.quorum_membership.clone();
-    
-    let (_, precompute_data) =
-        precompute_vid_commitment(&[], quorum_membership.total_nodes());
+
+    let (_, precompute_data) = precompute_vid_commitment(&[], quorum_membership.total_nodes());
 
     // current view
     let mut exp_packed_bundle = PackedBundle::new(
@@ -55,6 +59,7 @@ async fn test_transaction_task_leader_two_views_in_a_row() {
     exp_packed_bundle.view_number = current_view + 1;
     output.push(HotShotEvent::BlockRecv(exp_packed_bundle));
 
-    let transaction_state = TransactionTaskState::<TestConsecutiveLeaderTypes, MemoryImpl>::create_from(&handle).await;
+    let transaction_state =
+        TransactionTaskState::<TestConsecutiveLeaderTypes, MemoryImpl>::create_from(&handle).await;
     run_harness(input, output, transaction_state, false).await;
 }


### PR DESCRIPTION
### This PR: 
Adds `generic_builder_url` to `SystemContext::new/init` via a new `MarketplaceConfig` struct.

### This PR does not: 
The `generic_builder_url` is not actually implemented in the tests/examples.

### Key places to review: 
