### PR TITLE
Add builder_commitment to new_marketplace

### DIFF
--- a/crates/example-types/src/block_types.rs
+++ b/crates/example-types/src/block_types.rs
@@ -245,6 +245,29 @@ pub struct TestBlockHeader {
     pub timestamp: u64,
 }
 
+impl TestBlockHeader {
+    fn new<TYPES: NodeType<BlockHeader = Self>>(
+        parent_leaf: &Leaf<TYPES>,
+        payload_commitment: VidCommitment,
+        builder_commitment: BuilderCommitment,
+    ) -> Self {
+        let parent = parent_leaf.block_header();
+
+        let mut timestamp = OffsetDateTime::now_utc().unix_timestamp() as u64;
+        if timestamp < parent.timestamp {
+            // Prevent decreasing timestamps.
+            timestamp = parent.timestamp;
+        }
+
+        Self {
+            block_number: parent.block_number + 1,
+            payload_commitment,
+            builder_commitment,
+            timestamp,
+        }
+    }
+}
+
 impl<TYPES: NodeType<BlockHeader = Self, BlockPayload = TestBlockPayload>> BlockHeader<TYPES>
     for TestBlockHeader
 {
@@ -261,34 +284,30 @@ impl<TYPES: NodeType<BlockHeader = Self, BlockPayload = TestBlockPayload>> Block
         _vid_common: VidCommon,
         _version: Version,
     ) -> Result<Self, Self::Error> {
-        let parent = parent_leaf.block_header();
-
-        let mut timestamp = OffsetDateTime::now_utc().unix_timestamp() as u64;
-        if timestamp < parent.timestamp {
-            // Prevent decreasing timestamps.
-            timestamp = parent.timestamp;
-        }
-
-        Ok(Self {
-            block_number: parent.block_number + 1,
+        Ok(Self::new(
+            parent_leaf,
             payload_commitment,
             builder_commitment,
-            timestamp,
-        })
+        ))
     }
 
     async fn new_marketplace(
         _parent_state: &TYPES::ValidatedState,
         _instance_state: &<TYPES::ValidatedState as ValidatedState<TYPES>>::Instance,
-        _parent_leaf: &Leaf<TYPES>,
-        _payload_commitment: VidCommitment,
+        parent_leaf: &Leaf<TYPES>,
+        payload_commitment: VidCommitment,
+        builder_commitment: BuilderCommitment,
         _metadata: <TYPES::BlockPayload as BlockPayload<TYPES>>::Metadata,
         _builder_fee: Vec<BuilderFee<TYPES>>,
         _vid_common: VidCommon,
         _auction_results: Option<TYPES::AuctionResult>,
         _version: Version,
     ) -> Result<Self, Self::Error> {
-        unimplemented!()
+        Ok(Self::new(
+            parent_leaf,
+            payload_commitment,
+            builder_commitment,
+        ))
     }
 
     fn genesis(

--- a/crates/hotshot/src/tasks/mod.rs
+++ b/crates/hotshot/src/tasks/mod.rs
@@ -32,8 +32,7 @@ use hotshot_task_impls::{
 use hotshot_types::{
     constants::EVENT_CHANNEL_SIZE,
     data::QuorumProposal,
-    message::Proposal,
-    message::{Messages, VersionedMessage},
+    message::{Messages, Proposal, VersionedMessage},
     traits::{
         network::ConnectedNetwork,
         node_implementation::{ConsensusTime, NodeImplementation, NodeType},

--- a/crates/libp2p-networking/src/network/transport.rs
+++ b/crates/libp2p-networking/src/network/transport.rs
@@ -1,28 +1,25 @@
-use anyhow::Result as AnyhowResult;
-use anyhow::{ensure, Context};
-use async_compatibility_layer::art::async_timeout;
-use futures::AsyncRead;
-use futures::AsyncWrite;
-use serde::Deserialize;
-use serde::Serialize;
-use std::collections::HashSet;
-use std::future::Future;
-use std::hash::BuildHasher;
-use std::pin::Pin;
-use std::sync::Arc;
-use std::task::Poll;
-use tracing::warn;
-use {std::io::Error as IoError, std::io::ErrorKind as IoErrorKind};
+use std::{
+    collections::HashSet,
+    future::Future,
+    hash::BuildHasher,
+    io::{Error as IoError, ErrorKind as IoErrorKind},
+    pin::Pin,
+    sync::Arc,
+    task::Poll,
+};
 
-use futures::future::poll_fn;
-use futures::{AsyncReadExt, AsyncWriteExt};
+use anyhow::{ensure, Context, Result as AnyhowResult};
+use async_compatibility_layer::art::async_timeout;
+use futures::{future::poll_fn, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use hotshot_types::traits::signature_key::SignatureKey;
-use libp2p::core::muxing::StreamMuxerExt;
-use libp2p::core::transport::TransportEvent;
-use libp2p::core::StreamMuxer;
-use libp2p::identity::PeerId;
-use libp2p::Transport;
+use libp2p::{
+    core::{muxing::StreamMuxerExt, transport::TransportEvent, StreamMuxer},
+    identity::PeerId,
+    Transport,
+};
 use pin_project::pin_project;
+use serde::{Deserialize, Serialize};
+use tracing::warn;
 
 /// The maximum size of an authentication message. This is used to prevent
 /// DoS attacks by sending large messages.
@@ -516,13 +513,13 @@ pub async fn write_length_delimited<S: AsyncWrite + Unpin>(
 
 #[cfg(test)]
 mod test {
+    use std::{collections::HashSet, sync::Arc};
+
+    use hotshot_types::{signature_key::BLSPubKey, traits::signature_key::SignatureKey};
     use libp2p::{core::transport::dummy::DummyTransport, quic::Connection};
     use rand::Rng;
 
-    use std::{collections::HashSet, sync::Arc};
-
     use super::*;
-    use hotshot_types::{signature_key::BLSPubKey, traits::signature_key::SignatureKey};
 
     /// A mock type to help with readability
     type MockStakeTableAuth = StakeTableAuthentication<DummyTransport, BLSPubKey, Connection>;

--- a/crates/task-impls/src/consensus/handlers.rs
+++ b/crates/task-impls/src/consensus/handlers.rs
@@ -103,6 +103,7 @@ pub async fn create_and_send_proposal<TYPES: NodeType>(
             instance_state.as_ref(),
             &parent_leaf,
             commitment_and_metadata.commitment,
+            commitment_and_metadata.builder_commitment,
             commitment_and_metadata.metadata,
             commitment_and_metadata.fees.to_vec(),
             vid_share.data.common,

--- a/crates/task-impls/src/quorum_proposal/handlers.rs
+++ b/crates/task-impls/src/quorum_proposal/handlers.rs
@@ -190,6 +190,7 @@ impl<TYPES: NodeType> ProposalDependencyHandle<TYPES> {
                 self.instance_state.as_ref(),
                 &parent_leaf,
                 commitment_and_metadata.commitment,
+                commitment_and_metadata.builder_commitment,
                 commitment_and_metadata.metadata,
                 commitment_and_metadata.fees.to_vec(),
                 vid_share.data.common.clone(),

--- a/crates/testing/tests/tests_1/test_with_failures_2.rs
+++ b/crates/testing/tests/tests_1/test_with_failures_2.rs
@@ -6,6 +6,11 @@
 
 // TODO: Remove this after integration
 #![allow(unused_imports)]
+use std::{
+    collections::{HashMap, HashSet},
+    time::Duration,
+};
+
 use hotshot_example_types::{
     node_types::{Libp2pImpl, MemoryImpl, PushCdnImpl, TestConsecutiveLeaderTypes},
     state_types::TestTypes,
@@ -18,11 +23,7 @@ use hotshot_testing::{
     test_builder::TestDescription,
     view_sync_task::ViewSyncTaskDescription,
 };
-use hotshot_types::data::ViewNumber;
-use hotshot_types::traits::node_implementation::ConsensusTime;
-use std::collections::HashSet;
-use std::{collections::HashMap, time::Duration};
-
+use hotshot_types::{data::ViewNumber, traits::node_implementation::ConsensusTime};
 #[cfg(async_executor_impl = "async-std")]
 use {hotshot::tasks::DishonestLeader, hotshot_testing::test_builder::Behaviour, std::rc::Rc};
 // Test that a good leader can succeed in the view directly after view sync

--- a/crates/testing/tests/tests_1/vote_dependency_handle.rs
+++ b/crates/testing/tests/tests_1/vote_dependency_handle.rs
@@ -1,6 +1,5 @@
 #![cfg(feature = "dependency-tasks")]
 
-use itertools::Itertools;
 use std::time::Duration;
 
 use async_compatibility_layer::art::async_timeout;
@@ -25,6 +24,7 @@ use hotshot_types::{
     consensus::OuterConsensus, data::ViewNumber, traits::node_implementation::ConsensusTime,
     vote::HasViewNumber,
 };
+use itertools::Itertools;
 
 const TIMEOUT: Duration = Duration::from_millis(35);
 

--- a/crates/types/src/traits/block_contents.rs
+++ b/crates/types/src/traits/block_contents.rs
@@ -189,7 +189,7 @@ pub trait BlockHeader<TYPES: NodeType>:
     type Error: Error + Debug + Send + Sync;
 
     /// Build a header with the parent validate state, instance-level state, parent leaf, payload
-    /// commitment, and metadata. This is only used in pre-marketplace versions
+    /// and builder commitments, and metadata. This is only used in pre-marketplace versions
     #[allow(clippy::too_many_arguments)]
     fn new_legacy(
         parent_state: &TYPES::ValidatedState,
@@ -204,13 +204,15 @@ pub trait BlockHeader<TYPES: NodeType>:
     ) -> impl Future<Output = Result<Self, Self::Error>> + Send;
 
     /// Build a header with the parent validate state, instance-level state, parent leaf, payload
-    /// commitment, metadata, and auction results. This is only used in post-marketplace versions
+    /// and builder commitments, metadata, and auction results. This is only used in post-marketplace
+    /// versions
     #[allow(clippy::too_many_arguments)]
     fn new_marketplace(
         parent_state: &TYPES::ValidatedState,
         instance_state: &<TYPES::ValidatedState as ValidatedState<TYPES>>::Instance,
         parent_leaf: &Leaf<TYPES>,
         payload_commitment: VidCommitment,
+        builder_commitment: BuilderCommitment,
         metadata: <TYPES::BlockPayload as BlockPayload<TYPES>>::Metadata,
         builder_fee: Vec<BuilderFee<TYPES>>,
         vid_common: VidCommon,


### PR DESCRIPTION
Closes #0000

### This PR: 
Adds builder_commitment to `new_marketplace` of the `BlockHeader` trait. Builder uses the commitment to correlate quorum and DA proposals and there's no way to calculate it having just the header.

### This PR does not: 
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->

### Key places to review: 
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
