### PR TITLE
Adding delays to trait functions the sequencer implements

### DIFF
--- a/crates/example-types/src/block_types.rs
+++ b/crates/example-types/src/block_types.rs
@@ -4,12 +4,10 @@
 // You should have received a copy of the MIT License
 // along with the HotShot repository. If not, see <https://mit-license.org/>.
 
-use async_compatibility_layer::art::async_sleep;
 use std::{
     fmt::{Debug, Display},
     mem::size_of,
     sync::Arc,
-    time::Duration,
 };
 
 use async_trait::async_trait;
@@ -24,7 +22,6 @@ use hotshot_types::{
     utils::BuilderCommitment,
     vid::{VidCommitment, VidCommon},
 };
-use rand::Rng;
 use serde::{Deserialize, Serialize};
 use sha3::{Digest, Keccak256};
 use snafu::Snafu;
@@ -34,7 +31,7 @@ use vbs::version::Version;
 use crate::{
     node_types::TestTypes,
     state_types::{TestInstanceState, TestValidatedState},
-    testable_delay::{DelayConfig, DelayOptions, SupportedTypes, TestableDelay},
+    testable_delay::{DelayConfig, SupportedTraitTypesForAsyncDelay, TestableDelay},
 };
 
 /// The transaction in a [`TestBlockPayload`].
@@ -293,7 +290,7 @@ impl<
         _vid_common: VidCommon,
         _version: Version,
     ) -> Result<Self, Self::Error> {
-        Self::handle_async_delay(instance_state.delay_config.clone()).await;
+        Self::run_delay_settings_from_config(&instance_state.delay_config).await;
         Ok(Self::new(
             parent_leaf,
             payload_commitment,
@@ -313,7 +310,7 @@ impl<
         _auction_results: Option<TYPES::AuctionResult>,
         _version: Version,
     ) -> Result<Self, Self::Error> {
-        Self::handle_async_delay(instance_state.delay_config.clone()).await;
+        Self::run_delay_settings_from_config(&instance_state.delay_config).await;
         Ok(Self::new(
             parent_leaf,
             payload_commitment,
@@ -379,21 +376,11 @@ impl Committable for TestBlockHeader {
 
 #[async_trait]
 impl TestableDelay for TestBlockHeader {
-    async fn handle_async_delay(delay_config: DelayConfig) {
-        if let Some(settings) = delay_config.get_setting(SupportedTypes::BlockHeader) {
-            match settings.delay_option {
-                DelayOptions::None => {}
-                DelayOptions::Fixed => {
-                    async_sleep(Duration::from_millis(settings.fixed_time_in_milliseconds)).await;
-                }
-                DelayOptions::Random => {
-                    let sleep_in_millis = rand::thread_rng().gen_range(
-                        settings.min_time_in_milliseconds..=settings.max_time_in_milliseconds,
-                    );
-
-                    async_sleep(Duration::from_millis(sleep_in_millis)).await;
-                }
-            }
+    async fn run_delay_settings_from_config(delay_config: &DelayConfig) {
+        if let Some(settings) =
+            delay_config.get_setting(&SupportedTraitTypesForAsyncDelay::BlockHeader)
+        {
+            Self::handle_async_delay(settings).await;
         }
     }
 }

--- a/crates/example-types/src/block_types.rs
+++ b/crates/example-types/src/block_types.rs
@@ -29,8 +29,8 @@ use time::OffsetDateTime;
 use vbs::version::Version;
 
 use crate::{
-    node_types::TestTypes,
-    state_types::{TestInstanceState, TestValidatedState},
+    node_types::{TestTypes, TestableDelayImpl},
+    state_types::{DelayOptions, TestInstanceState, TestValidatedState},
 };
 
 /// The transaction in a [`TestBlockPayload`].

--- a/crates/example-types/src/lib.rs
+++ b/crates/example-types/src/lib.rs
@@ -18,3 +18,6 @@ pub mod storage_types;
 
 /// auction types for solver-to-hotshot interactions
 pub mod auction_results_provider_types;
+
+/// add a delay to async functions
+pub mod testable_delay;

--- a/crates/example-types/src/node_types.rs
+++ b/crates/example-types/src/node_types.rs
@@ -4,6 +4,7 @@
 // You should have received a copy of the MIT License
 // along with the HotShot repository. If not, see <https://mit-license.org/>.
 
+use async_trait::async_trait;
 use hotshot::traits::{
     election::{
         static_committee::{GeneralStaticCommittee, StaticCommittee},
@@ -23,7 +24,7 @@ use vbs::version::StaticVersion;
 use crate::{
     auction_results_provider_types::{TestAuctionResult, TestAuctionResultsProvider},
     block_types::{TestBlockHeader, TestBlockPayload, TestTransaction},
-    state_types::{TestInstanceState, TestValidatedState},
+    state_types::{DelayOptions, TestInstanceState, TestValidatedState},
     storage_types::TestStorage,
 };
 
@@ -143,4 +144,9 @@ impl<TYPES: NodeType> NodeImplementation<TYPES> for Libp2pImpl {
     type Network = Libp2pNetwork<TYPES::SignatureKey>;
     type Storage = TestStorage<TYPES>;
     type AuctionResultsProvider = TestAuctionResultsProvider<TYPES>;
+}
+
+#[async_trait]
+pub trait TestableDelayImpl {
+    async fn add_delay(delay_option: DelayOptions);
 }

--- a/crates/example-types/src/node_types.rs
+++ b/crates/example-types/src/node_types.rs
@@ -4,7 +4,6 @@
 // You should have received a copy of the MIT License
 // along with the HotShot repository. If not, see <https://mit-license.org/>.
 
-use async_trait::async_trait;
 use hotshot::traits::{
     election::{
         static_committee::{GeneralStaticCommittee, StaticCommittee},
@@ -24,7 +23,7 @@ use vbs::version::StaticVersion;
 use crate::{
     auction_results_provider_types::{TestAuctionResult, TestAuctionResultsProvider},
     block_types::{TestBlockHeader, TestBlockPayload, TestTransaction},
-    state_types::{DelayOptions, TestInstanceState, TestValidatedState},
+    state_types::{TestInstanceState, TestValidatedState},
     storage_types::TestStorage,
 };
 
@@ -144,9 +143,4 @@ impl<TYPES: NodeType> NodeImplementation<TYPES> for Libp2pImpl {
     type Network = Libp2pNetwork<TYPES::SignatureKey>;
     type Storage = TestStorage<TYPES>;
     type AuctionResultsProvider = TestAuctionResultsProvider<TYPES>;
-}
-
-#[async_trait]
-pub trait TestableDelayImpl {
-    async fn add_delay(delay_option: DelayOptions);
 }

--- a/crates/example-types/src/state_types.rs
+++ b/crates/example-types/src/state_types.rs
@@ -20,19 +20,19 @@ use hotshot_types::{
 };
 use rand::Rng;
 use serde::{Deserialize, Serialize};
-use std::{fmt::Debug, time::Duration};
+use std::{collections::HashMap, fmt::Debug, time::Duration};
 use vbs::version::Version;
 
 pub use crate::node_types::TestTypes;
 use crate::{
     block_types::{TestBlockPayload, TestTransaction},
-    testable_delay::{DelayOptions, TestableDelay},
+    testable_delay::{DelayConfig, DelayOptions, TestableDelay},
 };
 
 /// Instance-level state implementation for testing purposes.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 pub struct TestInstanceState {
-    pub delay_option: DelayOptions,
+    pub delay_config: DelayConfig,
 }
 
 impl InstanceState for TestInstanceState {}
@@ -40,14 +40,14 @@ impl InstanceState for TestInstanceState {}
 impl Default for TestInstanceState {
     fn default() -> Self {
         TestInstanceState {
-            delay_option: DelayOptions::None,
+            delay_config: DelayConfig::default(),
         }
     }
 }
 
 impl TestInstanceState {
-    pub fn new(delay_option: DelayOptions) -> Self {
-        TestInstanceState { delay_option }
+    pub fn new(delay_config: DelayConfig) -> Self {
+        TestInstanceState { delay_config }
     }
 }
 

--- a/crates/example-types/src/storage_types.rs
+++ b/crates/example-types/src/storage_types.rs
@@ -22,6 +22,8 @@ use hotshot_types::{
     vote::HasViewNumber,
 };
 
+use crate::{node_types::TestableDelayImpl, state_types::DelayOptions};
+
 type VidShares<TYPES> = HashMap<
     <TYPES as NodeType>::Time,
     HashMap<<TYPES as NodeType>::SignatureKey, Proposal<TYPES, VidDisperseShare<TYPES>>>,
@@ -51,6 +53,7 @@ pub struct TestStorage<TYPES: NodeType> {
     inner: Arc<RwLock<TestStorageState<TYPES>>>,
     /// `should_return_err` is a testing utility to validate negative cases.
     pub should_return_err: bool,
+    pub delay_options: DelayOptions,
 }
 
 impl<TYPES: NodeType> Default for TestStorage<TYPES> {
@@ -58,6 +61,24 @@ impl<TYPES: NodeType> Default for TestStorage<TYPES> {
         Self {
             inner: Arc::new(RwLock::new(TestStorageState::default())),
             should_return_err: false,
+            delay_options: DelayOptions::None,
+        }
+    }
+}
+
+#[async_trait]
+impl<TYPES: NodeType> TestableDelayImpl for TestStorage<TYPES> {
+    async fn add_delay(delay_option: DelayOptions) {
+        match delay_option {
+            DelayOptions::None => {
+                tracing::error!("no delay");
+            }
+            DelayOptions::Fixed => {
+                tracing::error!("fixed delay");
+            }
+            DelayOptions::Random => {
+                tracing::error!("random delay");
+            }
         }
     }
 }
@@ -79,6 +100,7 @@ impl<TYPES: NodeType> Storage<TYPES> for TestStorage<TYPES> {
         if self.should_return_err {
             bail!("Failed to append VID proposal to storage");
         }
+        Self::add_delay(self.delay_options).await;
         let mut inner = self.inner.write().await;
         inner
             .vids
@@ -92,6 +114,7 @@ impl<TYPES: NodeType> Storage<TYPES> for TestStorage<TYPES> {
         if self.should_return_err {
             bail!("Failed to append VID proposal to storage");
         }
+        Self::add_delay(self.delay_options).await;
         let mut inner = self.inner.write().await;
         inner
             .das
@@ -105,6 +128,7 @@ impl<TYPES: NodeType> Storage<TYPES> for TestStorage<TYPES> {
         if self.should_return_err {
             bail!("Failed to append VID proposal to storage");
         }
+        Self::add_delay(self.delay_options).await;
         let mut inner = self.inner.write().await;
         inner
             .proposals
@@ -120,6 +144,7 @@ impl<TYPES: NodeType> Storage<TYPES> for TestStorage<TYPES> {
         if self.should_return_err {
             bail!("Failed to append Action to storage");
         }
+        Self::add_delay(self.delay_options).await;
         Ok(())
     }
 
@@ -130,6 +155,7 @@ impl<TYPES: NodeType> Storage<TYPES> for TestStorage<TYPES> {
         if self.should_return_err {
             bail!("Failed to update high qc to storage");
         }
+        Self::add_delay(self.delay_options).await;
         let mut inner = self.inner.write().await;
         if let Some(ref current_high_qc) = inner.high_qc {
             if new_high_qc.view_number() > current_high_qc.view_number() {
@@ -148,6 +174,7 @@ impl<TYPES: NodeType> Storage<TYPES> for TestStorage<TYPES> {
         if self.should_return_err {
             bail!("Failed to update high qc to storage");
         }
+        Self::add_delay(self.delay_options).await;
         Ok(())
     }
 }

--- a/crates/example-types/src/testable_delay.rs
+++ b/crates/example-types/src/testable_delay.rs
@@ -1,13 +1,75 @@
+use std::collections::HashMap;
+
 use async_trait::async_trait;
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Eq, Hash, PartialEq, Debug, Clone)]
+/// What type of delay we want to apply to
 pub enum DelayOptions {
     None,
     Random,
     Fixed,
 }
 
+#[derive(Eq, Hash, PartialEq, Debug, Clone)]
+/// Current implementations that are supported for testing async delays
+pub enum SupportedTypes {
+    Storage,
+    ValidatedState,
+    BlockHeader,
+}
+
+#[derive(Eq, Hash, PartialEq, Debug, Clone)]
+/// Config for each supported type
+pub struct DelaySettings {
+    // Option to tell the async function what to do
+    delay_option: DelayOptions,
+    // Rng min time
+    min_time: u64,
+    // Rng max time
+    max_time: u64,
+    // Fixed time for fixed delay option
+    fixed_time: u64,
+}
+
+impl Default for DelaySettings {
+    fn default() -> Self {
+        DelaySettings {
+            delay_option: DelayOptions::None,
+            min_time: 0,
+            max_time: 0,
+            fixed_time: 0,
+        }
+    }
+}
+
+#[derive(Eq, Hash, PartialEq, Debug, Clone)]
+pub struct DelayConfig {
+    config: HashMap<SupportedTypes, DelaySettings>,
+}
+
+impl Default for DelayConfig {
+    fn default() -> Self {
+        DelayConfig {
+            config: HashMap::new(),
+        }
+    }
+}
+
+impl DelayConfig {
+    pub fn new(config: HashMap<SupportedTypes, DelaySettings>) -> Self {
+        DelayConfig { config }
+    }
+
+    pub fn add_setting(&mut self, supported_type: SupportedTypes, settings: DelaySettings) {
+        self.config.insert(supported_type, settings);
+    }
+
+    pub fn get_setting(&self, supported_type: SupportedTypes) -> Option<&DelaySettings> {
+        self.config.get(&supported_type)
+    }
+}
+
 #[async_trait]
 pub trait TestableDelay {
-    async fn handle_delay_option(delay_option: DelayOptions);
+    async fn handle_delay_option(config: DelayConfig);
 }

--- a/crates/example-types/src/testable_delay.rs
+++ b/crates/example-types/src/testable_delay.rs
@@ -1,6 +1,8 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, time::Duration};
 
+use async_compatibility_layer::art::async_sleep;
 use async_trait::async_trait;
+use rand::Rng;
 
 #[derive(Eq, Hash, PartialEq, Debug, Clone)]
 /// What type of delay we want to apply to
@@ -12,7 +14,7 @@ pub enum DelayOptions {
 
 #[derive(Eq, Hash, PartialEq, Debug, Clone)]
 /// Current implementations that are supported for testing async delays
-pub enum SupportedTypes {
+pub enum SupportedTraitTypesForAsyncDelay {
     Storage,
     ValidatedState,
     BlockHeader,
@@ -45,56 +47,80 @@ impl Default for DelaySettings {
 #[derive(Eq, PartialEq, Debug, Clone, Default)]
 /// Settings for each type
 pub struct DelayConfig {
-    config: HashMap<SupportedTypes, DelaySettings>,
+    config: HashMap<SupportedTraitTypesForAsyncDelay, DelaySettings>,
 }
 
 impl DelayConfig {
-    pub fn new(config: HashMap<SupportedTypes, DelaySettings>) -> Self {
+    pub fn new(config: HashMap<SupportedTraitTypesForAsyncDelay, DelaySettings>) -> Self {
         DelayConfig { config }
     }
 
     pub fn add_settings_for_all_types(&mut self, settings: DelaySettings) {
-        let iterator = SupportedTypesIterator::new();
+        let iterator = SupportedTraitTypesForAsyncDelayIterator::new();
 
         for supported_type in iterator {
             self.config.insert(supported_type, settings.clone());
         }
     }
 
-    pub fn add_setting(&mut self, supported_type: SupportedTypes, settings: DelaySettings) {
-        self.config.insert(supported_type, settings);
+    pub fn add_setting(
+        &mut self,
+        supported_type: SupportedTraitTypesForAsyncDelay,
+        settings: &DelaySettings,
+    ) {
+        self.config.insert(supported_type, settings.clone());
     }
 
-    pub fn get_setting(&self, supported_type: SupportedTypes) -> Option<&DelaySettings> {
-        self.config.get(&supported_type)
+    pub fn get_setting(
+        &self,
+        supported_type: &SupportedTraitTypesForAsyncDelay,
+    ) -> Option<&DelaySettings> {
+        self.config.get(supported_type)
     }
 }
 
 #[async_trait]
 /// Implement this method to add some delay to async call
 pub trait TestableDelay {
-    async fn handle_async_delay(config: DelayConfig);
+    /// Add a delay from settings
+    async fn handle_async_delay(settings: &DelaySettings) {
+        match settings.delay_option {
+            DelayOptions::None => {}
+            DelayOptions::Fixed => {
+                async_sleep(Duration::from_millis(settings.fixed_time_in_milliseconds)).await;
+            }
+            DelayOptions::Random => {
+                let sleep_in_millis = rand::thread_rng().gen_range(
+                    settings.min_time_in_milliseconds..=settings.max_time_in_milliseconds,
+                );
+                async_sleep(Duration::from_millis(sleep_in_millis)).await;
+            }
+        }
+    }
+
+    /// Look for settings in the config and run it
+    async fn run_delay_settings_from_config(delay_config: &DelayConfig);
 }
 
 /// Iterator to iterate over enum
-struct SupportedTypesIterator {
+struct SupportedTraitTypesForAsyncDelayIterator {
     index: usize,
 }
 
-impl SupportedTypesIterator {
+impl SupportedTraitTypesForAsyncDelayIterator {
     fn new() -> Self {
-        SupportedTypesIterator { index: 0 }
+        SupportedTraitTypesForAsyncDelayIterator { index: 0 }
     }
 }
 
-impl Iterator for SupportedTypesIterator {
-    type Item = SupportedTypes;
+impl Iterator for SupportedTraitTypesForAsyncDelayIterator {
+    type Item = SupportedTraitTypesForAsyncDelay;
 
     fn next(&mut self) -> Option<Self::Item> {
         let supported_type = match self.index {
-            0 => Some(SupportedTypes::Storage),
-            1 => Some(SupportedTypes::ValidatedState),
-            2 => Some(SupportedTypes::BlockHeader),
+            0 => Some(SupportedTraitTypesForAsyncDelay::Storage),
+            1 => Some(SupportedTraitTypesForAsyncDelay::ValidatedState),
+            2 => Some(SupportedTraitTypesForAsyncDelay::BlockHeader),
             _ => {
                 assert_eq!(self.index, 3, "Need to ensure that newly added or removed `SupportedTypes` enum is handled in iterator");
                 return None;

--- a/crates/example-types/src/testable_delay.rs
+++ b/crates/example-types/src/testable_delay.rs
@@ -1,0 +1,13 @@
+use async_trait::async_trait;
+
+#[derive(Clone, Copy, Debug)]
+pub enum DelayOptions {
+    None,
+    Random,
+    Fixed,
+}
+
+#[async_trait]
+pub trait TestableDelay {
+    async fn handle_delay_option(delay_option: DelayOptions);
+}

--- a/crates/example-types/src/testable_delay.rs
+++ b/crates/example-types/src/testable_delay.rs
@@ -122,7 +122,7 @@ impl Iterator for SupportedTraitTypesForAsyncDelayIterator {
             1 => Some(SupportedTraitTypesForAsyncDelay::ValidatedState),
             2 => Some(SupportedTraitTypesForAsyncDelay::BlockHeader),
             _ => {
-                assert_eq!(self.index, 3, "Need to ensure that newly added or removed `SupportedTypes` enum is handled in iterator");
+                assert_eq!(self.index, 3, "Need to ensure that newly added or removed `SupportedTraitTypesForAsyncDelay` enum is handled in iterator");
                 return None;
             }
         };

--- a/crates/examples/infra/mod.rs
+++ b/crates/examples/infra/mod.rs
@@ -365,9 +365,10 @@ pub trait RunDa<
     /// get the anchored view
     /// Note: sequencing leaf does not have state, so does not return state
     async fn initialize_state_and_hotshot(&self) -> SystemContextHandle<TYPES, NODE> {
-        let initializer = hotshot::HotShotInitializer::<TYPES>::from_genesis(TestInstanceState {})
-            .await
-            .expect("Couldn't generate genesis block");
+        let initializer =
+            hotshot::HotShotInitializer::<TYPES>::from_genesis(TestInstanceState::default())
+                .await
+                .expect("Couldn't generate genesis block");
 
         let config = self.config();
 

--- a/crates/testing/src/helpers.rs
+++ b/crates/testing/src/helpers.rs
@@ -72,9 +72,11 @@ pub async fn build_system_handle<
     let marketplace_config = (launcher.resource_generator.marketplace_config)(node_id);
     let config = launcher.resource_generator.config.clone();
 
-    let initializer = HotShotInitializer::<TYPES>::from_genesis(TestInstanceState::default())
-        .await
-        .unwrap();
+    let initializer = HotShotInitializer::<TYPES>::from_genesis(TestInstanceState::new(
+        launcher.metadata.async_delay,
+    ))
+    .await
+    .unwrap();
 
     let known_nodes_with_stake = config.known_nodes_with_stake.clone();
     let private_key = config.my_own_validator_config.private_key.clone();

--- a/crates/testing/src/helpers.rs
+++ b/crates/testing/src/helpers.rs
@@ -72,7 +72,7 @@ pub async fn build_system_handle<
     let marketplace_config = (launcher.resource_generator.marketplace_config)(node_id);
     let config = launcher.resource_generator.config.clone();
 
-    let initializer = HotShotInitializer::<TYPES>::from_genesis(TestInstanceState {})
+    let initializer = HotShotInitializer::<TYPES>::from_genesis(TestInstanceState::default())
         .await
         .unwrap();
 

--- a/crates/testing/src/helpers.rs
+++ b/crates/testing/src/helpers.rs
@@ -73,7 +73,7 @@ pub async fn build_system_handle<
     let config = launcher.resource_generator.config.clone();
 
     let initializer = HotShotInitializer::<TYPES>::from_genesis(TestInstanceState::new(
-        launcher.metadata.async_delay,
+        launcher.metadata.async_delay_config,
     ))
     .await
     .unwrap();

--- a/crates/testing/src/spinning_task.rs
+++ b/crates/testing/src/spinning_task.rs
@@ -18,7 +18,7 @@ use hotshot_example_types::{
     auction_results_provider_types::TestAuctionResultsProvider,
     state_types::{TestInstanceState, TestValidatedState},
     storage_types::TestStorage,
-    testable_delay::DelayOptions,
+    testable_delay::DelayConfig,
 };
 use hotshot_types::{
     data::Leaf,
@@ -60,7 +60,7 @@ pub struct SpinningTask<TYPES: NodeType, I: TestableNodeImplementation<TYPES>> {
     /// Highest qc seen in the test for restarting nodes
     pub(crate) high_qc: QuorumCertificate<TYPES>,
     /// Add specified delay to async calls
-    pub(crate) async_delay: DelayOptions,
+    pub(crate) async_delay_config: DelayConfig,
 }
 
 #[async_trait]
@@ -131,7 +131,7 @@ where
 
                                         let initializer = HotShotInitializer::<TYPES>::from_reload(
                                             self.last_decided_leaf.clone(),
-                                            TestInstanceState::new(self.async_delay),
+                                            TestInstanceState::new(self.async_delay_config.clone()),
                                             None,
                                             view_number,
                                             BTreeMap::new(),
@@ -208,7 +208,7 @@ where
                                 let read_storage = storage.read().await;
                                 let initializer = HotShotInitializer::<TYPES>::from_reload(
                                     self.last_decided_leaf.clone(),
-                                    TestInstanceState::new(self.async_delay),
+                                    TestInstanceState::new(self.async_delay_config.clone()),
                                     None,
                                     view_number,
                                     read_storage.proposals_cloned().await,

--- a/crates/testing/src/spinning_task.rs
+++ b/crates/testing/src/spinning_task.rs
@@ -128,7 +128,7 @@ where
 
                                         let initializer = HotShotInitializer::<TYPES>::from_reload(
                                             self.last_decided_leaf.clone(),
-                                            TestInstanceState {},
+                                            TestInstanceState::default(),
                                             None,
                                             view_number,
                                             BTreeMap::new(),
@@ -205,14 +205,14 @@ where
                                 let read_storage = storage.read().await;
                                 let initializer = HotShotInitializer::<TYPES>::from_reload(
                                     self.last_decided_leaf.clone(),
-                                    TestInstanceState {},
+                                    TestInstanceState::default(),
                                     None,
                                     view_number,
                                     read_storage.proposals_cloned().await,
                                     read_storage.high_qc_cloned().await.unwrap_or(
                                         QuorumCertificate::genesis(
                                             &TestValidatedState::default(),
-                                            &TestInstanceState {},
+                                            &TestInstanceState::default(),
                                         )
                                         .await,
                                     ),

--- a/crates/testing/src/spinning_task.rs
+++ b/crates/testing/src/spinning_task.rs
@@ -18,6 +18,7 @@ use hotshot_example_types::{
     auction_results_provider_types::TestAuctionResultsProvider,
     state_types::{TestInstanceState, TestValidatedState},
     storage_types::TestStorage,
+    testable_delay::DelayOptions,
 };
 use hotshot_types::{
     data::Leaf,
@@ -58,6 +59,8 @@ pub struct SpinningTask<TYPES: NodeType, I: TestableNodeImplementation<TYPES>> {
     pub(crate) last_decided_leaf: Leaf<TYPES>,
     /// Highest qc seen in the test for restarting nodes
     pub(crate) high_qc: QuorumCertificate<TYPES>,
+    /// Add specified delay to async calls
+    pub(crate) async_delay: DelayOptions,
 }
 
 #[async_trait]
@@ -128,7 +131,7 @@ where
 
                                         let initializer = HotShotInitializer::<TYPES>::from_reload(
                                             self.last_decided_leaf.clone(),
-                                            TestInstanceState::default(),
+                                            TestInstanceState::new(self.async_delay),
                                             None,
                                             view_number,
                                             BTreeMap::new(),
@@ -205,7 +208,7 @@ where
                                 let read_storage = storage.read().await;
                                 let initializer = HotShotInitializer::<TYPES>::from_reload(
                                     self.last_decided_leaf.clone(),
-                                    TestInstanceState::default(),
+                                    TestInstanceState::new(self.async_delay),
                                     None,
                                     view_number,
                                     read_storage.proposals_cloned().await,

--- a/crates/testing/src/test_builder.rs
+++ b/crates/testing/src/test_builder.rs
@@ -14,7 +14,7 @@ use hotshot::{
 };
 use hotshot_example_types::{
     auction_results_provider_types::TestAuctionResultsProvider, state_types::TestInstanceState,
-    storage_types::TestStorage,
+    storage_types::TestStorage, testable_delay::DelayOptions,
 };
 use hotshot_types::{
     consensus::ConsensusMetricsValue, traits::node_implementation::NodeType, ExecutionType,
@@ -92,6 +92,8 @@ pub struct TestDescription<TYPES: NodeType, I: NodeImplementation<TYPES>> {
     pub solver: FakeSolverApiDescription,
     /// nodes with byzantine behaviour
     pub behaviour: Rc<dyn Fn(u64) -> Behaviour<TYPES, I>>,
+    /// Type of delay we will add to async calls
+    pub async_delay: DelayOptions,
 }
 
 #[derive(Debug)]
@@ -105,7 +107,7 @@ pub async fn create_test_handle<
     TYPES: NodeType<InstanceState = TestInstanceState>,
     I: NodeImplementation<TYPES>,
 >(
-    behaviour: Behaviour<TYPES, I>,
+    metadata: TestDescription<TYPES, I>,
     node_id: u64,
     network: Network<TYPES, I>,
     memberships: Memberships<TYPES>,
@@ -113,9 +115,10 @@ pub async fn create_test_handle<
     storage: I::Storage,
     marketplace_config: MarketplaceConfig<TYPES, I>,
 ) -> SystemContextHandle<TYPES, I> {
-    let initializer = HotShotInitializer::<TYPES>::from_genesis(TestInstanceState::default())
-        .await
-        .unwrap();
+    let initializer =
+        HotShotInitializer::<TYPES>::from_genesis(TestInstanceState::new(metadata.async_delay))
+            .await
+            .unwrap();
 
     // See whether or not we should be DA
     let is_da = node_id < config.da_staked_committee_size as u64;
@@ -127,6 +130,7 @@ pub async fn create_test_handle<
     let private_key = validator_config.private_key.clone();
     let public_key = validator_config.public_key.clone();
 
+    let behaviour = (metadata.behaviour)(node_id);
     match behaviour {
         Behaviour::ByzantineTwins(state) => {
             let state = Box::leak(state);
@@ -367,6 +371,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> Default for TestDescription<
                 error_pct: 0.1,
             },
             behaviour: Rc::new(|_| Behaviour::Standard),
+            async_delay: DelayOptions::None,
         }
     }
 }
@@ -486,7 +491,12 @@ where
                     unreliable_network,
                     secondary_network_delay,
                 ),
-                storage: Box::new(|_| TestStorage::<TYPES>::default()),
+                storage: Box::new(move |_| {
+                    let mut storage = TestStorage::<TYPES>::default();
+                    // update storage impl to use settings delay option
+                    storage.delay_option = self.async_delay;
+                    storage
+                }),
                 config,
                 marketplace_config: Box::new(|_| MarketplaceConfig::<TYPES, I> {
                     auction_results_provider: TestAuctionResultsProvider::<TYPES>::default().into(),

--- a/crates/testing/src/test_builder.rs
+++ b/crates/testing/src/test_builder.rs
@@ -14,7 +14,7 @@ use hotshot::{
 };
 use hotshot_example_types::{
     auction_results_provider_types::TestAuctionResultsProvider, state_types::TestInstanceState,
-    storage_types::TestStorage, testable_delay::DelayOptions,
+    storage_types::TestStorage, testable_delay::DelayConfig,
 };
 use hotshot_types::{
     consensus::ConsensusMetricsValue, traits::node_implementation::NodeType, ExecutionType,
@@ -92,8 +92,8 @@ pub struct TestDescription<TYPES: NodeType, I: NodeImplementation<TYPES>> {
     pub solver: FakeSolverApiDescription,
     /// nodes with byzantine behaviour
     pub behaviour: Rc<dyn Fn(u64) -> Behaviour<TYPES, I>>,
-    /// Type of delay we will add to async calls
-    pub async_delay: DelayOptions,
+    /// Delay config if any to add delays to asynchronous calls
+    pub async_delay_config: DelayConfig,
 }
 
 #[derive(Debug)]
@@ -115,10 +115,11 @@ pub async fn create_test_handle<
     storage: I::Storage,
     marketplace_config: MarketplaceConfig<TYPES, I>,
 ) -> SystemContextHandle<TYPES, I> {
-    let initializer =
-        HotShotInitializer::<TYPES>::from_genesis(TestInstanceState::new(metadata.async_delay))
-            .await
-            .unwrap();
+    let initializer = HotShotInitializer::<TYPES>::from_genesis(TestInstanceState::new(
+        metadata.async_delay_config,
+    ))
+    .await
+    .unwrap();
 
     // See whether or not we should be DA
     let is_da = node_id < config.da_staked_committee_size as u64;
@@ -371,7 +372,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> Default for TestDescription<
                 error_pct: 0.1,
             },
             behaviour: Rc::new(|_| Behaviour::Standard),
-            async_delay: DelayOptions::None,
+            async_delay_config: DelayConfig::default(),
         }
     }
 }
@@ -482,6 +483,7 @@ where
                 a.view_sync_timeout = view_sync_timeout;
             };
 
+        let metadata = self.clone();
         TestLauncher {
             resource_generator: ResourceGenerators {
                 channel_generator: <I as TestableNodeImplementation<TYPES>>::gen_networks(
@@ -494,7 +496,7 @@ where
                 storage: Box::new(move |_| {
                     let mut storage = TestStorage::<TYPES>::default();
                     // update storage impl to use settings delay option
-                    storage.delay_option = self.async_delay;
+                    storage.delay_config = metadata.async_delay_config.clone();
                     storage
                 }),
                 config,

--- a/crates/testing/src/test_builder.rs
+++ b/crates/testing/src/test_builder.rs
@@ -113,7 +113,7 @@ pub async fn create_test_handle<
     storage: I::Storage,
     marketplace_config: MarketplaceConfig<TYPES, I>,
 ) -> SystemContextHandle<TYPES, I> {
-    let initializer = HotShotInitializer::<TYPES>::from_genesis(TestInstanceState {})
+    let initializer = HotShotInitializer::<TYPES>::from_genesis(TestInstanceState::default())
         .await
         .unwrap();
 

--- a/crates/testing/src/test_runner.rs
+++ b/crates/testing/src/test_runner.rs
@@ -178,11 +178,14 @@ where
             late_start,
             latest_view: None,
             changes,
-            last_decided_leaf: Leaf::genesis(&TestValidatedState::default(), &TestInstanceState {})
-                .await,
+            last_decided_leaf: Leaf::genesis(
+                &TestValidatedState::default(),
+                &TestInstanceState::default(),
+            )
+            .await,
             high_qc: QuorumCertificate::genesis(
                 &TestValidatedState::default(),
-                &TestInstanceState {},
+                &TestInstanceState::default(),
             )
             .await,
         };
@@ -471,7 +474,7 @@ where
                     );
                 } else {
                     let initializer =
-                        HotShotInitializer::<TYPES>::from_genesis(TestInstanceState {})
+                        HotShotInitializer::<TYPES>::from_genesis(TestInstanceState::default())
                             .await
                             .unwrap();
 

--- a/crates/testing/src/test_runner.rs
+++ b/crates/testing/src/test_runner.rs
@@ -188,7 +188,7 @@ where
                 &TestInstanceState::default(),
             )
             .await,
-            async_delay: self.launcher.metadata.async_delay,
+            async_delay_config: self.launcher.metadata.async_delay_config,
         };
         let spinning_task = TestTask::<SpinningTask<TYPES, I>>::new(
             spinning_task_state,
@@ -475,7 +475,7 @@ where
                     );
                 } else {
                     let initializer = HotShotInitializer::<TYPES>::from_genesis(
-                        TestInstanceState::new(self.launcher.metadata.async_delay),
+                        TestInstanceState::new(self.launcher.metadata.async_delay_config.clone()),
                     )
                     .await
                     .unwrap();

--- a/crates/testing/src/test_runner.rs
+++ b/crates/testing/src/test_runner.rs
@@ -188,6 +188,7 @@ where
                 &TestInstanceState::default(),
             )
             .await,
+            async_delay: self.launcher.metadata.async_delay,
         };
         let spinning_task = TestTask::<SpinningTask<TYPES, I>>::new(
             spinning_task_state,
@@ -473,10 +474,11 @@ where
                         },
                     );
                 } else {
-                    let initializer =
-                        HotShotInitializer::<TYPES>::from_genesis(TestInstanceState::default())
-                            .await
-                            .unwrap();
+                    let initializer = HotShotInitializer::<TYPES>::from_genesis(
+                        TestInstanceState::new(self.launcher.metadata.async_delay),
+                    )
+                    .await
+                    .unwrap();
 
                     // See whether or not we should be DA
                     let is_da = node_id < config.da_staked_committee_size as u64;
@@ -539,9 +541,8 @@ where
         for (node_id, network, memberships, config, storage, marketplace_config) in
             uninitialized_nodes
         {
-            let behaviour = (self.launcher.metadata.behaviour)(node_id);
             let handle = create_test_handle(
-                behaviour,
+                self.launcher.metadata.clone(),
                 node_id,
                 network.clone(),
                 memberships,

--- a/crates/testing/src/view_generator.rs
+++ b/crates/testing/src/view_generator.rs
@@ -81,7 +81,7 @@ impl TestView {
             <TestBlockPayload as BlockPayload<TestTypes>>::from_transactions(
                 transactions.clone(),
                 &TestValidatedState::default(),
-                &TestInstanceState {},
+                &TestInstanceState::default(),
             )
             .await
             .unwrap();
@@ -125,7 +125,7 @@ impl TestView {
             view_number: genesis_view,
             justify_qc: QuorumCertificate::genesis(
                 &TestValidatedState::default(),
-                &TestInstanceState {},
+                &TestInstanceState::default(),
             )
             .await,
             upgrade_certificate: None,
@@ -215,7 +215,7 @@ impl TestView {
             <TestBlockPayload as BlockPayload<TestTypes>>::from_transactions(
                 transactions.clone(),
                 &TestValidatedState::default(),
-                &TestInstanceState {},
+                &TestInstanceState::default(),
             )
             .await
             .unwrap();

--- a/crates/testing/tests/tests_1/test_success.rs
+++ b/crates/testing/tests/tests_1/test_success.rs
@@ -60,7 +60,6 @@ cross_tests!(
 
         metadata.overall_safety_properties.num_failed_views = 0;
         metadata.overall_safety_properties.num_successful_views = 10;
-        
         let mut config = DelayConfig::default();
         let delay_settings = DelaySettings {
             delay_option: DelayOptions::Random,
@@ -68,7 +67,6 @@ cross_tests!(
             max_time_in_milliseconds: 100,
             fixed_time_in_milliseconds: 0,
         };
-        
         config.add_settings_for_all_types(delay_settings);
         metadata.async_delay_config = config;
         metadata
@@ -93,7 +91,6 @@ cross_tests!(
 
         metadata.overall_safety_properties.num_failed_views = 0;
         metadata.overall_safety_properties.num_successful_views = 10;
-        
         let mut config = DelayConfig::default();
         let mut delay_settings = DelaySettings {
             delay_option: DelayOptions::Random,
@@ -101,7 +98,6 @@ cross_tests!(
             max_time_in_milliseconds: 100,
             fixed_time_in_milliseconds: 15,
         };
-        
         config.add_setting(SupportedTraitTypesForAsyncDelay::Storage, &delay_settings);
 
         delay_settings.delay_option = DelayOptions::Fixed;

--- a/crates/testing/tests/tests_1/test_success.rs
+++ b/crates/testing/tests/tests_1/test_success.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 use hotshot_example_types::{
     node_types::{Libp2pImpl, MemoryImpl, PushCdnImpl, TestConsecutiveLeaderTypes},
     state_types::TestTypes,
-    testable_delay::{DelayConfig, DelayOptions, DelaySettings},
+    testable_delay::{DelayConfig, DelayOptions, DelaySettings, SupportedTraitTypesForAsyncDelay},
 };
 use hotshot_macros::cross_tests;
 use hotshot_testing::{
@@ -60,14 +60,57 @@ cross_tests!(
 
         metadata.overall_safety_properties.num_failed_views = 0;
         metadata.overall_safety_properties.num_successful_views = 10;
+        
+        let mut config = DelayConfig::default();
         let delay_settings = DelaySettings {
             delay_option: DelayOptions::Random,
             min_time_in_milliseconds: 10,
             max_time_in_milliseconds: 100,
             fixed_time_in_milliseconds: 0,
         };
-        let mut config = DelayConfig::default();
+        
         config.add_settings_for_all_types(delay_settings);
+        metadata.async_delay_config = config;
+        metadata
+    },
+);
+
+cross_tests!(
+    TestName: test_success_with_async_delay_2,
+    Impls: [MemoryImpl, Libp2pImpl, PushCdnImpl],
+    Types: [TestTypes],
+    Ignore: false,
+    Metadata: {
+        let mut metadata = TestDescription {
+            // allow more time to pass in CI
+            completion_task_description: CompletionTaskDescription::TimeBasedCompletionTaskBuilder(
+                                             TimeBasedCompletionTaskDescription {
+                                                 duration: Duration::from_secs(60),
+                                             },
+                                         ),
+            ..TestDescription::default()
+        };
+
+        metadata.overall_safety_properties.num_failed_views = 0;
+        metadata.overall_safety_properties.num_successful_views = 10;
+        
+        let mut config = DelayConfig::default();
+        let mut delay_settings = DelaySettings {
+            delay_option: DelayOptions::Random,
+            min_time_in_milliseconds: 10,
+            max_time_in_milliseconds: 100,
+            fixed_time_in_milliseconds: 15,
+        };
+        
+        config.add_setting(SupportedTraitTypesForAsyncDelay::Storage, &delay_settings);
+
+        delay_settings.delay_option = DelayOptions::Fixed;
+        config.add_setting(SupportedTraitTypesForAsyncDelay::BlockHeader, &delay_settings);
+
+        delay_settings.delay_option = DelayOptions::Random;
+        delay_settings.min_time_in_milliseconds = 5;
+        delay_settings.max_time_in_milliseconds = 20;
+        config.add_setting(SupportedTraitTypesForAsyncDelay::ValidatedState, &delay_settings);
         metadata.async_delay_config = config;
         metadata
     },

--- a/crates/testing/tests/tests_1/test_success.rs
+++ b/crates/testing/tests/tests_1/test_success.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 use hotshot_example_types::{
     node_types::{Libp2pImpl, MemoryImpl, PushCdnImpl, TestConsecutiveLeaderTypes},
     state_types::TestTypes,
-    testable_delay::DelayOptions,
+    testable_delay::{DelayConfig, DelaySettings, DelayOptions},
 };
 use hotshot_macros::cross_tests;
 use hotshot_testing::{
@@ -60,7 +60,15 @@ cross_tests!(
 
         metadata.overall_safety_properties.num_failed_views = 0;
         metadata.overall_safety_properties.num_successful_views = 10;
-        metadata.async_delay = DelayOptions::Random;
+        let delay_settings = DelaySettings {
+            delay_option: DelayOptions::Random,
+            min_time_in_milliseconds: 10,
+            max_time_in_milliseconds: 100,
+            fixed_time_in_milliseconds: 0,
+        };
+        let mut config = DelayConfig::default();
+        config.add_settings_for_all_types(delay_settings);
+        metadata.async_delay_config = config;
         metadata
     },
 );

--- a/crates/testing/tests/tests_1/test_success.rs
+++ b/crates/testing/tests/tests_1/test_success.rs
@@ -73,7 +73,6 @@ cross_tests!(
     },
 );
 
-#[cfg(async_executor_impl = "async-std")]
 cross_tests!(
     TestName: double_propose_vote,
     Impls: [MemoryImpl],

--- a/crates/testing/tests/tests_1/test_success.rs
+++ b/crates/testing/tests/tests_1/test_success.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 use hotshot_example_types::{
     node_types::{Libp2pImpl, MemoryImpl, PushCdnImpl, TestConsecutiveLeaderTypes},
     state_types::TestTypes,
-    testable_delay::{DelayConfig, DelaySettings, DelayOptions},
+    testable_delay::{DelayConfig, DelayOptions, DelaySettings},
 };
 use hotshot_macros::cross_tests;
 use hotshot_testing::{

--- a/crates/testing/tests/tests_1/test_success.rs
+++ b/crates/testing/tests/tests_1/test_success.rs
@@ -9,6 +9,7 @@ use std::time::Duration;
 use hotshot_example_types::{
     node_types::{Libp2pImpl, MemoryImpl, PushCdnImpl, TestConsecutiveLeaderTypes},
     state_types::TestTypes,
+    testable_delay::DelayOptions,
 };
 use hotshot_macros::cross_tests;
 use hotshot_testing::{
@@ -41,6 +42,30 @@ cross_tests!(
     },
 );
 
+cross_tests!(
+    TestName: test_success_with_async_delay,
+    Impls: [MemoryImpl, Libp2pImpl, PushCdnImpl],
+    Types: [TestTypes],
+    Ignore: false,
+    Metadata: {
+        let mut metadata = TestDescription {
+            // allow more time to pass in CI
+            completion_task_description: CompletionTaskDescription::TimeBasedCompletionTaskBuilder(
+                                             TimeBasedCompletionTaskDescription {
+                                                 duration: Duration::from_secs(60),
+                                             },
+                                         ),
+            ..TestDescription::default()
+        };
+
+        metadata.overall_safety_properties.num_failed_views = 0;
+        metadata.overall_safety_properties.num_successful_views = 10;
+        metadata.async_delay = DelayOptions::Random;
+        metadata
+    },
+);
+
+#[cfg(async_executor_impl = "async-std")]
 cross_tests!(
     TestName: double_propose_vote,
     Impls: [MemoryImpl],

--- a/crates/testing/tests/tests_1/vid_task.rs
+++ b/crates/testing/tests/tests_1/vid_task.rs
@@ -55,7 +55,7 @@ async fn test_vid_task() {
     let (payload, metadata) = <TestBlockPayload as BlockPayload<TestTypes>>::from_transactions(
         transactions.clone(),
         &TestValidatedState::default(),
-        &TestInstanceState {},
+        &TestInstanceState::default(),
     )
     .await
     .unwrap();


### PR DESCRIPTION
Closes https://github.com/EspressoSystems/HotShot/issues/3456
<!-- See here for keywords in Github -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

### This PR: 
<!-- Describe what this PR adds to HotSHot -->
<!-- E.g. -->
<!-- * Implements feature 1 -->
<!-- * Implements feature 2 -->
<!-- * Fixes bug 3 -->
Add support to add delays to functions that the sequencer implements, method calls currently return immediately as of now. We want to mock behavior where one of these trait functions may take more time to complete

### This PR does not: 
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->

### Key places to review: 
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
