### PR TITLE
[AUDIT] - Investigate Double View Update from View Sync task

### DIFF
--- a/crates/task-impls/src/view_sync.rs
+++ b/crates/task-impls/src/view_sync.rs
@@ -598,12 +598,6 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> ViewSyncReplicaTaskState<TYP
                 );
 
                 broadcast_event(
-                    Arc::new(HotShotEvent::ViewChange(self.next_view - 1)),
-                    &event_stream,
-                )
-                .await;
-
-                broadcast_event(
                     Arc::new(HotShotEvent::ViewChange(self.next_view)),
                     &event_stream,
                 )

--- a/crates/testing/tests/tests_1/test_with_failures_2.rs
+++ b/crates/testing/tests/tests_1/test_with_failures_2.rs
@@ -2,7 +2,7 @@
 #![allow(unused_imports)]
 use hotshot_example_types::{
     node_types::{Libp2pImpl, MemoryImpl, PushCdnImpl, TestConsecutiveLeaderTypes},
-    state_types::TestTypes
+    state_types::TestTypes,
 };
 use hotshot_macros::cross_tests;
 use hotshot_testing::{
@@ -10,12 +10,12 @@ use hotshot_testing::{
     completion_task::{CompletionTaskDescription, TimeBasedCompletionTaskDescription},
     spinning_task::{ChangeNode, SpinningTaskDescription, UpDown},
     test_builder::TestDescription,
-    view_sync_task::ViewSyncTaskDescription
+    view_sync_task::ViewSyncTaskDescription,
 };
 use hotshot_types::data::ViewNumber;
 use hotshot_types::traits::node_implementation::ConsensusTime;
-use std::{collections::HashMap, time::Duration};
 use std::collections::HashSet;
+use std::{collections::HashMap, time::Duration};
 
 #[cfg(async_executor_impl = "async-std")]
 use {hotshot::tasks::DishonestLeader, hotshot_testing::test_builder::Behaviour, std::rc::Rc};
@@ -139,7 +139,7 @@ cross_tests!(
         ]);
         // Make sure we keep committing rounds after the bad leaders, but not the full 50 because of the numerous timeouts
         metadata.overall_safety_properties.num_successful_views = 13;
-        
+
         // only turning off 1 node, so expected should be num_nodes_with_stake - 1
         let expected_nodes_in_view_sync = metadata.num_nodes_with_stake-1;
         metadata.view_sync_properties = ViewSyncTaskDescription::Threshold(expected_nodes_in_view_sync, expected_nodes_in_view_sync);

--- a/crates/testing/tests/tests_1/test_with_failures_2.rs
+++ b/crates/testing/tests/tests_1/test_with_failures_2.rs
@@ -134,14 +134,14 @@ cross_tests!(
         metadata.overall_safety_properties.num_failed_views = 2;
         metadata.overall_safety_properties.expected_views_to_fail = HashMap::from([
             // next views after turning node off
-            (ViewNumber::new(view_spin_node_down+1), false),
-            (ViewNumber::new(view_spin_node_down+2), false)
+            (ViewNumber::new(view_spin_node_down + 1), false),
+            (ViewNumber::new(view_spin_node_down + 2), false)
         ]);
         // Make sure we keep committing rounds after the bad leaders, but not the full 50 because of the numerous timeouts
         metadata.overall_safety_properties.num_successful_views = 13;
 
         // only turning off 1 node, so expected should be num_nodes_with_stake - 1
-        let expected_nodes_in_view_sync = metadata.num_nodes_with_stake-1;
+        let expected_nodes_in_view_sync = metadata.num_nodes_with_stake - 1;
         metadata.view_sync_properties = ViewSyncTaskDescription::Threshold(expected_nodes_in_view_sync, expected_nodes_in_view_sync);
 
         metadata


### PR DESCRIPTION
Closes https://github.com/EspressoSystems/HotShot/issues/3463
<!-- See here for keywords in Github -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

### This PR: 
<!-- Describe what this PR adds to HotSHot -->
<!-- E.g. -->
<!-- * Implements feature 1 -->
<!-- * Implements feature 2 -->
<!-- * Fixes bug 3 -->
We have added logic to properly handle fetching blocks when a node is the the leader two views in a row (see https://github.com/EspressoSystems/HotShot/issues/3462). Now, we can remove the double update from View Sync and write a integration test to verify when view sync triggers after 2 failures that we fetch both blocks for the next leader who will lead 2 consecutive views

### This PR does not: 
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->

### Key places to review: 
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
