### PR TITLE
Authenticate Libp2p connections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4486,6 +4486,7 @@ dependencies = [
  "libp2p",
  "libp2p-identity",
  "libp2p-swarm-derive",
+ "pin-project",
  "rand 0.8.5",
  "serde",
  "serde_bytes",

--- a/crates/hotshot/src/traits/networking/libp2p_network.rs
+++ b/crates/hotshot/src/traits/networking/libp2p_network.rs
@@ -58,7 +58,9 @@ use libp2p_identity::{
 use libp2p_networking::{
     network::{
         behaviours::request_response::{Request, Response},
-        spawn_network_node, MeshParams,
+        spawn_network_node,
+        transport::construct_auth_message,
+        MeshParams,
         NetworkEvent::{self, DirectRequest, DirectResponse, GossipMsg},
         NetworkNodeConfig, NetworkNodeConfigBuilder, NetworkNodeHandle, NetworkNodeReceiver,
         NetworkNodeType, DEFAULT_REPLICATION_FACTOR,
@@ -144,7 +146,7 @@ struct Libp2pNetworkInner<K: SignatureKey + 'static> {
     /// this node's public key
     pk: K,
     /// handle to control the network
-    handle: Arc<NetworkNodeHandle>,
+    handle: Arc<NetworkNodeHandle<K>>,
     /// Message Receiver
     receiver: UnboundedReceiver<Vec<u8>>,
     /// Receiver for Requests for Data, includes the request and the response chan
@@ -393,7 +395,23 @@ impl<K: SignatureKey + 'static> Libp2pNetwork<K> {
         .parse()?;
 
         // Build our libp2p configuration from our global, network configuration
-        let mut config_builder: NetworkNodeConfigBuilder = NetworkNodeConfigBuilder::default();
+        let mut config_builder = NetworkNodeConfigBuilder::default();
+
+        // Extrapolate the stake table from the known nodes
+        let stake_table: HashSet<K> = config
+            .config
+            .known_nodes_with_stake
+            .iter()
+            .map(|node| K::public_key(&node.stake_table_entry))
+            .collect();
+
+        let auth_message = construct_auth_message(pub_key, priv_key)
+            .with_context(|| "Failed to construct auth message")?;
+
+        // Set the auth message and stake table
+        config_builder
+            .stake_table(Some(stake_table))
+            .auth_message(Some(auth_message));
 
         // The replication factor is the minimum of [the default and 2/3 the number of nodes]
         let Some(default_replication_factor) = DEFAULT_REPLICATION_FACTOR else {
@@ -486,7 +504,7 @@ impl<K: SignatureKey + 'static> Libp2pNetwork<K> {
     #[allow(clippy::too_many_arguments)]
     pub async fn new(
         metrics: Libp2pMetricsValue,
-        config: NetworkNodeConfig,
+        config: NetworkNodeConfig<K>,
         pk: K,
         bootstrap_addrs: BootstrapAddrs,
         id: usize,

--- a/crates/libp2p-networking/Cargo.toml
+++ b/crates/libp2p-networking/Cargo.toml
@@ -36,6 +36,7 @@ tide = { version = "0.16", optional = true, default-features = false, features =
 tracing = { workspace = true }
 void = "1"
 lazy_static = { workspace = true }
+pin-project = "1"
 
 [target.'cfg(all(async_executor_impl = "tokio"))'.dependencies]
 libp2p = { workspace = true, features = ["tokio"] }

--- a/crates/libp2p-networking/src/network/mod.rs
+++ b/crates/libp2p-networking/src/network/mod.rs
@@ -6,10 +6,13 @@ mod def;
 pub mod error;
 /// functionality of a libp2p network node
 mod node;
+/// Alternative Libp2p transport implementations
+pub mod transport;
 
 use std::{collections::HashSet, fmt::Debug, str::FromStr};
 
 use futures::channel::oneshot::{self, Sender};
+use hotshot_types::traits::signature_key::SignatureKey;
 #[cfg(async_executor_impl = "async-std")]
 use libp2p::dns::async_std::Transport as DnsTransport;
 #[cfg(async_executor_impl = "tokio")]
@@ -31,6 +34,7 @@ use quic::async_std::Transport as QuicTransport;
 use quic::tokio::Transport as QuicTransport;
 use serde::{Deserialize, Serialize};
 use tracing::instrument;
+use transport::StakeTableAuthentication;
 
 use self::behaviours::request_response::{Request, Response};
 pub use self::{
@@ -205,31 +209,34 @@ pub fn gen_multiaddr(port: u16) -> Multiaddr {
 /// This type is used to represent a transport in the libp2p network framework. The `PeerId` is a unique identifier for each peer in the network, and the `StreamMuxerBox` is a type of multiplexer that can handle multiple substreams over a single connection.
 type BoxedTransport = Boxed<(PeerId, StreamMuxerBox)>;
 
-/// Generate authenticated transport
+/// Generates an authenticated transport checked against the stake table.
+/// If the stake table or authentication message is not provided, the transport will
+/// not participate in stake table authentication.
+///
 /// # Errors
-/// could not sign the quic key with `identity`
+/// If we could not create a DNS transport
 #[instrument(skip(identity))]
-pub async fn gen_transport(identity: Keypair) -> Result<BoxedTransport, NetworkError> {
-    let quic_transport = {
+pub async fn gen_transport<K: SignatureKey + 'static>(
+    identity: Keypair,
+    stake_table: Option<HashSet<K>>,
+    auth_message: Option<Vec<u8>>,
+) -> Result<BoxedTransport, NetworkError> {
+    // Create the initial `Quic` transport
+    let transport = {
         let mut config = quic::Config::new(&identity);
         config.handshake_timeout = std::time::Duration::from_secs(20);
         QuicTransport::new(config)
     };
 
-    let dns_quic = {
-        #[cfg(async_executor_impl = "async-std")]
-        {
-            DnsTransport::system(quic_transport).await
-        }
+    // Require authentication against the stake table
+    let transport = StakeTableAuthentication::new(transport, stake_table, auth_message);
 
-        #[cfg(async_executor_impl = "tokio")]
-        {
-            DnsTransport::system(quic_transport)
-        }
-    }
-    .map_err(|e| NetworkError::TransportLaunch { source: e })?;
+    // Support DNS resolution
+    let transport = DnsTransport::system(transport)
+        .await
+        .map_err(|e| NetworkError::TransportLaunch { source: e })?;
 
-    Ok(dns_quic
+    Ok(transport
         .map(|(peer_id, connection), _| (peer_id, StreamMuxerBox::new(connection)))
         .boxed())
 }

--- a/crates/libp2p-networking/src/network/node.rs
+++ b/crates/libp2p-networking/src/network/node.rs
@@ -17,7 +17,9 @@ use async_compatibility_layer::{
     channel::{unbounded, UnboundedReceiver, UnboundedRecvError, UnboundedSender},
 };
 use futures::{channel::mpsc, select, FutureExt, SinkExt, StreamExt};
-use hotshot_types::constants::KAD_DEFAULT_REPUB_INTERVAL_SEC;
+use hotshot_types::{
+    constants::KAD_DEFAULT_REPUB_INTERVAL_SEC, traits::signature_key::SignatureKey,
+};
 use libp2p::{
     autonat,
     core::transport::ListenerId,
@@ -76,7 +78,7 @@ pub const ESTABLISHED_LIMIT_UNWR: u32 = 10;
 
 /// Network definition
 #[derive(custom_debug::Debug)]
-pub struct NetworkNode {
+pub struct NetworkNode<K: SignatureKey + 'static> {
     /// pub/private key from with peer_id is derived
     identity: Keypair,
     /// peer id of network node
@@ -85,7 +87,7 @@ pub struct NetworkNode {
     #[debug(skip)]
     swarm: Swarm<NetworkDef>,
     /// the configuration parameters of the netework
-    config: NetworkNodeConfig,
+    config: NetworkNodeConfig<K>,
     /// the listener id we are listening on, if it exists
     listener_id: Option<ListenerId>,
     /// Handler for requests and response behavior events.
@@ -100,7 +102,7 @@ pub struct NetworkNode {
     bootstrap_tx: Option<mpsc::Sender<bootstrap::InputEvent>>,
 }
 
-impl NetworkNode {
+impl<K: SignatureKey + 'static> NetworkNode<K> {
     /// Returns number of peers this node is connected to
     pub fn num_connected(&self) -> usize {
         self.swarm.connected_peers().count()
@@ -158,17 +160,25 @@ impl NetworkNode {
     ///   * Generates a connection to the "broadcast" topic
     ///   * Creates a swarm to manage peers and events
     #[instrument]
-    pub async fn new(config: NetworkNodeConfig) -> Result<Self, NetworkError> {
-        // Generate a random PeerId
+    pub async fn new(config: NetworkNodeConfig<K>) -> Result<Self, NetworkError> {
+        // Generate a random `KeyPair` if one is not specified
         let identity = if let Some(ref kp) = config.identity {
             kp.clone()
         } else {
             Keypair::generate_ed25519()
         };
+
+        // Get the `PeerId` from the `KeyPair`
         let peer_id = PeerId::from(identity.public());
-        debug!(?peer_id);
-        let transport: BoxedTransport = gen_transport(identity.clone()).await?;
-        debug!("Launched network transport");
+
+        // Generate the transport from the identity, stake table, and auth message
+        let transport: BoxedTransport = gen_transport::<K>(
+            identity.clone(),
+            config.stake_table.clone(),
+            config.auth_message.clone(),
+        )
+        .await?;
+
         // Generate the swarm
         let mut swarm: Swarm<NetworkDef> = {
             // Use the hash of the message's contents as the ID

--- a/crates/libp2p-networking/src/network/node/config.rs
+++ b/crates/libp2p-networking/src/network/node/config.rs
@@ -1,5 +1,6 @@
 use std::{collections::HashSet, num::NonZeroUsize, time::Duration};
 
+use hotshot_types::traits::signature_key::SignatureKey;
 use libp2p::{identity::Keypair, Multiaddr};
 use libp2p_identity::PeerId;
 
@@ -10,7 +11,7 @@ pub const DEFAULT_REPLICATION_FACTOR: Option<NonZeroUsize> = NonZeroUsize::new(1
 
 /// describe the configuration of the network
 #[derive(Clone, Default, derive_builder::Builder, custom_debug::Debug)]
-pub struct NetworkNodeConfig {
+pub struct NetworkNodeConfig<K: SignatureKey + 'static> {
     #[builder(default)]
     /// The type of node (bootstrap etc)
     pub node_type: NetworkNodeType,
@@ -40,6 +41,16 @@ pub struct NetworkNodeConfig {
     /// whether to start in libp2p::kad::Mode::Server mode
     #[builder(default = "false")]
     pub server_mode: bool,
+
+    /// The stake table. Used for authenticating other nodes. If not supplied
+    /// we will not check other nodes against the stake table
+    #[builder(default)]
+    pub stake_table: Option<HashSet<K>>,
+
+    /// The signed authentication message sent to the remote peer
+    /// If not supplied we will not send an authentication message during the handshake
+    #[builder(default)]
+    pub auth_message: Option<Vec<u8>>,
 }
 
 /// NOTE: `mesh_outbound_min <= mesh_n_low <= mesh_n <= mesh_n_high`

--- a/crates/libp2p-networking/src/network/node/handle.rs
+++ b/crates/libp2p-networking/src/network/node/handle.rs
@@ -5,7 +5,9 @@ use async_compatibility_layer::{
     channel::{Receiver, SendError, UnboundedReceiver, UnboundedRecvError, UnboundedSender},
 };
 use futures::channel::oneshot;
-use hotshot_types::traits::network::NetworkError as HotshotNetworkError;
+use hotshot_types::traits::{
+    network::NetworkError as HotshotNetworkError, signature_key::SignatureKey,
+};
 use libp2p::{request_response::ResponseChannel, Multiaddr};
 use libp2p_identity::PeerId;
 use snafu::{ResultExt, Snafu};
@@ -22,9 +24,9 @@ use crate::network::{
 /// - A reference to the state
 /// - Controls for the swarm
 #[derive(Debug, Clone)]
-pub struct NetworkNodeHandle {
+pub struct NetworkNodeHandle<K: SignatureKey + 'static> {
     /// network configuration
-    network_config: NetworkNodeConfig,
+    network_config: NetworkNodeConfig<K>,
 
     /// send an action to the networkbehaviour
     send_network: UnboundedSender<ClientRequest>,
@@ -70,10 +72,10 @@ impl NetworkNodeReceiver {
 /// Spawn a network node task task and return the handle and the receiver for it
 /// # Errors
 /// Errors if spawning the task fails
-pub async fn spawn_network_node(
-    config: NetworkNodeConfig,
+pub async fn spawn_network_node<K: SignatureKey + 'static>(
+    config: NetworkNodeConfig<K>,
     id: usize,
-) -> Result<(NetworkNodeReceiver, NetworkNodeHandle), NetworkNodeHandleError> {
+) -> Result<(NetworkNodeReceiver, NetworkNodeHandle<K>), NetworkNodeHandleError> {
     let mut network = NetworkNode::new(config.clone())
         .await
         .context(NetworkSnafu)?;
@@ -107,7 +109,7 @@ pub async fn spawn_network_node(
     Ok((receiver, handle))
 }
 
-impl NetworkNodeHandle {
+impl<K: SignatureKey + 'static> NetworkNodeHandle<K> {
     /// Cleanly shuts down a swarm node
     /// This is done by sending a message to
     /// the swarm itself to spin down
@@ -487,7 +489,7 @@ impl NetworkNodeHandle {
 
     /// Return a reference to the network config
     #[must_use]
-    pub fn config(&self) -> &NetworkNodeConfig {
+    pub fn config(&self) -> &NetworkNodeConfig<K> {
         &self.network_config
     }
 }

--- a/crates/libp2p-networking/src/network/transport.rs
+++ b/crates/libp2p-networking/src/network/transport.rs
@@ -1,0 +1,541 @@
+use anyhow::Context;
+use anyhow::Result as AnyhowResult;
+use async_compatibility_layer::art::async_timeout;
+use futures::AsyncRead;
+use futures::AsyncWrite;
+use serde::Deserialize;
+use serde::Serialize;
+use std::collections::HashSet;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::Poll;
+use tracing::warn;
+
+use async_std::io::ReadExt;
+use async_std::io::WriteExt;
+use futures::future::poll_fn;
+use hotshot_types::traits::signature_key::SignatureKey;
+use libp2p::core::muxing::StreamMuxerExt;
+use libp2p::core::transport::TransportEvent;
+use libp2p::core::StreamMuxer;
+use libp2p::identity::PeerId;
+use libp2p::Transport;
+use pin_project::pin_project;
+
+/// The maximum size of an authentication message. This is used to prevent
+/// DoS attacks by sending large messages.
+const MAX_AUTH_MESSAGE_SIZE: usize = 1024;
+
+/// The timeout for the authentication handshake. This is used to prevent
+/// attacks that keep connections open indefinitely by half-finishing the
+/// handshake.
+const AUTH_HANDSHAKE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+
+/// A wrapper for a `Transport` that bidirectionally authenticates connections
+/// by performing a handshake that checks if the remote peer is present in the
+/// stake table.
+#[pin_project]
+pub struct StakeTableAuthentication<T: Transport, S: SignatureKey, C: StreamMuxer + Unpin> {
+    #[pin]
+    /// The underlying transport we are wrapping
+    pub inner: T,
+
+    /// The stake table we check against to authenticate connections
+    pub stake_table: Arc<Option<HashSet<S>>>,
+
+    /// A pre-signed message that we send to the remote peer for authentication
+    pub auth_message: Arc<Option<Vec<u8>>>,
+
+    /// Phantom data for the connection type
+    pd: std::marker::PhantomData<C>,
+}
+
+impl<T: Transport, S: SignatureKey, C: StreamMuxer + Unpin> StakeTableAuthentication<T, S, C> {
+    /// Create a new `StakeTableAuthentication` transport that wraps the given transport
+    /// and authenticates connections against the stake table.
+    pub fn new(inner: T, stake_table: Option<HashSet<S>>, auth_message: Option<Vec<u8>>) -> Self {
+        Self {
+            inner,
+            stake_table: Arc::from(stake_table),
+            auth_message: Arc::from(auth_message),
+            pd: std::marker::PhantomData,
+        }
+    }
+
+    /// Prove to the remote peer that we are in the stake table by sending
+    /// them our authentication message.
+    pub async fn authenticate_with_remote_peer(
+        stream: &mut C::Substream,
+        auth_message: Arc<Option<Vec<u8>>>,
+    ) -> AnyhowResult<()>
+    where
+        C::Substream: Unpin,
+    {
+        // If we have an auth message, send it to the remote peer, prefixed with
+        // the message length
+        if let Some(auth_message) = auth_message.as_ref() {
+            // Write the length-delimited message
+            write_length_delimited(stream, auth_message).await?;
+        }
+
+        Ok(())
+    }
+
+    /// Verify that the remote peer is in the stake table by checking their
+    /// authentication message.
+    pub async fn verify_peer_authentication(
+        stream: &mut C::Substream,
+        stake_table: Arc<Option<HashSet<S>>>,
+    ) -> AnyhowResult<()>
+    where
+        C::Substream: Unpin,
+    {
+        // Read the length-delimited message from the remote peer
+        let message = read_length_delimited(stream, MAX_AUTH_MESSAGE_SIZE).await?;
+
+        // If we have a stake table, check if the remote peer is in it
+        if let Some(stake_table) = stake_table.as_ref() {
+            // Deserialize the authentication message
+            let auth_message: AuthMessage<S> = bincode::deserialize(&message)
+                .with_context(|| "Failed to deserialize auth message")?;
+
+            // Verify the signature on the public key
+            let public_key = auth_message
+                .validate()
+                .with_context(|| "Failed to verify authentication message")?;
+
+            // Check if the public key is in the stake table
+            if !stake_table.contains(&public_key) {
+                return Err(anyhow::anyhow!("Peer not in stake table"));
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// The deserialized form of an authentication message that is sent to the remote peer
+#[derive(Clone, Serialize, Deserialize)]
+struct AuthMessage<S: SignatureKey> {
+    pub_key_bytes: Vec<u8>,
+    signature: S::PureAssembledSignatureType,
+}
+
+impl<S: SignatureKey> AuthMessage<S> {
+    /// Validate the signature on the public key and return it if valid
+    pub fn validate(&self) -> AnyhowResult<S> {
+        // Deserialize the public key
+        let public_key = S::from_bytes(&self.pub_key_bytes)
+            .with_context(|| "Failed to deserialize public key")?;
+
+        // Check if the signature is valid
+        if !public_key.validate(&self.signature, &self.pub_key_bytes) {
+            return Err(anyhow::anyhow!("Invalid signature"));
+        }
+
+        Ok(public_key)
+    }
+}
+
+/// Create an sign an authentication message to be sent to the remote peer
+pub fn construct_auth_message<S: SignatureKey + 'static>(
+    public_key: &S,
+    private_key: &S::PrivateKey,
+) -> AnyhowResult<Vec<u8>> {
+    // Serialize the public key
+    let pub_key_bytes = public_key.to_bytes();
+
+    // Sign our public key
+    let signature =
+        S::sign(private_key, &pub_key_bytes).with_context(|| "Failed to sign public key")?;
+
+    // Create the auth message
+    let auth_message = AuthMessage::<S> {
+        pub_key_bytes,
+        signature,
+    };
+
+    // Serialize the auth message
+    Ok(bincode::serialize(&auth_message).with_context(|| "Failed to serialize auth message")?)
+}
+
+/// A helper function to read a length-delimited message from a stream. Takes into
+/// account the maximum message size.
+pub async fn read_length_delimited<S: AsyncRead + Unpin>(
+    stream: &mut S,
+    max_size: usize,
+) -> AnyhowResult<Vec<u8>> {
+    // Receive the first 8 bytes of the message, which is the length
+    let mut len_bytes = [0u8; 8];
+    stream
+        .read_exact(&mut len_bytes)
+        .await
+        .with_context(|| "Failed to read message length")?;
+
+    // Parse the length of the message
+    let len = u64::from_be_bytes(len_bytes) as usize;
+
+    // Quit if the message is too large
+    if len > max_size {
+        return Err(anyhow::anyhow!("Message too large"));
+    }
+
+    // Read the actual message
+    let mut message = vec![0u8; len];
+    stream
+        .read_exact(&mut message)
+        .await
+        .with_context(|| "Failed to read message")?;
+
+    Ok(message)
+}
+
+/// A helper function to write a length-delimited message to a stream.
+pub async fn write_length_delimited<S: AsyncWrite + Unpin>(
+    stream: &mut S,
+    message: &[u8],
+) -> AnyhowResult<()> {
+    // Write the length of the message
+    stream
+        .write_all(&(message.len() as u64).to_be_bytes())
+        .await
+        .with_context(|| "Failed to write message length")?;
+
+    // Write the actual message
+    stream
+        .write_all(message)
+        .await
+        .with_context(|| "Failed to write message")?;
+
+    Ok(())
+}
+
+impl<T: Transport, S: SignatureKey + 'static, C: StreamMuxer + Unpin> Transport
+    for StakeTableAuthentication<T, S, C>
+where
+    T::Dial: Future<Output = Result<T::Output, T::Error>> + Send + 'static,
+    T::ListenerUpgrade: Send + 'static,
+    T::Output: AsConnection<C> + Send,
+    T::Error: From<<C as StreamMuxer>::Error> + From<std::io::Error>,
+
+    C::Substream: Unpin + Send,
+{
+    // `Dial` is for connecting out, `ListenerUpgrade` is for accepting incoming connections
+    type Dial = Pin<Box<dyn Future<Output = Result<T::Output, T::Error>> + Send>>;
+    type ListenerUpgrade = Pin<Box<dyn Future<Output = Result<T::Output, T::Error>> + Send>>;
+
+    // These are just passed through
+    type Output = T::Output;
+    type Error = T::Error;
+
+    /// Dial a remote peer. This function is changed to perform an authentication handshake
+    /// on top.
+    fn dial(
+        &mut self,
+        addr: libp2p::Multiaddr,
+    ) -> Result<Self::Dial, libp2p::TransportError<Self::Error>> {
+        // Perform the inner dial
+        let res = self.inner.dial(addr);
+
+        // Clone the necessary fields
+        let auth_message = self.auth_message.clone();
+        let stake_table = self.stake_table.clone();
+
+        // If the dial was successful, perform the authentication handshake on top
+        match res {
+            Ok(dial) => Ok(Box::pin(async move {
+                // Perform the inner dial
+                let mut stream = dial.await?;
+
+                // Time out the authentication block
+                async_timeout(AUTH_HANDSHAKE_TIMEOUT, async {
+                    // Open a substream for the handshake
+                    let mut substream =
+                        poll_fn(|cx| stream.as_connection().poll_outbound_unpin(cx)).await?;
+
+                    // (outbound) Authenticate with the remote peer
+                    Self::authenticate_with_remote_peer(&mut substream, auth_message)
+                        .await
+                        .map_err(|e| {
+                            warn!("Failed to authenticate with remote peer: {:?}", e);
+                            std::io::Error::new(std::io::ErrorKind::Other, e)
+                        })?;
+
+                    // (inbound) Verify the remote peer's authentication
+                    Self::verify_peer_authentication(&mut substream, stake_table)
+                        .await
+                        .map_err(|e| {
+                            warn!("Failed to verify remote peer: {:?}", e);
+                            std::io::Error::new(std::io::ErrorKind::Other, e)
+                        })?;
+
+                    Ok::<(), T::Error>(())
+                })
+                .await
+                .map_err(|e| {
+                    warn!("Timed out during authentication handshake: {:?}", e);
+                    std::io::Error::new(std::io::ErrorKind::TimedOut, e)
+                })??;
+
+                Ok(stream)
+            })),
+            Err(err) => Err(err),
+        }
+    }
+
+    /// Dial a remote peer as a listener. This function is changed to perform an authentication
+    /// handshake on top. The flow should be the same as the `dial` function.
+    fn dial_as_listener(
+        &mut self,
+        addr: libp2p::Multiaddr,
+    ) -> Result<Self::Dial, libp2p::TransportError<Self::Error>> {
+        // Perform the inner dial
+        let res = self.inner.dial(addr);
+
+        // Clone the necessary fields
+        let auth_message = self.auth_message.clone();
+        let stake_table = self.stake_table.clone();
+
+        // If the dial was successful, perform the authentication handshake on top
+        match res {
+            Ok(dial) => Ok(Box::pin(async move {
+                // Perform the inner dial
+                let mut stream = dial.await?;
+
+                // Time out the authentication block
+                async_timeout(AUTH_HANDSHAKE_TIMEOUT, async {
+                    // Open a substream for the handshake
+                    let mut substream =
+                        poll_fn(|cx| stream.as_connection().poll_outbound_unpin(cx)).await?;
+
+                    // (inbound) Verify the remote peer's authentication
+                    Self::verify_peer_authentication(&mut substream, stake_table)
+                        .await
+                        .map_err(|e| {
+                            warn!("Failed to verify remote peer: {:?}", e);
+                            std::io::Error::new(std::io::ErrorKind::Other, e)
+                        })?;
+
+                    // (outbound) Authenticate with the remote peer
+                    Self::authenticate_with_remote_peer(&mut substream, auth_message)
+                        .await
+                        .map_err(|e| {
+                            warn!("Failed to authenticate with remote peer: {:?}", e);
+                            std::io::Error::new(std::io::ErrorKind::Other, e)
+                        })?;
+
+                    Ok::<(), T::Error>(())
+                })
+                .await
+                .map_err(|e| {
+                    warn!("Timed out performing authentication handshake: {:?}", e);
+                    std::io::Error::new(std::io::ErrorKind::TimedOut, e)
+                })??;
+
+                Ok(stream)
+            })),
+            Err(err) => Err(err),
+        }
+    }
+
+    /// This function is where we perform the authentication handshake for _incoming_ connections.
+    /// The flow in this case is the reverse of the `dial` function: we first verify the remote peer's
+    /// authentication, and then authenticate with them.
+    fn poll(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<libp2p::core::transport::TransportEvent<Self::ListenerUpgrade, Self::Error>>
+    {
+        match self.as_mut().project().inner.poll(cx) {
+            Poll::Ready(event) => Poll::Ready(match event {
+                // If we have an incoming connection, we need to perform the authentication handshake
+                TransportEvent::Incoming {
+                    listener_id,
+                    upgrade,
+                    local_addr,
+                    send_back_addr,
+                } => {
+                    // Clone the necessary fields
+                    let auth_message = self.auth_message.clone();
+                    let stake_table = self.stake_table.clone();
+
+                    // Create a new upgrade that performs the authentication handshake on top
+                    let auth_upgrade = Box::pin(async move {
+                        // Perform the inner upgrade
+                        let mut stream = upgrade.await?;
+
+                        // Time out the authentication block
+                        async_timeout(AUTH_HANDSHAKE_TIMEOUT, async {
+                            // Open a substream for the handshake
+                            let mut substream =
+                                poll_fn(|cx| stream.as_connection().poll_inbound_unpin(cx)).await?;
+
+                            // (inbound) Verify the remote peer's authentication
+                            Self::verify_peer_authentication(&mut substream, stake_table)
+                                .await
+                                .map_err(|e| {
+                                    warn!("Failed to verify remote peer: {:?}", e);
+                                    std::io::Error::new(std::io::ErrorKind::Other, e)
+                                })?;
+
+                            // (outbound) Authenticate with the remote peer
+                            Self::authenticate_with_remote_peer(&mut substream, auth_message)
+                                .await
+                                .map_err(|e| {
+                                    warn!("Failed to authenticate with remote peer: {:?}", e);
+                                    std::io::Error::new(std::io::ErrorKind::Other, e)
+                                })?;
+
+                            Ok::<(), T::Error>(())
+                        })
+                        .await
+                        .map_err(|e| {
+                            warn!("Timed out performing authentication handshake: {:?}", e);
+                            std::io::Error::new(std::io::ErrorKind::TimedOut, e)
+                        })??;
+
+                        Ok(stream)
+                    });
+
+                    // Return the new event
+                    TransportEvent::Incoming {
+                        listener_id,
+                        upgrade: auth_upgrade,
+                        local_addr,
+                        send_back_addr,
+                    }
+                }
+
+                // We need to re-map the other events because we changed the type of the upgrade
+                TransportEvent::AddressExpired {
+                    listener_id,
+                    listen_addr,
+                } => TransportEvent::AddressExpired {
+                    listener_id,
+                    listen_addr,
+                },
+                TransportEvent::ListenerClosed {
+                    listener_id,
+                    reason,
+                } => TransportEvent::ListenerClosed {
+                    listener_id,
+                    reason,
+                },
+                TransportEvent::ListenerError { listener_id, error } => {
+                    TransportEvent::ListenerError { listener_id, error }
+                }
+                TransportEvent::NewAddress {
+                    listener_id,
+                    listen_addr,
+                } => TransportEvent::NewAddress {
+                    listener_id,
+                    listen_addr,
+                },
+            }),
+
+            Poll::Pending => Poll::Pending,
+        }
+    }
+
+    /// The below functions just pass through to the inner transport, but we had
+    /// to define them
+    fn remove_listener(&mut self, id: libp2p::core::transport::ListenerId) -> bool {
+        self.inner.remove_listener(id)
+    }
+    fn address_translation(
+        &self,
+        listen: &libp2p::Multiaddr,
+        observed: &libp2p::Multiaddr,
+    ) -> Option<libp2p::Multiaddr> {
+        self.inner.address_translation(listen, observed)
+    }
+    fn listen_on(
+        &mut self,
+        id: libp2p::core::transport::ListenerId,
+        addr: libp2p::Multiaddr,
+    ) -> Result<(), libp2p::TransportError<Self::Error>> {
+        self.inner.listen_on(id, addr)
+    }
+}
+
+/// A helper trait that allows us to access the underlying connection
+trait AsConnection<C: StreamMuxer + Unpin> {
+    fn as_connection(&mut self) -> &mut C;
+}
+
+/// The implementation of the `AsConnection` trait for a tuple of a `PeerId`
+/// and a connection.
+impl<C: StreamMuxer + Unpin> AsConnection<C> for (PeerId, C) {
+    fn as_connection(&mut self) -> &mut C {
+        &mut self.1
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use hotshot_types::{signature_key::BLSPubKey, traits::signature_key::SignatureKey};
+
+    /// Test valid construction and verification of an authentication message
+    #[test]
+    fn construct_and_verify_auth_message() {
+        // Create a new keypair
+        let keypair = BLSPubKey::generated_from_seed_indexed([1u8; 32], 1337);
+
+        // Construct an authentication message
+        let auth_message = super::construct_auth_message(&keypair.0, &keypair.1).unwrap();
+
+        // Verify the authentication message
+        let public_key = super::AuthMessage::<BLSPubKey>::validate(
+            &bincode::deserialize(&auth_message).unwrap(),
+        );
+        assert!(public_key.is_ok());
+    }
+
+    /// Test invalid construction and verification of an authentication message
+    #[test]
+    fn construct_and_verify_invalid_auth_message() {
+        // Create a new keypair
+        let keypair = BLSPubKey::generated_from_seed_indexed([1u8; 32], 1337);
+
+        // Construct an authentication message
+        let auth_message = super::construct_auth_message(&keypair.0, &keypair.1).unwrap();
+
+        // Change the public key in the message
+        let mut auth_message: super::AuthMessage<BLSPubKey> =
+            bincode::deserialize(&auth_message).unwrap();
+
+        // Change the public key
+        auth_message.pub_key_bytes[0] ^= 0x01;
+
+        // Serialize the message again
+        let auth_message = bincode::serialize(&auth_message).unwrap();
+
+        // Verify the authentication message
+        let public_key = super::AuthMessage::<BLSPubKey>::validate(
+            &bincode::deserialize(&auth_message).unwrap(),
+        );
+        assert!(public_key.is_err());
+    }
+
+    #[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
+    #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
+    async fn read_and_write_length_delimited() {
+        // Create a message
+        let message = b"Hello, world!";
+
+        // Write the message to a buffer
+        let mut buffer = Vec::new();
+        super::write_length_delimited(&mut buffer, message)
+            .await
+            .unwrap();
+
+        // Read the message from the buffer
+        let read_message = super::read_length_delimited(&mut buffer.as_slice(), 1024)
+            .await
+            .unwrap();
+
+        // Check if the messages are the same
+        assert_eq!(message, read_message.as_slice());
+    }
+}

--- a/crates/libp2p-networking/tests/common/mod.rs
+++ b/crates/libp2p-networking/tests/common/mod.rs
@@ -14,6 +14,7 @@ use async_compatibility_layer::{
     logging::{setup_backtrace, setup_logging},
 };
 use futures::{future::join_all, Future, FutureExt};
+use hotshot_types::traits::signature_key::SignatureKey;
 use libp2p::{identity::Keypair, Multiaddr};
 use libp2p_identity::PeerId;
 use libp2p_networking::network::{
@@ -25,8 +26,8 @@ use snafu::{ResultExt, Snafu};
 use tracing::{info, instrument, warn};
 
 #[derive(Clone, Debug)]
-pub(crate) struct HandleWithState<S: Debug + Default + Send> {
-    pub(crate) handle: Arc<NetworkNodeHandle>,
+pub(crate) struct HandleWithState<S: Debug + Default + Send, K: SignatureKey + 'static> {
+    pub(crate) handle: Arc<NetworkNodeHandle<K>>,
     pub(crate) state: Arc<SubscribableMutex<S>>,
 }
 
@@ -35,13 +36,13 @@ pub(crate) struct HandleWithState<S: Debug + Default + Send> {
 /// # Panics
 ///
 /// Will panic if a handler is already spawned
-pub fn spawn_handler<F, RET, S>(
-    handle_and_state: HandleWithState<S>,
+pub fn spawn_handler<F, RET, S, K: SignatureKey + 'static>(
+    handle_and_state: HandleWithState<S, K>,
     mut receiver: NetworkNodeReceiver,
     cb: F,
 ) -> impl Future
 where
-    F: Fn(NetworkEvent, HandleWithState<S>) -> RET + Sync + Send + 'static,
+    F: Fn(NetworkEvent, HandleWithState<S, K>) -> RET + Sync + Send + 'static,
     RET: Future<Output = Result<(), NetworkNodeHandleError>> + Send + 'static,
     S: Debug + Default + Send + Clone + 'static,
 {
@@ -91,7 +92,14 @@ where
 /// - Initialize network nodes
 /// - Kill network nodes
 /// - A test assertion fails
-pub async fn test_bed<S: 'static + Send + Default + Debug + Clone, F, FutF, G, FutG>(
+pub async fn test_bed<
+    S: 'static + Send + Default + Debug + Clone,
+    F,
+    FutF,
+    G,
+    FutG,
+    K: SignatureKey + 'static,
+>(
     run_test: F,
     client_handler: G,
     num_nodes: usize,
@@ -100,8 +108,8 @@ pub async fn test_bed<S: 'static + Send + Default + Debug + Clone, F, FutF, G, F
 ) where
     FutF: Future<Output = ()>,
     FutG: Future<Output = Result<(), NetworkNodeHandleError>> + 'static + Send + Sync,
-    F: FnOnce(Vec<HandleWithState<S>>, Duration) -> FutF,
-    G: Fn(NetworkEvent, HandleWithState<S>) -> FutG + 'static + Send + Sync + Clone,
+    F: FnOnce(Vec<HandleWithState<S, K>>, Duration) -> FutF,
+    G: Fn(NetworkEvent, HandleWithState<S, K>) -> FutG + 'static + Send + Sync + Clone,
 {
     setup_logging();
     setup_backtrace();
@@ -109,7 +117,7 @@ pub async fn test_bed<S: 'static + Send + Default + Debug + Clone, F, FutF, G, F
     let mut kill_switches = Vec::new();
     // NOTE we want this to panic if we can't spin up the swarms.
     // that amounts to a failed test.
-    let handles_and_receivers = spin_up_swarms::<S>(num_nodes, timeout, num_of_bootstrap)
+    let handles_and_receivers = spin_up_swarms::<S, K>(num_nodes, timeout, num_of_bootstrap)
         .await
         .unwrap();
 
@@ -139,7 +147,9 @@ pub async fn test_bed<S: 'static + Send + Default + Debug + Clone, F, FutF, G, F
     }
 }
 
-fn gen_peerid_map(handles: &[Arc<NetworkNodeHandle>]) -> HashMap<PeerId, usize> {
+fn gen_peerid_map<K: SignatureKey + 'static>(
+    handles: &[Arc<NetworkNodeHandle<K>>],
+) -> HashMap<PeerId, usize> {
     let mut r_val = HashMap::new();
     for handle in handles {
         r_val.insert(handle.peer_id(), handle.id());
@@ -149,7 +159,7 @@ fn gen_peerid_map(handles: &[Arc<NetworkNodeHandle>]) -> HashMap<PeerId, usize> 
 
 /// print the connections for each handle in `handles`
 /// useful for debugging
-pub async fn print_connections(handles: &[Arc<NetworkNodeHandle>]) {
+pub async fn print_connections<K: SignatureKey + 'static>(handles: &[Arc<NetworkNodeHandle<K>>]) {
     let m = gen_peerid_map(handles);
     warn!("PRINTING CONNECTION STATES");
     for handle in handles {
@@ -171,11 +181,11 @@ pub async fn print_connections(handles: &[Arc<NetworkNodeHandle>]) {
 /// and waits for connections to propagate to all nodes.
 #[allow(clippy::type_complexity)]
 #[instrument]
-pub async fn spin_up_swarms<S: Debug + Default + Send>(
+pub async fn spin_up_swarms<S: Debug + Default + Send, K: SignatureKey + 'static>(
     num_of_nodes: usize,
     timeout_len: Duration,
     num_bootstrap: usize,
-) -> Result<Vec<(HandleWithState<S>, NetworkNodeReceiver)>, TestError<S>> {
+) -> Result<Vec<(HandleWithState<S, K>, NetworkNodeReceiver)>, TestError<S>> {
     let mut handles = Vec::new();
     let mut bootstrap_addrs = Vec::<(PeerId, Multiaddr)>::new();
     let mut connecting_futs = Vec::new();

--- a/crates/libp2p-networking/tests/counter.rs
+++ b/crates/libp2p-networking/tests/counter.rs
@@ -8,6 +8,7 @@ use async_lock::RwLock;
 #[cfg(async_executor_impl = "async-std")]
 use async_std::prelude::StreamExt;
 use common::{test_bed, HandleSnafu, HandleWithState, TestError};
+use hotshot_types::{signature_key::BLSPubKey, traits::signature_key::SignatureKey};
 use libp2p_networking::network::{NetworkEvent, NetworkNodeHandleError};
 use rand::seq::IteratorRandom;
 use serde::{Deserialize, Serialize};
@@ -53,10 +54,10 @@ pub enum CounterMessage {
 /// chooses one
 /// # Panics
 /// panics if handles is of length 0
-fn random_handle<S: Debug + Default + Send + Clone>(
-    handles: &[HandleWithState<S>],
+fn random_handle<S: Debug + Default + Send + Clone, K: SignatureKey + 'static>(
+    handles: &[HandleWithState<S, K>],
     rng: &mut dyn rand::RngCore,
-) -> HandleWithState<S> {
+) -> HandleWithState<S, K> {
     handles.iter().choose(rng).unwrap().clone()
 }
 
@@ -64,9 +65,9 @@ fn random_handle<S: Debug + Default + Send + Clone>(
 /// - updates state based on events received
 /// - replies to direct messages
 #[instrument]
-pub async fn counter_handle_network_event(
+pub async fn counter_handle_network_event<K: SignatureKey + 'static>(
     event: NetworkEvent,
-    handle: HandleWithState<CounterState>,
+    handle: HandleWithState<CounterState, K>,
 ) -> Result<(), NetworkNodeHandleError> {
     use CounterMessage::*;
     use NetworkEvent::*;
@@ -158,9 +159,9 @@ pub async fn counter_handle_network_event(
 /// # Panics
 /// on error
 #[allow(clippy::similar_names)]
-async fn run_request_response_increment<'a>(
-    requester_handle: HandleWithState<CounterState>,
-    requestee_handle: HandleWithState<CounterState>,
+async fn run_request_response_increment<'a, K: SignatureKey + 'static>(
+    requester_handle: HandleWithState<CounterState, K>,
+    requestee_handle: HandleWithState<CounterState, K>,
     timeout: Duration,
 ) -> Result<(), TestError<CounterState>> {
     async move {
@@ -210,8 +211,8 @@ async fn run_request_response_increment<'a>(
 
 /// broadcasts `msg` from a randomly chosen handle
 /// then asserts that all nodes match `new_state`
-async fn run_gossip_round(
-    handles: &[HandleWithState<CounterState>],
+async fn run_gossip_round<K: SignatureKey + 'static>(
+    handles: &[HandleWithState<CounterState, K>],
     msg: CounterMessage,
     new_state: CounterState,
     timeout_duration: Duration,
@@ -285,8 +286,8 @@ async fn run_gossip_round(
     Ok(())
 }
 
-async fn run_intersperse_many_rounds(
-    handles: Vec<HandleWithState<CounterState>>,
+async fn run_intersperse_many_rounds<K: SignatureKey + 'static>(
+    handles: Vec<HandleWithState<CounterState, K>>,
     timeout: Duration,
 ) {
     for i in 0..u32::try_from(NUM_ROUNDS).unwrap() {
@@ -301,16 +302,22 @@ async fn run_intersperse_many_rounds(
     }
 }
 
-async fn run_dht_many_rounds(handles: Vec<HandleWithState<CounterState>>, timeout: Duration) {
+async fn run_dht_many_rounds<K: SignatureKey + 'static>(
+    handles: Vec<HandleWithState<CounterState, K>>,
+    timeout: Duration,
+) {
     run_dht_rounds(&handles, timeout, 0, NUM_ROUNDS).await;
 }
 
-async fn run_dht_one_round(handles: Vec<HandleWithState<CounterState>>, timeout: Duration) {
+async fn run_dht_one_round<K: SignatureKey + 'static>(
+    handles: Vec<HandleWithState<CounterState, K>>,
+    timeout: Duration,
+) {
     run_dht_rounds(&handles, timeout, 0, 1).await;
 }
 
-async fn run_request_response_many_rounds(
-    handles: Vec<HandleWithState<CounterState>>,
+async fn run_request_response_many_rounds<K: SignatureKey + 'static>(
+    handles: Vec<HandleWithState<CounterState, K>>,
     timeout: Duration,
 ) {
     for _i in 0..NUM_ROUNDS {
@@ -324,8 +331,8 @@ async fn run_request_response_many_rounds(
 /// runs one round of request response
 /// # Panics
 /// on error
-async fn run_request_response_one_round(
-    handles: Vec<HandleWithState<CounterState>>,
+async fn run_request_response_one_round<K: SignatureKey + 'static>(
+    handles: Vec<HandleWithState<CounterState, K>>,
     timeout: Duration,
 ) {
     run_request_response_increment_all(&handles, timeout).await;
@@ -337,22 +344,28 @@ async fn run_request_response_one_round(
 /// runs multiple rounds of gossip
 /// # Panics
 /// on error
-async fn run_gossip_many_rounds(handles: Vec<HandleWithState<CounterState>>, timeout: Duration) {
+async fn run_gossip_many_rounds<K: SignatureKey + 'static>(
+    handles: Vec<HandleWithState<CounterState, K>>,
+    timeout: Duration,
+) {
     run_gossip_rounds(&handles, NUM_ROUNDS, 0, timeout).await;
 }
 
 /// runs one round of gossip
 /// # Panics
 /// on error
-async fn run_gossip_one_round(handles: Vec<HandleWithState<CounterState>>, timeout: Duration) {
+async fn run_gossip_one_round<K: SignatureKey + 'static>(
+    handles: Vec<HandleWithState<CounterState, K>>,
+    timeout: Duration,
+) {
     run_gossip_rounds(&handles, 1, 0, timeout).await;
 }
 
 /// runs many rounds of dht
 /// # Panics
 /// on error
-async fn run_dht_rounds(
-    handles: &[HandleWithState<CounterState>],
+async fn run_dht_rounds<K: SignatureKey + 'static>(
+    handles: &[HandleWithState<CounterState, K>],
     timeout: Duration,
     starting_val: usize,
     num_rounds: usize,
@@ -388,8 +401,8 @@ async fn run_dht_rounds(
 }
 
 /// runs `num_rounds` of message broadcast, incrementing the state of all nodes each broadcast
-async fn run_gossip_rounds(
-    handles: &[HandleWithState<CounterState>],
+async fn run_gossip_rounds<K: SignatureKey + 'static>(
+    handles: &[HandleWithState<CounterState, K>],
     num_rounds: usize,
     starting_state: CounterState,
     timeout: Duration,
@@ -414,8 +427,8 @@ async fn run_gossip_rounds(
 /// then has all other peers request its state
 /// and update their state to the recv'ed state
 #[allow(clippy::similar_names)]
-async fn run_request_response_increment_all(
-    handles: &[HandleWithState<CounterState>],
+async fn run_request_response_increment_all<K: SignatureKey + 'static>(
+    handles: &[HandleWithState<CounterState, K>],
     timeout: Duration,
 ) {
     let mut rng = rand::thread_rng();
@@ -490,7 +503,7 @@ async fn run_request_response_increment_all(
 #[instrument]
 async fn test_coverage_request_response_one_round() {
     Box::pin(test_bed(
-        run_request_response_one_round,
+        run_request_response_one_round::<BLSPubKey>,
         counter_handle_network_event,
         TOTAL_NUM_PEERS_COVERAGE,
         NUM_OF_BOOTSTRAP_COVERAGE,
@@ -505,7 +518,7 @@ async fn test_coverage_request_response_one_round() {
 #[instrument]
 async fn test_coverage_request_response_many_rounds() {
     Box::pin(test_bed(
-        run_request_response_many_rounds,
+        run_request_response_many_rounds::<BLSPubKey>,
         counter_handle_network_event,
         TOTAL_NUM_PEERS_COVERAGE,
         NUM_OF_BOOTSTRAP_COVERAGE,
@@ -520,7 +533,7 @@ async fn test_coverage_request_response_many_rounds() {
 #[instrument]
 async fn test_coverage_intersperse_many_rounds() {
     Box::pin(test_bed(
-        run_intersperse_many_rounds,
+        run_intersperse_many_rounds::<BLSPubKey>,
         counter_handle_network_event,
         TOTAL_NUM_PEERS_COVERAGE,
         NUM_OF_BOOTSTRAP_COVERAGE,
@@ -535,7 +548,7 @@ async fn test_coverage_intersperse_many_rounds() {
 #[instrument]
 async fn test_coverage_gossip_many_rounds() {
     Box::pin(test_bed(
-        run_gossip_many_rounds,
+        run_gossip_many_rounds::<BLSPubKey>,
         counter_handle_network_event,
         TOTAL_NUM_PEERS_COVERAGE,
         NUM_OF_BOOTSTRAP_COVERAGE,
@@ -550,7 +563,7 @@ async fn test_coverage_gossip_many_rounds() {
 #[instrument]
 async fn test_coverage_gossip_one_round() {
     Box::pin(test_bed(
-        run_gossip_one_round,
+        run_gossip_one_round::<BLSPubKey>,
         counter_handle_network_event,
         TOTAL_NUM_PEERS_COVERAGE,
         NUM_OF_BOOTSTRAP_COVERAGE,
@@ -566,7 +579,7 @@ async fn test_coverage_gossip_one_round() {
 #[ignore]
 async fn test_stress_request_response_one_round() {
     Box::pin(test_bed(
-        run_request_response_one_round,
+        run_request_response_one_round::<BLSPubKey>,
         counter_handle_network_event,
         TOTAL_NUM_PEERS_STRESS,
         NUM_OF_BOOTSTRAP_STRESS,
@@ -582,7 +595,7 @@ async fn test_stress_request_response_one_round() {
 #[ignore]
 async fn test_stress_request_response_many_rounds() {
     Box::pin(test_bed(
-        run_request_response_many_rounds,
+        run_request_response_many_rounds::<BLSPubKey>,
         counter_handle_network_event,
         TOTAL_NUM_PEERS_STRESS,
         NUM_OF_BOOTSTRAP_STRESS,
@@ -598,7 +611,7 @@ async fn test_stress_request_response_many_rounds() {
 #[ignore]
 async fn test_stress_intersperse_many_rounds() {
     Box::pin(test_bed(
-        run_intersperse_many_rounds,
+        run_intersperse_many_rounds::<BLSPubKey>,
         counter_handle_network_event,
         TOTAL_NUM_PEERS_STRESS,
         NUM_OF_BOOTSTRAP_STRESS,
@@ -614,7 +627,7 @@ async fn test_stress_intersperse_many_rounds() {
 #[ignore]
 async fn test_stress_gossip_many_rounds() {
     Box::pin(test_bed(
-        run_gossip_many_rounds,
+        run_gossip_many_rounds::<BLSPubKey>,
         counter_handle_network_event,
         TOTAL_NUM_PEERS_STRESS,
         NUM_OF_BOOTSTRAP_STRESS,
@@ -630,7 +643,7 @@ async fn test_stress_gossip_many_rounds() {
 #[ignore]
 async fn test_stress_gossip_one_round() {
     Box::pin(test_bed(
-        run_gossip_one_round,
+        run_gossip_one_round::<BLSPubKey>,
         counter_handle_network_event,
         TOTAL_NUM_PEERS_STRESS,
         NUM_OF_BOOTSTRAP_STRESS,
@@ -646,7 +659,7 @@ async fn test_stress_gossip_one_round() {
 #[ignore]
 async fn test_stress_dht_one_round() {
     Box::pin(test_bed(
-        run_dht_one_round,
+        run_dht_one_round::<BLSPubKey>,
         counter_handle_network_event,
         TOTAL_NUM_PEERS_STRESS,
         NUM_OF_BOOTSTRAP_STRESS,
@@ -662,7 +675,7 @@ async fn test_stress_dht_one_round() {
 #[ignore]
 async fn test_stress_dht_many_rounds() {
     Box::pin(test_bed(
-        run_dht_many_rounds,
+        run_dht_many_rounds::<BLSPubKey>,
         counter_handle_network_event,
         TOTAL_NUM_PEERS_STRESS,
         NUM_OF_BOOTSTRAP_STRESS,
@@ -677,7 +690,7 @@ async fn test_stress_dht_many_rounds() {
 #[instrument]
 async fn test_coverage_dht_one_round() {
     Box::pin(test_bed(
-        run_dht_one_round,
+        run_dht_one_round::<BLSPubKey>,
         counter_handle_network_event,
         TOTAL_NUM_PEERS_COVERAGE,
         NUM_OF_BOOTSTRAP_COVERAGE,
@@ -692,7 +705,7 @@ async fn test_coverage_dht_one_round() {
 #[instrument]
 async fn test_coverage_dht_many_rounds() {
     Box::pin(test_bed(
-        run_dht_many_rounds,
+        run_dht_many_rounds::<BLSPubKey>,
         counter_handle_network_event,
         TOTAL_NUM_PEERS_COVERAGE,
         NUM_OF_BOOTSTRAP_COVERAGE,


### PR DESCRIPTION
Closes #3490 

### This PR: 
<!-- Describe what this PR adds to HotSHot -->
<!-- E.g. -->
<!-- * Implements feature 1 -->
<!-- * Implements feature 2 -->
<!-- * Fixes bug 3 -->

Implements authentication against the stake table for Libp2p connections. It does this by introducing a mutual, bidirectional authentication handshake when a new connection is established.

Here's how it works:
- On a new connection, we require the peer to send a signed message of their public key.
- This message is first checked for a proper signature, and then the public key is checked against the stake table.
- The handshake flow depends on whether or not you were the connection initiator. This allows both the connecting peer and the accepting peer to "agree" on the proper flow, but both will authenticate with each other.

The authentication message is pre-signed to minimize scope of the private key in networking segments of the code. TLS should prevent replay attacks on the network-level, and see below for application-level mitigations.

It also:
- Has sane timeouts and max message size defaults to prevent DoS attacks at this level
- Includes some tests
- Breaks interoperability with older versions of HS. We may end up doing an upgrade path where it only begins checking after a certain view, but I haven't decided

### This PR does not: 
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->

- Implement DHT authentication

### Key places to review: 
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->

`transport.rs` - almost all of the logic is here

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

Since the examples use `from_config`, you can test in the examples. Try signing the wrong thing and see what happens.

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->

Currently in draft while I finish up working on a way to mitigate replay attacks if you have a _decrypted_ copy of the message (e.g. you tricked a node to try to authenticate with you and re-use the message). It will either be including the remote IP as part of the signature or a timestamp.