### PR TITLE
Don't skip fallback builder when solver fails

### DIFF
--- a/crates/examples/infra/mod.rs
+++ b/crates/examples/infra/mod.rs
@@ -404,8 +404,8 @@ pub trait RunDa<
 
         let marketplace_config = MarketplaceConfig {
             auction_results_provider: TestAuctionResultsProvider::<TYPES>::default().into(),
-            // TODO: we need to pass a valid generic builder url here somehow
-            generic_builder_url: url::Url::parse("http://localhost").unwrap(),
+            // TODO: we need to pass a valid fallback builder url here somehow
+            fallback_builder_url: url::Url::parse("http://localhost").unwrap(),
         };
 
         SystemContext::init(

--- a/crates/hotshot/src/lib.rs
+++ b/crates/hotshot/src/lib.rs
@@ -83,8 +83,8 @@ pub const H_256: usize = 32;
 pub struct MarketplaceConfig<TYPES: NodeType, I: NodeImplementation<TYPES>> {
     /// auction results provider
     pub auction_results_provider: Arc<I::AuctionResultsProvider>,
-    /// generic builder
-    pub generic_builder_url: Url,
+    /// fallback builder
+    pub fallback_builder_url: Url,
 }
 
 /// Bundle of all the memberships a consensus instance uses

--- a/crates/hotshot/src/tasks/task_state.rs
+++ b/crates/hotshot/src/tasks/task_state.rs
@@ -213,10 +213,10 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> CreateTaskState<TYPES, I>
             auction_results_provider: Arc::clone(
                 &handle.hotshot.marketplace_config.auction_results_provider,
             ),
-            generic_builder_url: handle
+            fallback_builder_url: handle
                 .hotshot
                 .marketplace_config
-                .generic_builder_url
+                .fallback_builder_url
                 .clone(),
         }
     }

--- a/crates/testing/src/test_builder.rs
+++ b/crates/testing/src/test_builder.rs
@@ -490,8 +490,7 @@ where
                 config,
                 marketplace_config: Box::new(|_| MarketplaceConfig::<TYPES, I> {
                     auction_results_provider: TestAuctionResultsProvider::<TYPES>::default().into(),
-                    // TODO: we need to pass a valid generic builder url here somehow
-                    generic_builder_url: Url::parse("http://localhost").unwrap(),
+                    fallback_builder_url: Url::parse("http://localhost").unwrap(),
                 }),
             },
             metadata: self,


### PR DESCRIPTION
Closes #0000

### This PR: 
- Prevents transaction task from skipping querying the fallback builder when solver doesn't return auction results
- Renames generic builder to fallback builder ([see Zulip](https://espresso.zulipchat.com/#narrow/stream/440749-Marketplace/topic/Async.20Standup/near/455711468))

### This PR does not: 
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->

### Key places to review: 
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
