### PR TITLE
[AUDIT][MEDIUM][QVM-1] Fix `VoteDependencyData` To Include Proper State

### DIFF
--- a/crates/task-impls/src/quorum_proposal_recv/mod.rs
+++ b/crates/task-impls/src/quorum_proposal_recv/mod.rs
@@ -161,14 +161,15 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> QuorumProposalRecvTaskState<
                         );
                         return;
                     };
+
+                    let leaf = Leaf::from_quorum_proposal(&proposal.data);
+
                     broadcast_event(
                         Arc::new(HotShotEvent::VoteNow(
                             view_number,
                             VoteDependencyData {
-                                quorum_proposal: proposal.data.clone(),
-                                parent_leaf,
+                                leaf,
                                 vid_share: vid_share.clone(),
-                                da_cert: da_cert.clone(),
                             },
                         )),
                         &event_stream,

--- a/crates/task-impls/src/quorum_vote/mod.rs
+++ b/crates/task-impls/src/quorum_vote/mod.rs
@@ -307,7 +307,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static> HandleDepOutput
                     }
                 }
                 HotShotEvent::VoteNow(_, vote_dependency_data) => {
-                    leaf = Some(vote_dependency_data.parent_leaf.clone());
+                    leaf = Some(vote_dependency_data.leaf.clone());
                     vid_share = Some(vote_dependency_data.vid_share.clone());
                 }
                 _ => {}

--- a/crates/testing/tests/tests_1/quorum_vote_task.rs
+++ b/crates/testing/tests/tests_1/quorum_vote_task.rs
@@ -114,10 +114,8 @@ async fn test_quorum_vote_task_vote_now() {
     let view = generator.current_view.clone().unwrap();
 
     let vote_dependency_data = VoteDependencyData {
-        quorum_proposal: view.quorum_proposal.data.clone(),
-        parent_leaf: view.leaf.clone(),
+        leaf: view.leaf.clone(),
         vid_share: view.vid_proposal.0[0].clone(),
-        da_cert: view.da_certificate.clone(),
     };
 
     // Submit an event with just the `VoteNow` event which should successfully send a vote.

--- a/crates/testing/tests/tests_1/vote_dependency_handle.rs
+++ b/crates/testing/tests/tests_1/vote_dependency_handle.rs
@@ -7,18 +7,13 @@ use async_compatibility_layer::art::async_timeout;
 use futures::StreamExt;
 use hotshot::tasks::task_state::CreateTaskState;
 use hotshot_example_types::node_types::{MemoryImpl, TestTypes};
-use hotshot_macros::{run_test, test_scripts};
 use hotshot_task_impls::{
     events::HotShotEvent::*,
     quorum_vote::{QuorumVoteTaskState, VoteDependencyHandle},
 };
 use hotshot_testing::{
-    all_predicates,
-    helpers::{build_fake_view_with_leaf, build_system_handle, vid_share},
+    helpers::{build_fake_view_with_leaf, build_system_handle},
     predicates::{event::*, Predicate, PredicateResult},
-    random,
-    script::{Expectations, InputOrder, TaskScript},
-    serial,
     view_generator::TestViewGenerator,
 };
 use hotshot_types::{
@@ -99,6 +94,7 @@ async fn test_vote_dependency_handle() {
         let mut event_receiver = handle.internal_event_stream_receiver_known_impl();
         let view_number = ViewNumber::new(node_id);
 
+        #[allow(unused)]
         let vote_dependency_handle_state = VoteDependencyHandle::<TestTypes, MemoryImpl> {
             public_key: qv.public_key.clone(),
             private_key: qv.private_key.clone(),

--- a/crates/types/src/vote.rs
+++ b/crates/types/src/vote.rs
@@ -187,7 +187,7 @@ type VoteMap2<COMMITMENT, PK, SIG> = HashMap<COMMITMENT, (U256, BTreeMap<PK, (SI
 /// obtained via a `QuorumProposalValidated` event being processed.
 #[derive(Eq, Hash, PartialEq, Debug, Clone)]
 pub struct VoteDependencyData<TYPES: NodeType> {
-    /// The quorum proposal (not necessarily valid).
+    /// The leaf of the quorum proposal that we're voting on.
     pub leaf: Leaf<TYPES>,
 
     /// The VID share proposal.

--- a/crates/types/src/vote.rs
+++ b/crates/types/src/vote.rs
@@ -12,9 +12,9 @@ use ethereum_types::U256;
 use tracing::error;
 
 use crate::{
-    data::{Leaf, QuorumProposal, VidDisperseShare},
+    data::{Leaf, VidDisperseShare},
     message::Proposal,
-    simple_certificate::{DaCertificate, Threshold},
+    simple_certificate::Threshold,
     simple_vote::Voteable,
     traits::{
         election::Membership,
@@ -188,15 +188,8 @@ type VoteMap2<COMMITMENT, PK, SIG> = HashMap<COMMITMENT, (U256, BTreeMap<PK, (SI
 #[derive(Eq, Hash, PartialEq, Debug, Clone)]
 pub struct VoteDependencyData<TYPES: NodeType> {
     /// The quorum proposal (not necessarily valid).
-    pub quorum_proposal: QuorumProposal<TYPES>,
-
-    /// The leaf we've obtained from the `QuorumProposalValidated` event. This is the
-    /// parent leaf.
-    pub parent_leaf: Leaf<TYPES>,
+    pub leaf: Leaf<TYPES>,
 
     /// The VID share proposal.
     pub vid_share: Proposal<TYPES, VidDisperseShare<TYPES>>,
-
-    /// The DA certificate.
-    pub da_cert: DaCertificate<TYPES>,
 }


### PR DESCRIPTION
Closes #<ISSUE_NUMBER>
<!-- See here for keywords in Github -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

### This PR: 
The `VoteNow` task uses the wrong data in `VoteDependencyData` which uses the parent leaf instead of the proposal leaf, leading to a break in the chain in the vote for the received quorum proposal. 

This PR fixes that by using the proposal to make the leaf, instead of the parent leaf. This also fixes a couple linter errors in the linting on the dependency tasks branch.

### This PR does not: 
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->

### Key places to review: 
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
