### PR TITLE
Fix The Justfile Lints

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -56,5 +56,12 @@ jobs:
       - name: Install Rust
         uses: mkroening/rust-toolchain-toml@main
 
+      - name: Install Just
+        run: |
+          wget https://github.com/casey/just/releases/download/1.14.0/just-1.14.0-x86_64-unknown-linux-musl.tar.gz
+          tar -vxf just-1.14.0-x86_64-unknown-linux-musl.tar.gz just
+          sudo cp just /usr/bin/just
+
       - name: Check rustfmt
-        run: cargo fmt --check
+        run: |
+          just ${{ matrix.just_variants }} fmt_check

--- a/crates/testing/tests/tests_1/quorum_vote_task.rs
+++ b/crates/testing/tests/tests_1/quorum_vote_task.rs
@@ -276,4 +276,3 @@ async fn test_quorum_vote_task_incorrect_dependency() {
     };
     run_test![inputs, script].await;
 }
-

--- a/crates/testing/tests/tests_1/test_with_failures_2.rs
+++ b/crates/testing/tests/tests_1/test_with_failures_2.rs
@@ -13,8 +13,8 @@ use hotshot_testing::{
 };
 use hotshot_types::data::ViewNumber;
 use hotshot_types::traits::node_implementation::ConsensusTime;
-use std::{collections::HashMap, time::Duration};
 use std::collections::HashSet;
+use std::{collections::HashMap, time::Duration};
 
 #[cfg(async_executor_impl = "async-std")]
 use {hotshot::tasks::DishonestLeader, hotshot_testing::test_builder::Behaviour, std::rc::Rc};

--- a/crates/testing/tests/tests_2/catchup.rs
+++ b/crates/testing/tests/tests_2/catchup.rs
@@ -312,9 +312,10 @@ async fn test_all_restart() {
     let mut catchup_nodes = vec![];
     for i in 1..20 {
         catchup_nodes.push(ChangeNode {
-        idx: i,
-        updown: UpDown::Restart,
-    })};
+            idx: i,
+            updown: UpDown::Restart,
+        })
+    }
 
     metadata.timing_data = timing_data;
     metadata.start_nodes = 20;

--- a/justfile
+++ b/justfile
@@ -188,26 +188,26 @@ clippy:
 
 lint:
   echo linting
-  cargo fmt --check
+  rustfmt crates/**/*.rs --check
   cargo clippy --workspace --examples --bins --tests -- -D warnings
 
 lint_release:
   echo linting
-  cargo fmt --check
+  rustfmt crates/**/*.rs --check
   cargo clippy --package hotshot --no-default-features --features="docs, doc-images" -- -D warnings
 
 fmt:
-  echo Running cargo fmt
-  cargo fmt
+  echo Running rustfmt crates/**/*.rs
+  rustfmt crates/**/*.rs
 
 fmt_lint:
   echo Formatting and linting
-  cargo fmt
+  rustfmt crates/**/*.rs
   cargo clippy --workspace --examples --bins --tests -- -D warnings
 
 fmt_lint_dependency_tasks:
   echo Formatting and linting
-  cargo fmt
+  rustfmt crates/**/*.rs
   cargo clippy --workspace --examples --bins --tests --features "dependency-tasks" -- -D warnings
 
 careful:
@@ -236,7 +236,7 @@ doc_test:
 
 lint_imports:
   echo Linting imports
-  cargo fmt --all -- --config unstable_features=true,imports_granularity=Crate
+  rustfmt crates/**/*.rs --config unstable_features=true,imports_granularity=Crate
 
 gen_key_pair:
   echo Generating key pair from config file in config/

--- a/justfile
+++ b/justfile
@@ -186,29 +186,31 @@ clippy:
   echo clippy
   cargo clippy --workspace --examples --bins --tests -- -D warnings
 
-lint:
-  echo linting
-  rustfmt crates/**/*.rs --check
-  cargo clippy --workspace --examples --bins --tests -- -D warnings
+clippy_dependency_tasks:
+  echo clippy release
+  cargo clippy --workspace --examples --bins --tests --features "dependency-tasks" -- -D warnings
 
-lint_release:
-  echo linting
-  rustfmt crates/**/*.rs --check
+clippy_release:
+  echo clippy release
   cargo clippy --package hotshot --no-default-features --features="docs, doc-images" -- -D warnings
 
 fmt:
-  echo Running rustfmt crates/**/*.rs
-  rustfmt crates/**/*.rs
+  echo Running cargo fmt
+  cargo fmt -- crates/**/*.rs
+  cargo fmt -- crates/**/tests/**/**.rs
 
-fmt_lint:
-  echo Formatting and linting
-  rustfmt crates/**/*.rs
-  cargo clippy --workspace --examples --bins --tests -- -D warnings
+fmt_check:
+  echo Running cargo fmt --check
+  cargo fmt --check -- crates/**/*.rs
+  cargo fmt --check -- crates/**/tests/**/**.rs
 
-fmt_lint_dependency_tasks:
-  echo Formatting and linting
-  rustfmt crates/**/*.rs
-  cargo clippy --workspace --examples --bins --tests --features "dependency-tasks" -- -D warnings
+lint: clippy fmt_check
+
+lint_release: clippy_release fmt_check
+
+fmt_clippy: fmt clippy
+
+fmt_clippy_dependency_tasks: fmt clippy_dependency_tasks
 
 careful:
   echo Careful-ing with tokio executor
@@ -236,7 +238,7 @@ doc_test:
 
 lint_imports:
   echo Linting imports
-  rustfmt crates/**/*.rs --config unstable_features=true,imports_granularity=Crate
+  cargo fmt --all -- --config unstable_features=true,imports_granularity=Crate
 
 gen_key_pair:
   echo Generating key pair from config file in config/


### PR DESCRIPTION
Closes #<ISSUE_NUMBER>
<!-- See here for keywords in Github -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

### This PR: 
Makes linting more consistent and applies it to all files. Removes some of the redundancy and inconsistent naming in the justfile. Specifically pertaining the the delineation of `linting` and `clippy` commands. Right now if you ran `fmt_lint` it ran `fmt` then `clippy`, but the individual `lint` command has distinct behavior, so the disambiguation that this PR adds makes it slightly more clear.

Also, the CI for `lint.yml` was not using the just command and instead was running a raw `cargo` command, so any changes to the justfile, and subsequent lints, would not be captured.

### This PR does not: 
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->

### Key places to review: 
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
