### PR TITLE
Use AuctionResults::default when building empty blocks for marketplace

### DIFF
--- a/crates/task-impls/src/transactions.rs
+++ b/crates/task-impls/src/transactions.rs
@@ -373,7 +373,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> TransactionTaskState<TYPES, 
                 block_view,
                 vec1::vec1![null_fee],
                 Some(precompute_data),
-                None,
+                Some(TYPES::AuctionResult::default()),
             ))),
             event_stream,
         )


### PR DESCRIPTION
Closes #0000


### This PR: 
Sequencer expects to always receive `AuctionResults` when constructing block header for marketplace.

### This PR does not: 
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->

### Key places to review: 
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
