### PR TITLE
Consecutive Leader Proposal Fix

### DIFF
--- a/crates/task-impls/src/quorum_proposal/mod.rs
+++ b/crates/task-impls/src/quorum_proposal/mod.rs
@@ -345,17 +345,6 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> QuorumProposalTaskState<TYPE
             self.latest_proposed_view = new_view;
 
             return true;
-        } else if self.quorum_membership.leader(new_view) == self.public_key
-            && self.quorum_membership.leader(new_view + 1) == self.public_key
-        {
-            // this means we were the leader for the current view and for the next view we will be leader again
-            // there is no dependency task for the current view and we need to create one for the next view
-            // so we return true
-            debug!(
-                "Leader for connsecutive views, latest proposed view {}",
-                *self.latest_proposed_view,
-            );
-            return true;
         }
         false
     }
@@ -448,7 +437,6 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> QuorumProposalTaskState<TYPE
                 // All nodes get the latest proposed view as a proxy of `cur_view` of old.
                 if !self.update_latest_proposed_view(view_number).await {
                     tracing::trace!("Failed to update latest proposed view");
-                    return;
                 }
 
                 self.create_dependency_task_if_new(

--- a/crates/task-impls/src/quorum_proposal/mod.rs
+++ b/crates/task-impls/src/quorum_proposal/mod.rs
@@ -345,6 +345,17 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> QuorumProposalTaskState<TYPE
             self.latest_proposed_view = new_view;
 
             return true;
+        } else if self.quorum_membership.leader(new_view) == self.public_key
+            && self.quorum_membership.leader(new_view + 1) == self.public_key
+        {
+            // this means we were the leader for the current view and for the next view we will be leader again
+            // there is no dependency task for the current view and we need to create one for the next view
+            // so we return true
+            debug!(
+                "Leader for connsecutive views, latest proposed view {}",
+                *self.latest_proposed_view,
+            );
+            return true;
         }
         false
     }

--- a/crates/testing/tests/tests_1/test_success.rs
+++ b/crates/testing/tests/tests_1/test_success.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use hotshot_example_types::{
-    node_types::{Libp2pImpl, MemoryImpl, PushCdnImpl},
+    node_types::{Libp2pImpl, MemoryImpl, PushCdnImpl, TestConsecutiveLeaderTypes},
     state_types::TestTypes,
 };
 use hotshot_macros::cross_tests;
@@ -9,6 +9,7 @@ use hotshot_testing::{
     block_builder::SimpleBuilderImplementation,
     completion_task::{CompletionTaskDescription, TimeBasedCompletionTaskDescription},
     test_builder::TestDescription,
+    view_sync_task::ViewSyncTaskDescription,
 };
 #[cfg(async_executor_impl = "async-std")]
 use {
@@ -88,4 +89,24 @@ cross_tests!(
 
         metadata
     },
+);
+
+cross_tests!(
+    TestName: test_with_double_leader_no_failures,
+    Impls: [MemoryImpl, Libp2pImpl, PushCdnImpl],
+    Types: [TestConsecutiveLeaderTypes],
+    Ignore: false,
+    Metadata: {
+        let mut metadata = TestDescription::default_more_nodes();
+        metadata.num_bootstrap_nodes = 10;
+        metadata.num_nodes_with_stake = 12;
+        metadata.da_staked_committee_size = 12;
+        metadata.start_nodes = 12;
+
+        metadata.overall_safety_properties.num_failed_views = 0;
+
+        metadata.view_sync_properties = ViewSyncTaskDescription::Threshold(0, 0);
+
+        metadata
+    }
 );

--- a/crates/testing/tests/tests_1/test_with_failures_2.rs
+++ b/crates/testing/tests/tests_1/test_with_failures_2.rs
@@ -20,7 +20,6 @@ use std::{collections::HashMap, time::Duration};
 #[cfg(async_executor_impl = "async-std")]
 use {hotshot::tasks::DishonestLeader, hotshot_testing::test_builder::Behaviour, std::rc::Rc};
 // Test that a good leader can succeed in the view directly after view sync
-#[cfg(not(feature = "dependency-tasks"))]
 cross_tests!(
     TestName: test_with_failures_2,
     Impls: [MemoryImpl, Libp2pImpl, PushCdnImpl],
@@ -103,7 +102,6 @@ cross_tests!(
     },
 );
 
-#[cfg(not(feature = "dependency-tasks"))]
 cross_tests!(
     TestName: test_with_double_leader_failures,
     Impls: [MemoryImpl, Libp2pImpl, PushCdnImpl],


### PR DESCRIPTION
Closes #<ISSUE_NUMBER>
<!-- See here for keywords in Github -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

### This PR: 
<!-- Describe what this PR adds to HotSHot -->
<!-- E.g. -->
<!-- * Implements feature 1 -->
<!-- * Implements feature 2 -->
<!-- * Fixes bug 3 -->
Fix a bug where we would not propose when a node is the leader for two views in a row.

### This PR does not: 
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->

### Key places to review: 
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->
`src/quorum/proposal/mod.rs` in `handle`, removing the return statement if we fail to update the latest proposed view
<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
