### PR TITLE
Re-Enable `test_with_failures_2` For The Dependency Tasks

### DIFF
--- a/crates/testing/tests/tests_1/test_with_failures_2.rs
+++ b/crates/testing/tests/tests_1/test_with_failures_2.rs
@@ -19,8 +19,8 @@ use std::{collections::HashMap, time::Duration};
 
 #[cfg(async_executor_impl = "async-std")]
 use {hotshot::tasks::DishonestLeader, hotshot_testing::test_builder::Behaviour, std::rc::Rc};
+
 // Test that a good leader can succeed in the view directly after view sync
-#[cfg(not(feature = "dependency-tasks"))]
 cross_tests!(
     TestName: test_with_failures_2,
     Impls: [MemoryImpl, Libp2pImpl, PushCdnImpl],
@@ -103,7 +103,6 @@ cross_tests!(
     },
 );
 
-#[cfg(not(feature = "dependency-tasks"))]
 cross_tests!(
     TestName: test_with_double_leader_failures,
     Impls: [MemoryImpl, Libp2pImpl, PushCdnImpl],


### PR DESCRIPTION
Closes #<ISSUE_NUMBER>
<!-- See here for keywords in Github -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

### This PR: 
<!-- Describe what this PR adds to HotSHot -->
<!-- E.g. -->
<!-- * Implements feature 1 -->
<!-- * Implements feature 2 -->
<!-- * Fixes bug 3 -->

### This PR does not: 
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->

### Key places to review: 
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
