### PR TITLE
Separate versioning from `NodeType`

### DIFF
--- a/crates/example-types/src/node_types.rs
+++ b/crates/example-types/src/node_types.rs
@@ -4,7 +4,6 @@
 // You should have received a copy of the MIT License
 // along with the HotShot repository. If not, see <https://mit-license.org/>.
 
-use hotshot_types::traits::node_implementation::Versions;
 use hotshot::traits::{
     election::{
         static_committee::{GeneralStaticCommittee, StaticCommittee},
@@ -16,7 +15,7 @@ use hotshot::traits::{
 use hotshot_types::{
     data::ViewNumber,
     signature_key::{BLSPubKey, BuilderKey},
-    traits::node_implementation::NodeType,
+    traits::node_implementation::{NodeType, Versions},
 };
 use serde::{Deserialize, Serialize};
 use vbs::version::StaticVersion;

--- a/crates/example-types/src/node_types.rs
+++ b/crates/example-types/src/node_types.rs
@@ -45,12 +45,6 @@ use crate::{
 pub struct TestTypes;
 impl NodeType for TestTypes {
     type AuctionResult = TestAuctionResult;
-    type Base = StaticVersion<0, 1>;
-    type Upgrade = StaticVersion<0, 2>;
-    const UPGRADE_HASH: [u8; 32] = [
-        1, 0, 1, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0,
-        0, 0,
-    ];
     type Time = ViewNumber;
     type BlockHeader = TestBlockHeader;
     type BlockPayload = TestBlockPayload;
@@ -80,12 +74,6 @@ impl NodeType for TestTypes {
 pub struct TestConsecutiveLeaderTypes;
 impl NodeType for TestConsecutiveLeaderTypes {
     type AuctionResult = TestAuctionResult;
-    type Base = StaticVersion<0, 1>;
-    type Upgrade = StaticVersion<0, 2>;
-    const UPGRADE_HASH: [u8; 32] = [
-        1, 0, 1, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0,
-        0, 0,
-    ];
     type Time = ViewNumber;
     type BlockHeader = TestBlockHeader;
     type BlockPayload = TestBlockPayload;

--- a/crates/example-types/src/node_types.rs
+++ b/crates/example-types/src/node_types.rs
@@ -4,6 +4,7 @@
 // You should have received a copy of the MIT License
 // along with the HotShot repository. If not, see <https://mit-license.org/>.
 
+use hotshot_types::traits::node_implementation::Versions;
 use hotshot::traits::{
     election::{
         static_committee::{GeneralStaticCommittee, StaticCommittee},
@@ -143,4 +144,18 @@ impl<TYPES: NodeType> NodeImplementation<TYPES> for Libp2pImpl {
     type Network = Libp2pNetwork<TYPES::SignatureKey>;
     type Storage = TestStorage<TYPES>;
     type AuctionResultsProvider = TestAuctionResultsProvider<TYPES>;
+}
+
+#[derive(Clone, Debug, Copy)]
+pub struct TestVersions {}
+
+impl Versions for TestVersions {
+    type Base = StaticVersion<0, 1>;
+    type Upgrade = StaticVersion<0, 2>;
+    const UPGRADE_HASH: [u8; 32] = [
+        1, 0, 1, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0,
+        0, 0,
+    ];
+
+    type Marketplace = StaticVersion<0, 3>;
 }

--- a/crates/examples/combined/all.rs
+++ b/crates/examples/combined/all.rs
@@ -20,7 +20,7 @@ use hotshot::{
     traits::implementations::{KeyPair, TestingDef, WrappedSignatureKey},
     types::SignatureKey,
 };
-use hotshot_example_types::state_types::TestTypes;
+use hotshot_example_types::{node_types::TestVersions, state_types::TestTypes};
 use hotshot_orchestrator::client::ValidatorArgs;
 use hotshot_types::traits::node_implementation::NodeType;
 use infra::{gen_local_address, BUILDER_BASE_PORT, VALIDATOR_BASE_PORT};
@@ -146,12 +146,14 @@ async fn main() {
         let builder_address = gen_local_address::<BUILDER_BASE_PORT>(i);
 
         let node = async_spawn(async move {
-            infra::main_entry_point::<TestTypes, Network, NodeImpl, ThisRun>(ValidatorArgs {
-                url: orchestrator_url,
-                advertise_address: Some(advertise_address),
-                builder_address: Some(builder_address),
-                network_config_file: None,
-            })
+            infra::main_entry_point::<TestTypes, Network, NodeImpl, TestVersions, ThisRun>(
+                ValidatorArgs {
+                    url: orchestrator_url,
+                    advertise_address: Some(advertise_address),
+                    builder_address: Some(builder_address),
+                    network_config_file: None,
+                },
+            )
             .await;
         });
         nodes.push(node);

--- a/crates/examples/combined/multi-validator.rs
+++ b/crates/examples/combined/multi-validator.rs
@@ -10,7 +10,7 @@ use async_compatibility_layer::{
     logging::{setup_backtrace, setup_logging},
 };
 use clap::Parser;
-use hotshot_example_types::state_types::TestTypes;
+use hotshot_example_types::{node_types::TestVersions, state_types::TestTypes};
 use hotshot_orchestrator::client::{MultiValidatorArgs, ValidatorArgs};
 use tracing::instrument;
 
@@ -36,7 +36,7 @@ async fn main() {
         let args = args.clone();
 
         let node = async_spawn(async move {
-            infra::main_entry_point::<TestTypes, Network, NodeImpl, ThisRun>(
+            infra::main_entry_point::<TestTypes, Network, NodeImpl, TestVersions, ThisRun>(
                 ValidatorArgs::from_multi_args(args, node_index),
             )
             .await;

--- a/crates/examples/combined/validator.rs
+++ b/crates/examples/combined/validator.rs
@@ -9,7 +9,7 @@ use std::{net::SocketAddr, str::FromStr};
 
 use async_compatibility_layer::logging::{setup_backtrace, setup_logging};
 use clap::Parser;
-use hotshot_example_types::state_types::TestTypes;
+use hotshot_example_types::{node_types::TestVersions, state_types::TestTypes};
 use hotshot_orchestrator::client::ValidatorArgs;
 use local_ip_address::local_ip;
 use tracing::{debug, instrument};
@@ -42,5 +42,5 @@ async fn main() {
     );
 
     debug!("connecting to orchestrator at {:?}", args.url);
-    infra::main_entry_point::<TestTypes, Network, NodeImpl, ThisRun>(args).await;
+    infra::main_entry_point::<TestTypes, Network, NodeImpl, TestVersions, ThisRun>(args).await;
 }

--- a/crates/examples/infra/mod.rs
+++ b/crates/examples/infra/mod.rs
@@ -38,7 +38,7 @@ use hotshot::{
 use hotshot_example_types::{
     auction_results_provider_types::TestAuctionResultsProvider,
     block_types::{TestBlockHeader, TestBlockPayload, TestTransaction},
-    node_types::{Libp2pImpl, PushCdnImpl, TestVersions},
+    node_types::{Libp2pImpl, PushCdnImpl},
     state_types::TestInstanceState,
     storage_types::TestStorage,
 };

--- a/crates/examples/infra/mod.rs
+++ b/crates/examples/infra/mod.rs
@@ -38,7 +38,7 @@ use hotshot::{
 use hotshot_example_types::{
     auction_results_provider_types::TestAuctionResultsProvider,
     block_types::{TestBlockHeader, TestBlockPayload, TestTransaction},
-    node_types::{Libp2pImpl, PushCdnImpl},
+    node_types::{Libp2pImpl, PushCdnImpl, TestVersions},
     state_types::TestInstanceState,
     storage_types::TestStorage,
 };
@@ -59,7 +59,7 @@ use hotshot_types::{
         block_contents::{BlockHeader, TestableBlock},
         election::Membership,
         network::{ConnectedNetwork, Topic},
-        node_implementation::{ConsensusTime, NodeType},
+        node_implementation::{ConsensusTime, NodeType, Versions},
         states::TestableState,
     },
     HotShotConfig, PeerConfig, ValidatorConfig,
@@ -347,6 +347,7 @@ pub trait RunDa<
         Storage = TestStorage<TYPES>,
         AuctionResultsProvider = TestAuctionResultsProvider<TYPES>,
     >,
+    V: Versions,
 > where
     <TYPES as NodeType>::ValidatedState: TestableState<TYPES>,
     <TYPES as NodeType>::BlockPayload: TestableBlock<TYPES>,
@@ -364,7 +365,7 @@ pub trait RunDa<
     /// # Panics if it cannot generate a genesis block, fails to initialize HotShot, or cannot
     /// get the anchored view
     /// Note: sequencing leaf does not have state, so does not return state
-    async fn initialize_state_and_hotshot(&self) -> SystemContextHandle<TYPES, NODE> {
+    async fn initialize_state_and_hotshot(&self) -> SystemContextHandle<TYPES, NODE, V> {
         let initializer = hotshot::HotShotInitializer::<TYPES>::from_genesis(TestInstanceState {})
             .await
             .expect("Couldn't generate genesis block");
@@ -429,7 +430,7 @@ pub trait RunDa<
     #[allow(clippy::too_many_lines)]
     async fn run_hotshot(
         &self,
-        context: SystemContextHandle<TYPES, NODE>,
+        context: SystemContextHandle<TYPES, NODE, V>,
         transactions: &mut Vec<TestTransaction>,
         transactions_to_send_per_round: u64,
         transaction_size_in_bytes: u64,
@@ -618,7 +619,8 @@ impl<
             Storage = TestStorage<TYPES>,
             AuctionResultsProvider = TestAuctionResultsProvider<TYPES>,
         >,
-    > RunDa<TYPES, PushCdnNetwork<TYPES>, NODE> for PushCdnDaRun<TYPES>
+        V: Versions,
+    > RunDa<TYPES, PushCdnNetwork<TYPES>, NODE, V> for PushCdnDaRun<TYPES>
 where
     <TYPES as NodeType>::ValidatedState: TestableState<TYPES>,
     <TYPES as NodeType>::BlockPayload: TestableBlock<TYPES>,
@@ -695,7 +697,8 @@ impl<
             Storage = TestStorage<TYPES>,
             AuctionResultsProvider = TestAuctionResultsProvider<TYPES>,
         >,
-    > RunDa<TYPES, Libp2pNetwork<TYPES::SignatureKey>, NODE> for Libp2pDaRun<TYPES>
+        V: Versions,
+    > RunDa<TYPES, Libp2pNetwork<TYPES::SignatureKey>, NODE, V> for Libp2pDaRun<TYPES>
 where
     <TYPES as NodeType>::ValidatedState: TestableState<TYPES>,
     <TYPES as NodeType>::BlockPayload: TestableBlock<TYPES>,
@@ -781,7 +784,8 @@ impl<
             Storage = TestStorage<TYPES>,
             AuctionResultsProvider = TestAuctionResultsProvider<TYPES>,
         >,
-    > RunDa<TYPES, CombinedNetworks<TYPES>, NODE> for CombinedDaRun<TYPES>
+        V: Versions,
+    > RunDa<TYPES, CombinedNetworks<TYPES>, NODE, V> for CombinedDaRun<TYPES>
 where
     <TYPES as NodeType>::ValidatedState: TestableState<TYPES>,
     <TYPES as NodeType>::BlockPayload: TestableBlock<TYPES>,
@@ -793,20 +797,21 @@ where
         libp2p_advertise_address: Option<SocketAddr>,
     ) -> CombinedDaRun<TYPES> {
         // Initialize our Libp2p network
-        let libp2p_network: Libp2pDaRun<TYPES> = <Libp2pDaRun<TYPES> as RunDa<
-            TYPES,
-            Libp2pNetwork<TYPES::SignatureKey>,
-            Libp2pImpl,
-        >>::initialize_networking(
-            config.clone(), libp2p_advertise_address
-        )
-        .await;
+        let libp2p_network: Libp2pDaRun<TYPES> =
+            <Libp2pDaRun<TYPES> as RunDa<
+                TYPES,
+                Libp2pNetwork<TYPES::SignatureKey>,
+                Libp2pImpl,
+                V,
+            >>::initialize_networking(config.clone(), libp2p_advertise_address)
+            .await;
 
         // Initialize our CDN network
         let cdn_network: PushCdnDaRun<TYPES> = <PushCdnDaRun<TYPES> as RunDa<
             TYPES,
             PushCdnNetwork<TYPES>,
             PushCdnImpl,
+            V,
         >>::initialize_networking(
             config.clone(), libp2p_advertise_address
         )
@@ -851,7 +856,8 @@ pub async fn main_entry_point<
         Storage = TestStorage<TYPES>,
         AuctionResultsProvider = TestAuctionResultsProvider<TYPES>,
     >,
-    RUNDA: RunDa<TYPES, NETWORK, NODE>,
+    V: Versions,
+    RUNDA: RunDa<TYPES, NETWORK, NODE, V>,
 >(
     args: ValidatorArgs,
 ) where

--- a/crates/examples/libp2p/all.rs
+++ b/crates/examples/libp2p/all.rs
@@ -12,7 +12,7 @@ use async_compatibility_layer::{
     art::async_spawn,
     logging::{setup_backtrace, setup_logging},
 };
-use hotshot_example_types::state_types::TestTypes;
+use hotshot_example_types::{node_types::TestVersions, state_types::TestTypes};
 use hotshot_orchestrator::client::ValidatorArgs;
 use infra::{gen_local_address, BUILDER_BASE_PORT, VALIDATOR_BASE_PORT};
 use tracing::instrument;
@@ -51,12 +51,14 @@ async fn main() {
         let builder_address = gen_local_address::<BUILDER_BASE_PORT>(i);
         let orchestrator_url = orchestrator_url.clone();
         let node = async_spawn(async move {
-            infra::main_entry_point::<TestTypes, Network, NodeImpl, ThisRun>(ValidatorArgs {
-                url: orchestrator_url,
-                advertise_address: Some(advertise_address),
-                builder_address: Some(builder_address),
-                network_config_file: None,
-            })
+            infra::main_entry_point::<TestTypes, Network, NodeImpl, TestVersions, ThisRun>(
+                ValidatorArgs {
+                    url: orchestrator_url,
+                    advertise_address: Some(advertise_address),
+                    builder_address: Some(builder_address),
+                    network_config_file: None,
+                },
+            )
             .await;
         });
         nodes.push(node);

--- a/crates/examples/libp2p/multi-validator.rs
+++ b/crates/examples/libp2p/multi-validator.rs
@@ -10,7 +10,7 @@ use async_compatibility_layer::{
     logging::{setup_backtrace, setup_logging},
 };
 use clap::Parser;
-use hotshot_example_types::state_types::TestTypes;
+use hotshot_example_types::{node_types::TestVersions, state_types::TestTypes};
 use hotshot_orchestrator::client::{MultiValidatorArgs, ValidatorArgs};
 use tracing::instrument;
 
@@ -36,7 +36,7 @@ async fn main() {
         let args = args.clone();
 
         let node = async_spawn(async move {
-            infra::main_entry_point::<TestTypes, Network, NodeImpl, ThisRun>(
+            infra::main_entry_point::<TestTypes, Network, NodeImpl, TestVersions, ThisRun>(
                 ValidatorArgs::from_multi_args(args, node_index),
             )
             .await;

--- a/crates/examples/libp2p/validator.rs
+++ b/crates/examples/libp2p/validator.rs
@@ -9,7 +9,7 @@ use std::{net::SocketAddr, str::FromStr};
 
 use async_compatibility_layer::logging::{setup_backtrace, setup_logging};
 use clap::Parser;
-use hotshot_example_types::state_types::TestTypes;
+use hotshot_example_types::{node_types::TestVersions, state_types::TestTypes};
 use hotshot_orchestrator::client::ValidatorArgs;
 use local_ip_address::local_ip;
 use tracing::{debug, instrument};
@@ -41,5 +41,5 @@ async fn main() {
     );
 
     debug!("connecting to orchestrator at {:?}", args.url);
-    infra::main_entry_point::<TestTypes, Network, NodeImpl, ThisRun>(args).await;
+    infra::main_entry_point::<TestTypes, Network, NodeImpl, TestVersions, ThisRun>(args).await;
 }

--- a/crates/examples/push-cdn/all.rs
+++ b/crates/examples/push-cdn/all.rs
@@ -17,7 +17,7 @@ use hotshot::{
     traits::implementations::{TestingDef, WrappedSignatureKey},
     types::SignatureKey,
 };
-use hotshot_example_types::state_types::TestTypes;
+use hotshot_example_types::{node_types::TestVersions, state_types::TestTypes};
 use hotshot_orchestrator::client::ValidatorArgs;
 use hotshot_types::traits::node_implementation::NodeType;
 use infra::{gen_local_address, BUILDER_BASE_PORT};
@@ -140,12 +140,14 @@ async fn main() {
         let orchestrator_url = orchestrator_url.clone();
         let builder_address = gen_local_address::<BUILDER_BASE_PORT>(i);
         let node = async_spawn(async move {
-            infra::main_entry_point::<TestTypes, Network, NodeImpl, ThisRun>(ValidatorArgs {
-                url: orchestrator_url,
-                advertise_address: None,
-                builder_address: Some(builder_address),
-                network_config_file: None,
-            })
+            infra::main_entry_point::<TestTypes, Network, NodeImpl, TestVersions, ThisRun>(
+                ValidatorArgs {
+                    url: orchestrator_url,
+                    advertise_address: None,
+                    builder_address: Some(builder_address),
+                    network_config_file: None,
+                },
+            )
             .await;
         });
         nodes.push(node);

--- a/crates/examples/push-cdn/multi-validator.rs
+++ b/crates/examples/push-cdn/multi-validator.rs
@@ -10,7 +10,7 @@ use async_compatibility_layer::{
     logging::{setup_backtrace, setup_logging},
 };
 use clap::Parser;
-use hotshot_example_types::state_types::TestTypes;
+use hotshot_example_types::{node_types::TestVersions, state_types::TestTypes};
 use hotshot_orchestrator::client::{MultiValidatorArgs, ValidatorArgs};
 use tracing::instrument;
 
@@ -36,7 +36,7 @@ async fn main() {
         let args = args.clone();
 
         let node = async_spawn(async move {
-            infra::main_entry_point::<TestTypes, Network, NodeImpl, ThisRun>(
+            infra::main_entry_point::<TestTypes, Network, NodeImpl, TestVersions, ThisRun>(
                 ValidatorArgs::from_multi_args(args, node_index),
             )
             .await;

--- a/crates/examples/push-cdn/validator.rs
+++ b/crates/examples/push-cdn/validator.rs
@@ -7,7 +7,7 @@
 //! A validator
 use async_compatibility_layer::logging::{setup_backtrace, setup_logging};
 use clap::Parser;
-use hotshot_example_types::state_types::TestTypes;
+use hotshot_example_types::{node_types::TestVersions, state_types::TestTypes};
 use hotshot_orchestrator::client::ValidatorArgs;
 use tracing::{debug, instrument};
 
@@ -28,5 +28,5 @@ async fn main() {
     setup_backtrace();
     let args = ValidatorArgs::parse();
     debug!("connecting to orchestrator at {:?}", args.url);
-    infra::main_entry_point::<TestTypes, Network, NodeImpl, ThisRun>(args).await;
+    infra::main_entry_point::<TestTypes, Network, NodeImpl, TestVersions, ThisRun>(args).await;
 }

--- a/crates/hotshot/src/lib.rs
+++ b/crates/hotshot/src/lib.rs
@@ -18,7 +18,6 @@ use hotshot_types::{
 };
 use rand::Rng;
 use url::Url;
-use vbs::version::StaticVersionType;
 
 /// Contains traits consumed by [`SystemContext`]
 pub mod traits;
@@ -50,8 +49,8 @@ use hotshot_types::{
     constants::{EVENT_CHANNEL_SIZE, EXTERNAL_EVENT_CHANNEL_SIZE},
     data::{Leaf, QuorumProposal},
     event::{EventType, LeafInfo},
-    message::{DataMessage, Message, MessageKind, Proposal, VersionedMessage},
-    simple_certificate::{QuorumCertificate, UpgradeCertificate},
+    message::{DataMessage, Message, MessageKind, Proposal},
+    simple_certificate::QuorumCertificate,
     traits::{
         consensus_api::ConsensusApi,
         election::Membership,
@@ -68,7 +67,6 @@ use hotshot_types::{
 /// Reexport rand crate
 pub use rand;
 use tracing::{debug, instrument, trace};
-use vbs::version::Version;
 
 use crate::{
     tasks::{add_consensus_tasks, add_network_tasks},

--- a/crates/hotshot/src/lib.rs
+++ b/crates/hotshot/src/lib.rs
@@ -11,10 +11,11 @@
 #[cfg(feature = "docs")]
 pub mod documentation;
 
-use hotshot_types::traits::node_implementation::Versions;
-use hotshot_types::message::UpgradeLock;
 use futures::future::{select, Either};
-use hotshot_types::traits::network::BroadcastDelay;
+use hotshot_types::{
+    message::UpgradeLock,
+    traits::{network::BroadcastDelay, node_implementation::Versions},
+};
 use rand::Rng;
 use url::Url;
 use vbs::version::StaticVersionType;
@@ -162,7 +163,9 @@ pub struct SystemContext<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versi
     /// Marketplace config for this instance of HotShot
     pub marketplace_config: MarketplaceConfig<TYPES, I>,
 }
-impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> Clone for SystemContext<TYPES, I, V> {
+impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> Clone
+    for SystemContext<TYPES, I, V>
+{
     #![allow(deprecated)]
     fn clone(&self) -> Self {
         Self {
@@ -745,7 +748,10 @@ where
         metrics: ConsensusMetricsValue,
         storage: I::Storage,
         marketplace_config: MarketplaceConfig<TYPES, I>,
-    ) -> (SystemContextHandle<TYPES, I, V>, SystemContextHandle<TYPES, I, V>) {
+    ) -> (
+        SystemContextHandle<TYPES, I, V>,
+        SystemContextHandle<TYPES, I, V>,
+    ) {
         let left_system_context = SystemContext::new(
             public_key.clone(),
             private_key.clone(),

--- a/crates/hotshot/src/tasks/mod.rs
+++ b/crates/hotshot/src/tasks/mod.rs
@@ -32,7 +32,7 @@ use hotshot_task_impls::{
 use hotshot_types::{
     constants::EVENT_CHANNEL_SIZE,
     data::QuorumProposal,
-    message::{Messages, Proposal, VersionedMessage},
+    message::{Messages, Proposal},
     traits::{
         network::ConnectedNetwork,
         node_implementation::{ConsensusTime, NodeImplementation, NodeType},

--- a/crates/hotshot/src/tasks/mod.rs
+++ b/crates/hotshot/src/tasks/mod.rs
@@ -9,7 +9,6 @@
 /// Provides trait to create task states from a `SystemContextHandle`
 pub mod task_state;
 use std::{collections::HashSet, sync::Arc, time::Duration};
-use crate::Versions;
 
 use async_broadcast::broadcast;
 use async_compatibility_layer::art::{async_sleep, async_spawn};
@@ -44,7 +43,7 @@ use vbs::version::StaticVersionType;
 use crate::{
     tasks::task_state::CreateTaskState, types::SystemContextHandle, ConsensusApi,
     ConsensusMetricsValue, ConsensusTaskRegistry, HotShotConfig, HotShotInitializer,
-    MarketplaceConfig, Memberships, NetworkTaskRegistry, SignatureKey, SystemContext,
+    MarketplaceConfig, Memberships, NetworkTaskRegistry, SignatureKey, SystemContext, Versions,
 };
 
 /// event for global event stream
@@ -57,7 +56,11 @@ pub enum GlobalEvent {
 }
 
 /// Add tasks for network requests and responses
-pub async fn add_request_network_task<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions>(
+pub async fn add_request_network_task<
+    TYPES: NodeType,
+    I: NodeImplementation<TYPES>,
+    V: Versions,
+>(
     handle: &mut SystemContextHandle<TYPES, I, V>,
 ) {
     let state = NetworkRequestState::<TYPES, I>::create_from(handle).await;
@@ -104,7 +107,8 @@ pub fn add_network_message_task<
         external_event_stream: handle.output_event_stream.0.clone(),
     };
 
-    let decided_upgrade_certificate = Arc::clone(&handle.hotshot.upgrade_lock.decided_upgrade_certificate);
+    let decided_upgrade_certificate =
+        Arc::clone(&handle.hotshot.upgrade_lock.decided_upgrade_certificate);
 
     let network = Arc::clone(channel);
     let mut state = network_state.clone();

--- a/crates/hotshot/src/tasks/mod.rs
+++ b/crates/hotshot/src/tasks/mod.rs
@@ -189,18 +189,18 @@ pub async fn add_consensus_tasks<TYPES: NodeType, I: NodeImplementation<TYPES>, 
     handle.add_task(ViewSyncTaskState::<TYPES, I>::create_from(handle).await);
     handle.add_task(VidTaskState::<TYPES, I>::create_from(handle).await);
     handle.add_task(DaTaskState::<TYPES, I>::create_from(handle).await);
-    handle.add_task(TransactionTaskState::<TYPES, I>::create_from(handle).await);
+    handle.add_task(TransactionTaskState::<TYPES, I, V>::create_from(handle).await);
 
     // only spawn the upgrade task if we are actually configured to perform an upgrade.
-    if TYPES::Base::VERSION < TYPES::Upgrade::VERSION {
-        handle.add_task(UpgradeTaskState::<TYPES, I>::create_from(handle).await);
+    if V::Base::VERSION < V::Upgrade::VERSION {
+        handle.add_task(UpgradeTaskState::<TYPES, I, V>::create_from(handle).await);
     }
 
     {
         #![cfg(not(feature = "dependency-tasks"))]
         use hotshot_task_impls::consensus::ConsensusTaskState;
 
-        handle.add_task(ConsensusTaskState::<TYPES, I>::create_from(handle).await);
+        handle.add_task(ConsensusTaskState::<TYPES, I, V>::create_from(handle).await);
     }
     {
         #![cfg(feature = "dependency-tasks")]
@@ -209,10 +209,10 @@ pub async fn add_consensus_tasks<TYPES: NodeType, I: NodeImplementation<TYPES>, 
             quorum_proposal_recv::QuorumProposalRecvTaskState, quorum_vote::QuorumVoteTaskState,
         };
 
-        handle.add_task(QuorumProposalTaskState::<TYPES, I>::create_from(handle).await);
-        handle.add_task(QuorumVoteTaskState::<TYPES, I>::create_from(handle).await);
-        handle.add_task(QuorumProposalRecvTaskState::<TYPES, I>::create_from(handle).await);
-        handle.add_task(Consensus2TaskState::<TYPES, I>::create_from(handle).await);
+        handle.add_task(QuorumProposalTaskState::<TYPES, I, V>::create_from(handle).await);
+        handle.add_task(QuorumVoteTaskState::<TYPES, I, V>::create_from(handle).await);
+        handle.add_task(QuorumProposalRecvTaskState::<TYPES, I, V>::create_from(handle).await);
+        handle.add_task(Consensus2TaskState::<TYPES, I, V>::create_from(handle).await);
     }
 
     #[cfg(feature = "rewind")]

--- a/crates/hotshot/src/tasks/task_state.rs
+++ b/crates/hotshot/src/tasks/task_state.rs
@@ -11,16 +11,13 @@ use std::{
 
 use async_trait::async_trait;
 use chrono::Utc;
-#[cfg(not(feature = "dependency-tasks"))]
 use hotshot_task_impls::consensus::ConsensusTaskState;
-#[cfg(feature = "rewind")]
 use hotshot_task_impls::rewind::RewindTaskState;
 use hotshot_task_impls::{
     builder::BuilderClient, da::DaTaskState, request::NetworkRequestState,
     transactions::TransactionTaskState, upgrade::UpgradeTaskState, vid::VidTaskState,
     view_sync::ViewSyncTaskState,
 };
-#[cfg(feature = "dependency-tasks")]
 use hotshot_task_impls::{
     consensus2::Consensus2TaskState, quorum_proposal::QuorumProposalTaskState,
     quorum_proposal_recv::QuorumProposalRecvTaskState, quorum_vote::QuorumVoteTaskState,
@@ -53,8 +50,8 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> CreateTaskState
 {
     async fn create_from(
         handle: &SystemContextHandle<TYPES, I, V>,
-    ) -> NetworkRequestState<TYPES, I> {
-        NetworkRequestState {
+    ) -> Self {
+        Self {
             network: Arc::clone(&handle.hotshot.network),
             state: OuterConsensus::new(handle.hotshot.consensus()),
             view: handle.cur_view().await,
@@ -72,11 +69,11 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> CreateTaskState
 
 #[async_trait]
 impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> CreateTaskState<TYPES, I, V>
-    for UpgradeTaskState<TYPES, I>
+    for UpgradeTaskState<TYPES, I, V>
 {
-    async fn create_from(handle: &SystemContextHandle<TYPES, I, V>) -> UpgradeTaskState<TYPES, I> {
+    async fn create_from(handle: &SystemContextHandle<TYPES, I, V>) -> Self {
         #[cfg(not(feature = "example-upgrade"))]
-        return UpgradeTaskState {
+        return Self {
             output_event_stream: handle.hotshot.external_event_stream.0.clone(),
             cur_view: handle.cur_view().await,
             quorum_membership: handle.hotshot.memberships.quorum_membership.clone().into(),
@@ -93,13 +90,11 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> CreateTaskState
             stop_proposing_time: handle.hotshot.config.stop_proposing_time,
             start_voting_time: handle.hotshot.config.start_voting_time,
             stop_voting_time: handle.hotshot.config.stop_voting_time,
-            decided_upgrade_certificate: Arc::clone(
-                &handle.hotshot.upgrade_lock.decided_upgrade_certificate,
-            ),
+            upgrade_lock: handle.hotshot.upgrade_lock.clone(),
         };
 
         #[cfg(feature = "example-upgrade")]
-        return UpgradeTaskState {
+        return Self {
             output_event_stream: handle.hotshot.external_event_stream.0.clone(),
             cur_view: handle.cur_view().await,
             quorum_membership: handle.hotshot.memberships.quorum_membership.clone().into(),
@@ -116,9 +111,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> CreateTaskState
             stop_proposing_time: u64::MAX,
             start_voting_time: 0,
             stop_voting_time: u64::MAX,
-            decided_upgrade_certificate: Arc::clone(
-                &handle.hotshot.upgrade_lock.decided_upgrade_certificate,
-            ),
+            upgrade_lock: handle.hotshot.upgrade_lock.clone(),
         };
     }
 }
@@ -127,8 +120,8 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> CreateTaskState
 impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> CreateTaskState<TYPES, I, V>
     for VidTaskState<TYPES, I>
 {
-    async fn create_from(handle: &SystemContextHandle<TYPES, I, V>) -> VidTaskState<TYPES, I> {
-        VidTaskState {
+    async fn create_from(handle: &SystemContextHandle<TYPES, I, V>) -> Self {
+        Self {
             consensus: OuterConsensus::new(handle.hotshot.consensus()),
             cur_view: handle.cur_view().await,
             vote_collector: None,
@@ -145,8 +138,8 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> CreateTaskState
 impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> CreateTaskState<TYPES, I, V>
     for DaTaskState<TYPES, I>
 {
-    async fn create_from(handle: &SystemContextHandle<TYPES, I, V>) -> DaTaskState<TYPES, I> {
-        DaTaskState {
+    async fn create_from(handle: &SystemContextHandle<TYPES, I, V>) -> Self {
+        Self {
             consensus: OuterConsensus::new(handle.hotshot.consensus()),
             output_event_stream: handle.hotshot.external_event_stream.0.clone(),
             da_membership: handle.hotshot.memberships.da_membership.clone().into(),
@@ -166,9 +159,10 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> CreateTaskState
 impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> CreateTaskState<TYPES, I, V>
     for ViewSyncTaskState<TYPES, I>
 {
-    async fn create_from(handle: &SystemContextHandle<TYPES, I, V>) -> ViewSyncTaskState<TYPES, I> {
+    async fn create_from(handle: &SystemContextHandle<TYPES, I, V>) -> Self {
         let cur_view = handle.cur_view().await;
-        ViewSyncTaskState {
+
+        Self {
             current_view: cur_view,
             next_view: cur_view,
             network: Arc::clone(&handle.hotshot.network),
@@ -194,12 +188,12 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> CreateTaskState
 
 #[async_trait]
 impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> CreateTaskState<TYPES, I, V>
-    for TransactionTaskState<TYPES, I>
+    for TransactionTaskState<TYPES, I, V>
 {
     async fn create_from(
         handle: &SystemContextHandle<TYPES, I, V>,
-    ) -> TransactionTaskState<TYPES, I> {
-        TransactionTaskState {
+    ) -> Self {
+        Self {
             builder_timeout: handle.builder_timeout(),
             output_event_stream: handle.hotshot.external_event_stream.0.clone(),
             consensus: OuterConsensus::new(handle.hotshot.consensus()),
@@ -218,9 +212,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> CreateTaskState
                 .cloned()
                 .map(BuilderClient::new)
                 .collect(),
-            decided_upgrade_certificate: Arc::clone(
-                &handle.hotshot.upgrade_lock.decided_upgrade_certificate,
-            ),
+            upgrade_lock: handle.hotshot.upgrade_lock.clone(),
             auction_results_provider: Arc::clone(
                 &handle.hotshot.marketplace_config.auction_results_provider,
             ),
@@ -233,18 +225,17 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> CreateTaskState
     }
 }
 
-#[cfg(not(feature = "dependency-tasks"))]
 #[async_trait]
 impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> CreateTaskState<TYPES, I, V>
-    for ConsensusTaskState<TYPES, I>
+    for ConsensusTaskState<TYPES, I, V>
 {
     async fn create_from(
         handle: &SystemContextHandle<TYPES, I, V>,
-    ) -> ConsensusTaskState<TYPES, I> {
+    ) -> Self {
         let consensus = handle.hotshot.consensus();
         let timeout_task = handle.spawn_initial_timeout_task();
 
-        ConsensusTaskState {
+        Self {
             consensus: OuterConsensus::new(consensus),
             instance_state: handle.hotshot.instance_state(),
             timeout: handle.hotshot.config.next_view_timeout,
@@ -268,24 +259,21 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> CreateTaskState
             quorum_membership: handle.hotshot.memberships.quorum_membership.clone().into(),
             da_membership: handle.hotshot.memberships.da_membership.clone().into(),
             storage: Arc::clone(&handle.storage),
-            decided_upgrade_certificate: Arc::clone(
-                &handle.hotshot.upgrade_lock.decided_upgrade_certificate,
-            ),
+            upgrade_lock: handle.hotshot.upgrade_lock.clone(),
         }
     }
 }
 
-#[cfg(feature = "dependency-tasks")]
 #[async_trait]
 impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> CreateTaskState<TYPES, I, V>
-    for QuorumVoteTaskState<TYPES, I>
+    for QuorumVoteTaskState<TYPES, I, V>
 {
     async fn create_from(
         handle: &SystemContextHandle<TYPES, I, V>,
-    ) -> QuorumVoteTaskState<TYPES, I> {
+    ) -> Self {
         let consensus = handle.hotshot.consensus();
 
-        QuorumVoteTaskState {
+        Self {
             public_key: handle.public_key().clone(),
             private_key: handle.private_key().clone(),
             consensus: OuterConsensus::new(consensus),
@@ -298,25 +286,22 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> CreateTaskState
             output_event_stream: handle.hotshot.external_event_stream.0.clone(),
             id: handle.hotshot.id,
             storage: Arc::clone(&handle.storage),
-            decided_upgrade_certificate: Arc::clone(
-                &handle.hotshot.upgrade_lock.decided_upgrade_certificate,
-            ),
+            upgrade_lock: handle.hotshot.upgrade_lock.clone(),
         }
     }
 }
 
-#[cfg(feature = "dependency-tasks")]
 #[async_trait]
 impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> CreateTaskState<TYPES, I, V>
-    for QuorumProposalTaskState<TYPES, I>
+    for QuorumProposalTaskState<TYPES, I, V>
 {
     async fn create_from(
         handle: &SystemContextHandle<TYPES, I, V>,
-    ) -> QuorumProposalTaskState<TYPES, I> {
+    ) -> Self {
         let consensus = handle.hotshot.consensus();
         let timeout_task = handle.spawn_initial_timeout_task();
 
-        QuorumProposalTaskState {
+        Self {
             latest_proposed_view: handle.cur_view().await,
             proposal_dependencies: HashMap::new(),
             network: Arc::clone(&handle.hotshot.network),
@@ -333,25 +318,22 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> CreateTaskState
             round_start_delay: handle.hotshot.config.round_start_delay,
             id: handle.hotshot.id,
             formed_upgrade_certificate: None,
-            decided_upgrade_certificate: Arc::clone(
-                &handle.hotshot.upgrade_lock.decided_upgrade_certificate,
-            ),
+            upgrade_lock: handle.hotshot.upgrade_lock.clone(),
         }
     }
 }
 
-#[cfg(feature = "dependency-tasks")]
 #[async_trait]
 impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> CreateTaskState<TYPES, I, V>
-    for QuorumProposalRecvTaskState<TYPES, I>
+    for QuorumProposalRecvTaskState<TYPES, I, V>
 {
     async fn create_from(
         handle: &SystemContextHandle<TYPES, I, V>,
-    ) -> QuorumProposalRecvTaskState<TYPES, I> {
+    ) -> Self {
         let consensus = handle.hotshot.consensus();
         let timeout_task = handle.spawn_initial_timeout_task();
 
-        QuorumProposalRecvTaskState {
+        Self {
             public_key: handle.public_key().clone(),
             private_key: handle.private_key().clone(),
             consensus: OuterConsensus::new(consensus),
@@ -369,25 +351,22 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> CreateTaskState
             spawned_tasks: BTreeMap::new(),
             instance_state: handle.hotshot.instance_state(),
             id: handle.hotshot.id,
-            decided_upgrade_certificate: Arc::clone(
-                &handle.hotshot.upgrade_lock.decided_upgrade_certificate,
-            ),
+            upgrade_lock: handle.hotshot.upgrade_lock.clone(),
         }
     }
 }
 
-#[cfg(feature = "dependency-tasks")]
 #[async_trait]
 impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> CreateTaskState<TYPES, I, V>
-    for Consensus2TaskState<TYPES, I>
+    for Consensus2TaskState<TYPES, I, V>
 {
     async fn create_from(
         handle: &SystemContextHandle<TYPES, I, V>,
-    ) -> Consensus2TaskState<TYPES, I> {
+    ) -> Self {
         let consensus = handle.hotshot.consensus();
         let timeout_task = handle.spawn_initial_timeout_task();
 
-        Consensus2TaskState {
+        Self {
             public_key: handle.public_key().clone(),
             private_key: handle.private_key().clone(),
             instance_state: handle.hotshot.instance_state(),
@@ -406,20 +385,17 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> CreateTaskState
             consensus: OuterConsensus::new(consensus),
             last_decided_view: handle.cur_view().await,
             id: handle.hotshot.id,
-            decided_upgrade_certificate: Arc::clone(
-                &handle.hotshot.upgrade_lock.decided_upgrade_certificate,
-            ),
+            upgrade_lock: handle.hotshot.upgrade_lock.clone(),
         }
     }
 }
 
-#[cfg(feature = "rewind")]
 #[async_trait]
 impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> CreateTaskState<TYPES, I, V>
     for RewindTaskState<TYPES>
 {
-    async fn create_from(handle: &SystemContextHandle<TYPES, I, V>) -> RewindTaskState<TYPES> {
-        RewindTaskState {
+    async fn create_from(handle: &SystemContextHandle<TYPES, I, V>) -> Self {
+        Self {
             events: Vec::new(),
             id: handle.hotshot.id,
         }

--- a/crates/hotshot/src/tasks/task_state.rs
+++ b/crates/hotshot/src/tasks/task_state.rs
@@ -11,16 +11,12 @@ use std::{
 
 use async_trait::async_trait;
 use chrono::Utc;
-use hotshot_task_impls::consensus::ConsensusTaskState;
-use hotshot_task_impls::rewind::RewindTaskState;
 use hotshot_task_impls::{
-    builder::BuilderClient, da::DaTaskState, request::NetworkRequestState,
-    transactions::TransactionTaskState, upgrade::UpgradeTaskState, vid::VidTaskState,
-    view_sync::ViewSyncTaskState,
-};
-use hotshot_task_impls::{
-    consensus2::Consensus2TaskState, quorum_proposal::QuorumProposalTaskState,
+    builder::BuilderClient, consensus::ConsensusTaskState, consensus2::Consensus2TaskState,
+    da::DaTaskState, quorum_proposal::QuorumProposalTaskState,
     quorum_proposal_recv::QuorumProposalRecvTaskState, quorum_vote::QuorumVoteTaskState,
+    request::NetworkRequestState, rewind::RewindTaskState, transactions::TransactionTaskState,
+    upgrade::UpgradeTaskState, vid::VidTaskState, view_sync::ViewSyncTaskState,
 };
 use hotshot_types::{
     consensus::OuterConsensus,
@@ -48,9 +44,7 @@ where
 impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> CreateTaskState<TYPES, I, V>
     for NetworkRequestState<TYPES, I>
 {
-    async fn create_from(
-        handle: &SystemContextHandle<TYPES, I, V>,
-    ) -> Self {
+    async fn create_from(handle: &SystemContextHandle<TYPES, I, V>) -> Self {
         Self {
             network: Arc::clone(&handle.hotshot.network),
             state: OuterConsensus::new(handle.hotshot.consensus()),
@@ -190,9 +184,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> CreateTaskState
 impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> CreateTaskState<TYPES, I, V>
     for TransactionTaskState<TYPES, I, V>
 {
-    async fn create_from(
-        handle: &SystemContextHandle<TYPES, I, V>,
-    ) -> Self {
+    async fn create_from(handle: &SystemContextHandle<TYPES, I, V>) -> Self {
         Self {
             builder_timeout: handle.builder_timeout(),
             output_event_stream: handle.hotshot.external_event_stream.0.clone(),
@@ -229,9 +221,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> CreateTaskState
 impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> CreateTaskState<TYPES, I, V>
     for ConsensusTaskState<TYPES, I, V>
 {
-    async fn create_from(
-        handle: &SystemContextHandle<TYPES, I, V>,
-    ) -> Self {
+    async fn create_from(handle: &SystemContextHandle<TYPES, I, V>) -> Self {
         let consensus = handle.hotshot.consensus();
         let timeout_task = handle.spawn_initial_timeout_task();
 
@@ -268,9 +258,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> CreateTaskState
 impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> CreateTaskState<TYPES, I, V>
     for QuorumVoteTaskState<TYPES, I, V>
 {
-    async fn create_from(
-        handle: &SystemContextHandle<TYPES, I, V>,
-    ) -> Self {
+    async fn create_from(handle: &SystemContextHandle<TYPES, I, V>) -> Self {
         let consensus = handle.hotshot.consensus();
 
         Self {
@@ -295,9 +283,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> CreateTaskState
 impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> CreateTaskState<TYPES, I, V>
     for QuorumProposalTaskState<TYPES, I, V>
 {
-    async fn create_from(
-        handle: &SystemContextHandle<TYPES, I, V>,
-    ) -> Self {
+    async fn create_from(handle: &SystemContextHandle<TYPES, I, V>) -> Self {
         let consensus = handle.hotshot.consensus();
         let timeout_task = handle.spawn_initial_timeout_task();
 
@@ -327,9 +313,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> CreateTaskState
 impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> CreateTaskState<TYPES, I, V>
     for QuorumProposalRecvTaskState<TYPES, I, V>
 {
-    async fn create_from(
-        handle: &SystemContextHandle<TYPES, I, V>,
-    ) -> Self {
+    async fn create_from(handle: &SystemContextHandle<TYPES, I, V>) -> Self {
         let consensus = handle.hotshot.consensus();
         let timeout_task = handle.spawn_initial_timeout_task();
 
@@ -360,9 +344,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> CreateTaskState
 impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> CreateTaskState<TYPES, I, V>
     for Consensus2TaskState<TYPES, I, V>
 {
-    async fn create_from(
-        handle: &SystemContextHandle<TYPES, I, V>,
-    ) -> Self {
+    async fn create_from(handle: &SystemContextHandle<TYPES, I, V>) -> Self {
         let consensus = handle.hotshot.consensus();
         let timeout_task = handle.spawn_initial_timeout_task();
 

--- a/crates/hotshot/src/tasks/task_state.rs
+++ b/crates/hotshot/src/tasks/task_state.rs
@@ -4,7 +4,6 @@
 // You should have received a copy of the MIT License
 // along with the HotShot repository. If not, see <https://mit-license.org/>.
 
-use crate::Versions;
 use std::{
     collections::{BTreeMap, HashMap},
     sync::{atomic::AtomicBool, Arc},
@@ -34,7 +33,7 @@ use hotshot_types::{
     },
 };
 
-use crate::types::SystemContextHandle;
+use crate::{types::SystemContextHandle, Versions};
 
 /// Trait for creating task states.
 #[async_trait]
@@ -52,7 +51,9 @@ where
 impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> CreateTaskState<TYPES, I, V>
     for NetworkRequestState<TYPES, I>
 {
-    async fn create_from(handle: &SystemContextHandle<TYPES, I, V>) -> NetworkRequestState<TYPES, I> {
+    async fn create_from(
+        handle: &SystemContextHandle<TYPES, I, V>,
+    ) -> NetworkRequestState<TYPES, I> {
         NetworkRequestState {
             network: Arc::clone(&handle.hotshot.network),
             state: OuterConsensus::new(handle.hotshot.consensus()),
@@ -92,7 +93,9 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> CreateTaskState
             stop_proposing_time: handle.hotshot.config.stop_proposing_time,
             start_voting_time: handle.hotshot.config.start_voting_time,
             stop_voting_time: handle.hotshot.config.stop_voting_time,
-            decided_upgrade_certificate: Arc::clone(&handle.hotshot.upgrade_lock.decided_upgrade_certificate),
+            decided_upgrade_certificate: Arc::clone(
+                &handle.hotshot.upgrade_lock.decided_upgrade_certificate,
+            ),
         };
 
         #[cfg(feature = "example-upgrade")]
@@ -113,7 +116,9 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> CreateTaskState
             stop_proposing_time: u64::MAX,
             start_voting_time: 0,
             stop_voting_time: u64::MAX,
-            decided_upgrade_certificate: Arc::clone(&handle.hotshot.upgrade_lock.decided_upgrade_certificate),
+            decided_upgrade_certificate: Arc::clone(
+                &handle.hotshot.upgrade_lock.decided_upgrade_certificate,
+            ),
         };
     }
 }
@@ -191,7 +196,9 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> CreateTaskState
 impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> CreateTaskState<TYPES, I, V>
     for TransactionTaskState<TYPES, I>
 {
-    async fn create_from(handle: &SystemContextHandle<TYPES, I, V>) -> TransactionTaskState<TYPES, I> {
+    async fn create_from(
+        handle: &SystemContextHandle<TYPES, I, V>,
+    ) -> TransactionTaskState<TYPES, I> {
         TransactionTaskState {
             builder_timeout: handle.builder_timeout(),
             output_event_stream: handle.hotshot.external_event_stream.0.clone(),
@@ -211,7 +218,9 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> CreateTaskState
                 .cloned()
                 .map(BuilderClient::new)
                 .collect(),
-            decided_upgrade_certificate: Arc::clone(&handle.hotshot.upgrade_lock.decided_upgrade_certificate),
+            decided_upgrade_certificate: Arc::clone(
+                &handle.hotshot.upgrade_lock.decided_upgrade_certificate,
+            ),
             auction_results_provider: Arc::clone(
                 &handle.hotshot.marketplace_config.auction_results_provider,
             ),
@@ -229,7 +238,9 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> CreateTaskState
 impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> CreateTaskState<TYPES, I, V>
     for ConsensusTaskState<TYPES, I>
 {
-    async fn create_from(handle: &SystemContextHandle<TYPES, I, V>) -> ConsensusTaskState<TYPES, I> {
+    async fn create_from(
+        handle: &SystemContextHandle<TYPES, I, V>,
+    ) -> ConsensusTaskState<TYPES, I> {
         let consensus = handle.hotshot.consensus();
         let timeout_task = handle.spawn_initial_timeout_task();
 
@@ -257,7 +268,9 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> CreateTaskState
             quorum_membership: handle.hotshot.memberships.quorum_membership.clone().into(),
             da_membership: handle.hotshot.memberships.da_membership.clone().into(),
             storage: Arc::clone(&handle.storage),
-            decided_upgrade_certificate: Arc::clone(&handle.hotshot.upgrade_lock.decided_upgrade_certificate),
+            decided_upgrade_certificate: Arc::clone(
+                &handle.hotshot.upgrade_lock.decided_upgrade_certificate,
+            ),
         }
     }
 }
@@ -267,7 +280,9 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> CreateTaskState
 impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> CreateTaskState<TYPES, I, V>
     for QuorumVoteTaskState<TYPES, I>
 {
-    async fn create_from(handle: &SystemContextHandle<TYPES, I, V>) -> QuorumVoteTaskState<TYPES, I> {
+    async fn create_from(
+        handle: &SystemContextHandle<TYPES, I, V>,
+    ) -> QuorumVoteTaskState<TYPES, I> {
         let consensus = handle.hotshot.consensus();
 
         QuorumVoteTaskState {
@@ -283,7 +298,9 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> CreateTaskState
             output_event_stream: handle.hotshot.external_event_stream.0.clone(),
             id: handle.hotshot.id,
             storage: Arc::clone(&handle.storage),
-            decided_upgrade_certificate: Arc::clone(&handle.hotshot.upgrade_lock.decided_upgrade_certificate),
+            decided_upgrade_certificate: Arc::clone(
+                &handle.hotshot.upgrade_lock.decided_upgrade_certificate,
+            ),
         }
     }
 }
@@ -316,7 +333,9 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> CreateTaskState
             round_start_delay: handle.hotshot.config.round_start_delay,
             id: handle.hotshot.id,
             formed_upgrade_certificate: None,
-            decided_upgrade_certificate: Arc::clone(&handle.hotshot.upgrade_lock.decided_upgrade_certificate),
+            decided_upgrade_certificate: Arc::clone(
+                &handle.hotshot.upgrade_lock.decided_upgrade_certificate,
+            ),
         }
     }
 }
@@ -350,7 +369,9 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> CreateTaskState
             spawned_tasks: BTreeMap::new(),
             instance_state: handle.hotshot.instance_state(),
             id: handle.hotshot.id,
-            decided_upgrade_certificate: Arc::clone(&handle.hotshot.upgrade_lock.decided_upgrade_certificate),
+            decided_upgrade_certificate: Arc::clone(
+                &handle.hotshot.upgrade_lock.decided_upgrade_certificate,
+            ),
         }
     }
 }
@@ -360,7 +381,9 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> CreateTaskState
 impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> CreateTaskState<TYPES, I, V>
     for Consensus2TaskState<TYPES, I>
 {
-    async fn create_from(handle: &SystemContextHandle<TYPES, I, V>) -> Consensus2TaskState<TYPES, I> {
+    async fn create_from(
+        handle: &SystemContextHandle<TYPES, I, V>,
+    ) -> Consensus2TaskState<TYPES, I> {
         let consensus = handle.hotshot.consensus();
         let timeout_task = handle.spawn_initial_timeout_task();
 
@@ -383,7 +406,9 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> CreateTaskState
             consensus: OuterConsensus::new(consensus),
             last_decided_view: handle.cur_view().await,
             id: handle.hotshot.id,
-            decided_upgrade_certificate: Arc::clone(&handle.hotshot.upgrade_lock.decided_upgrade_certificate),
+            decided_upgrade_certificate: Arc::clone(
+                &handle.hotshot.upgrade_lock.decided_upgrade_certificate,
+            ),
         }
     }
 }

--- a/crates/hotshot/src/types/handle.rs
+++ b/crates/hotshot/src/types/handle.rs
@@ -8,7 +8,6 @@
 
 use std::{sync::Arc, time::Duration};
 
-use crate::Versions;
 use async_broadcast::{InactiveReceiver, Receiver, Sender};
 use async_compatibility_layer::art::{async_sleep, async_spawn};
 use async_lock::RwLock;
@@ -27,7 +26,7 @@ use hotshot_types::{
 use tokio::task::JoinHandle;
 use tracing::instrument;
 
-use crate::{traits::NodeImplementation, types::Event, Memberships, SystemContext};
+use crate::{traits::NodeImplementation, types::Event, Memberships, SystemContext, Versions};
 
 /// Event streaming handle for a [`SystemContext`] instance running in the background
 ///
@@ -64,7 +63,9 @@ pub struct SystemContextHandle<TYPES: NodeType, I: NodeImplementation<TYPES>, V:
     pub memberships: Arc<Memberships<TYPES>>,
 }
 
-impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static, V: Versions> SystemContextHandle<TYPES, I, V> {
+impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static, V: Versions>
+    SystemContextHandle<TYPES, I, V>
+{
     /// Adds a hotshot consensus-related task to the `SystemContextHandle`.
     pub fn add_task<S: TaskState<Event = HotShotEvent<TYPES>> + 'static>(&mut self, task_state: S) {
         let task = Task::new(
@@ -156,7 +157,10 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static, V: Versions> Syste
         tx: TYPES::Transaction,
     ) -> Result<(), HotShotError<TYPES>> {
         self.hotshot
-            .publish_transaction_async(tx, Arc::clone(&self.hotshot.upgrade_lock.decided_upgrade_certificate))
+            .publish_transaction_async(
+                tx,
+                Arc::clone(&self.hotshot.upgrade_lock.decided_upgrade_certificate),
+            )
             .await
     }
 

--- a/crates/hotshot/src/types/handle.rs
+++ b/crates/hotshot/src/types/handle.rs
@@ -156,12 +156,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static, V: Versions>
         &self,
         tx: TYPES::Transaction,
     ) -> Result<(), HotShotError<TYPES>> {
-        self.hotshot
-            .publish_transaction_async(
-                tx,
-                Arc::clone(&self.hotshot.upgrade_lock.decided_upgrade_certificate),
-            )
-            .await
+        self.hotshot.publish_transaction_async(tx).await
     }
 
     /// Get the underlying consensus state for this [`SystemContext`]

--- a/crates/macros/src/lib.rs
+++ b/crates/macros/src/lib.rs
@@ -227,27 +227,28 @@ fn cross_tests_internal(test_spec: CrossTestData) -> TokenStream {
     for ty in types.clone() {
         let mut type_mod = quote! {};
         for imp in impls.clone() {
-          for version in versions.clone() {
-            let test_data = TestDataBuilder::create_empty()
-                .test_name(test_spec.test_name.clone())
-                .metadata(test_spec.metadata.clone())
-                .ignore(test_spec.ignore.clone())
-                .version(version.clone())
-                .imply(imp.clone())
-                .ty(ty.clone())
-                .build()
-                .unwrap();
-            let test = test_data.generate_test();
+            for version in versions.clone() {
+                let test_data = TestDataBuilder::create_empty()
+                    .test_name(test_spec.test_name.clone())
+                    .metadata(test_spec.metadata.clone())
+                    .ignore(test_spec.ignore.clone())
+                    .version(version.clone())
+                    .imply(imp.clone())
+                    .ty(ty.clone())
+                    .build()
+                    .unwrap();
+                let test = test_data.generate_test();
 
-            let impl_str = format_ident!("{}", imp.to_lower_snake_str());
-            let impl_result = quote! {
-                pub mod #impl_str {
-                    use super::*;
-                    #test
-                }
-            };
-            type_mod.extend(impl_result);
-        } }
+                let impl_str = format_ident!("{}", imp.to_lower_snake_str());
+                let impl_result = quote! {
+                    pub mod #impl_str {
+                        use super::*;
+                        #test
+                    }
+                };
+                type_mod.extend(impl_result);
+            }
+        }
         let ty_str = format_ident!("{}", ty.to_lower_snake_str());
         let typ_result = quote! {
             pub mod #ty_str {

--- a/crates/macros/src/lib.rs
+++ b/crates/macros/src/lib.rs
@@ -19,6 +19,8 @@ use syn::{
 struct CrossTestData {
     /// imlementations
     impls: ExprArray,
+    /// versions
+    versions: ExprArray,
     /// types
     types: ExprArray,
     /// name of the test
@@ -34,6 +36,7 @@ impl CrossTestDataBuilder {
     fn is_ready(&self) -> bool {
         self.impls.is_some()
             && self.types.is_some()
+            && self.versions.is_some()
             && self.test_name.is_some()
             && self.metadata.is_some()
             && self.test_name.is_some()
@@ -48,6 +51,8 @@ struct TestData {
     ty: ExprPath,
     /// impl
     imply: ExprPath,
+    /// impl
+    version: ExprPath,
     /// name of test
     test_name: Ident,
     /// test description
@@ -101,6 +106,7 @@ impl TestData {
         let TestData {
             ty,
             imply,
+            version,
             test_name,
             metadata,
             ignore,
@@ -124,7 +130,7 @@ impl TestData {
             async fn #test_name() {
                 async_compatibility_layer::logging::setup_logging();
                 async_compatibility_layer::logging::setup_backtrace();
-                TestDescription::<#ty, #imply>::gen_launcher((#metadata), 0).launch().run_test::<SimpleBuilderImplementation>().await;
+                TestDescription::<#ty, #imply, #version>::gen_launcher((#metadata), 0).launch().run_test::<SimpleBuilderImplementation>().await;
             }
         }
     }
@@ -137,6 +143,7 @@ mod keywords {
     syn::custom_keyword!(TestName);
     syn::custom_keyword!(Types);
     syn::custom_keyword!(Impls);
+    syn::custom_keyword!(Versions);
 }
 
 impl Parse for CrossTestData {
@@ -156,6 +163,11 @@ impl Parse for CrossTestData {
                 input.parse::<Token![:]>()?;
                 let impls = input.parse::<ExprArray>()?;
                 description.impls(impls);
+            } else if input.peek(keywords::Versions) {
+                let _ = input.parse::<keywords::Versions>()?;
+                input.parse::<Token![:]>()?;
+                let versions = input.parse::<ExprArray>()?;
+                description.versions(versions);
             } else if input.peek(keywords::TestName) {
                 let _ = input.parse::<keywords::TestName>()?;
                 input.parse::<Token![:]>()?;
@@ -173,7 +185,7 @@ impl Parse for CrossTestData {
                 description.ignore(ignore);
             } else {
                 panic!(
-                    "Unexpected token. Expected one of: Metadata, Ignore, Impls, Types, Testname"
+                    "Unexpected token. Expected one of: Metadata, Ignore, Impls, Versions, Types, Testname"
                 );
             }
             if input.peek(Token![,]) {
@@ -204,14 +216,23 @@ fn cross_tests_internal(test_spec: CrossTestData) -> TokenStream {
         p
     });
 
+    let versions = test_spec.versions.elems.iter().map(|t| {
+        let Expr::Path(p) = t else {
+            panic!("Expected Path for Version! Got {t:?}");
+        };
+        p
+    });
+
     let mut result = quote! {};
     for ty in types.clone() {
         let mut type_mod = quote! {};
         for imp in impls.clone() {
+          for version in versions.clone() {
             let test_data = TestDataBuilder::create_empty()
                 .test_name(test_spec.test_name.clone())
                 .metadata(test_spec.metadata.clone())
                 .ignore(test_spec.ignore.clone())
+                .version(version.clone())
                 .imply(imp.clone())
                 .ty(ty.clone())
                 .build()
@@ -226,7 +247,7 @@ fn cross_tests_internal(test_spec: CrossTestData) -> TokenStream {
                 }
             };
             type_mod.extend(impl_result);
-        }
+        } }
         let ty_str = format_ident!("{}", ty.to_lower_snake_str());
         let typ_result = quote! {
             pub mod #ty_str {

--- a/crates/task-impls/src/consensus/handlers.rs
+++ b/crates/task-impls/src/consensus/handlers.rs
@@ -6,7 +6,6 @@
 
 use core::time::Duration;
 use std::{marker::PhantomData, sync::Arc};
-use crate::consensus::Versions;
 
 use anyhow::{bail, ensure, Context, Result};
 use async_broadcast::Sender;
@@ -23,7 +22,7 @@ use hotshot_types::{
     data::{null_block, Leaf, QuorumProposal, ViewChangeEvidence},
     event::{Event, EventType},
     message::{GeneralConsensusMessage, Proposal},
-    simple_certificate::{version, UpgradeCertificate},
+    simple_certificate::UpgradeCertificate,
     simple_vote::QuorumData,
     traits::{
         block_contents::BlockHeader,
@@ -43,6 +42,7 @@ use vbs::version::{StaticVersionType, Version};
 
 use super::ConsensusTaskState;
 use crate::{
+    consensus::{UpgradeLock, Versions},
     events::HotShotEvent,
     helpers::{
         broadcast_event, decide_from_proposal, fetch_proposal, parent_leaf_and_state, update_view,
@@ -161,7 +161,7 @@ pub async fn create_and_send_proposal<TYPES: NodeType>(
 /// standard case proposal scenario.
 #[allow(clippy::too_many_arguments)]
 #[instrument(skip_all)]
-pub async fn publish_proposal_from_commitment_and_metadata<TYPES: NodeType>(
+pub async fn publish_proposal_from_commitment_and_metadata<TYPES: NodeType, V: Versions>(
     view: TYPES::Time,
     sender: Sender<Arc<HotShotEvent<TYPES>>>,
     quorum_membership: Arc<TYPES::Membership>,
@@ -170,7 +170,7 @@ pub async fn publish_proposal_from_commitment_and_metadata<TYPES: NodeType>(
     consensus: OuterConsensus<TYPES>,
     delay: u64,
     formed_upgrade_certificate: Option<UpgradeCertificate<TYPES>>,
-    decided_upgrade_certificate: Arc<RwLock<Option<UpgradeCertificate<TYPES>>>>,
+    upgrade_lock: UpgradeLock<TYPES, V>,
     commitment_and_metadata: Option<CommitmentAndMetadata<TYPES>>,
     proposal_cert: Option<ViewChangeEvidence<TYPES>>,
     instance_state: Arc<TYPES::InstanceState>,
@@ -198,7 +198,7 @@ pub async fn publish_proposal_from_commitment_and_metadata<TYPES: NodeType>(
 
     if let Some(cert) = proposal_upgrade_certificate.clone() {
         if cert
-            .is_relevant(view, Arc::clone(&decided_upgrade_certificate))
+            .is_relevant(view, Arc::clone(&upgrade_lock.decided_upgrade_certificate))
             .await
             .is_err()
         {
@@ -223,7 +223,7 @@ pub async fn publish_proposal_from_commitment_and_metadata<TYPES: NodeType>(
         "Cannot propose because our VID payload commitment and metadata is for an older view."
     );
 
-    let version = version(view, &decided_upgrade_certificate.read().await.clone())?;
+    let version = upgrade_lock.version(view).await?;
 
     let create_and_send_proposal_handle = async_spawn(async move {
         match create_and_send_proposal(
@@ -258,7 +258,7 @@ pub async fn publish_proposal_from_commitment_and_metadata<TYPES: NodeType>(
 /// `commitment_and_metadata`, or a `decided_upgrade_certificate`.
 #[allow(clippy::too_many_arguments)]
 #[instrument(skip_all)]
-pub async fn publish_proposal_if_able<TYPES: NodeType>(
+pub async fn publish_proposal_if_able<TYPES: NodeType, V: Versions>(
     view: TYPES::Time,
     sender: Sender<Arc<HotShotEvent<TYPES>>>,
     quorum_membership: Arc<TYPES::Membership>,
@@ -267,7 +267,7 @@ pub async fn publish_proposal_if_able<TYPES: NodeType>(
     consensus: OuterConsensus<TYPES>,
     delay: u64,
     formed_upgrade_certificate: Option<UpgradeCertificate<TYPES>>,
-    decided_upgrade_certificate: Arc<RwLock<Option<UpgradeCertificate<TYPES>>>>,
+    upgrade_lock: UpgradeLock<TYPES, V>,
     commitment_and_metadata: Option<CommitmentAndMetadata<TYPES>>,
     proposal_cert: Option<ViewChangeEvidence<TYPES>>,
     instance_state: Arc<TYPES::InstanceState>,
@@ -282,7 +282,7 @@ pub async fn publish_proposal_if_able<TYPES: NodeType>(
         consensus,
         delay,
         formed_upgrade_certificate,
-        decided_upgrade_certificate,
+        upgrade_lock,
         commitment_and_metadata,
         proposal_cert,
         instance_state,
@@ -296,7 +296,11 @@ pub async fn publish_proposal_if_able<TYPES: NodeType>(
 /// Returns the proposal that should be used to set the `cur_proposal` for other tasks.
 #[allow(clippy::too_many_lines)]
 #[instrument(skip_all)]
-pub(crate) async fn handle_quorum_proposal_recv<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions>(
+pub(crate) async fn handle_quorum_proposal_recv<
+    TYPES: NodeType,
+    I: NodeImplementation<TYPES>,
+    V: Versions,
+>(
     proposal: &Proposal<TYPES, QuorumProposal<TYPES>>,
     sender: &TYPES::SignatureKey,
     event_stream: Sender<Arc<HotShotEvent<TYPES>>>,
@@ -474,7 +478,7 @@ pub(crate) async fn handle_quorum_proposal_recv<TYPES: NodeType, I: NodeImplemen
                     OuterConsensus::new(Arc::clone(&task_state.consensus.inner_consensus)),
                     task_state.round_start_delay,
                     task_state.formed_upgrade_certificate.clone(),
-                    Arc::clone(&task_state.upgrade_lock.decided_upgrade_certificate),
+                    task_state.upgrade_lock.clone(),
                     task_state.payload_commitment_and_metadata.clone(),
                     task_state.proposal_cert.clone(),
                     Arc::clone(&task_state.instance_state),
@@ -519,7 +523,11 @@ pub(crate) async fn handle_quorum_proposal_recv<TYPES: NodeType, I: NodeImplemen
 /// Handle `QuorumProposalValidated` event content and submit a proposal if possible.
 #[allow(clippy::too_many_lines)]
 #[instrument(skip_all)]
-pub async fn handle_quorum_proposal_validated<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions>(
+pub async fn handle_quorum_proposal_validated<
+    TYPES: NodeType,
+    I: NodeImplementation<TYPES>,
+    V: Versions,
+>(
     proposal: &QuorumProposal<TYPES>,
     event_stream: Sender<Arc<HotShotEvent<TYPES>>>,
     task_state: &mut ConsensusTaskState<TYPES, I, V>,
@@ -536,7 +544,11 @@ pub async fn handle_quorum_proposal_validated<TYPES: NodeType, I: NodeImplementa
     .await;
 
     if let Some(cert) = res.decided_upgrade_cert {
-        let mut decided_certificate_lock = task_state.upgrade_lock.decided_upgrade_certificate.write().await;
+        let mut decided_certificate_lock = task_state
+            .upgrade_lock
+            .decided_upgrade_certificate
+            .write()
+            .await;
         *decided_certificate_lock = Some(cert.clone());
         drop(decided_certificate_lock);
         let _ = event_stream
@@ -635,9 +647,9 @@ pub async fn handle_quorum_proposal_validated<TYPES: NodeType, I: NodeImplementa
 
 /// Private key, latest decided upgrade certificate, committee membership, and event stream, for
 /// sending the vote.
-type VoteInfo<TYPES> = (
+type VoteInfo<TYPES, V> = (
     <<TYPES as NodeType>::SignatureKey as SignatureKey>::PrivateKey,
-    Arc<RwLock<Option<UpgradeCertificate<TYPES>>>>,
+    UpgradeLock<TYPES, V>,
     Arc<<TYPES as NodeType>::Membership>,
     Sender<Arc<HotShotEvent<TYPES>>>,
 );
@@ -648,7 +660,11 @@ type VoteInfo<TYPES> = (
 /// Check if we are able to vote, like whether the proposal is valid,
 /// whether we have DAC and VID share, and if so, vote.
 #[instrument(skip_all, fields(id = id, view = *cur_view))]
-pub async fn update_state_and_vote_if_able<TYPES: NodeType, I: NodeImplementation<TYPES>>(
+pub async fn update_state_and_vote_if_able<
+    TYPES: NodeType,
+    I: NodeImplementation<TYPES>,
+    V: Versions,
+>(
     cur_view: TYPES::Time,
     proposal: QuorumProposal<TYPES>,
     public_key: TYPES::SignatureKey,
@@ -656,7 +672,7 @@ pub async fn update_state_and_vote_if_able<TYPES: NodeType, I: NodeImplementatio
     storage: Arc<RwLock<I::Storage>>,
     quorum_membership: Arc<TYPES::Membership>,
     instance_state: Arc<TYPES::InstanceState>,
-    vote_info: VoteInfo<TYPES>,
+    vote_info: VoteInfo<TYPES, V>,
     id: u64,
 ) -> bool {
     use hotshot_types::simple_vote::QuorumVote;
@@ -680,7 +696,7 @@ pub async fn update_state_and_vote_if_able<TYPES: NodeType, I: NodeImplementatio
         return false;
     };
 
-    if let Some(upgrade_cert) = &vote_info.1.read().await.clone() {
+    if let Some(upgrade_cert) = &vote_info.1.decided_upgrade_certificate.read().await.clone() {
         if upgrade_cert.upgrading_in(cur_view)
             && Some(proposal.block_header.payload_commitment())
                 != null_block::commitment(quorum_membership.total_nodes())
@@ -735,7 +751,7 @@ pub async fn update_state_and_vote_if_able<TYPES: NodeType, I: NodeImplementatio
     };
     drop(read_consnesus);
 
-    let version = match version(view, &vote_info.1.read().await.clone()) {
+    let version = match vote_info.1.version(view).await {
         Ok(version) => version,
         Err(e) => {
             error!("Failed to calculate the version: {e:?}");

--- a/crates/task-impls/src/consensus2/handlers.rs
+++ b/crates/task-impls/src/consensus2/handlers.rs
@@ -5,8 +5,6 @@
 // along with the HotShot repository. If not, see <https://mit-license.org/>.
 
 use std::{sync::Arc, time::Duration};
-use crate::consensus2::{Versions, UpgradeLock};
-
 
 use anyhow::{ensure, Context, Result};
 use async_broadcast::Sender;
@@ -26,13 +24,18 @@ use tracing::{debug, error, instrument};
 
 use super::Consensus2TaskState;
 use crate::{
+    consensus2::{UpgradeLock, Versions},
     events::{HotShotEvent, HotShotTaskCompleted},
     helpers::{broadcast_event, cancel_task},
     vote_collection::{create_vote_accumulator, AccumulatorInfo, HandleVoteEvent},
 };
 
 /// Handle a `QuorumVoteRecv` event.
-pub(crate) async fn handle_quorum_vote_recv<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions>(
+pub(crate) async fn handle_quorum_vote_recv<
+    TYPES: NodeType,
+    I: NodeImplementation<TYPES>,
+    V: Versions,
+>(
     vote: &QuorumVote<TYPES>,
     event: Arc<HotShotEvent<TYPES>>,
     sender: &Sender<Arc<HotShotEvent<TYPES>>>,
@@ -75,7 +78,11 @@ pub(crate) async fn handle_quorum_vote_recv<TYPES: NodeType, I: NodeImplementati
 }
 
 /// Handle a `TimeoutVoteRecv` event.
-pub(crate) async fn handle_timeout_vote_recv<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions>(
+pub(crate) async fn handle_timeout_vote_recv<
+    TYPES: NodeType,
+    I: NodeImplementation<TYPES>,
+    V: Versions,
+>(
     vote: &TimeoutVote<TYPES>,
     event: Arc<HotShotEvent<TYPES>>,
     sender: &Sender<Arc<HotShotEvent<TYPES>>>,
@@ -120,7 +127,11 @@ pub(crate) async fn handle_timeout_vote_recv<TYPES: NodeType, I: NodeImplementat
 
 /// Handle a `ViewChange` event.
 #[instrument(skip_all)]
-pub(crate) async fn handle_view_change<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions>(
+pub(crate) async fn handle_view_change<
+    TYPES: NodeType,
+    I: NodeImplementation<TYPES>,
+    V: Versions,
+>(
     new_view_number: TYPES::Time,
     sender: &Sender<Arc<HotShotEvent<TYPES>>>,
     task_state: &mut Consensus2TaskState<TYPES, I, V>,
@@ -137,8 +148,12 @@ pub(crate) async fn handle_view_change<TYPES: NodeType, I: NodeImplementation<TY
     task_state.cur_view = new_view_number;
 
     // If we have a decided upgrade certificate, the protocol version may also have been upgraded.
-    let decided_upgrade_certificate_read =
-        task_state.upgrade_lock.decided_upgrade_certificate.read().await.clone();
+    let decided_upgrade_certificate_read = task_state
+        .upgrade_lock
+        .decided_upgrade_certificate
+        .read()
+        .await
+        .clone();
     if let Some(cert) = decided_upgrade_certificate_read {
         if new_view_number == cert.data.new_version_first_view {
             error!(

--- a/crates/task-impls/src/consensus2/handlers.rs
+++ b/crates/task-impls/src/consensus2/handlers.rs
@@ -24,7 +24,7 @@ use tracing::{debug, error, instrument};
 
 use super::Consensus2TaskState;
 use crate::{
-    consensus2::{UpgradeLock, Versions},
+    consensus2::Versions,
     events::{HotShotEvent, HotShotTaskCompleted},
     helpers::{broadcast_event, cancel_task},
     vote_collection::{create_vote_accumulator, AccumulatorInfo, HandleVoteEvent},

--- a/crates/task-impls/src/consensus2/mod.rs
+++ b/crates/task-impls/src/consensus2/mod.rs
@@ -17,7 +17,7 @@ use hotshot_types::{
     consensus::OuterConsensus,
     event::Event,
     message::UpgradeLock,
-    simple_certificate::{QuorumCertificate, TimeoutCertificate, UpgradeCertificate},
+    simple_certificate::{QuorumCertificate, TimeoutCertificate},
     simple_vote::{QuorumVote, TimeoutVote},
     traits::{
         node_implementation::{NodeImplementation, NodeType, Versions},

--- a/crates/task-impls/src/consensus2/mod.rs
+++ b/crates/task-impls/src/consensus2/mod.rs
@@ -7,7 +7,6 @@
 use std::sync::Arc;
 
 use anyhow::Result;
-use hotshot_types::message::UpgradeLock;use hotshot_types::traits::node_implementation::Versions;
 use async_broadcast::{Receiver, Sender};
 use async_lock::RwLock;
 #[cfg(async_executor_impl = "async-std")]
@@ -17,10 +16,11 @@ use hotshot_task::task::TaskState;
 use hotshot_types::{
     consensus::OuterConsensus,
     event::Event,
+    message::UpgradeLock,
     simple_certificate::{QuorumCertificate, TimeoutCertificate, UpgradeCertificate},
     simple_vote::{QuorumVote, TimeoutVote},
     traits::{
-        node_implementation::{NodeImplementation, NodeType},
+        node_implementation::{NodeImplementation, NodeType, Versions},
         signature_key::SignatureKey,
     },
 };
@@ -154,7 +154,9 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> Consensus2TaskS
 }
 
 #[async_trait]
-impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> TaskState for Consensus2TaskState<TYPES, I, V> {
+impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> TaskState
+    for Consensus2TaskState<TYPES, I, V>
+{
     type Event = HotShotEvent<TYPES>;
 
     async fn handle_event(

--- a/crates/task-impls/src/lib.rs
+++ b/crates/task-impls/src/lib.rs
@@ -63,5 +63,4 @@ pub mod quorum_proposal;
 pub mod quorum_proposal_recv;
 
 /// Task for storing and replaying all received tasks by a node
-#[cfg(feature = "rewind")]
 pub mod rewind;

--- a/crates/task-impls/src/network.rs
+++ b/crates/task-impls/src/network.rs
@@ -17,13 +17,13 @@ use hotshot_types::{
     event::{Event, EventType, HotShotAction},
     message::{
         DaConsensusMessage, DataMessage, GeneralConsensusMessage, Message, MessageKind, Proposal,
-        SequencingMessage, VersionedMessage,
+        SequencingMessage, UpgradeLock, VersionedMessage,
     },
     simple_certificate::UpgradeCertificate,
     traits::{
         election::Membership,
         network::{BroadcastDelay, ConnectedNetwork, TransmitType, ViewMessage},
-        node_implementation::{ConsensusTime, NodeType},
+        node_implementation::{ConsensusTime, NodeType, Versions},
         storage::Storage,
     },
     vote::{HasViewNumber, Vote},
@@ -210,6 +210,7 @@ impl<TYPES: NodeType> NetworkMessageTaskState<TYPES> {
 /// network event task state
 pub struct NetworkEventTaskState<
     TYPES: NodeType,
+    V: Versions,
     COMMCHANNEL: ConnectedNetwork<TYPES::SignatureKey>,
     S: Storage<TYPES>,
 > {
@@ -224,16 +225,17 @@ pub struct NetworkEventTaskState<
     pub filter: fn(&Arc<HotShotEvent<TYPES>>) -> bool,
     /// Storage to store actionable events
     pub storage: Arc<RwLock<S>>,
-    /// Decided upgrade certificate
-    pub decided_upgrade_certificate: Option<UpgradeCertificate<TYPES>>,
+    /// Lock for a decided upgrade
+    pub upgrade_lock: UpgradeLock<TYPES, V>,
 }
 
 #[async_trait]
 impl<
         TYPES: NodeType,
+        V: Versions,
         COMMCHANNEL: ConnectedNetwork<TYPES::SignatureKey>,
         S: Storage<TYPES> + 'static,
-    > TaskState for NetworkEventTaskState<TYPES, COMMCHANNEL, S>
+    > TaskState for NetworkEventTaskState<TYPES, V, COMMCHANNEL, S>
 {
     type Event = HotShotEvent<TYPES>;
 
@@ -257,9 +259,10 @@ impl<
 
 impl<
         TYPES: NodeType,
+        V: Versions,
         COMMCHANNEL: ConnectedNetwork<TYPES::SignatureKey>,
         S: Storage<TYPES> + 'static,
-    > NetworkEventTaskState<TYPES, COMMCHANNEL, S>
+    > NetworkEventTaskState<TYPES, V, COMMCHANNEL, S>
 {
     /// Handle the given event.
     ///
@@ -297,7 +300,7 @@ impl<
                     )
                 }
                 HotShotEvent::VidDisperseSend(proposal, sender) => {
-                    self.handle_vid_disperse_proposal(proposal, &sender);
+                    self.handle_vid_disperse_proposal(proposal, &sender).await;
                     return;
                 }
                 HotShotEvent::DaProposalSend(proposal, sender) => {
@@ -404,10 +407,6 @@ impl<
                         .await;
                     return;
                 }
-                HotShotEvent::UpgradeDecided(cert) => {
-                    self.decided_upgrade_certificate = Some(cert.clone());
-                    return;
-                }
                 _ => {
                     return;
                 }
@@ -428,9 +427,9 @@ impl<
         let committee_topic = membership.committee_topic();
         let net = Arc::clone(&self.channel);
         let storage = Arc::clone(&self.storage);
-        let decided_upgrade_certificate = self.decided_upgrade_certificate.clone();
+        let upgrade_lock = self.upgrade_lock.clone();
         async_spawn(async move {
-            if NetworkEventTaskState::<TYPES, COMMCHANNEL, S>::maybe_record_action(
+            if NetworkEventTaskState::<TYPES, V, COMMCHANNEL, S>::maybe_record_action(
                 maybe_action,
                 Arc::clone(&storage),
                 view,
@@ -449,7 +448,7 @@ impl<
                 }
             }
 
-            let serialized_message = match message.serialize(&decided_upgrade_certificate) {
+            let serialized_message = match upgrade_lock.serialize(&message).await {
                 Ok(serialized) => serialized,
                 Err(e) => {
                     error!("Failed to serialize message: {}", e);
@@ -479,7 +478,7 @@ impl<
     }
 
     /// handle `VidDisperseSend`
-    fn handle_vid_disperse_proposal(
+    async fn handle_vid_disperse_proposal(
         &self,
         vid_proposal: Proposal<TYPES, VidDisperse<TYPES>>,
         sender: &<TYPES as NodeType>::SignatureKey,
@@ -496,7 +495,7 @@ impl<
                     DaConsensusMessage::VidDisperseMsg(proposal),
                 )), // TODO not a DaConsensusMessage https://github.com/EspressoSystems/HotShot/issues/1696
             };
-            let serialized_message = match message.serialize(&self.decided_upgrade_certificate) {
+            let serialized_message = match self.upgrade_lock.serialize(&message).await {
                 Ok(serialized) => serialized,
                 Err(e) => {
                     error!("Failed to serialize message: {}", e);
@@ -510,7 +509,7 @@ impl<
         let net = Arc::clone(&self.channel);
         let storage = Arc::clone(&self.storage);
         async_spawn(async move {
-            if NetworkEventTaskState::<TYPES, COMMCHANNEL, S>::maybe_record_action(
+            if NetworkEventTaskState::<TYPES, V, COMMCHANNEL, S>::maybe_record_action(
                 Some(HotShotAction::VidDisperse),
                 storage,
                 view,

--- a/crates/task-impls/src/network.rs
+++ b/crates/task-impls/src/network.rs
@@ -17,9 +17,8 @@ use hotshot_types::{
     event::{Event, EventType, HotShotAction},
     message::{
         DaConsensusMessage, DataMessage, GeneralConsensusMessage, Message, MessageKind, Proposal,
-        SequencingMessage, UpgradeLock, VersionedMessage,
+        SequencingMessage, UpgradeLock,
     },
-    simple_certificate::UpgradeCertificate,
     traits::{
         election::Membership,
         network::{BroadcastDelay, ConnectedNetwork, TransmitType, ViewMessage},

--- a/crates/task-impls/src/quorum_proposal/handlers.rs
+++ b/crates/task-impls/src/quorum_proposal/handlers.rs
@@ -20,7 +20,6 @@ use hotshot_task::{
 };
 use hotshot_types::{
     consensus::{CommitmentAndMetadata, OuterConsensus},
-    constants::MarketplaceVersion,
     data::{Leaf, QuorumProposal, VidDisperse, ViewChangeEvidence},
     message::Proposal,
     simple_certificate::UpgradeCertificate,
@@ -168,7 +167,7 @@ impl<TYPES: NodeType, V: Versions> ProposalDependencyHandle<TYPES, V> {
 
         let version = self.upgrade_lock.version(self.view_number).await?;
 
-        let block_header = if version < MarketplaceVersion::VERSION {
+        let block_header = if version < V::Marketplace::VERSION {
             TYPES::BlockHeader::new_legacy(
                 state.as_ref(),
                 self.instance_state.as_ref(),

--- a/crates/task-impls/src/quorum_proposal/handlers.rs
+++ b/crates/task-impls/src/quorum_proposal/handlers.rs
@@ -8,7 +8,7 @@
 //! initiate a proposal occurs.
 
 use std::{marker::PhantomData, sync::Arc, time::Duration};
-
+use crate::quorum_proposal::{UpgradeLock, Versions};
 use anyhow::{ensure, Context, Result};
 use async_broadcast::{Receiver, Sender};
 use async_compatibility_layer::art::{async_sleep, async_spawn};
@@ -59,7 +59,7 @@ pub(crate) enum ProposalDependency {
 }
 
 /// Handler for the proposal dependency
-pub struct ProposalDependencyHandle<TYPES: NodeType> {
+pub struct ProposalDependencyHandle<TYPES: NodeType, V: Versions> {
     /// Latest view number that has been proposed for (proxy for cur_view).
     pub latest_proposed_view: TYPES::Time,
 
@@ -98,14 +98,14 @@ pub struct ProposalDependencyHandle<TYPES: NodeType> {
     /// since they will be present in the leaf we propose off of.
     pub formed_upgrade_certificate: Option<UpgradeCertificate<TYPES>>,
 
-    /// An upgrade certificate that has been decided on, if any.
-    pub decided_upgrade_certificate: Arc<RwLock<Option<UpgradeCertificate<TYPES>>>>,
+    /// Lock for a decided upgrade
+    pub upgrade_lock: UpgradeLock<TYPES, V>,
 
     /// The node's id
     pub id: u64,
 }
 
-impl<TYPES: NodeType> ProposalDependencyHandle<TYPES> {
+impl<TYPES: NodeType, V: Versions> ProposalDependencyHandle<TYPES, V> {
     /// Publishes a proposal given the [`CommitmentAndMetadata`], [`VidDisperse`]
     /// and high qc [`hotshot_types::simple_certificate::QuorumCertificate`],
     /// with optional [`ViewChangeEvidence`].
@@ -167,7 +167,7 @@ impl<TYPES: NodeType> ProposalDependencyHandle<TYPES> {
 
         let version = version(
             self.view_number,
-            &self.decided_upgrade_certificate.read().await.clone(),
+            &self.upgrade_lock.decided_upgrade_certificate.read().await.clone(),
         )?;
 
         let block_header = if version < MarketplaceVersion::VERSION {
@@ -246,7 +246,7 @@ impl<TYPES: NodeType> ProposalDependencyHandle<TYPES> {
         Ok(())
     }
 }
-impl<TYPES: NodeType> HandleDepOutput for ProposalDependencyHandle<TYPES> {
+impl<TYPES: NodeType, V: Versions> HandleDepOutput for ProposalDependencyHandle<TYPES, V> {
     type Output = Vec<Vec<Vec<Arc<HotShotEvent<TYPES>>>>>;
 
     #[allow(clippy::no_effect_underscore_binding)]
@@ -347,7 +347,7 @@ impl<TYPES: NodeType> HandleDepOutput for ProposalDependencyHandle<TYPES> {
                 vid_share.unwrap(),
                 proposal_cert,
                 self.formed_upgrade_certificate.clone(),
-                Arc::clone(&self.decided_upgrade_certificate),
+                Arc::clone(&self.upgrade_lock.decided_upgrade_certificate),
             )
             .await
         {

--- a/crates/task-impls/src/quorum_proposal/mod.rs
+++ b/crates/task-impls/src/quorum_proposal/mod.rs
@@ -21,6 +21,7 @@ use hotshot_task::{
 use hotshot_types::{
     consensus::OuterConsensus,
     event::Event,
+    message::UpgradeLock,
     simple_certificate::UpgradeCertificate,
     traits::{
         election::Membership,
@@ -28,7 +29,6 @@ use hotshot_types::{
         signature_key::SignatureKey,
         storage::Storage,
     },
-    message::UpgradeLock,
     vote::{Certificate, HasViewNumber},
 };
 #[cfg(async_executor_impl = "tokio")]
@@ -102,7 +102,9 @@ pub struct QuorumProposalTaskState<TYPES: NodeType, I: NodeImplementation<TYPES>
     pub upgrade_lock: UpgradeLock<TYPES, V>,
 }
 
-impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> QuorumProposalTaskState<TYPES, I, V> {
+impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions>
+    QuorumProposalTaskState<TYPES, I, V>
+{
     /// Create an event dependency
     #[instrument(skip_all, fields(id = self.id, latest_proposed_view = *self.latest_proposed_view), name = "Create event dependency", level = "info")]
     fn create_event_dependency(

--- a/crates/task-impls/src/quorum_proposal/mod.rs
+++ b/crates/task-impls/src/quorum_proposal/mod.rs
@@ -24,10 +24,11 @@ use hotshot_types::{
     simple_certificate::UpgradeCertificate,
     traits::{
         election::Membership,
-        node_implementation::{ConsensusTime, NodeImplementation, NodeType},
+        node_implementation::{ConsensusTime, NodeImplementation, NodeType, Versions},
         signature_key::SignatureKey,
         storage::Storage,
     },
+    message::UpgradeLock,
     vote::{Certificate, HasViewNumber},
 };
 #[cfg(async_executor_impl = "tokio")]
@@ -43,7 +44,7 @@ use crate::{
 mod handlers;
 
 /// The state for the quorum proposal task.
-pub struct QuorumProposalTaskState<TYPES: NodeType, I: NodeImplementation<TYPES>> {
+pub struct QuorumProposalTaskState<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> {
     /// Latest view number that has been proposed for.
     pub latest_proposed_view: TYPES::Time,
 
@@ -97,11 +98,11 @@ pub struct QuorumProposalTaskState<TYPES: NodeType, I: NodeImplementation<TYPES>
     /// since they will be present in the leaf we propose off of.
     pub formed_upgrade_certificate: Option<UpgradeCertificate<TYPES>>,
 
-    /// An upgrade certificate that has been decided on, if any.
-    pub decided_upgrade_certificate: Arc<RwLock<Option<UpgradeCertificate<TYPES>>>>,
+    /// Lock for a decided upgrade
+    pub upgrade_lock: UpgradeLock<TYPES, V>,
 }
 
-impl<TYPES: NodeType, I: NodeImplementation<TYPES>> QuorumProposalTaskState<TYPES, I> {
+impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> QuorumProposalTaskState<TYPES, I, V> {
     /// Create an event dependency
     #[instrument(skip_all, fields(id = self.id, latest_proposed_view = *self.latest_proposed_view), name = "Create event dependency", level = "info")]
     fn create_event_dependency(
@@ -323,7 +324,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> QuorumProposalTaskState<TYPE
                 instance_state: Arc::clone(&self.instance_state),
                 consensus: OuterConsensus::new(Arc::clone(&self.consensus.inner_consensus)),
                 formed_upgrade_certificate: self.formed_upgrade_certificate.clone(),
-                decided_upgrade_certificate: Arc::clone(&self.decided_upgrade_certificate),
+                upgrade_lock: self.upgrade_lock.clone(),
                 id: self.id,
             },
         );
@@ -501,8 +502,8 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> QuorumProposalTaskState<TYPE
 }
 
 #[async_trait]
-impl<TYPES: NodeType, I: NodeImplementation<TYPES>> TaskState
-    for QuorumProposalTaskState<TYPES, I>
+impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> TaskState
+    for QuorumProposalTaskState<TYPES, I, V>
 {
     type Event = HotShotEvent<TYPES>;
 

--- a/crates/task-impls/src/quorum_proposal_recv/handlers.rs
+++ b/crates/task-impls/src/quorum_proposal_recv/handlers.rs
@@ -6,7 +6,7 @@
 
 #![allow(dead_code)]
 
-use std::sync::Arc;use crate::quorum_proposal_recv::{Versions, UpgradeLock};
+use std::sync::Arc;
 
 use anyhow::{bail, Context, Result};
 use async_broadcast::{broadcast, Sender};
@@ -35,6 +35,7 @@ use crate::{
         broadcast_event, fetch_proposal, update_view, validate_proposal_safety_and_liveness,
         validate_proposal_view_and_certs, SEND_VIEW_CHANGE_EVENT,
     },
+    quorum_proposal_recv::{UpgradeLock, Versions},
 };
 
 /// Whether the proposal contained in `QuorumProposalRecv` is fully validated or only the liveness
@@ -134,7 +135,11 @@ async fn validate_proposal_liveness<TYPES: NodeType, I: NodeImplementation<TYPES
 /// - The sequencer storage update fails.
 #[allow(clippy::too_many_lines)]
 #[instrument(skip_all)]
-pub(crate) async fn handle_quorum_proposal_recv<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions>(
+pub(crate) async fn handle_quorum_proposal_recv<
+    TYPES: NodeType,
+    I: NodeImplementation<TYPES>,
+    V: Versions,
+>(
     proposal: &Proposal<TYPES, QuorumProposal<TYPES>>,
     sender: &TYPES::SignatureKey,
     event_sender: &Sender<Arc<HotShotEvent<TYPES>>>,

--- a/crates/task-impls/src/quorum_proposal_recv/handlers.rs
+++ b/crates/task-impls/src/quorum_proposal_recv/handlers.rs
@@ -6,7 +6,7 @@
 
 #![allow(dead_code)]
 
-use std::sync::Arc;
+use std::sync::Arc;use crate::quorum_proposal_recv::{Versions, UpgradeLock};
 
 use anyhow::{bail, Context, Result};
 use async_broadcast::{broadcast, Sender};
@@ -49,10 +49,10 @@ pub(crate) enum QuorumProposalValidity {
 
 /// Update states in the event that the parent state is not found for a given `proposal`.
 #[instrument(skip_all)]
-async fn validate_proposal_liveness<TYPES: NodeType, I: NodeImplementation<TYPES>>(
+async fn validate_proposal_liveness<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions>(
     proposal: &Proposal<TYPES, QuorumProposal<TYPES>>,
     event_sender: &Sender<Arc<HotShotEvent<TYPES>>>,
-    task_state: &mut QuorumProposalRecvTaskState<TYPES, I>,
+    task_state: &mut QuorumProposalRecvTaskState<TYPES, I, V>,
 ) -> Result<QuorumProposalValidity> {
     let view_number = proposal.data.view_number();
     let mut consensus_write = task_state.consensus.write().await;
@@ -134,11 +134,11 @@ async fn validate_proposal_liveness<TYPES: NodeType, I: NodeImplementation<TYPES
 /// - The sequencer storage update fails.
 #[allow(clippy::too_many_lines)]
 #[instrument(skip_all)]
-pub(crate) async fn handle_quorum_proposal_recv<TYPES: NodeType, I: NodeImplementation<TYPES>>(
+pub(crate) async fn handle_quorum_proposal_recv<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions>(
     proposal: &Proposal<TYPES, QuorumProposal<TYPES>>,
     sender: &TYPES::SignatureKey,
     event_sender: &Sender<Arc<HotShotEvent<TYPES>>>,
-    task_state: &mut QuorumProposalRecvTaskState<TYPES, I>,
+    task_state: &mut QuorumProposalRecvTaskState<TYPES, I, V>,
 ) -> Result<QuorumProposalValidity> {
     let sender = sender.clone();
     let cur_view = task_state.cur_view;
@@ -239,7 +239,7 @@ pub(crate) async fn handle_quorum_proposal_recv<TYPES: NodeType, I: NodeImplemen
         proposal.clone(),
         parent_leaf,
         OuterConsensus::new(Arc::clone(&task_state.consensus.inner_consensus)),
-        Arc::clone(&task_state.decided_upgrade_certificate),
+        Arc::clone(&task_state.upgrade_lock.decided_upgrade_certificate),
         Arc::clone(&task_state.quorum_membership),
         event_sender.clone(),
         sender,

--- a/crates/task-impls/src/quorum_proposal_recv/mod.rs
+++ b/crates/task-impls/src/quorum_proposal_recv/mod.rs
@@ -7,6 +7,7 @@
 #![allow(unused_imports)]
 
 use std::{collections::BTreeMap, sync::Arc};
+use hotshot_types::message::UpgradeLock;use hotshot_types::traits::node_implementation::Versions;
 
 use anyhow::{bail, Result};
 use async_broadcast::{broadcast, Receiver, Sender};
@@ -44,7 +45,7 @@ mod handlers;
 
 /// The state for the quorum proposal task. Contains all of the information for
 /// handling [`HotShotEvent::QuorumProposalRecv`] events.
-pub struct QuorumProposalRecvTaskState<TYPES: NodeType, I: NodeImplementation<TYPES>> {
+pub struct QuorumProposalRecvTaskState<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> {
     /// Our public key
     pub public_key: TYPES::SignatureKey,
 
@@ -97,11 +98,11 @@ pub struct QuorumProposalRecvTaskState<TYPES: NodeType, I: NodeImplementation<TY
     /// The node's id
     pub id: u64,
 
-    /// An upgrade certificate that has been decided on, if any.
-    pub decided_upgrade_certificate: Arc<RwLock<Option<UpgradeCertificate<TYPES>>>>,
+    /// Lock for a decided upgrade
+    pub upgrade_lock: UpgradeLock<TYPES, V>,
 }
 
-impl<TYPES: NodeType, I: NodeImplementation<TYPES>> QuorumProposalRecvTaskState<TYPES, I> {
+impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> QuorumProposalRecvTaskState<TYPES, I, V> {
     /// Cancel all tasks the consensus tasks has spawned before the given view
     pub async fn cancel_tasks(&mut self, view: TYPES::Time) {
         let keep = self.spawned_tasks.split_off(&view);
@@ -188,8 +189,8 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> QuorumProposalRecvTaskState<
 }
 
 #[async_trait]
-impl<TYPES: NodeType, I: NodeImplementation<TYPES>> TaskState
-    for QuorumProposalRecvTaskState<TYPES, I>
+impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> TaskState
+    for QuorumProposalRecvTaskState<TYPES, I, V>
 {
     type Event = HotShotEvent<TYPES>;
 

--- a/crates/task-impls/src/quorum_proposal_recv/mod.rs
+++ b/crates/task-impls/src/quorum_proposal_recv/mod.rs
@@ -7,7 +7,6 @@
 #![allow(unused_imports)]
 
 use std::{collections::BTreeMap, sync::Arc};
-use hotshot_types::message::UpgradeLock;use hotshot_types::traits::node_implementation::Versions;
 
 use anyhow::{bail, Result};
 use async_broadcast::{broadcast, Receiver, Sender};
@@ -21,9 +20,10 @@ use hotshot_types::{
     consensus::{Consensus, OuterConsensus},
     data::{Leaf, ViewChangeEvidence},
     event::Event,
+    message::UpgradeLock,
     simple_certificate::UpgradeCertificate,
     traits::{
-        node_implementation::{NodeImplementation, NodeType},
+        node_implementation::{NodeImplementation, NodeType, Versions},
         signature_key::SignatureKey,
     },
     vote::{HasViewNumber, VoteDependencyData},
@@ -102,7 +102,9 @@ pub struct QuorumProposalRecvTaskState<TYPES: NodeType, I: NodeImplementation<TY
     pub upgrade_lock: UpgradeLock<TYPES, V>,
 }
 
-impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> QuorumProposalRecvTaskState<TYPES, I, V> {
+impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions>
+    QuorumProposalRecvTaskState<TYPES, I, V>
+{
     /// Cancel all tasks the consensus tasks has spawned before the given view
     pub async fn cancel_tasks(&mut self, view: TYPES::Time) {
         let keep = self.spawned_tasks.split_off(&view);

--- a/crates/task-impls/src/quorum_vote/handlers.rs
+++ b/crates/task-impls/src/quorum_vote/handlers.rs
@@ -20,9 +20,9 @@ use tracing::{debug, instrument};
 
 use super::QuorumVoteTaskState;
 use crate::{
-  quorum_vote::Versions,
     events::HotShotEvent,
     helpers::{broadcast_event, decide_from_proposal, LeafChainTraversalOutcome},
+    quorum_vote::Versions,
 };
 
 /// Handles the `QuorumProposalValidated` event.
@@ -53,7 +53,11 @@ pub(crate) async fn handle_quorum_proposal_validated<
     .await;
 
     if let Some(cert) = decided_upgrade_cert.clone() {
-        let mut decided_certificate_lock = task_state.upgrade_lock.decided_upgrade_certificate.write().await;
+        let mut decided_certificate_lock = task_state
+            .upgrade_lock
+            .decided_upgrade_certificate
+            .write()
+            .await;
         *decided_certificate_lock = Some(cert.clone());
         drop(decided_certificate_lock);
         let _ = sender

--- a/crates/task-impls/src/quorum_vote/handlers.rs
+++ b/crates/task-impls/src/quorum_vote/handlers.rs
@@ -20,6 +20,7 @@ use tracing::{debug, instrument};
 
 use super::QuorumVoteTaskState;
 use crate::{
+  quorum_vote::Versions,
     events::HotShotEvent,
     helpers::{broadcast_event, decide_from_proposal, LeafChainTraversalOutcome},
 };
@@ -29,10 +30,11 @@ use crate::{
 pub(crate) async fn handle_quorum_proposal_validated<
     TYPES: NodeType,
     I: NodeImplementation<TYPES>,
+    V: Versions,
 >(
     proposal: &QuorumProposal<TYPES>,
     sender: &Sender<Arc<HotShotEvent<TYPES>>>,
-    task_state: &mut QuorumVoteTaskState<TYPES, I>,
+    task_state: &mut QuorumVoteTaskState<TYPES, I, V>,
 ) -> Result<()> {
     let LeafChainTraversalOutcome {
         new_locked_view_number,
@@ -45,13 +47,13 @@ pub(crate) async fn handle_quorum_proposal_validated<
     } = decide_from_proposal(
         proposal,
         OuterConsensus::new(Arc::clone(&task_state.consensus.inner_consensus)),
-        Arc::clone(&task_state.decided_upgrade_certificate),
+        Arc::clone(&task_state.upgrade_lock.decided_upgrade_certificate),
         &task_state.public_key,
     )
     .await;
 
     if let Some(cert) = decided_upgrade_cert.clone() {
-        let mut decided_certificate_lock = task_state.decided_upgrade_certificate.write().await;
+        let mut decided_certificate_lock = task_state.upgrade_lock.decided_upgrade_certificate.write().await;
         *decided_certificate_lock = Some(cert.clone());
         drop(decided_certificate_lock);
         let _ = sender

--- a/crates/task-impls/src/quorum_vote/mod.rs
+++ b/crates/task-impls/src/quorum_vote/mod.rs
@@ -23,7 +23,6 @@ use hotshot_types::{
     data::{Leaf, VidDisperseShare, ViewNumber},
     event::Event,
     message::{Proposal, UpgradeLock},
-    simple_certificate::UpgradeCertificate,
     simple_vote::{QuorumData, QuorumVote},
     traits::{
         block_contents::BlockHeader,

--- a/crates/task-impls/src/rewind.rs
+++ b/crates/task-impls/src/rewind.rs
@@ -26,8 +26,8 @@ pub struct RewindTaskState<TYPES: NodeType> {
 
 impl<TYPES: NodeType> RewindTaskState<TYPES> {
     /// Handles all events, storing them to the private state
-    pub fn handle(&mut self, event: Arc<HotShotEvent<TYPES>>) {
-        self.events.push(Arc::clone(&event));
+    pub fn handle(&mut self, event: &Arc<HotShotEvent<TYPES>>) {
+        self.events.push(Arc::clone(event));
     }
 }
 
@@ -41,7 +41,7 @@ impl<TYPES: NodeType> TaskState for RewindTaskState<TYPES> {
         _sender: &Sender<Arc<Self::Event>>,
         _receiver: &Receiver<Arc<Self::Event>>,
     ) -> Result<()> {
-        self.handle(event);
+        self.handle(&event);
         Ok(())
     }
 

--- a/crates/task-impls/src/transactions.rs
+++ b/crates/task-impls/src/transactions.rs
@@ -12,7 +12,6 @@ use std::{
 use anyhow::{bail, Result};
 use async_broadcast::{Receiver, Sender};
 use async_compatibility_layer::art::{async_sleep, async_timeout};
-use async_lock::RwLock;
 use async_trait::async_trait;
 use futures::{future::join_all, stream::FuturesUnordered, StreamExt};
 use hotshot_builder_api::v0_1::block_info::AvailableBlockInfo;
@@ -23,7 +22,6 @@ use hotshot_types::{
     data::{null_block, PackedBundle},
     event::{Event, EventType},
     message::UpgradeLock,
-    simple_certificate::UpgradeCertificate,
     traits::{
         auction_results_provider::AuctionResultsProvider,
         block_contents::{precompute_vid_commitment, BuilderFee, EncodeBytes},

--- a/crates/task-impls/src/transactions.rs
+++ b/crates/task-impls/src/transactions.rs
@@ -18,7 +18,6 @@ use hotshot_builder_api::v0_1::block_info::AvailableBlockInfo;
 use hotshot_task::task::TaskState;
 use hotshot_types::{
     consensus::OuterConsensus,
-    constants::MarketplaceVersion,
     data::{null_block, PackedBundle},
     event::{Event, EventType},
     message::UpgradeLock,
@@ -128,7 +127,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> TransactionTask
             }
         };
 
-        if version < MarketplaceVersion::VERSION {
+        if version < V::Marketplace::VERSION {
             self.handle_view_change_legacy(event_stream, block_view)
                 .await
         } else {
@@ -203,7 +202,8 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> TransactionTask
                 .add(1);
 
             let membership_total_nodes = self.membership.total_nodes();
-            let Some(null_fee) = null_block::builder_fee(self.membership.total_nodes(), version)
+            let Some(null_fee) =
+                null_block::builder_fee::<TYPES, V>(self.membership.total_nodes(), version)
             else {
                 error!("Failed to get null fee");
                 return None;
@@ -343,7 +343,9 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> TransactionTask
             .add(1);
 
         let membership_total_nodes = self.membership.total_nodes();
-        let Some(null_fee) = null_block::builder_fee(self.membership.total_nodes(), version) else {
+        let Some(null_fee) =
+            null_block::builder_fee::<TYPES, V>(self.membership.total_nodes(), version)
+        else {
             error!("Failed to get null fee");
             return None;
         };

--- a/crates/testing/src/block_builder/mod.rs
+++ b/crates/testing/src/block_builder/mod.rs
@@ -85,7 +85,7 @@ pub fn run_builder_source<TYPES, Source>(
             let mut app: App<Source, Error> = App::with_state(source);
             app.register_module("block_info", builder_api)
                 .expect("Failed to register the builder API");
-            async_spawn(app.serve(url, TYPES::Base::instance()))
+            async_spawn(app.serve(url, hotshot_builder_api::v0_1::Version::instance()))
         };
 
         let mut handle = Some(start_builder(url.clone(), source.clone()));

--- a/crates/testing/src/block_builder/simple.rs
+++ b/crates/testing/src/block_builder/simple.rs
@@ -252,7 +252,7 @@ impl<TYPES: NodeType> SimpleBuilderSource<TYPES> {
         app.register_module::<Error, _>("block_info", builder_api)
             .expect("Failed to register the builder API");
 
-        async_spawn(app.serve(url, TYPES::Base::instance()));
+        async_spawn(app.serve(url, hotshot_builder_api::v0_1::Version::instance()));
     }
 }
 

--- a/crates/testing/src/completion_task.rs
+++ b/crates/testing/src/completion_task.rs
@@ -5,6 +5,7 @@
 // along with the HotShot repository. If not, see <https://mit-license.org/>.
 
 use std::{sync::Arc, time::Duration};
+use hotshot_types::traits::node_implementation::Versions;
 
 use async_broadcast::{Receiver, Sender};
 use async_compatibility_layer::art::{async_spawn, async_timeout};
@@ -27,17 +28,17 @@ use crate::{test_runner::Node, test_task::TestEvent};
 pub struct CompletionTaskErr {}
 
 /// Completion task state
-pub struct CompletionTask<TYPES: NodeType, I: TestableNodeImplementation<TYPES>> {
+pub struct CompletionTask<TYPES: NodeType, I: TestableNodeImplementation<TYPES>, V: Versions> {
     pub tx: Sender<TestEvent>,
 
     pub rx: Receiver<TestEvent>,
     /// handles to the nodes in the test
-    pub(crate) handles: Arc<RwLock<Vec<Node<TYPES, I>>>>,
+    pub(crate) handles: Arc<RwLock<Vec<Node<TYPES, I, V>>>>,
     /// Duration of the task.
     pub duration: Duration,
 }
 
-impl<TYPES: NodeType, I: TestableNodeImplementation<TYPES>> CompletionTask<TYPES, I> {
+impl<TYPES: NodeType, I: TestableNodeImplementation<TYPES>, V: Versions> CompletionTask<TYPES, I, V> {
     pub fn run(mut self) -> JoinHandle<()> {
         async_spawn(async move {
             if async_timeout(self.duration, self.wait_for_shutdown())

--- a/crates/testing/src/completion_task.rs
+++ b/crates/testing/src/completion_task.rs
@@ -5,7 +5,6 @@
 // along with the HotShot repository. If not, see <https://mit-license.org/>.
 
 use std::{sync::Arc, time::Duration};
-use hotshot_types::traits::node_implementation::Versions;
 
 use async_broadcast::{Receiver, Sender};
 use async_compatibility_layer::art::{async_spawn, async_timeout};
@@ -14,7 +13,7 @@ use async_lock::RwLock;
 use async_std::task::JoinHandle;
 use hotshot::traits::TestableNodeImplementation;
 use hotshot_task_impls::helpers::broadcast_event;
-use hotshot_types::traits::node_implementation::NodeType;
+use hotshot_types::traits::node_implementation::{NodeType, Versions};
 use snafu::Snafu;
 #[cfg(async_executor_impl = "tokio")]
 use tokio::task::JoinHandle;
@@ -38,7 +37,9 @@ pub struct CompletionTask<TYPES: NodeType, I: TestableNodeImplementation<TYPES>,
     pub duration: Duration,
 }
 
-impl<TYPES: NodeType, I: TestableNodeImplementation<TYPES>, V: Versions> CompletionTask<TYPES, I, V> {
+impl<TYPES: NodeType, I: TestableNodeImplementation<TYPES>, V: Versions>
+    CompletionTask<TYPES, I, V>
+{
     pub fn run(mut self) -> JoinHandle<()> {
         async_spawn(async move {
             if async_timeout(self.duration, self.wait_for_shutdown())

--- a/crates/testing/src/helpers.rs
+++ b/crates/testing/src/helpers.rs
@@ -7,7 +7,6 @@
 #![allow(clippy::panic)]
 use std::{fmt::Debug, hash::Hash, marker::PhantomData, sync::Arc};
 
-use hotshot_types::traits::node_implementation::Versions;
 use async_broadcast::{Receiver, Sender};
 use bitvec::bitvec;
 use committable::Committable;
@@ -36,7 +35,7 @@ use hotshot_types::{
         consensus_api::ConsensusApi,
         election::Membership,
         network::Topic,
-        node_implementation::{ConsensusTime, NodeType},
+        node_implementation::{ConsensusTime, NodeType, Versions},
     },
     utils::{View, ViewInner},
     vid::{vid_scheme, VidCommitment, VidSchemeType},

--- a/crates/testing/src/helpers.rs
+++ b/crates/testing/src/helpers.rs
@@ -7,6 +7,7 @@
 #![allow(clippy::panic)]
 use std::{fmt::Debug, hash::Hash, marker::PhantomData, sync::Arc};
 
+use hotshot_types::traits::node_implementation::Versions;
 use async_broadcast::{Receiver, Sender};
 use bitvec::bitvec;
 use committable::Committable;
@@ -19,7 +20,7 @@ use hotshot::{
 use hotshot_example_types::{
     auction_results_provider_types::TestAuctionResultsProvider,
     block_types::TestTransaction,
-    node_types::{MemoryImpl, TestTypes},
+    node_types::{MemoryImpl, TestTypes, TestVersions},
     state_types::{TestInstanceState, TestValidatedState},
     storage_types::TestStorage,
 };
@@ -56,14 +57,15 @@ pub async fn build_system_handle<
             Storage = TestStorage<TYPES>,
             AuctionResultsProvider = TestAuctionResultsProvider<TYPES>,
         > + TestableNodeImplementation<TYPES>,
+    V: Versions,
 >(
     node_id: u64,
 ) -> (
-    SystemContextHandle<TYPES, I>,
+    SystemContextHandle<TYPES, I, V>,
     Sender<Arc<HotShotEvent<TYPES>>>,
     Receiver<Arc<HotShotEvent<TYPES>>>,
 ) {
-    let builder: TestDescription<TYPES, I> = TestDescription::default_multiple_rounds();
+    let builder: TestDescription<TYPES, I, V> = TestDescription::default_multiple_rounds();
 
     let launcher = builder.gen_launcher(node_id);
 
@@ -337,7 +339,7 @@ pub fn build_da_certificate(
 }
 
 pub async fn build_vote(
-    handle: &SystemContextHandle<TestTypes, MemoryImpl>,
+    handle: &SystemContextHandle<TestTypes, MemoryImpl, TestVersions>,
     proposal: QuorumProposal<TestTypes>,
 ) -> GeneralConsensusMessage<TestTypes> {
     let view = ViewNumber::new(*proposal.view_number);

--- a/crates/testing/src/overall_safety_task.rs
+++ b/crates/testing/src/overall_safety_task.rs
@@ -9,7 +9,6 @@ use std::{
     sync::Arc,
 };
 
-use hotshot_types::traits::node_implementation::Versions;
 use anyhow::Result;
 use async_broadcast::Sender;
 use async_lock::RwLock;
@@ -20,7 +19,7 @@ use hotshot_types::{
     error::RoundTimedoutState,
     event::{Event, EventType, LeafChain},
     simple_certificate::QuorumCertificate,
-    traits::node_implementation::{ConsensusTime, NodeType},
+    traits::node_implementation::{ConsensusTime, NodeType, Versions},
     vid::VidCommitment,
 };
 use snafu::Snafu;
@@ -99,7 +98,9 @@ pub struct OverallSafetyTask<TYPES: NodeType, I: TestableNodeImplementation<TYPE
     pub test_sender: Sender<TestEvent>,
 }
 
-impl<TYPES: NodeType, I: TestableNodeImplementation<TYPES>, V: Versions> OverallSafetyTask<TYPES, I, V> {
+impl<TYPES: NodeType, I: TestableNodeImplementation<TYPES>, V: Versions>
+    OverallSafetyTask<TYPES, I, V>
+{
     async fn handle_view_failure(&mut self, num_failed_views: usize, view_number: TYPES::Time) {
         let expected_views_to_fail = &mut self.properties.expected_views_to_fail;
 

--- a/crates/testing/src/overall_safety_task.rs
+++ b/crates/testing/src/overall_safety_task.rs
@@ -9,6 +9,7 @@ use std::{
     sync::Arc,
 };
 
+use hotshot_types::traits::node_implementation::Versions;
 use anyhow::Result;
 use async_broadcast::Sender;
 use async_lock::RwLock;
@@ -85,9 +86,9 @@ pub enum OverallSafetyTaskErr<TYPES: NodeType> {
 }
 
 /// Data availability task state
-pub struct OverallSafetyTask<TYPES: NodeType, I: TestableNodeImplementation<TYPES>> {
+pub struct OverallSafetyTask<TYPES: NodeType, I: TestableNodeImplementation<TYPES>, V: Versions> {
     /// handles
-    pub handles: Arc<RwLock<Vec<Node<TYPES, I>>>>,
+    pub handles: Arc<RwLock<Vec<Node<TYPES, I, V>>>>,
     /// ctx
     pub ctx: RoundCtx<TYPES>,
     /// configure properties
@@ -98,7 +99,7 @@ pub struct OverallSafetyTask<TYPES: NodeType, I: TestableNodeImplementation<TYPE
     pub test_sender: Sender<TestEvent>,
 }
 
-impl<TYPES: NodeType, I: TestableNodeImplementation<TYPES>> OverallSafetyTask<TYPES, I> {
+impl<TYPES: NodeType, I: TestableNodeImplementation<TYPES>, V: Versions> OverallSafetyTask<TYPES, I, V> {
     async fn handle_view_failure(&mut self, num_failed_views: usize, view_number: TYPES::Time) {
         let expected_views_to_fail = &mut self.properties.expected_views_to_fail;
 
@@ -128,8 +129,8 @@ impl<TYPES: NodeType, I: TestableNodeImplementation<TYPES>> OverallSafetyTask<TY
 }
 
 #[async_trait]
-impl<TYPES: NodeType, I: TestableNodeImplementation<TYPES>> TestTaskState
-    for OverallSafetyTask<TYPES, I>
+impl<TYPES: NodeType, I: TestableNodeImplementation<TYPES>, V: Versions> TestTaskState
+    for OverallSafetyTask<TYPES, I, V>
 {
     type Event = Event<TYPES>;
 

--- a/crates/testing/src/predicates/upgrade_with_consensus.rs
+++ b/crates/testing/src/predicates/upgrade_with_consensus.rs
@@ -9,13 +9,13 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use hotshot_example_types::node_types::{MemoryImpl, TestTypes};
+use hotshot_example_types::node_types::{MemoryImpl, TestTypes, TestVersions};
 use hotshot_task_impls::consensus::ConsensusTaskState;
 use hotshot_types::simple_certificate::UpgradeCertificate;
 
 use crate::predicates::{Predicate, PredicateResult};
 
-type ConsensusTaskTestState = ConsensusTaskState<TestTypes, MemoryImpl>;
+type ConsensusTaskTestState = ConsensusTaskState<TestTypes, MemoryImpl, TestVersions>;
 
 type UpgradeCertCallback =
     Arc<dyn Fn(Arc<Option<UpgradeCertificate<TestTypes>>>) -> bool + Send + Sync>;
@@ -34,7 +34,7 @@ impl std::fmt::Debug for UpgradeCertPredicate {
 #[async_trait]
 impl Predicate<ConsensusTaskTestState> for UpgradeCertPredicate {
     async fn evaluate(&self, input: &ConsensusTaskTestState) -> PredicateResult {
-        let upgrade_cert = input.decided_upgrade_certificate.read().await.clone();
+        let upgrade_cert = input.upgrade_lock.decided_upgrade_certificate.read().await.clone();
         PredicateResult::from((self.check)(upgrade_cert.into()))
     }
 

--- a/crates/testing/src/predicates/upgrade_with_consensus.rs
+++ b/crates/testing/src/predicates/upgrade_with_consensus.rs
@@ -34,7 +34,12 @@ impl std::fmt::Debug for UpgradeCertPredicate {
 #[async_trait]
 impl Predicate<ConsensusTaskTestState> for UpgradeCertPredicate {
     async fn evaluate(&self, input: &ConsensusTaskTestState) -> PredicateResult {
-        let upgrade_cert = input.upgrade_lock.decided_upgrade_certificate.read().await.clone();
+        let upgrade_cert = input
+            .upgrade_lock
+            .decided_upgrade_certificate
+            .read()
+            .await
+            .clone();
         PredicateResult::from((self.check)(upgrade_cert.into()))
     }
 

--- a/crates/testing/src/predicates/upgrade_with_proposal.rs
+++ b/crates/testing/src/predicates/upgrade_with_proposal.rs
@@ -32,7 +32,12 @@ impl std::fmt::Debug for UpgradeCertPredicate {
 #[async_trait]
 impl Predicate<QuorumProposalTaskTestState> for UpgradeCertPredicate {
     async fn evaluate(&self, input: &QuorumProposalTaskTestState) -> PredicateResult {
-        let upgrade_cert = input.upgrade_lock.decided_upgrade_certificate.read().await.clone();
+        let upgrade_cert = input
+            .upgrade_lock
+            .decided_upgrade_certificate
+            .read()
+            .await
+            .clone();
         PredicateResult::from((self.check)(upgrade_cert.into()))
     }
 

--- a/crates/testing/src/predicates/upgrade_with_proposal.rs
+++ b/crates/testing/src/predicates/upgrade_with_proposal.rs
@@ -4,18 +4,16 @@
 // You should have received a copy of the MIT License
 // along with the HotShot repository. If not, see <https://mit-license.org/>.
 
-#![cfg(feature = "dependency-tasks")]
-
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use hotshot_example_types::node_types::{MemoryImpl, TestTypes};
+use hotshot_example_types::node_types::{MemoryImpl, TestTypes, TestVersions};
 use hotshot_task_impls::quorum_proposal::QuorumProposalTaskState;
 use hotshot_types::simple_certificate::UpgradeCertificate;
 
 use crate::predicates::{Predicate, PredicateResult};
 
-type QuorumProposalTaskTestState = QuorumProposalTaskState<TestTypes, MemoryImpl>;
+type QuorumProposalTaskTestState = QuorumProposalTaskState<TestTypes, MemoryImpl, TestVersions>;
 
 type UpgradeCertCallback =
     Arc<dyn Fn(Arc<Option<UpgradeCertificate<TestTypes>>>) -> bool + Send + Sync>;
@@ -34,7 +32,7 @@ impl std::fmt::Debug for UpgradeCertPredicate {
 #[async_trait]
 impl Predicate<QuorumProposalTaskTestState> for UpgradeCertPredicate {
     async fn evaluate(&self, input: &QuorumProposalTaskTestState) -> PredicateResult {
-        let upgrade_cert = input.decided_upgrade_certificate.read().await.clone();
+        let upgrade_cert = input.upgrade_lock.decided_upgrade_certificate.read().await.clone();
         PredicateResult::from((self.check)(upgrade_cert.into()))
     }
 

--- a/crates/testing/src/predicates/upgrade_with_vote.rs
+++ b/crates/testing/src/predicates/upgrade_with_vote.rs
@@ -4,17 +4,15 @@
 // You should have received a copy of the MIT License
 // along with the HotShot repository. If not, see <https://mit-license.org/>.
 
-#![cfg(feature = "dependency-tasks")]
-
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use hotshot_example_types::node_types::{MemoryImpl, TestTypes};
+use hotshot_example_types::node_types::{MemoryImpl, TestTypes, TestVersions};
 use hotshot_task_impls::quorum_vote::QuorumVoteTaskState;
 use hotshot_types::simple_certificate::UpgradeCertificate;
 
 use crate::predicates::{Predicate, PredicateResult};
-type QuorumVoteTaskTestState = QuorumVoteTaskState<TestTypes, MemoryImpl>;
+type QuorumVoteTaskTestState = QuorumVoteTaskState<TestTypes, MemoryImpl, TestVersions>;
 
 type UpgradeCertCallback =
     Arc<dyn Fn(Arc<Option<UpgradeCertificate<TestTypes>>>) -> bool + Send + Sync>;
@@ -30,11 +28,10 @@ impl std::fmt::Debug for UpgradeCertPredicate {
     }
 }
 
-#[cfg(feature = "dependency-tasks")]
 #[async_trait]
 impl Predicate<QuorumVoteTaskTestState> for UpgradeCertPredicate {
     async fn evaluate(&self, input: &QuorumVoteTaskTestState) -> PredicateResult {
-        let upgrade_cert = input.decided_upgrade_certificate.read().await.clone();
+        let upgrade_cert = input.upgrade_lock.decided_upgrade_certificate.read().await.clone();
         PredicateResult::from((self.check)(upgrade_cert.into()))
     }
 

--- a/crates/testing/src/predicates/upgrade_with_vote.rs
+++ b/crates/testing/src/predicates/upgrade_with_vote.rs
@@ -31,7 +31,12 @@ impl std::fmt::Debug for UpgradeCertPredicate {
 #[async_trait]
 impl Predicate<QuorumVoteTaskTestState> for UpgradeCertPredicate {
     async fn evaluate(&self, input: &QuorumVoteTaskTestState) -> PredicateResult {
-        let upgrade_cert = input.upgrade_lock.decided_upgrade_certificate.read().await.clone();
+        let upgrade_cert = input
+            .upgrade_lock
+            .decided_upgrade_certificate
+            .read()
+            .await
+            .clone();
         PredicateResult::from((self.check)(upgrade_cert.into()))
     }
 

--- a/crates/testing/src/spinning_task.rs
+++ b/crates/testing/src/spinning_task.rs
@@ -4,6 +4,7 @@
 // You should have received a copy of the MIT License
 // along with the HotShot repository. If not, see <https://mit-license.org/>.
 
+use hotshot_types::traits::node_implementation::Versions;
 use std::{
     collections::{BTreeMap, HashMap},
     sync::Arc,
@@ -45,11 +46,11 @@ pub type StateAndBlock<S, B> = (Vec<S>, Vec<B>);
 pub struct SpinningTaskErr {}
 
 /// Spinning task state
-pub struct SpinningTask<TYPES: NodeType, I: TestableNodeImplementation<TYPES>> {
+pub struct SpinningTask<TYPES: NodeType, I: TestableNodeImplementation<TYPES>, V: Versions> {
     /// handle to the nodes
-    pub(crate) handles: Arc<RwLock<Vec<Node<TYPES, I>>>>,
+    pub(crate) handles: Arc<RwLock<Vec<Node<TYPES, I, V>>>>,
     /// late start nodes
-    pub(crate) late_start: HashMap<u64, LateStartNode<TYPES, I>>,
+    pub(crate) late_start: HashMap<u64, LateStartNode<TYPES, I, V>>,
     /// time based changes
     pub(crate) changes: BTreeMap<TYPES::Time, Vec<ChangeNode>>,
     /// most recent view seen by spinning task
@@ -65,7 +66,8 @@ impl<
         TYPES: NodeType<InstanceState = TestInstanceState, ValidatedState = TestValidatedState>,
         I: TestableNodeImplementation<TYPES>,
         N: ConnectedNetwork<TYPES::SignatureKey>,
-    > TestTaskState for SpinningTask<TYPES, I>
+        V: Versions,
+    > TestTaskState for SpinningTask<TYPES, I, V>
 where
     I: TestableNodeImplementation<TYPES>,
     I: NodeImplementation<
@@ -228,7 +230,7 @@ where
                                     node_id < config.da_staked_committee_size as u64,
                                 );
                                 let context =
-                                    TestRunner::<TYPES, I, N>::add_node_with_config_and_channels(
+                                    TestRunner::<TYPES, I, V, N>::add_node_with_config_and_channels(
                                         node_id,
                                         network.clone(),
                                         (*memberships).clone(),

--- a/crates/testing/src/spinning_task.rs
+++ b/crates/testing/src/spinning_task.rs
@@ -4,7 +4,6 @@
 // You should have received a copy of the MIT License
 // along with the HotShot repository. If not, see <https://mit-license.org/>.
 
-use hotshot_types::traits::node_implementation::Versions;
 use std::{
     collections::{BTreeMap, HashMap},
     sync::Arc,
@@ -26,7 +25,7 @@ use hotshot_types::{
     simple_certificate::QuorumCertificate,
     traits::{
         network::ConnectedNetwork,
-        node_implementation::{NodeImplementation, NodeType},
+        node_implementation::{NodeImplementation, NodeType, Versions},
     },
     vote::HasViewNumber,
     ValidatorConfig,

--- a/crates/testing/src/test_builder.rs
+++ b/crates/testing/src/test_builder.rs
@@ -5,7 +5,6 @@
 // along with the HotShot repository. If not, see <https://mit-license.org/>.
 
 use std::{collections::HashMap, num::NonZeroUsize, rc::Rc, sync::Arc, time::Duration};
-use hotshot_types::traits::node_implementation::Versions;
 
 use hotshot::{
     tasks::EventTransformerState,
@@ -18,8 +17,9 @@ use hotshot_example_types::{
     storage_types::TestStorage,
 };
 use hotshot_types::{
-    consensus::ConsensusMetricsValue, traits::node_implementation::NodeType, ExecutionType,
-    HotShotConfig, ValidatorConfig,
+    consensus::ConsensusMetricsValue,
+    traits::node_implementation::{NodeType, Versions},
+    ExecutionType, HotShotConfig, ValidatorConfig,
 };
 use tide_disco::Url;
 use vec1::Vec1;
@@ -327,7 +327,9 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> TestDescription
     }
 }
 
-impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> Default for TestDescription<TYPES, I, V> {
+impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> Default
+    for TestDescription<TYPES, I, V>
+{
     /// by default, just a single round
     #[allow(clippy::redundant_field_names)]
     fn default() -> Self {
@@ -373,8 +375,11 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> Default for Tes
     }
 }
 
-impl<TYPES: NodeType<InstanceState = TestInstanceState>, I: TestableNodeImplementation<TYPES>, V: Versions>
-    TestDescription<TYPES, I, V>
+impl<
+        TYPES: NodeType<InstanceState = TestInstanceState>,
+        I: TestableNodeImplementation<TYPES>,
+        V: Versions,
+    > TestDescription<TYPES, I, V>
 where
     I: NodeImplementation<TYPES, AuctionResultsProvider = TestAuctionResultsProvider<TYPES>>,
 {

--- a/crates/testing/src/test_launcher.rs
+++ b/crates/testing/src/test_launcher.rs
@@ -5,7 +5,6 @@
 // along with the HotShot repository. If not, see <https://mit-license.org/>.
 
 use std::{collections::HashMap, marker::PhantomData, sync::Arc};
-use hotshot_types::traits::node_implementation::Versions;
 
 use hotshot::{
     traits::{NodeImplementation, TestableNodeImplementation},
@@ -15,7 +14,7 @@ use hotshot_example_types::storage_types::TestStorage;
 use hotshot_types::{
     traits::{
         network::{AsyncGenerator, ConnectedNetwork},
-        node_implementation::NodeType,
+        node_implementation::{NodeType, Versions},
     },
     HotShotConfig,
 };

--- a/crates/testing/src/test_launcher.rs
+++ b/crates/testing/src/test_launcher.rs
@@ -5,6 +5,7 @@
 // along with the HotShot repository. If not, see <https://mit-license.org/>.
 
 use std::{collections::HashMap, marker::PhantomData, sync::Arc};
+use hotshot_types::traits::node_implementation::Versions;
 
 use hotshot::{
     traits::{NodeImplementation, TestableNodeImplementation},
@@ -40,18 +41,18 @@ pub struct ResourceGenerators<TYPES: NodeType, I: TestableNodeImplementation<TYP
 }
 
 /// test launcher
-pub struct TestLauncher<TYPES: NodeType, I: TestableNodeImplementation<TYPES>> {
+pub struct TestLauncher<TYPES: NodeType, I: TestableNodeImplementation<TYPES>, V: Versions> {
     /// generator for resources
     pub resource_generator: ResourceGenerators<TYPES, I>,
     /// metadata used for tasks
-    pub metadata: TestDescription<TYPES, I>,
+    pub metadata: TestDescription<TYPES, I, V>,
 }
 
-impl<TYPES: NodeType, I: TestableNodeImplementation<TYPES>> TestLauncher<TYPES, I> {
+impl<TYPES: NodeType, I: TestableNodeImplementation<TYPES>, V: Versions> TestLauncher<TYPES, I, V> {
     /// launch the test
     #[must_use]
-    pub fn launch<N: ConnectedNetwork<TYPES::SignatureKey>>(self) -> TestRunner<TYPES, I, N> {
-        TestRunner::<TYPES, I, N> {
+    pub fn launch<N: ConnectedNetwork<TYPES::SignatureKey>>(self) -> TestRunner<TYPES, I, V, N> {
+        TestRunner::<TYPES, I, V, N> {
             launcher: self,
             nodes: Vec::new(),
             solver_server: None,

--- a/crates/testing/src/test_runner.rs
+++ b/crates/testing/src/test_runner.rs
@@ -11,7 +11,6 @@ use std::{
     sync::Arc,
 };
 
-use hotshot_types::traits::node_implementation::Versions;
 use async_broadcast::{broadcast, Receiver, Sender};
 use async_compatibility_layer::art::async_spawn;
 use async_lock::RwLock;
@@ -38,7 +37,7 @@ use hotshot_types::{
     traits::{
         election::Membership,
         network::{ConnectedNetwork, Topic},
-        node_implementation::{ConsensusTime, NodeImplementation, NodeType},
+        node_implementation::{ConsensusTime, NodeImplementation, NodeType, Versions},
     },
     HotShotConfig, ValidatorConfig,
 };

--- a/crates/testing/src/test_runner.rs
+++ b/crates/testing/src/test_runner.rs
@@ -11,6 +11,7 @@ use std::{
     sync::Arc,
 };
 
+use hotshot_types::traits::node_implementation::Versions;
 use async_broadcast::{broadcast, Receiver, Sender};
 use async_compatibility_layer::art::async_spawn;
 use async_lock::RwLock;
@@ -70,8 +71,9 @@ impl<T: std::error::Error + Sync + Send + 'static> TaskErr for T {}
 impl<
         TYPES: NodeType<InstanceState = TestInstanceState, ValidatedState = TestValidatedState>,
         I: TestableNodeImplementation<TYPES>,
+        V: Versions,
         N: ConnectedNetwork<TYPES::SignatureKey>,
-    > TestRunner<TYPES, I, N>
+    > TestRunner<TYPES, I, V, N>
 where
     I: TestableNodeImplementation<TYPES>,
     I: NodeImplementation<
@@ -186,7 +188,7 @@ where
             )
             .await,
         };
-        let spinning_task = TestTask::<SpinningTask<TYPES, I>>::new(
+        let spinning_task = TestTask::<SpinningTask<TYPES, I, V>>::new(
             spinning_task_state,
             event_rxs.clone(),
             test_receiver.clone(),
@@ -211,7 +213,7 @@ where
             test_receiver.clone(),
         );
 
-        let overall_safety_task = TestTask::<OverallSafetyTask<TYPES, I>>::new(
+        let overall_safety_task = TestTask::<OverallSafetyTask<TYPES, I, V>>::new(
             overall_safety_task_state,
             event_rxs.clone(),
             test_receiver.clone(),
@@ -586,7 +588,7 @@ where
         validator_config: ValidatorConfig<TYPES::SignatureKey>,
         storage: I::Storage,
         marketplace_config: MarketplaceConfig<TYPES, I>,
-    ) -> Arc<SystemContext<TYPES, I>> {
+    ) -> Arc<SystemContext<TYPES, I, V>> {
         // Get key pair for certificate aggregation
         let private_key = validator_config.private_key.clone();
         let public_key = validator_config.public_key.clone();
@@ -623,7 +625,7 @@ where
             Receiver<Arc<HotShotEvent<TYPES>>>,
         ),
         external_channel: (Sender<Event<TYPES>>, Receiver<Event<TYPES>>),
-    ) -> Arc<SystemContext<TYPES, I>> {
+    ) -> Arc<SystemContext<TYPES, I, V>> {
         // Get key pair for certificate aggregation
         let private_key = validator_config.private_key.clone();
         let public_key = validator_config.public_key.clone();
@@ -646,13 +648,13 @@ where
 }
 
 /// a node participating in a test
-pub struct Node<TYPES: NodeType, I: TestableNodeImplementation<TYPES>> {
+pub struct Node<TYPES: NodeType, I: TestableNodeImplementation<TYPES>, V: Versions> {
     /// The node's unique identifier
     pub node_id: u64,
     /// The underlying network belonging to the node
     pub network: Network<TYPES, I>,
     /// The handle to the node's internals
-    pub handle: SystemContextHandle<TYPES, I>,
+    pub handle: SystemContextHandle<TYPES, I, V>,
 }
 
 /// This type combines all of the paramters needed to build the context for a node that started
@@ -673,10 +675,10 @@ pub struct LateNodeContextParameters<TYPES: NodeType, I: TestableNodeImplementat
 
 /// The late node context dictates how we're building a node that started late during the test.
 #[allow(clippy::large_enum_variant)]
-pub enum LateNodeContext<TYPES: NodeType, I: TestableNodeImplementation<TYPES>> {
+pub enum LateNodeContext<TYPES: NodeType, I: TestableNodeImplementation<TYPES>, V: Versions> {
     /// The system context that we're passing directly to the node, this means the node is already
     /// initialized successfully.
-    InitializedContext(Arc<SystemContext<TYPES, I>>),
+    InitializedContext(Arc<SystemContext<TYPES, I, V>>),
 
     /// The system context that we're passing to the node when it is not yet initialized, so we're
     /// initializing it based on the received leaf and init parameters.
@@ -686,12 +688,12 @@ pub enum LateNodeContext<TYPES: NodeType, I: TestableNodeImplementation<TYPES>> 
 }
 
 /// A yet-to-be-started node that participates in tests
-pub struct LateStartNode<TYPES: NodeType, I: TestableNodeImplementation<TYPES>> {
+pub struct LateStartNode<TYPES: NodeType, I: TestableNodeImplementation<TYPES>, V: Versions> {
     /// The underlying network belonging to the node
     pub network: Network<TYPES, I>,
     /// Either the context to which we will use to launch HotShot for initialized node when it's
     /// time, or the parameters that will be used to initialize the node and launch HotShot.
-    pub context: LateNodeContext<TYPES, I>,
+    pub context: LateNodeContext<TYPES, I, V>,
 }
 
 /// The runner of a test network
@@ -699,16 +701,17 @@ pub struct LateStartNode<TYPES: NodeType, I: TestableNodeImplementation<TYPES>> 
 pub struct TestRunner<
     TYPES: NodeType,
     I: TestableNodeImplementation<TYPES>,
+    V: Versions,
     N: ConnectedNetwork<TYPES::SignatureKey>,
 > {
     /// test launcher, contains a bunch of useful metadata and closures
-    pub(crate) launcher: TestLauncher<TYPES, I>,
+    pub(crate) launcher: TestLauncher<TYPES, I, V>,
     /// nodes in the test
-    pub(crate) nodes: Vec<Node<TYPES, I>>,
+    pub(crate) nodes: Vec<Node<TYPES, I, V>>,
     /// the solver server running in the test
     pub(crate) solver_server: Option<(Url, JoinHandle<()>)>,
     /// nodes with a late start
-    pub(crate) late_start: HashMap<u64, LateStartNode<TYPES, I>>,
+    pub(crate) late_start: HashMap<u64, LateStartNode<TYPES, I, V>>,
     /// the next node unique identifier
     pub(crate) next_node_id: u64,
     /// Phantom for N

--- a/crates/testing/src/test_task.rs
+++ b/crates/testing/src/test_task.rs
@@ -16,8 +16,11 @@ use futures::future::select_all;
 use hotshot::types::Event;
 use hotshot_task_impls::{events::HotShotEvent, network::NetworkMessageTaskState};
 use hotshot_types::{
-    message::{Messages, VersionedMessage},
-    traits::{network::ConnectedNetwork, node_implementation::NodeType},
+    message::{Messages, UpgradeLock, VersionedMessage},
+    traits::{
+        network::ConnectedNetwork,
+        node_implementation::{NodeType, Versions},
+    },
 };
 #[cfg(async_executor_impl = "tokio")]
 use tokio::task::{spawn, JoinHandle};
@@ -109,10 +112,12 @@ impl<S: TestTaskState + Send + 'static> TestTask<S> {
 /// Add the network task to handle messages and publish events.
 pub async fn add_network_message_test_task<
     TYPES: NodeType,
+    V: Versions,
     NET: ConnectedNetwork<TYPES::SignatureKey>,
 >(
     internal_event_stream: Sender<Arc<HotShotEvent<TYPES>>>,
     external_event_stream: Sender<Event<TYPES>>,
+    upgrade_lock: UpgradeLock<TYPES, V>,
     channel: Arc<NET>,
 ) -> JoinHandle<()> {
     let net = Arc::clone(&channel);
@@ -131,8 +136,7 @@ pub async fn add_network_message_test_task<
                     let mut deserialized_messages = Vec::new();
 
                     for msg in msgs {
-                        let deserialized_message = match VersionedMessage::deserialize(&msg, &None)
-                        {
+                        let deserialized_message = match upgrade_lock.deserialize(&msg).await {
                             Ok(deserialized) => deserialized,
                             Err(e) => {
                                 tracing::error!("Failed to deserialize message: {}", e);

--- a/crates/testing/src/test_task.rs
+++ b/crates/testing/src/test_task.rs
@@ -16,7 +16,7 @@ use futures::future::select_all;
 use hotshot::types::Event;
 use hotshot_task_impls::{events::HotShotEvent, network::NetworkMessageTaskState};
 use hotshot_types::{
-    message::{Messages, UpgradeLock, VersionedMessage},
+    message::{Messages, UpgradeLock},
     traits::{
         network::ConnectedNetwork,
         node_implementation::{NodeType, Versions},

--- a/crates/testing/src/txn_task.rs
+++ b/crates/testing/src/txn_task.rs
@@ -4,7 +4,6 @@
 // You should have received a copy of the MIT License
 // along with the HotShot repository. If not, see <https://mit-license.org/>.
 
-use hotshot_types::traits::node_implementation::Versions;
 use std::{sync::Arc, time::Duration};
 
 use async_broadcast::Receiver;
@@ -13,7 +12,7 @@ use async_lock::RwLock;
 #[cfg(async_executor_impl = "async-std")]
 use async_std::task::JoinHandle;
 use hotshot::traits::TestableNodeImplementation;
-use hotshot_types::traits::node_implementation::NodeType;
+use hotshot_types::traits::node_implementation::{NodeType, Versions};
 use rand::thread_rng;
 use snafu::Snafu;
 #[cfg(async_executor_impl = "tokio")]

--- a/crates/testing/src/txn_task.rs
+++ b/crates/testing/src/txn_task.rs
@@ -4,6 +4,7 @@
 // You should have received a copy of the MIT License
 // along with the HotShot repository. If not, see <https://mit-license.org/>.
 
+use hotshot_types::traits::node_implementation::Versions;
 use std::{sync::Arc, time::Duration};
 
 use async_broadcast::Receiver;
@@ -28,10 +29,10 @@ use crate::{test_runner::Node, test_task::TestEvent};
 pub struct TxnTaskErr {}
 
 /// state of task that decides when things are completed
-pub struct TxnTask<TYPES: NodeType, I: TestableNodeImplementation<TYPES>> {
+pub struct TxnTask<TYPES: NodeType, I: TestableNodeImplementation<TYPES>, V: Versions> {
     // TODO should this be in a rwlock? Or maybe a similar abstraction to the registry is in order
     /// Handles for all nodes.
-    pub handles: Arc<RwLock<Vec<Node<TYPES, I>>>>,
+    pub handles: Arc<RwLock<Vec<Node<TYPES, I, V>>>>,
     /// Optional index of the next node.
     pub next_node_idx: Option<usize>,
     /// time to wait between txns
@@ -40,7 +41,7 @@ pub struct TxnTask<TYPES: NodeType, I: TestableNodeImplementation<TYPES>> {
     pub shutdown_chan: Receiver<TestEvent>,
 }
 
-impl<TYPES: NodeType, I: TestableNodeImplementation<TYPES>> TxnTask<TYPES, I> {
+impl<TYPES: NodeType, I: TestableNodeImplementation<TYPES>, V: Versions> TxnTask<TYPES, I, V> {
     pub fn run(mut self) -> JoinHandle<()> {
         async_spawn(async move {
             async_sleep(Duration::from_millis(100)).await;

--- a/crates/testing/src/view_generator.rs
+++ b/crates/testing/src/view_generator.rs
@@ -17,7 +17,7 @@ use futures::{FutureExt, Stream};
 use hotshot::types::{BLSPubKey, SignatureKey, SystemContextHandle};
 use hotshot_example_types::{
     block_types::{TestBlockHeader, TestBlockPayload, TestMetadata, TestTransaction},
-    node_types::{MemoryImpl, TestTypes},
+    node_types::{MemoryImpl, TestTypes, TestVersions},
     state_types::{TestInstanceState, TestValidatedState},
 };
 use hotshot_types::{
@@ -394,7 +394,7 @@ impl TestView {
 
     pub fn create_quorum_vote(
         &self,
-        handle: &SystemContextHandle<TestTypes, MemoryImpl>,
+        handle: &SystemContextHandle<TestTypes, MemoryImpl, TestVersions>,
     ) -> QuorumVote<TestTypes> {
         QuorumVote::<TestTypes>::create_signed_vote(
             QuorumData {
@@ -410,7 +410,7 @@ impl TestView {
     pub fn create_upgrade_vote(
         &self,
         data: UpgradeProposalData<TestTypes>,
-        handle: &SystemContextHandle<TestTypes, MemoryImpl>,
+        handle: &SystemContextHandle<TestTypes, MemoryImpl, TestVersions>,
     ) -> UpgradeVote<TestTypes> {
         UpgradeVote::<TestTypes>::create_signed_vote(
             data,
@@ -424,7 +424,7 @@ impl TestView {
     pub fn create_da_vote(
         &self,
         data: DaData,
-        handle: &SystemContextHandle<TestTypes, MemoryImpl>,
+        handle: &SystemContextHandle<TestTypes, MemoryImpl, TestVersions>,
     ) -> DaVote<TestTypes> {
         DaVote::create_signed_vote(
             data,

--- a/crates/testing/tests/tests_1/block_builder.rs
+++ b/crates/testing/tests/tests_1/block_builder.rs
@@ -13,7 +13,7 @@ use async_compatibility_layer::art::async_sleep;
 use hotshot_builder_api::v0_1::block_info::AvailableBlockData;
 use hotshot_example_types::{
     block_types::{TestBlockPayload, TestMetadata, TestTransaction},
-    node_types::TestTypes,
+    node_types::{TestTypes, TestVersions},
 };
 use hotshot_orchestrator::config::RandomBuilderConfig;
 use hotshot_task_impls::builder::{BuilderClient, BuilderClientError};
@@ -21,7 +21,9 @@ use hotshot_testing::block_builder::{
     BuilderTask, RandomBuilderImplementation, TestBuilderImplementation,
 };
 use hotshot_types::traits::{
-    block_contents::vid_commitment, node_implementation::NodeType, signature_key::SignatureKey,
+    block_contents::vid_commitment,
+    node_implementation::{NodeType, Versions},
+    signature_key::SignatureKey,
     BlockPayload,
 };
 use tide_disco::Url;
@@ -50,7 +52,7 @@ async fn test_random_block_builder() {
 
     let builder_started = Instant::now();
 
-    let client: BuilderClient<TestTypes, <TestTypes as NodeType>::Base> =
+    let client: BuilderClient<TestTypes, <TestVersions as Versions>::Base> =
         BuilderClient::new(api_url);
     assert!(client.connect(Duration::from_millis(100)).await);
 

--- a/crates/testing/tests/tests_1/consensus_task.rs
+++ b/crates/testing/tests/tests_1/consensus_task.rs
@@ -37,7 +37,10 @@ use hotshot_testing::{
 use hotshot_types::{
     data::{null_block, ViewChangeEvidence, ViewNumber},
     simple_vote::{TimeoutData, TimeoutVote, ViewSyncFinalizeData},
-    traits::{election::Membership, node_implementation::ConsensusTime},
+    traits::{
+        election::Membership,
+        node_implementation::{ConsensusTime, Versions},
+    },
     utils::BuilderCommitment,
     vote::HasViewNumber,
 };
@@ -51,7 +54,6 @@ const TIMEOUT: Duration = Duration::from_millis(35);
 #[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 async fn test_consensus_task() {
-    use hotshot_types::constants::BaseVersion;
     use vbs::version::StaticVersionType;
 
     async_compatibility_layer::logging::setup_logging();
@@ -106,9 +108,9 @@ async fn test_consensus_task() {
                 builder_commitment,
                 TestMetadata,
                 ViewNumber::new(2),
-                vec1![null_block::builder_fee(
+                vec1![null_block::builder_fee::<TestTypes, TestVersions>(
                     quorum_membership.total_nodes(),
-                    BaseVersion::version()
+                    <TestVersions as Versions>::Base::VERSION,
                 )
                 .unwrap()],
                 None,
@@ -204,7 +206,7 @@ async fn test_consensus_vote() {
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 async fn test_view_sync_finalize_propose() {
     use hotshot_example_types::{block_types::TestMetadata, state_types::TestValidatedState};
-    use hotshot_types::{constants::BaseVersion, data::null_block};
+    use hotshot_types::data::null_block;
     use vbs::version::StaticVersionType;
 
     async_compatibility_layer::logging::setup_logging();
@@ -304,7 +306,11 @@ async fn test_view_sync_finalize_propose() {
                 builder_commitment,
                 TestMetadata,
                 ViewNumber::new(4),
-                vec1![null_block::builder_fee(4, BaseVersion::version()).unwrap()],
+                vec1![null_block::builder_fee::<TestTypes, TestVersions>(
+                    4,
+                    <TestVersions as Versions>::Base::VERSION
+                )
+                .unwrap()],
                 None,
             ),
         ],

--- a/crates/testing/tests/tests_1/consensus_task.rs
+++ b/crates/testing/tests/tests_1/consensus_task.rs
@@ -131,7 +131,8 @@ async fn test_consensus_task() {
         ]),
     ];
 
-    let consensus_state = ConsensusTaskState::<TestTypes, MemoryImpl, TestVersions>::create_from(&handle).await;
+    let consensus_state =
+        ConsensusTaskState::<TestTypes, MemoryImpl, TestVersions>::create_from(&handle).await;
     let mut consensus_script = TaskScript {
         timeout: TIMEOUT,
         state: consensus_state,
@@ -187,7 +188,8 @@ async fn test_consensus_vote() {
         exact(QuorumVoteSend(votes[0].clone())),
     ])];
 
-    let consensus_state = ConsensusTaskState::<TestTypes, MemoryImpl, TestVersions>::create_from(&handle).await;
+    let consensus_state =
+        ConsensusTaskState::<TestTypes, MemoryImpl, TestVersions>::create_from(&handle).await;
     let mut consensus_script = TaskScript {
         timeout: TIMEOUT,
         state: consensus_state,
@@ -326,7 +328,8 @@ async fn test_view_sync_finalize_propose() {
         ]),
     ];
 
-    let consensus_state = ConsensusTaskState::<TestTypes, MemoryImpl, TestVersions>::create_from(&handle).await;
+    let consensus_state =
+        ConsensusTaskState::<TestTypes, MemoryImpl, TestVersions>::create_from(&handle).await;
     let mut consensus_script = TaskScript {
         timeout: TIMEOUT,
         state: consensus_state,
@@ -423,7 +426,8 @@ async fn test_view_sync_finalize_vote() {
         ]),
     ];
 
-    let consensus_state = ConsensusTaskState::<TestTypes, MemoryImpl, TestVersions>::create_from(&handle).await;
+    let consensus_state =
+        ConsensusTaskState::<TestTypes, MemoryImpl, TestVersions>::create_from(&handle).await;
     let mut consensus_script = TaskScript {
         timeout: TIMEOUT,
         state: consensus_state,
@@ -527,7 +531,8 @@ async fn test_view_sync_finalize_vote_fail_view_number() {
         Expectations::from_outputs(vec![]),
     ];
 
-    let consensus_state = ConsensusTaskState::<TestTypes, MemoryImpl, TestVersions>::create_from(&handle).await;
+    let consensus_state =
+        ConsensusTaskState::<TestTypes, MemoryImpl, TestVersions>::create_from(&handle).await;
     let mut consensus_script = TaskScript {
         timeout: TIMEOUT,
         state: consensus_state,
@@ -581,7 +586,8 @@ async fn test_vid_disperse_storage_failure() {
         quorum_proposal_validated(),
     ])];
 
-    let consensus_state = ConsensusTaskState::<TestTypes, MemoryImpl, TestVersions>::create_from(&handle).await;
+    let consensus_state =
+        ConsensusTaskState::<TestTypes, MemoryImpl, TestVersions>::create_from(&handle).await;
     let mut consensus_script = TaskScript {
         timeout: TIMEOUT,
         state: consensus_state,

--- a/crates/testing/tests/tests_1/consensus_task.rs
+++ b/crates/testing/tests/tests_1/consensus_task.rs
@@ -57,7 +57,9 @@ async fn test_consensus_task() {
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
 
-    let handle = build_system_handle::<TestTypes, MemoryImpl, TestVersions>(2).await.0;
+    let handle = build_system_handle::<TestTypes, MemoryImpl, TestVersions>(2)
+        .await
+        .0;
     let quorum_membership = handle.hotshot.memberships.quorum_membership.clone();
     let da_membership = handle.hotshot.memberships.da_membership.clone();
 
@@ -146,7 +148,9 @@ async fn test_consensus_vote() {
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
 
-    let handle = build_system_handle::<TestTypes, MemoryImpl, TestVersions>(2).await.0;
+    let handle = build_system_handle::<TestTypes, MemoryImpl, TestVersions>(2)
+        .await
+        .0;
     let quorum_membership = handle.hotshot.memberships.quorum_membership.clone();
     let da_membership = handle.hotshot.memberships.da_membership.clone();
 
@@ -204,7 +208,9 @@ async fn test_view_sync_finalize_propose() {
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
 
-    let handle = build_system_handle::<TestTypes, MemoryImpl, TestVersions>(4).await.0;
+    let handle = build_system_handle::<TestTypes, MemoryImpl, TestVersions>(4)
+        .await
+        .0;
     let (priv_key, pub_key) = key_pair_for_id(4);
     let quorum_membership = handle.hotshot.memberships.quorum_membership.clone();
     let da_membership = handle.hotshot.memberships.da_membership.clone();
@@ -339,7 +345,9 @@ async fn test_view_sync_finalize_vote() {
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
 
-    let handle = build_system_handle::<TestTypes, MemoryImpl, TestVersions>(5).await.0;
+    let handle = build_system_handle::<TestTypes, MemoryImpl, TestVersions>(5)
+        .await
+        .0;
     let quorum_membership = handle.hotshot.memberships.quorum_membership.clone();
     let da_membership = handle.hotshot.memberships.da_membership.clone();
 
@@ -434,7 +442,9 @@ async fn test_view_sync_finalize_vote_fail_view_number() {
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
 
-    let handle = build_system_handle::<TestTypes, MemoryImpl, TestVersions>(5).await.0;
+    let handle = build_system_handle::<TestTypes, MemoryImpl, TestVersions>(5)
+        .await
+        .0;
     let quorum_membership = handle.hotshot.memberships.quorum_membership.clone();
     let da_membership = handle.hotshot.memberships.da_membership.clone();
 
@@ -534,7 +544,9 @@ async fn test_vid_disperse_storage_failure() {
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
 
-    let handle = build_system_handle::<TestTypes, MemoryImpl, TestVersions>(2).await.0;
+    let handle = build_system_handle::<TestTypes, MemoryImpl, TestVersions>(2)
+        .await
+        .0;
 
     // Set the error flag here for the system handle. This causes it to emit an error on append.
     handle.storage().write().await.should_return_err = true;

--- a/crates/testing/tests/tests_1/consensus_task.rs
+++ b/crates/testing/tests/tests_1/consensus_task.rs
@@ -14,7 +14,7 @@ use futures::StreamExt;
 use hotshot::tasks::task_state::CreateTaskState;
 use hotshot_example_types::{
     block_types::TestMetadata,
-    node_types::{MemoryImpl, TestTypes},
+    node_types::{MemoryImpl, TestTypes, TestVersions},
     state_types::TestInstanceState,
 };
 use hotshot_macros::{run_test, test_scripts};
@@ -57,7 +57,7 @@ async fn test_consensus_task() {
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
 
-    let handle = build_system_handle::<TestTypes, MemoryImpl>(2).await.0;
+    let handle = build_system_handle::<TestTypes, MemoryImpl, TestVersions>(2).await.0;
     let quorum_membership = handle.hotshot.memberships.quorum_membership.clone();
     let da_membership = handle.hotshot.memberships.da_membership.clone();
 
@@ -146,7 +146,7 @@ async fn test_consensus_vote() {
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
 
-    let handle = build_system_handle::<TestTypes, MemoryImpl>(2).await.0;
+    let handle = build_system_handle::<TestTypes, MemoryImpl, TestVersions>(2).await.0;
     let quorum_membership = handle.hotshot.memberships.quorum_membership.clone();
     let da_membership = handle.hotshot.memberships.da_membership.clone();
 
@@ -204,7 +204,7 @@ async fn test_view_sync_finalize_propose() {
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
 
-    let handle = build_system_handle::<TestTypes, MemoryImpl>(4).await.0;
+    let handle = build_system_handle::<TestTypes, MemoryImpl, TestVersions>(4).await.0;
     let (priv_key, pub_key) = key_pair_for_id(4);
     let quorum_membership = handle.hotshot.memberships.quorum_membership.clone();
     let da_membership = handle.hotshot.memberships.da_membership.clone();
@@ -339,7 +339,7 @@ async fn test_view_sync_finalize_vote() {
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
 
-    let handle = build_system_handle::<TestTypes, MemoryImpl>(5).await.0;
+    let handle = build_system_handle::<TestTypes, MemoryImpl, TestVersions>(5).await.0;
     let quorum_membership = handle.hotshot.memberships.quorum_membership.clone();
     let da_membership = handle.hotshot.memberships.da_membership.clone();
 
@@ -434,7 +434,7 @@ async fn test_view_sync_finalize_vote_fail_view_number() {
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
 
-    let handle = build_system_handle::<TestTypes, MemoryImpl>(5).await.0;
+    let handle = build_system_handle::<TestTypes, MemoryImpl, TestVersions>(5).await.0;
     let quorum_membership = handle.hotshot.memberships.quorum_membership.clone();
     let da_membership = handle.hotshot.memberships.da_membership.clone();
 
@@ -534,7 +534,7 @@ async fn test_vid_disperse_storage_failure() {
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
 
-    let handle = build_system_handle::<TestTypes, MemoryImpl>(2).await.0;
+    let handle = build_system_handle::<TestTypes, MemoryImpl, TestVersions>(2).await.0;
 
     // Set the error flag here for the system handle. This causes it to emit an error on append.
     handle.storage().write().await.should_return_err = true;

--- a/crates/testing/tests/tests_1/consensus_task.rs
+++ b/crates/testing/tests/tests_1/consensus_task.rs
@@ -131,7 +131,7 @@ async fn test_consensus_task() {
         ]),
     ];
 
-    let consensus_state = ConsensusTaskState::<TestTypes, MemoryImpl>::create_from(&handle).await;
+    let consensus_state = ConsensusTaskState::<TestTypes, MemoryImpl, TestVersions>::create_from(&handle).await;
     let mut consensus_script = TaskScript {
         timeout: TIMEOUT,
         state: consensus_state,
@@ -187,7 +187,7 @@ async fn test_consensus_vote() {
         exact(QuorumVoteSend(votes[0].clone())),
     ])];
 
-    let consensus_state = ConsensusTaskState::<TestTypes, MemoryImpl>::create_from(&handle).await;
+    let consensus_state = ConsensusTaskState::<TestTypes, MemoryImpl, TestVersions>::create_from(&handle).await;
     let mut consensus_script = TaskScript {
         timeout: TIMEOUT,
         state: consensus_state,
@@ -326,7 +326,7 @@ async fn test_view_sync_finalize_propose() {
         ]),
     ];
 
-    let consensus_state = ConsensusTaskState::<TestTypes, MemoryImpl>::create_from(&handle).await;
+    let consensus_state = ConsensusTaskState::<TestTypes, MemoryImpl, TestVersions>::create_from(&handle).await;
     let mut consensus_script = TaskScript {
         timeout: TIMEOUT,
         state: consensus_state,
@@ -423,7 +423,7 @@ async fn test_view_sync_finalize_vote() {
         ]),
     ];
 
-    let consensus_state = ConsensusTaskState::<TestTypes, MemoryImpl>::create_from(&handle).await;
+    let consensus_state = ConsensusTaskState::<TestTypes, MemoryImpl, TestVersions>::create_from(&handle).await;
     let mut consensus_script = TaskScript {
         timeout: TIMEOUT,
         state: consensus_state,
@@ -527,7 +527,7 @@ async fn test_view_sync_finalize_vote_fail_view_number() {
         Expectations::from_outputs(vec![]),
     ];
 
-    let consensus_state = ConsensusTaskState::<TestTypes, MemoryImpl>::create_from(&handle).await;
+    let consensus_state = ConsensusTaskState::<TestTypes, MemoryImpl, TestVersions>::create_from(&handle).await;
     let mut consensus_script = TaskScript {
         timeout: TIMEOUT,
         state: consensus_state,
@@ -581,7 +581,7 @@ async fn test_vid_disperse_storage_failure() {
         quorum_proposal_validated(),
     ])];
 
-    let consensus_state = ConsensusTaskState::<TestTypes, MemoryImpl>::create_from(&handle).await;
+    let consensus_state = ConsensusTaskState::<TestTypes, MemoryImpl, TestVersions>::create_from(&handle).await;
     let mut consensus_script = TaskScript {
         timeout: TIMEOUT,
         state: consensus_state,

--- a/crates/testing/tests/tests_1/da_task.rs
+++ b/crates/testing/tests/tests_1/da_task.rs
@@ -10,7 +10,7 @@ use futures::StreamExt;
 use hotshot::tasks::task_state::CreateTaskState;
 use hotshot_example_types::{
     block_types::{TestMetadata, TestTransaction},
-    node_types::{MemoryImpl, TestTypes},
+    node_types::{MemoryImpl, TestTypes, TestVersions},
 };
 use hotshot_macros::{run_test, test_scripts};
 use hotshot_task_impls::{da::DaTaskState, events::HotShotEvent::*};
@@ -38,7 +38,7 @@ async fn test_da_task() {
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
 
-    let handle = build_system_handle::<TestTypes, MemoryImpl>(2).await.0;
+    let handle = build_system_handle::<TestTypes, MemoryImpl, TestVersions>(2).await.0;
     let quorum_membership = handle.hotshot.memberships.quorum_membership.clone();
     let da_membership = handle.hotshot.memberships.da_membership.clone();
 
@@ -122,7 +122,7 @@ async fn test_da_task_storage_failure() {
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
 
-    let handle = build_system_handle::<TestTypes, MemoryImpl>(2).await.0;
+    let handle = build_system_handle::<TestTypes, MemoryImpl, TestVersions>(2).await.0;
 
     // Set the error flag here for the system handle. This causes it to emit an error on append.
     handle.storage().write().await.should_return_err = true;

--- a/crates/testing/tests/tests_1/da_task.rs
+++ b/crates/testing/tests/tests_1/da_task.rs
@@ -38,7 +38,9 @@ async fn test_da_task() {
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
 
-    let handle = build_system_handle::<TestTypes, MemoryImpl, TestVersions>(2).await.0;
+    let handle = build_system_handle::<TestTypes, MemoryImpl, TestVersions>(2)
+        .await
+        .0;
     let quorum_membership = handle.hotshot.memberships.quorum_membership.clone();
     let da_membership = handle.hotshot.memberships.da_membership.clone();
 
@@ -122,7 +124,9 @@ async fn test_da_task_storage_failure() {
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
 
-    let handle = build_system_handle::<TestTypes, MemoryImpl, TestVersions>(2).await.0;
+    let handle = build_system_handle::<TestTypes, MemoryImpl, TestVersions>(2)
+        .await
+        .0;
 
     // Set the error flag here for the system handle. This causes it to emit an error on append.
     handle.storage().write().await.should_return_err = true;

--- a/crates/testing/tests/tests_1/da_task.rs
+++ b/crates/testing/tests/tests_1/da_task.rs
@@ -22,12 +22,12 @@ use hotshot_testing::{
     view_generator::TestViewGenerator,
 };
 use hotshot_types::{
-    constants::BaseVersion,
     data::{null_block, PackedBundle, ViewNumber},
     simple_vote::DaData,
     traits::{
-        block_contents::precompute_vid_commitment, election::Membership,
-        node_implementation::ConsensusTime,
+        block_contents::precompute_vid_commitment,
+        election::Membership,
+        node_implementation::{ConsensusTime, Versions},
     },
 };
 use vbs::version::StaticVersionType;
@@ -87,9 +87,9 @@ async fn test_da_task() {
                 encoded_transactions,
                 TestMetadata,
                 ViewNumber::new(2),
-                vec1::vec1![null_block::builder_fee(
+                vec1::vec1![null_block::builder_fee::<TestTypes, TestVersions>(
                     quorum_membership.total_nodes(),
-                    BaseVersion::version()
+                    <TestVersions as Versions>::Base::VERSION
                 )
                 .unwrap()],
                 Some(precompute),
@@ -176,9 +176,9 @@ async fn test_da_task_storage_failure() {
                 encoded_transactions,
                 TestMetadata,
                 ViewNumber::new(2),
-                vec1::vec1![null_block::builder_fee(
+                vec1::vec1![null_block::builder_fee::<TestTypes, TestVersions>(
                     quorum_membership.total_nodes(),
-                    BaseVersion::version()
+                    <TestVersions as Versions>::Base::VERSION
                 )
                 .unwrap()],
                 Some(precompute),

--- a/crates/testing/tests/tests_1/libp2p.rs
+++ b/crates/testing/tests/tests_1/libp2p.rs
@@ -102,7 +102,8 @@ async fn libp2p_network_failures_2() {
 async fn test_stress_libp2p_network() {
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
-    let metadata: TestDescription<TestTypes, Libp2pImpl, TestVersions> = TestDescription::default_stress();
+    let metadata: TestDescription<TestTypes, Libp2pImpl, TestVersions> =
+        TestDescription::default_stress();
     metadata
         .gen_launcher(0)
         .launch()

--- a/crates/testing/tests/tests_1/libp2p.rs
+++ b/crates/testing/tests/tests_1/libp2p.rs
@@ -6,7 +6,7 @@
 
 use std::time::Duration;
 
-use hotshot_example_types::node_types::{Libp2pImpl, TestTypes};
+use hotshot_example_types::node_types::{Libp2pImpl, TestTypes, TestVersions};
 use hotshot_testing::{
     block_builder::SimpleBuilderImplementation,
     completion_task::{CompletionTaskDescription, TimeBasedCompletionTaskDescription},
@@ -23,7 +23,7 @@ use tracing::instrument;
 async fn libp2p_network() {
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
-    let metadata: TestDescription<TestTypes, Libp2pImpl> = TestDescription {
+    let metadata: TestDescription<TestTypes, Libp2pImpl, TestVersions> = TestDescription {
         overall_safety_properties: OverallSafetyPropertiesDescription {
             check_leaf: true,
             ..Default::default()
@@ -54,7 +54,7 @@ async fn libp2p_network() {
 async fn libp2p_network_failures_2() {
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
-    let mut metadata: TestDescription<TestTypes, Libp2pImpl> = TestDescription {
+    let mut metadata: TestDescription<TestTypes, Libp2pImpl, TestVersions> = TestDescription {
         overall_safety_properties: OverallSafetyPropertiesDescription {
             check_leaf: true,
             ..Default::default()
@@ -102,7 +102,7 @@ async fn libp2p_network_failures_2() {
 async fn test_stress_libp2p_network() {
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
-    let metadata: TestDescription<TestTypes, Libp2pImpl> = TestDescription::default_stress();
+    let metadata: TestDescription<TestTypes, Libp2pImpl, TestVersions> = TestDescription::default_stress();
     metadata
         .gen_launcher(0)
         .launch()

--- a/crates/testing/tests/tests_1/network_task.rs
+++ b/crates/testing/tests/tests_1/network_task.rs
@@ -10,7 +10,7 @@ use async_broadcast::Sender;
 use async_compatibility_layer::art::async_timeout;
 use async_lock::RwLock;
 use hotshot::traits::implementations::MemoryNetwork;
-use hotshot_example_types::node_types::{MemoryImpl, TestTypes};
+use hotshot_example_types::node_types::{MemoryImpl, TestTypes, TestVersions};
 use hotshot_task::task::{ConsensusTaskRegistry, Task};
 use hotshot_task_impls::{
     events::HotShotEvent,
@@ -41,7 +41,7 @@ async fn test_network_task() {
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
 
-    let builder: TestDescription<TestTypes, MemoryImpl> =
+    let builder: TestDescription<TestTypes, MemoryImpl, TestVersions> =
         TestDescription::default_multiple_rounds();
     let node_id = 1;
 
@@ -114,7 +114,7 @@ async fn test_network_storage_fail() {
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
 
-    let builder: TestDescription<TestTypes, MemoryImpl> =
+    let builder: TestDescription<TestTypes, MemoryImpl, TestVersions> =
         TestDescription::default_multiple_rounds();
     let node_id = 1;
 

--- a/crates/testing/tests/tests_1/quorum_proposal_recv_task.rs
+++ b/crates/testing/tests/tests_1/quorum_proposal_recv_task.rs
@@ -11,7 +11,7 @@
 use futures::StreamExt;
 use hotshot::tasks::task_state::CreateTaskState;
 use hotshot_example_types::{
-    node_types::{MemoryImpl, TestTypes},
+    node_types::{MemoryImpl, TestTypes, TestVersions},
     state_types::TestValidatedState,
 };
 use hotshot_macros::{run_test, test_scripts};
@@ -46,7 +46,9 @@ async fn test_quorum_proposal_recv_task() {
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
 
-    let handle = build_system_handle::<TestTypes, MemoryImpl>(2).await.0;
+    let handle = build_system_handle::<TestTypes, MemoryImpl, TestVersions>(2)
+        .await
+        .0;
     let quorum_membership = handle.hotshot.memberships.quorum_membership.clone();
     let da_membership = handle.hotshot.memberships.da_membership.clone();
     let consensus = handle.hotshot.consensus();
@@ -104,7 +106,9 @@ async fn test_quorum_proposal_recv_task() {
         exact(ViewChange(ViewNumber::new(2))),
     ])];
 
-    let state = QuorumProposalRecvTaskState::<TestTypes, MemoryImpl>::create_from(&handle).await;
+    let state =
+        QuorumProposalRecvTaskState::<TestTypes, MemoryImpl, TestVersions>::create_from(&handle)
+            .await;
     let mut script = TaskScript {
         timeout: Duration::from_millis(35),
         state,
@@ -135,7 +139,9 @@ async fn test_quorum_proposal_recv_task_liveness_check() {
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
 
-    let handle = build_system_handle::<TestTypes, MemoryImpl>(4).await.0;
+    let handle = build_system_handle::<TestTypes, MemoryImpl, TestVersions>(4)
+        .await
+        .0;
     let quorum_membership = handle.hotshot.memberships.quorum_membership.clone();
     let da_membership = handle.hotshot.memberships.da_membership.clone();
     let consensus = handle.hotshot.consensus();
@@ -212,7 +218,9 @@ async fn test_quorum_proposal_recv_task_liveness_check() {
         vote_now(),
     ])];
 
-    let state = QuorumProposalRecvTaskState::<TestTypes, MemoryImpl>::create_from(&handle).await;
+    let state =
+        QuorumProposalRecvTaskState::<TestTypes, MemoryImpl, TestVersions>::create_from(&handle)
+            .await;
     let mut script = TaskScript {
         timeout: Duration::from_millis(35),
         state,

--- a/crates/testing/tests/tests_1/quorum_proposal_task.rs
+++ b/crates/testing/tests/tests_1/quorum_proposal_task.rs
@@ -29,7 +29,10 @@ use hotshot_testing::{
 use hotshot_types::{
     data::{null_block, Leaf, ViewChangeEvidence, ViewNumber},
     simple_vote::{TimeoutData, ViewSyncFinalizeData},
-    traits::{election::Membership, node_implementation::ConsensusTime},
+    traits::{
+        election::Membership,
+        node_implementation::{ConsensusTime, Versions},
+    },
     utils::BuilderCommitment,
     vote::HasViewNumber,
 };
@@ -43,7 +46,6 @@ const TIMEOUT: Duration = Duration::from_millis(35);
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 async fn test_quorum_proposal_task_quorum_proposal_view_1() {
     use hotshot_testing::script::{Expectations, TaskScript};
-    use hotshot_types::constants::BaseVersion;
     use vbs::version::StaticVersionType;
 
     async_compatibility_layer::logging::setup_logging();
@@ -83,8 +85,11 @@ async fn test_quorum_proposal_task_quorum_proposal_view_1() {
     // We must send the genesis cert here to initialize hotshot successfully.
     let genesis_cert = proposals[0].data.justify_qc.clone();
     let builder_commitment = BuilderCommitment::from_raw_digest(sha2::Sha256::new().finalize());
-    let builder_fee =
-        null_block::builder_fee(quorum_membership.total_nodes(), BaseVersion::version()).unwrap();
+    let builder_fee = null_block::builder_fee::<TestTypes, TestVersions>(
+        quorum_membership.total_nodes(),
+        <TestVersions as Versions>::Base::VERSION,
+    )
+    .unwrap();
     drop(consensus_writer);
 
     let inputs = vec![
@@ -133,7 +138,6 @@ async fn test_quorum_proposal_task_quorum_proposal_view_1() {
 #[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 async fn test_quorum_proposal_task_quorum_proposal_view_gt_1() {
-    use hotshot_types::constants::BaseVersion;
     use vbs::version::StaticVersionType;
 
     async_compatibility_layer::logging::setup_logging();
@@ -187,8 +191,11 @@ async fn test_quorum_proposal_task_quorum_proposal_view_gt_1() {
     drop(consensus_writer);
 
     let builder_commitment = BuilderCommitment::from_raw_digest(sha2::Sha256::new().finalize());
-    let builder_fee =
-        null_block::builder_fee(quorum_membership.total_nodes(), BaseVersion::version()).unwrap();
+    let builder_fee = null_block::builder_fee::<TestTypes, TestVersions>(
+        quorum_membership.total_nodes(),
+        <TestVersions as Versions>::Base::VERSION,
+    )
+    .unwrap();
 
     let inputs = vec![
         random![
@@ -317,7 +324,6 @@ async fn test_quorum_proposal_task_quorum_proposal_view_gt_1() {
 #[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 async fn test_quorum_proposal_task_qc_timeout() {
-    use hotshot_types::constants::BaseVersion;
     use vbs::version::StaticVersionType;
 
     async_compatibility_layer::logging::setup_logging();
@@ -372,10 +378,11 @@ async fn test_quorum_proposal_task_qc_timeout() {
             builder_commitment,
             TestMetadata,
             ViewNumber::new(3),
-            vec1![
-                null_block::builder_fee(quorum_membership.total_nodes(), BaseVersion::version())
-                    .unwrap()
-            ],
+            vec1![null_block::builder_fee::<TestTypes, TestVersions>(
+                quorum_membership.total_nodes(),
+                <TestVersions as Versions>::Base::VERSION
+            )
+            .unwrap()],
             None,
         ),
         VidDisperseSend(vid_dispersals[2].clone(), handle.public_key()),
@@ -403,7 +410,7 @@ async fn test_quorum_proposal_task_qc_timeout() {
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 async fn test_quorum_proposal_task_view_sync() {
     use hotshot_example_types::block_types::TestMetadata;
-    use hotshot_types::{constants::BaseVersion, data::null_block};
+    use hotshot_types::data::null_block;
     use vbs::version::StaticVersionType;
 
     async_compatibility_layer::logging::setup_logging();
@@ -460,10 +467,11 @@ async fn test_quorum_proposal_task_view_sync() {
             builder_commitment,
             TestMetadata,
             ViewNumber::new(2),
-            vec1![
-                null_block::builder_fee(quorum_membership.total_nodes(), BaseVersion::version())
-                    .unwrap()
-            ],
+            vec1![null_block::builder_fee::<TestTypes, TestVersions>(
+                quorum_membership.total_nodes(),
+                <TestVersions as Versions>::Base::VERSION
+            )
+            .unwrap()],
             None,
         ),
         VidDisperseSend(vid_dispersals[1].clone(), handle.public_key()),
@@ -490,7 +498,6 @@ async fn test_quorum_proposal_task_view_sync() {
 #[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 async fn test_quorum_proposal_task_liveness_check() {
-    use hotshot_types::constants::BaseVersion;
     use vbs::version::StaticVersionType;
 
     async_compatibility_layer::logging::setup_logging();
@@ -533,8 +540,11 @@ async fn test_quorum_proposal_task_liveness_check() {
     drop(consensus_writer);
 
     let builder_commitment = BuilderCommitment::from_raw_digest(sha2::Sha256::new().finalize());
-    let builder_fee =
-        null_block::builder_fee(quorum_membership.total_nodes(), BaseVersion::version()).unwrap();
+    let builder_fee = null_block::builder_fee::<TestTypes, TestVersions>(
+        quorum_membership.total_nodes(),
+        <TestVersions as Versions>::Base::VERSION,
+    )
+    .unwrap();
 
     // We need to handle the views where we aren't the leader to ensure that the states are
     // updated properly.

--- a/crates/testing/tests/tests_1/quorum_proposal_task.rs
+++ b/crates/testing/tests/tests_1/quorum_proposal_task.rs
@@ -12,7 +12,7 @@ use futures::StreamExt;
 use hotshot::{tasks::task_state::CreateTaskState, traits::ValidatedState};
 use hotshot_example_types::{
     block_types::TestMetadata,
-    node_types::{MemoryImpl, TestTypes},
+    node_types::{MemoryImpl, TestTypes, TestVersions},
     state_types::TestValidatedState,
 };
 use hotshot_macros::{run_test, test_scripts};
@@ -50,7 +50,7 @@ async fn test_quorum_proposal_task_quorum_proposal_view_1() {
     async_compatibility_layer::logging::setup_backtrace();
 
     let node_id = 1;
-    let handle = build_system_handle::<TestTypes, MemoryImpl>(node_id)
+    let handle = build_system_handle::<TestTypes, MemoryImpl, TestVersions>(node_id)
         .await
         .0;
     let quorum_membership = handle.hotshot.memberships.quorum_membership.clone();
@@ -119,7 +119,7 @@ async fn test_quorum_proposal_task_quorum_proposal_view_1() {
     ];
 
     let quorum_proposal_task_state =
-        QuorumProposalTaskState::<TestTypes, MemoryImpl>::create_from(&handle).await;
+        QuorumProposalTaskState::<TestTypes, MemoryImpl, TestVersions>::create_from(&handle).await;
 
     let mut script = TaskScript {
         timeout: TIMEOUT,
@@ -140,7 +140,7 @@ async fn test_quorum_proposal_task_quorum_proposal_view_gt_1() {
     async_compatibility_layer::logging::setup_backtrace();
 
     let node_id = 3;
-    let handle = build_system_handle::<TestTypes, MemoryImpl>(node_id)
+    let handle = build_system_handle::<TestTypes, MemoryImpl, TestVersions>(node_id)
         .await
         .0;
     let quorum_membership = handle.hotshot.memberships.quorum_membership.clone();
@@ -302,7 +302,7 @@ async fn test_quorum_proposal_task_quorum_proposal_view_gt_1() {
     ];
 
     let quorum_proposal_task_state =
-        QuorumProposalTaskState::<TestTypes, MemoryImpl>::create_from(&handle).await;
+        QuorumProposalTaskState::<TestTypes, MemoryImpl, TestVersions>::create_from(&handle).await;
 
     let mut script = TaskScript {
         timeout: TIMEOUT,
@@ -324,7 +324,7 @@ async fn test_quorum_proposal_task_qc_timeout() {
     async_compatibility_layer::logging::setup_backtrace();
 
     let node_id = 3;
-    let handle = build_system_handle::<TestTypes, MemoryImpl>(node_id)
+    let handle = build_system_handle::<TestTypes, MemoryImpl, TestVersions>(node_id)
         .await
         .0;
     let quorum_membership = handle.hotshot.memberships.quorum_membership.clone();
@@ -388,7 +388,7 @@ async fn test_quorum_proposal_task_qc_timeout() {
     let expectations = vec![Expectations::from_outputs(vec![quorum_proposal_send()])];
 
     let quorum_proposal_task_state =
-        QuorumProposalTaskState::<TestTypes, MemoryImpl>::create_from(&handle).await;
+        QuorumProposalTaskState::<TestTypes, MemoryImpl, TestVersions>::create_from(&handle).await;
 
     let mut script = TaskScript {
         timeout: TIMEOUT,
@@ -410,7 +410,7 @@ async fn test_quorum_proposal_task_view_sync() {
     async_compatibility_layer::logging::setup_backtrace();
 
     let node_id = 2;
-    let handle = build_system_handle::<TestTypes, MemoryImpl>(node_id)
+    let handle = build_system_handle::<TestTypes, MemoryImpl, TestVersions>(node_id)
         .await
         .0;
     let quorum_membership = handle.hotshot.memberships.quorum_membership.clone();
@@ -476,7 +476,7 @@ async fn test_quorum_proposal_task_view_sync() {
     let expectations = vec![Expectations::from_outputs(vec![quorum_proposal_send()])];
 
     let quorum_proposal_task_state =
-        QuorumProposalTaskState::<TestTypes, MemoryImpl>::create_from(&handle).await;
+        QuorumProposalTaskState::<TestTypes, MemoryImpl, TestVersions>::create_from(&handle).await;
 
     let mut script = TaskScript {
         timeout: TIMEOUT,
@@ -497,7 +497,7 @@ async fn test_quorum_proposal_task_liveness_check() {
     async_compatibility_layer::logging::setup_backtrace();
 
     let node_id = 3;
-    let handle = build_system_handle::<TestTypes, MemoryImpl>(node_id)
+    let handle = build_system_handle::<TestTypes, MemoryImpl, TestVersions>(node_id)
         .await
         .0;
     let quorum_membership = handle.hotshot.memberships.quorum_membership.clone();
@@ -657,7 +657,7 @@ async fn test_quorum_proposal_task_liveness_check() {
     ];
 
     let quorum_proposal_task_state =
-        QuorumProposalTaskState::<TestTypes, MemoryImpl>::create_from(&handle).await;
+        QuorumProposalTaskState::<TestTypes, MemoryImpl, TestVersions>::create_from(&handle).await;
 
     let mut script = TaskScript {
         timeout: TIMEOUT,
@@ -674,7 +674,9 @@ async fn test_quorum_proposal_task_with_incomplete_events() {
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
 
-    let handle = build_system_handle::<TestTypes, MemoryImpl>(2).await.0;
+    let handle = build_system_handle::<TestTypes, MemoryImpl, TestVersions>(2)
+        .await
+        .0;
     let quorum_membership = handle.hotshot.memberships.quorum_membership.clone();
     let da_membership = handle.hotshot.memberships.da_membership.clone();
 
@@ -700,7 +702,7 @@ async fn test_quorum_proposal_task_with_incomplete_events() {
     let expectations = vec![Expectations::from_outputs(vec![])];
 
     let quorum_proposal_task_state =
-        QuorumProposalTaskState::<TestTypes, MemoryImpl>::create_from(&handle).await;
+        QuorumProposalTaskState::<TestTypes, MemoryImpl, TestVersions>::create_from(&handle).await;
 
     let mut script = TaskScript {
         timeout: TIMEOUT,

--- a/crates/testing/tests/tests_1/quorum_vote_task.rs
+++ b/crates/testing/tests/tests_1/quorum_vote_task.rs
@@ -19,7 +19,6 @@ use hotshot_testing::{
     predicates::event::all_predicates,
     random,
     script::{Expectations, InputOrder, TaskScript},
-    serial,
 };
 use hotshot_types::{
     data::ViewNumber, traits::node_implementation::ConsensusTime, vote::HasViewNumber,

--- a/crates/testing/tests/tests_1/quorum_vote_task.rs
+++ b/crates/testing/tests/tests_1/quorum_vote_task.rs
@@ -11,7 +11,7 @@ use std::time::Duration;
 
 use futures::StreamExt;
 use hotshot::tasks::task_state::CreateTaskState;
-use hotshot_example_types::node_types::{MemoryImpl, TestTypes};
+use hotshot_example_types::node_types::{MemoryImpl, TestTypes, TestVersions};
 use hotshot_macros::{run_test, test_scripts};
 use hotshot_testing::{
     all_predicates,
@@ -41,7 +41,9 @@ async fn test_quorum_vote_task_success() {
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
 
-    let handle = build_system_handle::<TestTypes, MemoryImpl>(2).await.0;
+    let handle = build_system_handle::<TestTypes, MemoryImpl, TestVersions>(2)
+        .await
+        .0;
     let quorum_membership = handle.hotshot.memberships.quorum_membership.clone();
     let da_membership = handle.hotshot.memberships.da_membership.clone();
 
@@ -85,7 +87,7 @@ async fn test_quorum_vote_task_success() {
     ])];
 
     let quorum_vote_state =
-        QuorumVoteTaskState::<TestTypes, MemoryImpl>::create_from(&handle).await;
+        QuorumVoteTaskState::<TestTypes, MemoryImpl, TestVersions>::create_from(&handle).await;
 
     let mut script = TaskScript {
         timeout: TIMEOUT,
@@ -110,7 +112,9 @@ async fn test_quorum_vote_task_vote_now() {
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
 
-    let handle = build_system_handle::<TestTypes, MemoryImpl>(2).await.0;
+    let handle = build_system_handle::<TestTypes, MemoryImpl, TestVersions>(2)
+        .await
+        .0;
     let quorum_membership = handle.hotshot.memberships.quorum_membership.clone();
     let da_membership = handle.hotshot.memberships.da_membership.clone();
 
@@ -136,7 +140,7 @@ async fn test_quorum_vote_task_vote_now() {
     ])];
 
     let quorum_vote_state =
-        QuorumVoteTaskState::<TestTypes, MemoryImpl>::create_from(&handle).await;
+        QuorumVoteTaskState::<TestTypes, MemoryImpl, TestVersions>::create_from(&handle).await;
 
     let mut script = TaskScript {
         timeout: TIMEOUT,
@@ -158,7 +162,9 @@ async fn test_quorum_vote_task_miss_dependency() {
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
 
-    let handle = build_system_handle::<TestTypes, MemoryImpl>(2).await.0;
+    let handle = build_system_handle::<TestTypes, MemoryImpl, TestVersions>(2)
+        .await
+        .0;
     let quorum_membership = handle.hotshot.memberships.quorum_membership.clone();
     let da_membership = handle.hotshot.memberships.da_membership.clone();
 
@@ -221,7 +227,7 @@ async fn test_quorum_vote_task_miss_dependency() {
     ];
 
     let quorum_vote_state =
-        QuorumVoteTaskState::<TestTypes, MemoryImpl>::create_from(&handle).await;
+        QuorumVoteTaskState::<TestTypes, MemoryImpl, TestVersions>::create_from(&handle).await;
 
     let mut script = TaskScript {
         timeout: TIMEOUT,
@@ -243,7 +249,9 @@ async fn test_quorum_vote_task_incorrect_dependency() {
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
 
-    let handle = build_system_handle::<TestTypes, MemoryImpl>(2).await.0;
+    let handle = build_system_handle::<TestTypes, MemoryImpl, TestVersions>(2)
+        .await
+        .0;
     let quorum_membership = handle.hotshot.memberships.quorum_membership.clone();
     let da_membership = handle.hotshot.memberships.da_membership.clone();
 
@@ -273,7 +281,7 @@ async fn test_quorum_vote_task_incorrect_dependency() {
     ])];
 
     let quorum_vote_state =
-        QuorumVoteTaskState::<TestTypes, MemoryImpl>::create_from(&handle).await;
+        QuorumVoteTaskState::<TestTypes, MemoryImpl, TestVersions>::create_from(&handle).await;
 
     let mut script = TaskScript {
         timeout: TIMEOUT,

--- a/crates/testing/tests/tests_1/test_success.rs
+++ b/crates/testing/tests/tests_1/test_success.rs
@@ -7,7 +7,7 @@
 use std::time::Duration;
 
 use hotshot_example_types::{
-    node_types::{Libp2pImpl, MemoryImpl, PushCdnImpl},
+    node_types::{Libp2pImpl, MemoryImpl, PushCdnImpl, TestVersions},
     state_types::TestTypes,
 };
 use hotshot_macros::cross_tests;
@@ -27,6 +27,7 @@ cross_tests!(
     TestName: test_success,
     Impls: [MemoryImpl, Libp2pImpl, PushCdnImpl],
     Types: [TestTypes],
+    Versions: [TestVersions],
     Ignore: false,
     Metadata: {
         TestDescription {
@@ -46,6 +47,7 @@ cross_tests!(
     TestName: double_propose_vote,
     Impls: [MemoryImpl],
     Types: [TestTypes],
+    Versions: [TestVersions],
     Ignore: false,
     Metadata: {
         let behaviour = Rc::new(|node_id| { match node_id {
@@ -72,6 +74,7 @@ cross_tests!(
     TestName: multiple_bad_proposals,
     Impls: [MemoryImpl],
     Types: [TestTypes],
+    Versions: [TestVersions],
     Ignore: false,
     Metadata: {
         let behaviour = Rc::new(|node_id| { match node_id {

--- a/crates/testing/tests/tests_1/test_with_failures_2.rs
+++ b/crates/testing/tests/tests_1/test_with_failures_2.rs
@@ -12,7 +12,7 @@ use std::{
 };
 
 use hotshot_example_types::{
-    node_types::{Libp2pImpl, MemoryImpl, PushCdnImpl, TestConsecutiveLeaderTypes},
+    node_types::{Libp2pImpl, MemoryImpl, PushCdnImpl, TestConsecutiveLeaderTypes, TestVersions},
     state_types::TestTypes,
 };
 use hotshot_macros::cross_tests;
@@ -32,6 +32,7 @@ cross_tests!(
     TestName: test_with_failures_2,
     Impls: [MemoryImpl, Libp2pImpl, PushCdnImpl],
     Types: [TestTypes],
+    Versions: [TestVersions],
     Ignore: false,
     Metadata: {
         let mut metadata = TestDescription::default_more_nodes();
@@ -73,6 +74,7 @@ cross_tests!(
     TestName: dishonest_leader,
     Impls: [MemoryImpl],
     Types: [TestTypes],
+    Versions: [TestVersions],
     Ignore: false,
     Metadata: {
         let behaviour = Rc::new(|node_id| {
@@ -115,6 +117,7 @@ cross_tests!(
     TestName: test_with_double_leader_failures,
     Impls: [MemoryImpl, Libp2pImpl, PushCdnImpl],
     Types: [TestConsecutiveLeaderTypes],
+    Versions: [TestVersions],
     Ignore: false,
     Metadata: {
         let mut metadata = TestDescription::default_more_nodes();

--- a/crates/testing/tests/tests_1/transaction_task.rs
+++ b/crates/testing/tests/tests_1/transaction_task.rs
@@ -26,9 +26,10 @@ async fn test_transaction_task_leader_two_views_in_a_row() {
 
     // Build the API for node 2.
     let node_id = 2;
-    let handle = build_system_handle::<TestConsecutiveLeaderTypes, MemoryImpl, TestVersions>(node_id)
-        .await
-        .0;
+    let handle =
+        build_system_handle::<TestConsecutiveLeaderTypes, MemoryImpl, TestVersions>(node_id)
+            .await
+            .0;
 
     let mut input = Vec::new();
     let mut output = Vec::new();

--- a/crates/testing/tests/tests_1/transaction_task.rs
+++ b/crates/testing/tests/tests_1/transaction_task.rs
@@ -8,11 +8,11 @@ use hotshot_task_impls::{
 };
 use hotshot_testing::helpers::build_system_handle;
 use hotshot_types::{
-    constants::BaseVersion,
     data::{null_block, PackedBundle, ViewNumber},
     traits::{
-        block_contents::precompute_vid_commitment, election::Membership,
-        node_implementation::ConsensusTime,
+        block_contents::precompute_vid_commitment,
+        election::Membership,
+        node_implementation::{ConsensusTime, Versions},
     },
 };
 use vbs::version::StaticVersionType;
@@ -46,11 +46,13 @@ async fn test_transaction_task_leader_two_views_in_a_row() {
         vec![].into(),
         TestMetadata,
         current_view,
-        vec1::vec1![null_block::builder_fee(
-            quorum_membership.total_nodes(),
-            BaseVersion::version()
-        )
-        .unwrap()],
+        vec1::vec1![
+            null_block::builder_fee::<TestConsecutiveLeaderTypes, TestVersions>(
+                quorum_membership.total_nodes(),
+                <TestVersions as Versions>::Base::VERSION
+            )
+            .unwrap()
+        ],
         Some(precompute_data.clone()),
         None,
     );

--- a/crates/testing/tests/tests_1/transaction_task.rs
+++ b/crates/testing/tests/tests_1/transaction_task.rs
@@ -61,6 +61,9 @@ async fn test_transaction_task_leader_two_views_in_a_row() {
     output.push(HotShotEvent::BlockRecv(exp_packed_bundle));
 
     let transaction_state =
-        TransactionTaskState::<TestConsecutiveLeaderTypes, MemoryImpl, TestVersions>::create_from(&handle).await;
+        TransactionTaskState::<TestConsecutiveLeaderTypes, MemoryImpl, TestVersions>::create_from(
+            &handle,
+        )
+        .await;
     run_harness(input, output, transaction_state, false).await;
 }

--- a/crates/testing/tests/tests_1/transaction_task.rs
+++ b/crates/testing/tests/tests_1/transaction_task.rs
@@ -61,6 +61,6 @@ async fn test_transaction_task_leader_two_views_in_a_row() {
     output.push(HotShotEvent::BlockRecv(exp_packed_bundle));
 
     let transaction_state =
-        TransactionTaskState::<TestConsecutiveLeaderTypes, MemoryImpl>::create_from(&handle).await;
+        TransactionTaskState::<TestConsecutiveLeaderTypes, MemoryImpl, TestVersions>::create_from(&handle).await;
     run_harness(input, output, transaction_state, false).await;
 }

--- a/crates/testing/tests/tests_1/transaction_task.rs
+++ b/crates/testing/tests/tests_1/transaction_task.rs
@@ -1,7 +1,7 @@
 use hotshot::tasks::task_state::CreateTaskState;
 use hotshot_example_types::{
     block_types::TestMetadata,
-    node_types::{MemoryImpl, TestConsecutiveLeaderTypes},
+    node_types::{MemoryImpl, TestConsecutiveLeaderTypes, TestVersions},
 };
 use hotshot_task_impls::{
     events::HotShotEvent, harness::run_harness, transactions::TransactionTaskState,
@@ -26,7 +26,7 @@ async fn test_transaction_task_leader_two_views_in_a_row() {
 
     // Build the API for node 2.
     let node_id = 2;
-    let handle = build_system_handle::<TestConsecutiveLeaderTypes, MemoryImpl>(node_id)
+    let handle = build_system_handle::<TestConsecutiveLeaderTypes, MemoryImpl, TestVersions>(node_id)
         .await
         .0;
 

--- a/crates/testing/tests/tests_1/upgrade_task_with_consensus.rs
+++ b/crates/testing/tests/tests_1/upgrade_task_with_consensus.rs
@@ -47,7 +47,9 @@ async fn test_upgrade_task_vote() {
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
 
-    let handle = build_system_handle::<TestTypes, MemoryImpl, TestVersions>(1).await.0;
+    let handle = build_system_handle::<TestTypes, MemoryImpl, TestVersions>(1)
+        .await
+        .0;
     let quorum_membership = handle.hotshot.memberships.quorum_membership.clone();
     let da_membership = handle.hotshot.memberships.da_membership.clone();
 
@@ -204,7 +206,9 @@ async fn test_upgrade_task_propose() {
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
 
-    let handle = build_system_handle::<TestTypes, MemoryImpl, TestVersions>(3).await.0;
+    let handle = build_system_handle::<TestTypes, MemoryImpl, TestVersions>(3)
+        .await
+        .0;
     let quorum_membership = handle.hotshot.memberships.quorum_membership.clone();
     let da_membership = handle.hotshot.memberships.da_membership.clone();
 
@@ -366,7 +370,9 @@ async fn test_upgrade_task_blank_blocks() {
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
 
-    let handle = build_system_handle::<TestTypes, MemoryImpl, TestVersions>(6).await.0;
+    let handle = build_system_handle::<TestTypes, MemoryImpl, TestVersions>(6)
+        .await
+        .0;
     let quorum_membership = handle.hotshot.memberships.quorum_membership.clone();
     let da_membership = handle.hotshot.memberships.da_membership.clone();
 

--- a/crates/testing/tests/tests_1/upgrade_task_with_consensus.rs
+++ b/crates/testing/tests/tests_1/upgrade_task_with_consensus.rs
@@ -29,10 +29,12 @@ use hotshot_testing::{
     view_generator::TestViewGenerator,
 };
 use hotshot_types::{
-    constants::BaseVersion,
     data::{null_block, ViewNumber},
     simple_vote::UpgradeProposalData,
-    traits::{election::Membership, node_implementation::ConsensusTime},
+    traits::{
+        election::Membership,
+        node_implementation::{ConsensusTime, Versions},
+    },
     vote::HasViewNumber,
 };
 use vbs::version::{StaticVersionType, Version};
@@ -286,9 +288,9 @@ async fn test_upgrade_task_propose() {
                 proposals[2].data.block_header.builder_commitment.clone(),
                 TestMetadata,
                 ViewNumber::new(3),
-                vec1![null_block::builder_fee(
+                vec1![null_block::builder_fee::<TestTypes, TestVersions>(
                     quorum_membership.total_nodes(),
-                    BaseVersion::version()
+                    <TestVersions as Versions>::Base::VERSION
                 )
                 .unwrap()],
                 None,
@@ -382,8 +384,11 @@ async fn test_upgrade_task_blank_blocks() {
     let old_version = Version { major: 0, minor: 1 };
     let new_version = Version { major: 0, minor: 2 };
 
-    let builder_fee =
-        null_block::builder_fee(quorum_membership.total_nodes(), BaseVersion::version()).unwrap();
+    let builder_fee = null_block::builder_fee::<TestTypes, TestVersions>(
+        quorum_membership.total_nodes(),
+        <TestVersions as Versions>::Base::VERSION,
+    )
+    .unwrap();
 
     let upgrade_data: UpgradeProposalData<TestTypes> = UpgradeProposalData {
         old_version,

--- a/crates/testing/tests/tests_1/upgrade_task_with_consensus.rs
+++ b/crates/testing/tests/tests_1/upgrade_task_with_consensus.rs
@@ -15,7 +15,7 @@ use futures::StreamExt;
 use hotshot::{tasks::task_state::CreateTaskState, types::SystemContextHandle};
 use hotshot_example_types::{
     block_types::{TestMetadata, TestTransaction},
-    node_types::{MemoryImpl, TestTypes},
+    node_types::{MemoryImpl, TestTypes, TestVersions},
     state_types::TestInstanceState,
 };
 use hotshot_macros::test_scripts;
@@ -47,7 +47,7 @@ async fn test_upgrade_task_vote() {
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
 
-    let handle = build_system_handle::<TestTypes, MemoryImpl>(1).await.0;
+    let handle = build_system_handle::<TestTypes, MemoryImpl, TestVersions>(1).await.0;
     let quorum_membership = handle.hotshot.memberships.quorum_membership.clone();
     let da_membership = handle.hotshot.memberships.da_membership.clone();
 
@@ -204,7 +204,7 @@ async fn test_upgrade_task_propose() {
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
 
-    let handle = build_system_handle::<TestTypes, MemoryImpl>(3).await.0;
+    let handle = build_system_handle::<TestTypes, MemoryImpl, TestVersions>(3).await.0;
     let quorum_membership = handle.hotshot.memberships.quorum_membership.clone();
     let da_membership = handle.hotshot.memberships.da_membership.clone();
 
@@ -366,7 +366,7 @@ async fn test_upgrade_task_blank_blocks() {
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
 
-    let handle = build_system_handle::<TestTypes, MemoryImpl>(6).await.0;
+    let handle = build_system_handle::<TestTypes, MemoryImpl, TestVersions>(6).await.0;
     let quorum_membership = handle.hotshot.memberships.quorum_membership.clone();
     let da_membership = handle.hotshot.memberships.da_membership.clone();
 

--- a/crates/testing/tests/tests_1/upgrade_task_with_consensus.rs
+++ b/crates/testing/tests/tests_1/upgrade_task_with_consensus.rs
@@ -182,7 +182,8 @@ async fn test_upgrade_task_vote() {
         },
     ];
 
-    let consensus_state = ConsensusTaskState::<TestTypes, MemoryImpl, TestVersions>::create_from(&handle).await;
+    let consensus_state =
+        ConsensusTaskState::<TestTypes, MemoryImpl, TestVersions>::create_from(&handle).await;
     let mut consensus_script = TaskScript {
         timeout: Duration::from_millis(65),
         state: consensus_state,
@@ -259,8 +260,10 @@ async fn test_upgrade_task_propose() {
         .iter()
         .map(|h| views[2].create_upgrade_vote(upgrade_data.clone(), &h.0));
 
-    let consensus_state = ConsensusTaskState::<TestTypes, MemoryImpl, TestVersions>::create_from(&handle).await;
-    let upgrade_state = UpgradeTaskState::<TestTypes, MemoryImpl, TestVersions>::create_from(&handle).await;
+    let consensus_state =
+        ConsensusTaskState::<TestTypes, MemoryImpl, TestVersions>::create_from(&handle).await;
+    let upgrade_state =
+        UpgradeTaskState::<TestTypes, MemoryImpl, TestVersions>::create_from(&handle).await;
 
     let upgrade_vote_recvs: Vec<_> = upgrade_votes.map(UpgradeVoteRecv).collect();
 
@@ -458,8 +461,10 @@ async fn test_upgrade_task_blank_blocks() {
         views.push(view.clone());
     }
 
-    let consensus_state = ConsensusTaskState::<TestTypes, MemoryImpl, TestVersions>::create_from(&handle).await;
-    let upgrade_state = UpgradeTaskState::<TestTypes, MemoryImpl, TestVersions>::create_from(&handle).await;
+    let consensus_state =
+        ConsensusTaskState::<TestTypes, MemoryImpl, TestVersions>::create_from(&handle).await;
+    let upgrade_state =
+        UpgradeTaskState::<TestTypes, MemoryImpl, TestVersions>::create_from(&handle).await;
 
     let inputs = vec![
         vec![

--- a/crates/testing/tests/tests_1/upgrade_task_with_consensus.rs
+++ b/crates/testing/tests/tests_1/upgrade_task_with_consensus.rs
@@ -182,7 +182,7 @@ async fn test_upgrade_task_vote() {
         },
     ];
 
-    let consensus_state = ConsensusTaskState::<TestTypes, MemoryImpl>::create_from(&handle).await;
+    let consensus_state = ConsensusTaskState::<TestTypes, MemoryImpl, TestVersions>::create_from(&handle).await;
     let mut consensus_script = TaskScript {
         timeout: Duration::from_millis(65),
         state: consensus_state,
@@ -259,8 +259,8 @@ async fn test_upgrade_task_propose() {
         .iter()
         .map(|h| views[2].create_upgrade_vote(upgrade_data.clone(), &h.0));
 
-    let consensus_state = ConsensusTaskState::<TestTypes, MemoryImpl>::create_from(&handle).await;
-    let upgrade_state = UpgradeTaskState::<TestTypes, MemoryImpl>::create_from(&handle).await;
+    let consensus_state = ConsensusTaskState::<TestTypes, MemoryImpl, TestVersions>::create_from(&handle).await;
+    let upgrade_state = UpgradeTaskState::<TestTypes, MemoryImpl, TestVersions>::create_from(&handle).await;
 
     let upgrade_vote_recvs: Vec<_> = upgrade_votes.map(UpgradeVoteRecv).collect();
 
@@ -458,8 +458,8 @@ async fn test_upgrade_task_blank_blocks() {
         views.push(view.clone());
     }
 
-    let consensus_state = ConsensusTaskState::<TestTypes, MemoryImpl>::create_from(&handle).await;
-    let upgrade_state = UpgradeTaskState::<TestTypes, MemoryImpl>::create_from(&handle).await;
+    let consensus_state = ConsensusTaskState::<TestTypes, MemoryImpl, TestVersions>::create_from(&handle).await;
+    let upgrade_state = UpgradeTaskState::<TestTypes, MemoryImpl, TestVersions>::create_from(&handle).await;
 
     let inputs = vec![
         vec![

--- a/crates/testing/tests/tests_1/upgrade_task_with_proposal.rs
+++ b/crates/testing/tests/tests_1/upgrade_task_with_proposal.rs
@@ -14,7 +14,7 @@ use futures::StreamExt;
 use hotshot::{tasks::task_state::CreateTaskState, types::SystemContextHandle};
 use hotshot_example_types::{
     block_types::{TestMetadata, TestTransaction},
-    node_types::{MemoryImpl, TestTypes},
+    node_types::{MemoryImpl, TestTypes, TestVersions},
     state_types::{TestInstanceState, TestValidatedState},
 };
 use hotshot_macros::{run_test, test_scripts};
@@ -59,7 +59,9 @@ async fn test_upgrade_task_with_proposal() {
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
 
-    let handle = build_system_handle::<TestTypes, MemoryImpl>(3).await.0;
+    let handle = build_system_handle::<TestTypes, MemoryImpl, TestVersions>(3)
+        .await
+        .0;
     let quorum_membership = handle.hotshot.memberships.quorum_membership.clone();
     let da_membership = handle.hotshot.memberships.da_membership.clone();
 
@@ -140,8 +142,9 @@ async fn test_upgrade_task_with_proposal() {
         .map(|h| views[2].create_upgrade_vote(upgrade_data.clone(), &h.0));
 
     let proposal_state =
-        QuorumProposalTaskState::<TestTypes, MemoryImpl>::create_from(&handle).await;
-    let upgrade_state = UpgradeTaskState::<TestTypes, MemoryImpl>::create_from(&handle).await;
+        QuorumProposalTaskState::<TestTypes, MemoryImpl, TestVersions>::create_from(&handle).await;
+    let upgrade_state =
+        UpgradeTaskState::<TestTypes, MemoryImpl, TestVersions>::create_from(&handle).await;
 
     let upgrade_vote_recvs: Vec<_> = upgrade_votes.map(UpgradeVoteRecv).collect();
 

--- a/crates/testing/tests/tests_1/upgrade_task_with_proposal.rs
+++ b/crates/testing/tests/tests_1/upgrade_task_with_proposal.rs
@@ -32,10 +32,13 @@ use hotshot_testing::{
     view_generator::TestViewGenerator,
 };
 use hotshot_types::{
-    constants::BaseVersion,
     data::{null_block, Leaf, ViewNumber},
     simple_vote::UpgradeProposalData,
-    traits::{election::Membership, node_implementation::ConsensusTime, ValidatedState},
+    traits::{
+        election::Membership,
+        node_implementation::{ConsensusTime, Versions},
+        ValidatedState,
+    },
     utils::BuilderCommitment,
     vote::HasViewNumber,
 };
@@ -135,8 +138,11 @@ async fn test_upgrade_task_with_proposal() {
     let genesis_cert = proposals[0].data.justify_qc.clone();
     let genesis_leaf = Leaf::genesis(&validated_state, &*handle.hotshot.instance_state()).await;
     let builder_commitment = BuilderCommitment::from_raw_digest(sha2::Sha256::new().finalize());
-    let builder_fee =
-        null_block::builder_fee(quorum_membership.total_nodes(), BaseVersion::version()).unwrap();
+    let builder_fee = null_block::builder_fee::<TestTypes, TestVersions>(
+        quorum_membership.total_nodes(),
+        <TestVersions as Versions>::Base::VERSION,
+    )
+    .unwrap();
     let upgrade_votes = other_handles
         .iter()
         .map(|h| views[2].create_upgrade_vote(upgrade_data.clone(), &h.0));

--- a/crates/testing/tests/tests_1/upgrade_task_with_vote.rs
+++ b/crates/testing/tests/tests_1/upgrade_task_with_vote.rs
@@ -14,7 +14,7 @@ use futures::StreamExt;
 use hotshot::{tasks::task_state::CreateTaskState, types::SystemContextHandle};
 use hotshot_example_types::{
     block_types::{TestMetadata, TestTransaction},
-    node_types::{MemoryImpl, TestTypes},
+    node_types::{MemoryImpl, TestTypes, TestVersions},
     state_types::TestInstanceState,
 };
 use hotshot_macros::{run_test, test_scripts};
@@ -51,7 +51,9 @@ async fn test_upgrade_task_with_vote() {
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
 
-    let handle = build_system_handle::<TestTypes, MemoryImpl>(2).await.0;
+    let handle = build_system_handle::<TestTypes, MemoryImpl, TestVersions>(2)
+        .await
+        .0;
     let quorum_membership = handle.hotshot.memberships.quorum_membership.clone();
     let da_membership = handle.hotshot.memberships.da_membership.clone();
 
@@ -188,7 +190,8 @@ async fn test_upgrade_task_with_vote() {
         ),
     ];
 
-    let vote_state = QuorumVoteTaskState::<TestTypes, MemoryImpl>::create_from(&handle).await;
+    let vote_state =
+        QuorumVoteTaskState::<TestTypes, MemoryImpl, TestVersions>::create_from(&handle).await;
     let mut vote_script = TaskScript {
         timeout: TIMEOUT,
         state: vote_state,

--- a/crates/testing/tests/tests_1/vid_task.rs
+++ b/crates/testing/tests/tests_1/vid_task.rs
@@ -21,12 +21,11 @@ use hotshot_testing::{
     serial,
 };
 use hotshot_types::{
-    constants::BaseVersion,
     data::{null_block, DaProposal, PackedBundle, VidDisperse, ViewNumber},
     traits::{
         consensus_api::ConsensusApi,
         election::Membership,
-        node_implementation::{ConsensusTime, NodeType},
+        node_implementation::{ConsensusTime, NodeType, Versions},
         BlockPayload,
     },
 };
@@ -100,9 +99,9 @@ async fn test_vid_task() {
                 encoded_transactions,
                 TestMetadata,
                 ViewNumber::new(2),
-                vec1::vec1![null_block::builder_fee(
+                vec1::vec1![null_block::builder_fee::<TestTypes, TestVersions>(
                     quorum_membership.total_nodes(),
-                    BaseVersion::version()
+                    <TestVersions as Versions>::Base::VERSION
                 )
                 .unwrap()],
                 Some(vid_precompute),
@@ -119,9 +118,9 @@ async fn test_vid_task() {
                 builder_commitment,
                 TestMetadata,
                 ViewNumber::new(2),
-                vec1![null_block::builder_fee(
+                vec1![null_block::builder_fee::<TestTypes, TestVersions>(
                     quorum_membership.total_nodes(),
-                    BaseVersion::version()
+                    <TestVersions as Versions>::Base::VERSION
                 )
                 .unwrap()],
                 None,

--- a/crates/testing/tests/tests_1/vid_task.rs
+++ b/crates/testing/tests/tests_1/vid_task.rs
@@ -43,7 +43,9 @@ async fn test_vid_task() {
     async_compatibility_layer::logging::setup_backtrace();
 
     // Build the API for node 2.
-    let handle = build_system_handle::<TestTypes, MemoryImpl, TestVersions>(2).await.0;
+    let handle = build_system_handle::<TestTypes, MemoryImpl, TestVersions>(2)
+        .await
+        .0;
     let pub_key = handle.public_key();
 
     // quorum membership for VID share distribution

--- a/crates/testing/tests/tests_1/vid_task.rs
+++ b/crates/testing/tests/tests_1/vid_task.rs
@@ -9,7 +9,7 @@ use std::{marker::PhantomData, sync::Arc};
 use hotshot::{tasks::task_state::CreateTaskState, types::SignatureKey};
 use hotshot_example_types::{
     block_types::{TestBlockPayload, TestMetadata, TestTransaction},
-    node_types::{MemoryImpl, TestTypes},
+    node_types::{MemoryImpl, TestTypes, TestVersions},
     state_types::{TestInstanceState, TestValidatedState},
 };
 use hotshot_macros::{run_test, test_scripts};
@@ -43,7 +43,7 @@ async fn test_vid_task() {
     async_compatibility_layer::logging::setup_backtrace();
 
     // Build the API for node 2.
-    let handle = build_system_handle::<TestTypes, MemoryImpl>(2).await.0;
+    let handle = build_system_handle::<TestTypes, MemoryImpl, TestVersions>(2).await.0;
     let pub_key = handle.public_key();
 
     // quorum membership for VID share distribution

--- a/crates/testing/tests/tests_1/view_sync_task.rs
+++ b/crates/testing/tests/tests_1/view_sync_task.rs
@@ -23,7 +23,9 @@ async fn test_view_sync_task() {
     async_compatibility_layer::logging::setup_backtrace();
 
     // Build the API for node 5.
-    let handle = build_system_handle::<TestTypes, MemoryImpl, TestVersions>(5).await.0;
+    let handle = build_system_handle::<TestTypes, MemoryImpl, TestVersions>(5)
+        .await
+        .0;
 
     let vote_data = ViewSyncPreCommitData {
         relay: 0,

--- a/crates/testing/tests/tests_1/view_sync_task.rs
+++ b/crates/testing/tests/tests_1/view_sync_task.rs
@@ -5,7 +5,7 @@
 // along with the HotShot repository. If not, see <https://mit-license.org/>.
 
 use hotshot::tasks::task_state::CreateTaskState;
-use hotshot_example_types::node_types::{MemoryImpl, TestTypes};
+use hotshot_example_types::node_types::{MemoryImpl, TestTypes, TestVersions};
 use hotshot_task_impls::{
     events::HotShotEvent, harness::run_harness, view_sync::ViewSyncTaskState,
 };
@@ -23,7 +23,7 @@ async fn test_view_sync_task() {
     async_compatibility_layer::logging::setup_backtrace();
 
     // Build the API for node 5.
-    let handle = build_system_handle::<TestTypes, MemoryImpl>(5).await.0;
+    let handle = build_system_handle::<TestTypes, MemoryImpl, TestVersions>(5).await.0;
 
     let vote_data = ViewSyncPreCommitData {
         relay: 0,

--- a/crates/testing/tests/tests_2/catchup.rs
+++ b/crates/testing/tests/tests_2/catchup.rs
@@ -25,7 +25,8 @@ async fn test_catchup() {
         next_view_timeout: 2000,
         ..Default::default()
     };
-    let mut metadata: TestDescription<TestTypes, MemoryImpl, TestVersions> = TestDescription::default();
+    let mut metadata: TestDescription<TestTypes, MemoryImpl, TestVersions> =
+        TestDescription::default();
     let catchup_node = vec![ChangeNode {
         idx: 19,
         updown: UpDown::Up,
@@ -84,7 +85,8 @@ async fn test_catchup_cdn() {
         next_view_timeout: 2000,
         ..Default::default()
     };
-    let mut metadata: TestDescription<TestTypes, PushCdnImpl, TestVersions> = TestDescription::default();
+    let mut metadata: TestDescription<TestTypes, PushCdnImpl, TestVersions> =
+        TestDescription::default();
     let catchup_nodes = vec![ChangeNode {
         idx: 18,
         updown: UpDown::Up,
@@ -137,7 +139,8 @@ async fn test_catchup_one_node() {
         next_view_timeout: 2000,
         ..Default::default()
     };
-    let mut metadata: TestDescription<TestTypes, MemoryImpl, TestVersions> = TestDescription::default();
+    let mut metadata: TestDescription<TestTypes, MemoryImpl, TestVersions> =
+        TestDescription::default();
     let catchup_nodes = vec![ChangeNode {
         idx: 18,
         updown: UpDown::Up,
@@ -192,7 +195,8 @@ async fn test_catchup_in_view_sync() {
         next_view_timeout: 2000,
         ..Default::default()
     };
-    let mut metadata: TestDescription<TestTypes, MemoryImpl, TestVersions> = TestDescription::default();
+    let mut metadata: TestDescription<TestTypes, MemoryImpl, TestVersions> =
+        TestDescription::default();
     let catchup_nodes = vec![
         ChangeNode {
             idx: 18,
@@ -255,7 +259,8 @@ async fn test_catchup_reload() {
         next_view_timeout: 2000,
         ..Default::default()
     };
-    let mut metadata: TestDescription<TestTypes, MemoryImpl, TestVersions> = TestDescription::default();
+    let mut metadata: TestDescription<TestTypes, MemoryImpl, TestVersions> =
+        TestDescription::default();
     let catchup_node = vec![ChangeNode {
         idx: 19,
         updown: UpDown::Up,
@@ -314,7 +319,8 @@ async fn test_all_restart() {
         next_view_timeout: 2000,
         ..Default::default()
     };
-    let mut metadata: TestDescription<TestTypes, CombinedImpl, TestVersions> = TestDescription::default();
+    let mut metadata: TestDescription<TestTypes, CombinedImpl, TestVersions> =
+        TestDescription::default();
     let mut catchup_nodes = vec![];
     for i in 1..20 {
         catchup_nodes.push(ChangeNode {

--- a/crates/testing/tests/tests_2/catchup.rs
+++ b/crates/testing/tests/tests_2/catchup.rs
@@ -10,7 +10,7 @@
 async fn test_catchup() {
     use std::time::Duration;
 
-    use hotshot_example_types::node_types::{MemoryImpl, TestTypes};
+    use hotshot_example_types::node_types::{MemoryImpl, TestTypes, TestVersions};
     use hotshot_testing::{
         block_builder::SimpleBuilderImplementation,
         completion_task::{CompletionTaskDescription, TimeBasedCompletionTaskDescription},
@@ -25,7 +25,7 @@ async fn test_catchup() {
         next_view_timeout: 2000,
         ..Default::default()
     };
-    let mut metadata: TestDescription<TestTypes, MemoryImpl> = TestDescription::default();
+    let mut metadata: TestDescription<TestTypes, MemoryImpl, TestVersions> = TestDescription::default();
     let catchup_node = vec![ChangeNode {
         idx: 19,
         updown: UpDown::Up,
@@ -69,7 +69,7 @@ async fn test_catchup() {
 async fn test_catchup_cdn() {
     use std::time::Duration;
 
-    use hotshot_example_types::node_types::{PushCdnImpl, TestTypes};
+    use hotshot_example_types::node_types::{PushCdnImpl, TestTypes, TestVersions};
     use hotshot_testing::{
         block_builder::SimpleBuilderImplementation,
         completion_task::{CompletionTaskDescription, TimeBasedCompletionTaskDescription},
@@ -84,7 +84,7 @@ async fn test_catchup_cdn() {
         next_view_timeout: 2000,
         ..Default::default()
     };
-    let mut metadata: TestDescription<TestTypes, PushCdnImpl> = TestDescription::default();
+    let mut metadata: TestDescription<TestTypes, PushCdnImpl, TestVersions> = TestDescription::default();
     let catchup_nodes = vec![ChangeNode {
         idx: 18,
         updown: UpDown::Up,
@@ -123,7 +123,7 @@ async fn test_catchup_cdn() {
 async fn test_catchup_one_node() {
     use std::time::Duration;
 
-    use hotshot_example_types::node_types::{MemoryImpl, TestTypes};
+    use hotshot_example_types::node_types::{MemoryImpl, TestTypes, TestVersions};
     use hotshot_testing::{
         block_builder::SimpleBuilderImplementation,
         completion_task::{CompletionTaskDescription, TimeBasedCompletionTaskDescription},
@@ -137,7 +137,7 @@ async fn test_catchup_one_node() {
         next_view_timeout: 2000,
         ..Default::default()
     };
-    let mut metadata: TestDescription<TestTypes, MemoryImpl> = TestDescription::default();
+    let mut metadata: TestDescription<TestTypes, MemoryImpl, TestVersions> = TestDescription::default();
     let catchup_nodes = vec![ChangeNode {
         idx: 18,
         updown: UpDown::Up,
@@ -178,7 +178,7 @@ async fn test_catchup_one_node() {
 async fn test_catchup_in_view_sync() {
     use std::time::Duration;
 
-    use hotshot_example_types::node_types::{MemoryImpl, TestTypes};
+    use hotshot_example_types::node_types::{MemoryImpl, TestTypes, TestVersions};
     use hotshot_testing::{
         block_builder::SimpleBuilderImplementation,
         completion_task::{CompletionTaskDescription, TimeBasedCompletionTaskDescription},
@@ -192,7 +192,7 @@ async fn test_catchup_in_view_sync() {
         next_view_timeout: 2000,
         ..Default::default()
     };
-    let mut metadata: TestDescription<TestTypes, MemoryImpl> = TestDescription::default();
+    let mut metadata: TestDescription<TestTypes, MemoryImpl, TestVersions> = TestDescription::default();
     let catchup_nodes = vec![
         ChangeNode {
             idx: 18,
@@ -240,7 +240,7 @@ async fn test_catchup_in_view_sync() {
 async fn test_catchup_reload() {
     use std::time::Duration;
 
-    use hotshot_example_types::node_types::{MemoryImpl, TestTypes};
+    use hotshot_example_types::node_types::{MemoryImpl, TestTypes, TestVersions};
     use hotshot_testing::{
         block_builder::SimpleBuilderImplementation,
         completion_task::{CompletionTaskDescription, TimeBasedCompletionTaskDescription},
@@ -255,7 +255,7 @@ async fn test_catchup_reload() {
         next_view_timeout: 2000,
         ..Default::default()
     };
-    let mut metadata: TestDescription<TestTypes, MemoryImpl> = TestDescription::default();
+    let mut metadata: TestDescription<TestTypes, MemoryImpl, TestVersions> = TestDescription::default();
     let catchup_node = vec![ChangeNode {
         idx: 19,
         updown: UpDown::Up,
@@ -299,7 +299,7 @@ async fn test_catchup_reload() {
 async fn test_all_restart() {
     use std::time::Duration;
 
-    use hotshot_example_types::node_types::{CombinedImpl, TestTypes};
+    use hotshot_example_types::node_types::{CombinedImpl, TestTypes, TestVersions};
     use hotshot_testing::{
         block_builder::SimpleBuilderImplementation,
         completion_task::{CompletionTaskDescription, TimeBasedCompletionTaskDescription},
@@ -314,7 +314,7 @@ async fn test_all_restart() {
         next_view_timeout: 2000,
         ..Default::default()
     };
-    let mut metadata: TestDescription<TestTypes, CombinedImpl> = TestDescription::default();
+    let mut metadata: TestDescription<TestTypes, CombinedImpl, TestVersions> = TestDescription::default();
     let mut catchup_nodes = vec![];
     for i in 1..20 {
         catchup_nodes.push(ChangeNode {

--- a/crates/testing/tests/tests_2/push_cdn.rs
+++ b/crates/testing/tests/tests_2/push_cdn.rs
@@ -7,7 +7,7 @@
 use std::time::Duration;
 
 use async_compatibility_layer::logging::shutdown_logging;
-use hotshot_example_types::node_types::{PushCdnImpl, TestTypes};
+use hotshot_example_types::node_types::{PushCdnImpl, TestTypes, TestVersions};
 use hotshot_testing::{
     block_builder::SimpleBuilderImplementation,
     completion_task::{CompletionTaskDescription, TimeBasedCompletionTaskDescription},
@@ -23,7 +23,7 @@ use tracing::instrument;
 async fn push_cdn_network() {
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
-    let metadata: TestDescription<TestTypes, PushCdnImpl> = TestDescription {
+    let metadata: TestDescription<TestTypes, PushCdnImpl, TestVersions> = TestDescription {
         timing_data: TimingData {
             round_start_delay: 25,
             next_view_timeout: 10_000,

--- a/crates/testing/tests/tests_2/test_with_failures_one.rs
+++ b/crates/testing/tests/tests_2/test_with_failures_one.rs
@@ -5,7 +5,7 @@
 // along with the HotShot repository. If not, see <https://mit-license.org/>.
 
 use hotshot_example_types::{
-    node_types::{Libp2pImpl, MemoryImpl, PushCdnImpl},
+    node_types::{Libp2pImpl, MemoryImpl, PushCdnImpl, TestVersions},
     state_types::TestTypes,
 };
 use hotshot_macros::cross_tests;
@@ -20,6 +20,7 @@ cross_tests!(
     TestName: test_with_failures_one,
     Impls: [MemoryImpl, Libp2pImpl, PushCdnImpl],
     Types: [TestTypes],
+    Versions: [TestVersions],
     Ignore: false,
     Metadata: {
         let mut metadata = TestDescription::default_more_nodes();

--- a/crates/testing/tests/tests_3/memory_network.rs
+++ b/crates/testing/tests/tests_3/memory_network.rs
@@ -19,12 +19,13 @@ use hotshot::{
 use hotshot_example_types::{
     auction_results_provider_types::{TestAuctionResult, TestAuctionResultsProvider},
     block_types::{TestBlockHeader, TestBlockPayload, TestTransaction},
+    node_types::{TestTypes, TestVersions},
     state_types::{TestInstanceState, TestValidatedState},
     storage_types::TestStorage,
 };
 use hotshot_types::{
     data::ViewNumber,
-    message::{DataMessage, Message, MessageKind, VersionedMessage},
+    message::{DataMessage, Message, MessageKind, UpgradeLock, VersionedMessage},
     signature_key::{BLSPubKey, BuilderKey},
     traits::{
         network::{BroadcastDelay, ConnectedNetwork, TestableNetworkingImplementation, Topic},
@@ -53,12 +54,6 @@ pub struct Test;
 
 impl NodeType for Test {
     type AuctionResult = TestAuctionResult;
-    type Base = StaticVersion<0, 1>;
-    type Upgrade = StaticVersion<0, 2>;
-    const UPGRADE_HASH: [u8; 32] = [
-        1, 0, 1, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0,
-        0, 0,
-    ];
     type Time = ViewNumber;
     type BlockHeader = TestBlockHeader;
     type BlockPayload = TestBlockPayload;
@@ -167,10 +162,12 @@ async fn memory_network_direct_queue() {
 
     let first_messages: Vec<Message<Test>> = gen_messages(5, 100, pub_key_1);
 
+    let upgrade_lock = UpgradeLock::<Test, TestVersions>::new();
+
     // Test 1 -> 2
     // Send messages
     for sent_message in first_messages {
-        let serialized_message = VersionedMessage::serialize(&sent_message, &None).unwrap();
+        let serialized_message = upgrade_lock.serialize(&sent_message).await.unwrap();
         network1
             .direct_message(serialized_message.clone(), pub_key_2)
             .await
@@ -180,7 +177,7 @@ async fn memory_network_direct_queue() {
             .await
             .expect("Failed to receive message");
         let recv_message = recv_messages.pop().unwrap();
-        let deserialized_message = VersionedMessage::deserialize(&recv_message, &None).unwrap();
+        let deserialized_message = upgrade_lock.deserialize(&recv_message).await.unwrap();
         assert!(recv_messages.is_empty());
         fake_message_eq(sent_message, deserialized_message);
     }
@@ -190,7 +187,7 @@ async fn memory_network_direct_queue() {
     // Test 2 -> 1
     // Send messages
     for sent_message in second_messages {
-        let serialized_message = VersionedMessage::serialize(&sent_message, &None).unwrap();
+        let serialized_message = upgrade_lock.serialize(&sent_message).await.unwrap();
         network2
             .direct_message(serialized_message.clone(), pub_key_1)
             .await
@@ -200,7 +197,7 @@ async fn memory_network_direct_queue() {
             .await
             .expect("Failed to receive message");
         let recv_message = recv_messages.pop().unwrap();
-        let deserialized_message = VersionedMessage::deserialize(&recv_message, &None).unwrap();
+        let deserialized_message = upgrade_lock.deserialize(&recv_message).await.unwrap();
         assert!(recv_messages.is_empty());
         fake_message_eq(sent_message, deserialized_message);
     }
@@ -220,10 +217,12 @@ async fn memory_network_broadcast_queue() {
 
     let first_messages: Vec<Message<Test>> = gen_messages(5, 100, pub_key_1);
 
+    let upgrade_lock = UpgradeLock::<Test, TestVersions>::new();
+
     // Test 1 -> 2
     // Send messages
     for sent_message in first_messages {
-        let serialized_message = VersionedMessage::serialize(&sent_message, &None).unwrap();
+        let serialized_message = upgrade_lock.serialize(&sent_message).await.unwrap();
         network1
             .broadcast_message(serialized_message.clone(), Topic::Da, BroadcastDelay::None)
             .await
@@ -233,7 +232,7 @@ async fn memory_network_broadcast_queue() {
             .await
             .expect("Failed to receive message");
         let recv_message = recv_messages.pop().unwrap();
-        let deserialized_message = VersionedMessage::deserialize(&recv_message, &None).unwrap();
+        let deserialized_message = upgrade_lock.deserialize(&recv_message).await.unwrap();
         assert!(recv_messages.is_empty());
         fake_message_eq(sent_message, deserialized_message);
     }
@@ -243,7 +242,7 @@ async fn memory_network_broadcast_queue() {
     // Test 2 -> 1
     // Send messages
     for sent_message in second_messages {
-        let serialized_message = VersionedMessage::serialize(&sent_message, &None).unwrap();
+        let serialized_message = upgrade_lock.serialize(&sent_message).await.unwrap();
         network2
             .broadcast_message(
                 serialized_message.clone(),
@@ -257,7 +256,7 @@ async fn memory_network_broadcast_queue() {
             .await
             .expect("Failed to receive message");
         let recv_message = recv_messages.pop().unwrap();
-        let deserialized_message = VersionedMessage::deserialize(&recv_message, &None).unwrap();
+        let deserialized_message = upgrade_lock.deserialize(&recv_message).await.unwrap();
         assert!(recv_messages.is_empty());
         fake_message_eq(sent_message, deserialized_message);
     }
@@ -289,8 +288,10 @@ async fn memory_network_test_in_flight_message_count() {
         Some(0)
     );
 
+    let upgrade_lock = UpgradeLock::<Test, TestVersions>::new();
+
     for (count, message) in messages.iter().enumerate() {
-        let serialized_message = VersionedMessage::serialize(message, &None).unwrap();
+        let serialized_message = upgrade_lock.serialize(message).await.unwrap();
 
         network1
             .direct_message(serialized_message.clone(), pub_key_2)

--- a/crates/testing/tests/tests_3/memory_network.rs
+++ b/crates/testing/tests/tests_3/memory_network.rs
@@ -19,13 +19,13 @@ use hotshot::{
 use hotshot_example_types::{
     auction_results_provider_types::{TestAuctionResult, TestAuctionResultsProvider},
     block_types::{TestBlockHeader, TestBlockPayload, TestTransaction},
-    node_types::{TestTypes, TestVersions},
+    node_types::TestVersions,
     state_types::{TestInstanceState, TestValidatedState},
     storage_types::TestStorage,
 };
 use hotshot_types::{
     data::ViewNumber,
-    message::{DataMessage, Message, MessageKind, UpgradeLock, VersionedMessage},
+    message::{DataMessage, Message, MessageKind, UpgradeLock},
     signature_key::{BLSPubKey, BuilderKey},
     traits::{
         network::{BroadcastDelay, ConnectedNetwork, TestableNetworkingImplementation, Topic},
@@ -35,7 +35,6 @@ use hotshot_types::{
 use rand::{rngs::StdRng, RngCore, SeedableRng};
 use serde::{Deserialize, Serialize};
 use tracing::{instrument, trace};
-use vbs::version::StaticVersion;
 
 #[derive(
     Copy,

--- a/crates/testing/tests/tests_3/test_with_builder_failures.rs
+++ b/crates/testing/tests/tests_3/test_with_builder_failures.rs
@@ -6,7 +6,7 @@
 
 use std::time::Duration;
 
-use hotshot_example_types::node_types::{MemoryImpl, PushCdnImpl, TestTypes};
+use hotshot_example_types::node_types::{MemoryImpl, PushCdnImpl, TestTypes, TestVersions};
 use hotshot_macros::cross_tests;
 use hotshot_testing::{
     block_builder::SimpleBuilderImplementation,
@@ -19,6 +19,7 @@ cross_tests!(
     TestName: test_with_builder_failures,
     Impls: [MemoryImpl, PushCdnImpl],
     Types: [TestTypes],
+    Versions: [TestVersions],
     Ignore: false,
     Metadata: {
         let mut metadata = TestDescription::default_multiple_rounds();

--- a/crates/testing/tests/tests_3/test_with_failures_half_f.rs
+++ b/crates/testing/tests/tests_3/test_with_failures_half_f.rs
@@ -5,7 +5,7 @@
 // along with the HotShot repository. If not, see <https://mit-license.org/>.
 
 use hotshot_example_types::{
-    node_types::{Libp2pImpl, MemoryImpl, PushCdnImpl},
+    node_types::{Libp2pImpl, MemoryImpl, PushCdnImpl, TestVersions},
     state_types::TestTypes,
 };
 use hotshot_macros::cross_tests;
@@ -19,6 +19,7 @@ cross_tests!(
     TestName: test_with_failures_half_f,
     Impls: [MemoryImpl, Libp2pImpl, PushCdnImpl],
     Types: [TestTypes],
+    Versions: [TestVersions],
     Ignore: false,
     Metadata: {
         let mut metadata = TestDescription::default_more_nodes();

--- a/crates/testing/tests/tests_4/test_with_failures_f.rs
+++ b/crates/testing/tests/tests_4/test_with_failures_f.rs
@@ -5,7 +5,7 @@
 // along with the HotShot repository. If not, see <https://mit-license.org/>.
 
 use hotshot_example_types::{
-    node_types::{Libp2pImpl, MemoryImpl, PushCdnImpl},
+    node_types::{Libp2pImpl, MemoryImpl, PushCdnImpl, TestVersions},
     state_types::TestTypes,
 };
 use hotshot_macros::cross_tests;
@@ -19,6 +19,7 @@ cross_tests!(
     TestName: test_with_failures_f,
     Impls: [MemoryImpl, Libp2pImpl, PushCdnImpl],
     Types: [TestTypes],
+    Versions: [TestVersions],
     Ignore: false,
     Metadata: {
         let mut metadata = TestDescription::default_more_nodes();

--- a/crates/testing/tests/tests_5/combined_network.rs
+++ b/crates/testing/tests/tests_5/combined_network.rs
@@ -6,7 +6,7 @@
 
 use std::time::Duration;
 
-use hotshot_example_types::node_types::{CombinedImpl, TestTypes};
+use hotshot_example_types::node_types::{CombinedImpl, TestTypes, TestVersions};
 use hotshot_testing::{
     block_builder::SimpleBuilderImplementation,
     completion_task::{CompletionTaskDescription, TimeBasedCompletionTaskDescription},
@@ -27,7 +27,7 @@ async fn test_combined_network() {
 
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
-    let metadata: TestDescription<TestTypes, CombinedImpl> = TestDescription {
+    let metadata: TestDescription<TestTypes, CombinedImpl, TestVersions> = TestDescription {
         timing_data: TimingData {
             round_start_delay: 25,
             next_view_timeout: 10_000,
@@ -62,7 +62,7 @@ async fn test_combined_network() {
 async fn test_combined_network_cdn_crash() {
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
-    let mut metadata: TestDescription<TestTypes, CombinedImpl> = TestDescription {
+    let mut metadata: TestDescription<TestTypes, CombinedImpl, TestVersions> = TestDescription {
         timing_data: TimingData {
             round_start_delay: 25,
             next_view_timeout: 10_000,
@@ -109,7 +109,7 @@ async fn test_combined_network_cdn_crash() {
 async fn test_combined_network_reup() {
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
-    let mut metadata: TestDescription<TestTypes, CombinedImpl> = TestDescription {
+    let mut metadata: TestDescription<TestTypes, CombinedImpl, TestVersions> = TestDescription {
         timing_data: TimingData {
             round_start_delay: 25,
             next_view_timeout: 10_000,
@@ -162,7 +162,7 @@ async fn test_combined_network_reup() {
 async fn test_combined_network_half_dc() {
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
-    let mut metadata: TestDescription<TestTypes, CombinedImpl> = TestDescription {
+    let mut metadata: TestDescription<TestTypes, CombinedImpl, TestVersions> = TestDescription {
         timing_data: TimingData {
             round_start_delay: 25,
             next_view_timeout: 10_000,
@@ -238,7 +238,7 @@ fn generate_random_node_changes(
 async fn test_stress_combined_network_fuzzy() {
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
-    let mut metadata: TestDescription<TestTypes, CombinedImpl> = TestDescription {
+    let mut metadata: TestDescription<TestTypes, CombinedImpl, TestVersions> = TestDescription {
         num_bootstrap_nodes: 10,
         num_nodes_with_stake: 20,
         start_nodes: 20,

--- a/crates/testing/tests/tests_5/timeout.rs
+++ b/crates/testing/tests/tests_5/timeout.rs
@@ -12,7 +12,7 @@
 async fn test_timeout() {
     use std::time::Duration;
 
-    use hotshot_example_types::node_types::{MemoryImpl, TestTypes};
+    use hotshot_example_types::node_types::{MemoryImpl, TestTypes, TestVersions};
     use hotshot_testing::{
         block_builder::SimpleBuilderImplementation,
         completion_task::{CompletionTaskDescription, TimeBasedCompletionTaskDescription},
@@ -27,7 +27,7 @@ async fn test_timeout() {
         ..Default::default()
     };
 
-    let mut metadata: TestDescription<TestTypes, MemoryImpl> = TestDescription {
+    let mut metadata: TestDescription<TestTypes, MemoryImpl, TestVersions> = TestDescription {
         num_nodes_with_stake: 10,
         start_nodes: 10,
         ..Default::default()
@@ -72,7 +72,7 @@ async fn test_timeout() {
 async fn test_timeout_libp2p() {
     use std::time::Duration;
 
-    use hotshot_example_types::node_types::{Libp2pImpl, TestTypes};
+    use hotshot_example_types::node_types::{Libp2pImpl, TestTypes, TestVersions};
     use hotshot_testing::{
         block_builder::SimpleBuilderImplementation,
         completion_task::{CompletionTaskDescription, TimeBasedCompletionTaskDescription},
@@ -90,7 +90,7 @@ async fn test_timeout_libp2p() {
         ..Default::default()
     };
 
-    let mut metadata: TestDescription<TestTypes, Libp2pImpl> = TestDescription {
+    let mut metadata: TestDescription<TestTypes, Libp2pImpl, TestVersions> = TestDescription {
         num_nodes_with_stake: 10,
         start_nodes: 10,
         num_bootstrap_nodes: 10,

--- a/crates/testing/tests/tests_5/unreliable_network.rs
+++ b/crates/testing/tests/tests_5/unreliable_network.rs
@@ -103,7 +103,8 @@ async fn libp2p_network_async() {
         timing_data: TimingData {
             timeout_ratio: (1, 1),
             next_view_timeout: 25000,
-            ..TestDescription::<TestTypes, Libp2pImpl, TestVersions>::default_multiple_rounds().timing_data
+            ..TestDescription::<TestTypes, Libp2pImpl, TestVersions>::default_multiple_rounds()
+                .timing_data
         },
         unreliable_network: Some(Box::new(AsynchronousNetwork {
             keep_numerator: 9,
@@ -151,7 +152,8 @@ async fn test_memory_network_async() {
         timing_data: TimingData {
             timeout_ratio: (1, 1),
             next_view_timeout: 1000,
-            ..TestDescription::<TestTypes, MemoryImpl, TestVersions>::default_multiple_rounds().timing_data
+            ..TestDescription::<TestTypes, MemoryImpl, TestVersions>::default_multiple_rounds()
+                .timing_data
         },
         unreliable_network: Some(Box::new(AsynchronousNetwork {
             keep_numerator: 95,

--- a/crates/testing/tests/tests_5/unreliable_network.rs
+++ b/crates/testing/tests/tests_5/unreliable_network.rs
@@ -6,7 +6,7 @@
 
 use std::time::{Duration, Instant};
 
-use hotshot_example_types::node_types::{Libp2pImpl, TestTypes};
+use hotshot_example_types::node_types::{Libp2pImpl, TestTypes, TestVersions};
 use hotshot_testing::{
     block_builder::SimpleBuilderImplementation,
     completion_task::{CompletionTaskDescription, TimeBasedCompletionTaskDescription},
@@ -24,7 +24,7 @@ use tracing::instrument;
 async fn libp2p_network_sync() {
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
-    let metadata: TestDescription<TestTypes, Libp2pImpl> = TestDescription {
+    let metadata: TestDescription<TestTypes, Libp2pImpl, TestVersions> = TestDescription {
         overall_safety_properties: OverallSafetyPropertiesDescription {
             check_leaf: true,
             ..Default::default()
@@ -62,7 +62,7 @@ async fn test_memory_network_sync() {
 
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
-    let metadata: TestDescription<TestTypes, MemoryImpl> = TestDescription {
+    let metadata: TestDescription<TestTypes, MemoryImpl, TestVersions> = TestDescription {
         // allow more time to pass in CI
         completion_task_description: CompletionTaskDescription::TimeBasedCompletionTaskBuilder(
             TimeBasedCompletionTaskDescription {
@@ -89,7 +89,7 @@ async fn test_memory_network_sync() {
 async fn libp2p_network_async() {
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
-    let metadata: TestDescription<TestTypes, Libp2pImpl> = TestDescription {
+    let metadata: TestDescription<TestTypes, Libp2pImpl, TestVersions> = TestDescription {
         overall_safety_properties: OverallSafetyPropertiesDescription {
             check_leaf: true,
             num_failed_views: 50,
@@ -103,7 +103,7 @@ async fn libp2p_network_async() {
         timing_data: TimingData {
             timeout_ratio: (1, 1),
             next_view_timeout: 25000,
-            ..TestDescription::<TestTypes, Libp2pImpl>::default_multiple_rounds().timing_data
+            ..TestDescription::<TestTypes, Libp2pImpl, TestVersions>::default_multiple_rounds().timing_data
         },
         unreliable_network: Some(Box::new(AsynchronousNetwork {
             keep_numerator: 9,
@@ -136,7 +136,7 @@ async fn test_memory_network_async() {
 
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
-    let metadata: TestDescription<TestTypes, MemoryImpl> = TestDescription {
+    let metadata: TestDescription<TestTypes, MemoryImpl, TestVersions> = TestDescription {
         overall_safety_properties: OverallSafetyPropertiesDescription {
             check_leaf: true,
             num_failed_views: 5000,
@@ -151,7 +151,7 @@ async fn test_memory_network_async() {
         timing_data: TimingData {
             timeout_ratio: (1, 1),
             next_view_timeout: 1000,
-            ..TestDescription::<TestTypes, MemoryImpl>::default_multiple_rounds().timing_data
+            ..TestDescription::<TestTypes, MemoryImpl, TestVersions>::default_multiple_rounds().timing_data
         },
         unreliable_network: Some(Box::new(AsynchronousNetwork {
             keep_numerator: 95,
@@ -182,7 +182,7 @@ async fn test_memory_network_partially_sync() {
 
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
-    let metadata: TestDescription<TestTypes, MemoryImpl> = TestDescription {
+    let metadata: TestDescription<TestTypes, MemoryImpl, TestVersions> = TestDescription {
         overall_safety_properties: OverallSafetyPropertiesDescription {
             num_failed_views: 0,
             ..Default::default()
@@ -226,7 +226,7 @@ async fn test_memory_network_partially_sync() {
 async fn libp2p_network_partially_sync() {
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
-    let metadata: TestDescription<TestTypes, Libp2pImpl> = TestDescription {
+    let metadata: TestDescription<TestTypes, Libp2pImpl, TestVersions> = TestDescription {
         overall_safety_properties: OverallSafetyPropertiesDescription {
             num_failed_views: 0,
             ..Default::default()
@@ -275,7 +275,7 @@ async fn test_memory_network_chaos() {
 
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
-    let metadata: TestDescription<TestTypes, MemoryImpl> = TestDescription {
+    let metadata: TestDescription<TestTypes, MemoryImpl, TestVersions> = TestDescription {
         // allow more time to pass in CI
         completion_task_description: CompletionTaskDescription::TimeBasedCompletionTaskBuilder(
             TimeBasedCompletionTaskDescription {
@@ -306,7 +306,7 @@ async fn test_memory_network_chaos() {
 async fn libp2p_network_chaos() {
     async_compatibility_layer::logging::setup_logging();
     async_compatibility_layer::logging::setup_backtrace();
-    let metadata: TestDescription<TestTypes, Libp2pImpl> = TestDescription {
+    let metadata: TestDescription<TestTypes, Libp2pImpl, TestVersions> = TestDescription {
         overall_safety_properties: OverallSafetyPropertiesDescription {
             check_leaf: true,
             ..Default::default()

--- a/crates/types/src/constants.rs
+++ b/crates/types/src/constants.rs
@@ -8,8 +8,6 @@
 
 use std::time::Duration;
 
-use vbs::version::StaticVersion;
-
 /// timeout for fetching auction results from the solver
 pub const AUCTION_RESULTS_FETCH_TIMEOUT: Duration = Duration::from_millis(500);
 
@@ -42,27 +40,6 @@ pub const EVENT_CHANNEL_SIZE: usize = 100_000;
 
 /// Default channel size for HotShot -> application communication
 pub const EXTERNAL_EVENT_CHANNEL_SIZE: usize = 100_000;
-
-/// Constants for `WebServerNetwork` and `WebServer`
-/// The Web CDN is not, strictly speaking, bound to the network; it can have its own versioning.
-/// Web Server CDN Version (major)
-pub const WEB_SERVER_MAJOR_VERSION: u16 = 0;
-/// Web Server CDN Version (minor)
-pub const WEB_SERVER_MINOR_VERSION: u16 = 1;
-
-/// Type for Web Server CDN Version
-pub type WebServerVersion = StaticVersion<WEB_SERVER_MAJOR_VERSION, WEB_SERVER_MINOR_VERSION>;
-
-/// Constant for Web Server CDN Version
-pub const WEB_SERVER_VERSION: WebServerVersion = StaticVersion {};
-
-/// Type for semver representation of "Base" version
-pub type BaseVersion = StaticVersion<0, 1>;
-
-/// Type for semver representation of "Marketplace" version
-pub type MarketplaceVersion = StaticVersion<0, 3>;
-/// Constant for semver representation of "Marketplace" version
-pub const MARKETPLACE_VERSION: MarketplaceVersion = StaticVersion {};
 
 /// The offset for how far in the future we will send out a `QuorumProposal` with an `UpgradeCertificate` we form. This is also how far in advance of sending a `QuorumProposal` we begin collecting votes on an `UpgradeProposal`.
 pub const UPGRADE_PROPOSE_OFFSET: u64 = 5;

--- a/crates/types/src/data.rs
+++ b/crates/types/src/data.rs
@@ -802,8 +802,10 @@ pub mod null_block {
 
     use crate::{
         traits::{
-            block_contents::BuilderFee, node_implementation::NodeType,
-            signature_key::BuilderSignatureKey, BlockPayload,
+            block_contents::BuilderFee,
+            node_implementation::{NodeType, Versions},
+            signature_key::BuilderSignatureKey,
+            BlockPayload,
         },
         vid::{vid_scheme, VidCommitment},
     };
@@ -827,7 +829,7 @@ pub mod null_block {
 
     /// Builder fee data for a null block payload
     #[must_use]
-    pub fn builder_fee<TYPES: NodeType>(
+    pub fn builder_fee<TYPES: NodeType, V: Versions>(
         num_storage_nodes: usize,
         version: vbs::version::Version,
     ) -> Option<BuilderFee<TYPES>> {
@@ -839,7 +841,7 @@ pub mod null_block {
                 [0_u8; 32], 0,
             );
 
-        if version >= crate::constants::MarketplaceVersion::version() {
+        if version >= V::Marketplace::VERSION {
             match TYPES::BuilderSignatureKey::sign_sequencing_fee_marketplace(&priv_key, FEE_AMOUNT)
             {
                 Ok(sig) => Some(BuilderFee {

--- a/crates/types/src/message.rs
+++ b/crates/types/src/message.rs
@@ -371,13 +371,18 @@ where
 }
 
 #[derive(Clone)]
+/// A lock for an upgrade certificate decided by HotShot, which doubles as `PhantomData` for an instance of the `Versions` trait.
 pub struct UpgradeLock<TYPES: NodeType, V: Versions> {
+    /// a shared lock to an upgrade certificate decided by consensus
     pub decided_upgrade_certificate: Arc<RwLock<Option<UpgradeCertificate<TYPES>>>>,
 
+    /// phantom data for the `Versions` trait
     pub _pd: PhantomData<V>,
 }
 
 impl<TYPES: NodeType, V: Versions> UpgradeLock<TYPES, V> {
+    #[allow(clippy::new_without_default)]
+    /// Create a new `UpgradeLock` for a fresh instance of HotShot
     pub fn new() -> Self {
         Self {
             decided_upgrade_certificate: Arc::new(RwLock::new(None)),

--- a/crates/types/src/message.rs
+++ b/crates/types/src/message.rs
@@ -11,10 +11,8 @@
 
 use std::{fmt, fmt::Debug, marker::PhantomData, sync::Arc};
 
-use async_lock::RwLock;
-use crate::traits::node_implementation::Versions;
-
 use anyhow::{bail, ensure, Context, Result};
+use async_lock::RwLock;
 use cdn_proto::util::mnemonic;
 use committable::Committable;
 use derivative::Derivative;
@@ -37,7 +35,7 @@ use crate::{
     traits::{
         election::Membership,
         network::{DataRequest, ResponseMessage, ViewMessage},
-        node_implementation::{ConsensusTime, NodeType},
+        node_implementation::{ConsensusTime, NodeType, Versions},
         signature_key::SignatureKey,
     },
     vote::HasViewNumber,
@@ -426,16 +424,16 @@ where
 
 #[derive(Clone)]
 pub struct UpgradeLock<TYPES: NodeType, V: Versions> {
-  pub decided_upgrade_certificate: Arc<RwLock<Option<UpgradeCertificate<TYPES>>>>,
+    pub decided_upgrade_certificate: Arc<RwLock<Option<UpgradeCertificate<TYPES>>>>,
 
-  pub _pd: PhantomData<V>,
-  }
+    pub _pd: PhantomData<V>,
+}
 
 impl<TYPES: NodeType, V: Versions> UpgradeLock<TYPES, V> {
-  pub fn new() -> Self {
-    Self {
-      decided_upgrade_certificate: Arc::new(RwLock::new(None)),
-      _pd: PhantomData::<V>,
+    pub fn new() -> Self {
+        Self {
+            decided_upgrade_certificate: Arc::new(RwLock::new(None)),
+            _pd: PhantomData::<V>,
+        }
     }
-  }
 }

--- a/crates/types/src/message.rs
+++ b/crates/types/src/message.rs
@@ -25,7 +25,7 @@ use vbs::{
 use crate::{
     data::{DaProposal, Leaf, QuorumProposal, UpgradeProposal, VidDisperseShare},
     simple_certificate::{
-        version, DaCertificate, UpgradeCertificate, ViewSyncCommitCertificate2,
+        DaCertificate, UpgradeCertificate, ViewSyncCommitCertificate2,
         ViewSyncFinalizeCertificate2, ViewSyncPreCommitCertificate2,
     },
     simple_vote::{
@@ -53,72 +53,20 @@ pub struct Message<TYPES: NodeType> {
 }
 
 /// Trait for messages that have a versioned serialization.
-pub trait VersionedMessage<'a, TYPES>
+pub trait VersionedMessage<'a, TYPES, V>
 where
     TYPES: NodeType,
+    V: Versions,
     Self: Serialize + Deserialize<'a> + HasViewNumber<TYPES> + Sized,
 {
-    /// Serialize a message with a version number, using `message.view_number()` and an optional decided upgrade certificate to determine the message's version.
-    ///
-    /// # Errors
-    ///
-    /// Errors if serialization fails.
-    fn serialize(
-        &self,
-        upgrade_certificate: &Option<UpgradeCertificate<TYPES>>,
-    ) -> Result<Vec<u8>> {
-        let view = self.view_number();
-
-        let version = version(view, upgrade_certificate)?;
-
-        let serialized_message = match version {
-            // Associated constants cannot be used in pattern matches, so we do this trick instead.
-            v if v == TYPES::Base::VERSION => Serializer::<TYPES::Base>::serialize(&self),
-            v if v == TYPES::Upgrade::VERSION => Serializer::<TYPES::Upgrade>::serialize(&self),
-            _ => {
-                bail!("Attempted to serialize with an incompatible version. This should be impossible.");
-            }
-        };
-
-        serialized_message.context("Failed to serialize message!")
-    }
-
-    /// Deserialize a message with a version number, using `message.view_number()` and an optional decided upgrade certificate to determine the message's version. This function will fail on improperly versioned messages.
-    ///
-    /// # Errors
-    ///
-    /// Errors if deserialization fails.
-    fn deserialize(
-        message: &'a [u8],
-        upgrade_certificate: &Option<UpgradeCertificate<TYPES>>,
-    ) -> Result<Self> {
-        let actual_version = Version::deserialize(message)
-            .context("Failed to read message version!")?
-            .0;
-
-        let deserialized_message: Self = match actual_version {
-            v if v == TYPES::Base::VERSION => Serializer::<TYPES::Base>::deserialize(message),
-            v if v == TYPES::Upgrade::VERSION => Serializer::<TYPES::Upgrade>::deserialize(message),
-            _ => {
-                bail!("Cannot deserialize message!");
-            }
-        }
-        .context("Failed to deserialize message!")?;
-
-        let view = deserialized_message.view_number();
-
-        let expected_version = version(view, upgrade_certificate)?;
-
-        ensure!(
-            actual_version == expected_version,
-            "Message has invalid version number for its view. Expected: {expected_version}, Actual: {actual_version}, View: {view:?}"
-        );
-
-        Ok(deserialized_message)
-    }
 }
 
-impl<'a, TYPES> VersionedMessage<'a, TYPES> for Message<TYPES> where TYPES: NodeType {}
+impl<'a, TYPES, V> VersionedMessage<'a, TYPES, V> for Message<TYPES>
+where
+    TYPES: NodeType,
+    V: Versions,
+{
+}
 
 impl<TYPES: NodeType> fmt::Debug for Message<TYPES> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -435,5 +383,89 @@ impl<TYPES: NodeType, V: Versions> UpgradeLock<TYPES, V> {
             decided_upgrade_certificate: Arc::new(RwLock::new(None)),
             _pd: PhantomData::<V>,
         }
+    }
+
+    /// Calculate the version applied in a view, based on the provided upgrade lock.
+    ///
+    /// # Errors
+    /// Returns an error if we do not support the version required by the decided upgrade certificate.
+    pub async fn version(&self, view: TYPES::Time) -> Result<Version> {
+        let upgrade_certificate = self.decided_upgrade_certificate.read().await;
+
+        let version = match *upgrade_certificate {
+            Some(ref cert) => {
+                if view >= cert.data.new_version_first_view {
+                    if cert.data.new_version == V::Upgrade::VERSION {
+                        V::Upgrade::VERSION
+                    } else {
+                        bail!("The network has upgraded to a new version that we do not support!");
+                    }
+                } else {
+                    V::Base::VERSION
+                }
+            }
+            None => V::Base::VERSION,
+        };
+
+        Ok(version)
+    }
+
+    /// Serialize a message with a version number, using `message.view_number()` and an optional decided upgrade certificate to determine the message's version.
+    ///
+    /// # Errors
+    ///
+    /// Errors if serialization fails.
+    pub async fn serialize<M: HasViewNumber<TYPES> + Serialize>(
+        &self,
+        message: &M,
+    ) -> Result<Vec<u8>> {
+        let view = message.view_number();
+
+        let version = self.version(view).await?;
+
+        let serialized_message = match version {
+            // Associated constants cannot be used in pattern matches, so we do this trick instead.
+            v if v == V::Base::VERSION => Serializer::<V::Base>::serialize(&message),
+            v if v == V::Upgrade::VERSION => Serializer::<V::Upgrade>::serialize(&message),
+            _ => {
+                bail!("Attempted to serialize with an incompatible version. This should be impossible.");
+            }
+        };
+
+        serialized_message.context("Failed to serialize message!")
+    }
+
+    /// Deserialize a message with a version number, using `message.view_number()` to determine the message's version. This function will fail on improperly versioned messages.
+    ///
+    /// # Errors
+    ///
+    /// Errors if deserialization fails.
+    pub async fn deserialize<M: HasViewNumber<TYPES> + for<'a> Deserialize<'a>>(
+        &self,
+        message: &[u8],
+    ) -> Result<M> {
+        let actual_version = Version::deserialize(message)
+            .context("Failed to read message version!")?
+            .0;
+
+        let deserialized_message: M = match actual_version {
+            v if v == V::Base::VERSION => Serializer::<V::Base>::deserialize(message),
+            v if v == V::Upgrade::VERSION => Serializer::<V::Upgrade>::deserialize(message),
+            _ => {
+                bail!("Cannot deserialize message!");
+            }
+        }
+        .context("Failed to deserialize message!")?;
+
+        let view = deserialized_message.view_number();
+
+        let expected_version = self.version(view).await?;
+
+        ensure!(
+            actual_version == expected_version,
+            "Message has invalid version number for its view. Expected: {expected_version}, Actual: {actual_version}, View: {view:?}"
+        );
+
+        Ok(deserialized_message)
     }
 }

--- a/crates/types/src/message.rs
+++ b/crates/types/src/message.rs
@@ -9,7 +9,10 @@
 //! This module contains types used to represent the various types of messages that
 //! `HotShot` nodes can send among themselves.
 
-use std::{fmt, fmt::Debug, marker::PhantomData};
+use std::{fmt, fmt::Debug, marker::PhantomData, sync::Arc};
+
+use async_lock::RwLock;
+use crate::traits::node_implementation::Versions;
 
 use anyhow::{bail, ensure, Context, Result};
 use cdn_proto::util::mnemonic;
@@ -419,4 +422,20 @@ where
 
         Ok(())
     }
+}
+
+#[derive(Clone)]
+pub struct UpgradeLock<TYPES: NodeType, V: Versions> {
+  pub decided_upgrade_certificate: Arc<RwLock<Option<UpgradeCertificate<TYPES>>>>,
+
+  pub _pd: PhantomData<V>,
+  }
+
+impl<TYPES: NodeType, V: Versions> UpgradeLock<TYPES, V> {
+  pub fn new() -> Self {
+    Self {
+      decided_upgrade_certificate: Arc::new(RwLock::new(None)),
+      _pd: PhantomData::<V>,
+    }
+  }
 }

--- a/crates/types/src/message.rs
+++ b/crates/types/src/message.rs
@@ -52,22 +52,6 @@ pub struct Message<TYPES: NodeType> {
     pub kind: MessageKind<TYPES>,
 }
 
-/// Trait for messages that have a versioned serialization.
-pub trait VersionedMessage<'a, TYPES, V>
-where
-    TYPES: NodeType,
-    V: Versions,
-    Self: Serialize + Deserialize<'a> + HasViewNumber<TYPES> + Sized,
-{
-}
-
-impl<'a, TYPES, V> VersionedMessage<'a, TYPES, V> for Message<TYPES>
-where
-    TYPES: NodeType,
-    V: Versions,
-{
-}
-
 impl<TYPES: NodeType> fmt::Debug for Message<TYPES> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.debug_struct("Message")

--- a/crates/types/src/simple_certificate.rs
+++ b/crates/types/src/simple_certificate.rs
@@ -247,29 +247,3 @@ pub type ViewSyncFinalizeCertificate2<TYPES> =
 /// Type alias for a `UpgradeCertificate`, which is a `SimpleCertificate` of `UpgradeProposalData`
 pub type UpgradeCertificate<TYPES> =
     SimpleCertificate<TYPES, UpgradeProposalData<TYPES>, UpgradeThreshold>;
-
-/// Calculate the version applied in a view, based on the provided upgrade certificate.
-///
-/// # Errors
-/// Returns an error if we do not support the version required by the upgrade certificate.
-pub fn version<TYPES: NodeType>(
-    view: TYPES::Time,
-    upgrade_certificate: &Option<UpgradeCertificate<TYPES>>,
-) -> Result<Version> {
-    let version = match upgrade_certificate {
-        Some(ref cert) => {
-            if view >= cert.data.new_version_first_view {
-                if cert.data.new_version == TYPES::Upgrade::VERSION {
-                    TYPES::Upgrade::VERSION
-                } else {
-                    bail!("The network has upgraded to a new version that we do not support!");
-                }
-            } else {
-                TYPES::Base::VERSION
-            }
-        }
-        None => TYPES::Base::VERSION,
-    };
-
-    Ok(version)
-}

--- a/crates/types/src/simple_certificate.rs
+++ b/crates/types/src/simple_certificate.rs
@@ -13,12 +13,11 @@ use std::{
     sync::Arc,
 };
 
-use anyhow::{bail, ensure, Result};
+use anyhow::{ensure, Result};
 use async_lock::RwLock;
 use committable::{Commitment, Committable};
 use ethereum_types::U256;
 use serde::{Deserialize, Serialize};
-use vbs::version::{StaticVersionType, Version};
 
 use crate::{
     data::serialize_signature2,

--- a/crates/types/src/traits/node_implementation.rs
+++ b/crates/types/src/traits/node_implementation.rs
@@ -9,6 +9,8 @@
 //! This module defines the [`NodeImplementation`] trait, which is a composite trait used for
 //! describing the overall behavior of a node, as a composition of implementations of the node trait.
 
+
+
 use std::{
     fmt::Debug,
     hash::Hash,
@@ -17,6 +19,7 @@ use std::{
     time::Duration,
 };
 
+use async_lock::RwLock;
 use async_trait::async_trait;
 use committable::Committable;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
@@ -260,4 +263,26 @@ pub trait NodeType:
 
     /// The type builder uses to sign its messages
     type BuilderSignatureKey: BuilderSignatureKey;
+}
+
+/// Version information for HotShot
+pub trait Versions:
+    Clone
+    + Copy
+    + Debug
+    + Send
+    + Sync
+    + 'static
+{
+    /// The base version of HotShot this node is instantiated with.
+    type Base: StaticVersionType;
+
+    /// The version of HotShot this node may be upgraded to. Set equal to `Base` to disable upgrades.
+    type Upgrade: StaticVersionType;
+
+    /// The hash for the upgrade.
+    const UPGRADE_HASH: [u8; 32];
+
+    /// The version at which to switch over to marketplace logic
+    type Marketplace: StaticVersionType;
 }

--- a/crates/types/src/traits/node_implementation.rs
+++ b/crates/types/src/traits/node_implementation.rs
@@ -9,8 +9,6 @@
 //! This module defines the [`NodeImplementation`] trait, which is a composite trait used for
 //! describing the overall behavior of a node, as a composition of implementations of the node trait.
 
-
-
 use std::{
     fmt::Debug,
     hash::Hash,
@@ -266,14 +264,7 @@ pub trait NodeType:
 }
 
 /// Version information for HotShot
-pub trait Versions:
-    Clone
-    + Copy
-    + Debug
-    + Send
-    + Sync
-    + 'static
-{
+pub trait Versions: Clone + Copy + Debug + Send + Sync + 'static {
     /// The base version of HotShot this node is instantiated with.
     type Base: StaticVersionType;
 

--- a/crates/types/src/traits/node_implementation.rs
+++ b/crates/types/src/traits/node_implementation.rs
@@ -207,15 +207,6 @@ pub trait NodeType:
     + Sync
     + 'static
 {
-    /// The base version of HotShot this node is instantiated with.
-    type Base: StaticVersionType;
-
-    /// The version of HotShot this node may be upgraded to. Set equal to `Base` to disable upgrades.
-    type Upgrade: StaticVersionType;
-
-    /// The hash for the upgrade.
-    const UPGRADE_HASH: [u8; 32];
-
     /// The time type that this hotshot setup is using.
     ///
     /// This should be the same `Time` that `ValidatedState::Time` is using.

--- a/crates/types/src/traits/node_implementation.rs
+++ b/crates/types/src/traits/node_implementation.rs
@@ -17,7 +17,6 @@ use std::{
     time::Duration,
 };
 
-use async_lock::RwLock;
 use async_trait::async_trait;
 use committable::Committable;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};


### PR DESCRIPTION
Closes #3543

### This PR: 
- Moves versioning from `NodeType` into a separate `Versions` trait
- Moves the `decided_upgrade_certificate` field into a separate `UpgradeLock<TYPES: NodeType, V: Versions>` struct
- Removes the `VersionedMessage` trait, with de/serialization methods moved to the `UpgradeLock` struct.
- Propagates versioning where needed via the `Versions` trait and `UpgradeLock`.

### This PR does not: 

### Key places to review: 
The main trait changes are in `types/src/message.rs` and `types/src/traits/node_implementation.rs`. Most of the size of this PR is just correctly propagating these changes.