### PR TITLE
[CX_HARDENING] Enhance DA Task Test Coverage

### DIFF
--- a/crates/hotshot/src/lib.rs
+++ b/crates/hotshot/src/lib.rs
@@ -639,6 +639,31 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> SystemContext<T
     }
 }
 
+#[cfg(feature = "hotshot-testing")]
+impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> SystemContext<TYPES, I, V> {
+    /// Creates a lightweight version of the system handle for task state testing.
+    ///
+    /// This method provides a minimal context for task state tests, omitting the full
+    /// consensus and network task launches. It results in fewer traces and simplifies debugging.
+    ///
+    /// # Returns
+    /// A `SystemContextHandle<TYPES, I, V>` with minimal setup for task state testing.
+    pub fn create_lean_test_handle(&self) -> SystemContextHandle<TYPES, I, V> {
+        let (internal_sender, internal_receiver) = broadcast(EVENT_CHANNEL_SIZE);
+
+        SystemContextHandle {
+            consensus_registry: ConsensusTaskRegistry::new(),
+            network_registry: NetworkTaskRegistry::new(),
+            output_event_stream: self.external_event_stream.clone(),
+            internal_event_stream: (internal_sender, internal_receiver.deactivate()),
+            hotshot: self.clone().into(),
+            storage: Arc::clone(&self.storage),
+            network: Arc::clone(&self.network),
+            memberships: Arc::clone(&self.memberships),
+        }
+    }
+}
+
 /// An async broadcast channel
 type Channel<S> = (Sender<Arc<S>>, Receiver<Arc<S>>);
 

--- a/crates/testing/src/helpers.rs
+++ b/crates/testing/src/helpers.rs
@@ -5,15 +5,17 @@
 // along with the HotShot repository. If not, see <https://mit-license.org/>.
 
 #![allow(clippy::panic)]
-use std::{fmt::Debug, hash::Hash, marker::PhantomData, sync::Arc};
+use std::{fmt::Debug, hash::Hash, marker::PhantomData, sync::Arc, time::Duration};
 
 use async_broadcast::{Receiver, Sender};
+use async_compatibility_layer::art::async_timeout;
 use bitvec::bitvec;
 use committable::Committable;
 use ethereum_types::U256;
+use futures::StreamExt;
 use hotshot::{
     traits::{NodeImplementation, TestableNodeImplementation},
-    types::{BLSPubKey, SignatureKey, SystemContextHandle},
+    types::{BLSPubKey, Event, SignatureKey, SystemContextHandle},
     HotShotInitializer, Memberships, SystemContext,
 };
 use hotshot_example_types::{
@@ -40,11 +42,15 @@ use hotshot_types::{
     utils::{View, ViewInner},
     vid::{vid_scheme, VidCommitment, VidSchemeType},
     vote::{Certificate, HasViewNumber, Vote},
+    PeerConfig,
 };
 use jf_vid::VidScheme;
 use serde::Serialize;
 
-use crate::test_builder::TestDescription;
+use crate::{
+    predicates::PredicateResult, script::ExternalEventsExpectations, test_builder::TestDescription,
+    test_launcher::TestLauncher,
+};
 
 /// create the [`SystemContextHandle`] from a node id
 /// # Panics
@@ -128,6 +134,105 @@ pub async fn build_system_handle<
     .expect("Could not init hotshot")
 }
 
+/// create the [`SystemContextHandle`] from a launcher
+/// # Panics
+/// if cannot create a [`HotShotInitializer`]
+pub async fn build_system_handle_from_launcher<
+    TYPES: NodeType<InstanceState = TestInstanceState>,
+    I: NodeImplementation<
+            TYPES,
+            Storage = TestStorage<TYPES>,
+            AuctionResultsProvider = TestAuctionResultsProvider<TYPES>,
+        > + TestableNodeImplementation<TYPES>,
+    V: Versions,
+>(
+    node_id: u64,
+    launcher: TestLauncher<TYPES, I, V>,
+    membership_config: Option<Memberships<TYPES>>,
+) -> Result<SystemContextHandle<TYPES, I, V>, anyhow::Error> {
+    tracing::info!("Creating system handle for node {}", node_id);
+
+    let network = (launcher.resource_generator.channel_generator)(node_id).await;
+    let storage = (launcher.resource_generator.storage)(node_id);
+    let marketplace_config = (launcher.resource_generator.marketplace_config)(node_id);
+    let config = launcher.resource_generator.config.clone();
+
+    let known_nodes_with_stake = config.known_nodes_with_stake.clone();
+    let private_key = config.my_own_validator_config.private_key.clone();
+    let public_key = config.my_own_validator_config.public_key.clone();
+
+    let memberships = membership_config.unwrap_or_else(|| {
+        let create_membership = |nodes: &[PeerConfig<TYPES::SignatureKey>], topic: Topic| {
+            TYPES::Membership::create_election(
+                known_nodes_with_stake.clone(),
+                nodes.to_vec(),
+                topic,
+                config.fixed_leader_for_gpuvid,
+            )
+        };
+
+        Memberships {
+            quorum_membership: create_membership(&known_nodes_with_stake, Topic::Global),
+            da_membership: create_membership(&config.known_da_nodes, Topic::Da),
+            vid_membership: create_membership(&known_nodes_with_stake, Topic::Global),
+            view_sync_membership: create_membership(&known_nodes_with_stake, Topic::Global),
+        }
+    });
+
+    let initializer = HotShotInitializer::<TYPES>::from_genesis(TestInstanceState::new(
+        launcher.metadata.async_delay_config,
+    ))
+    .await
+    .unwrap();
+
+    let system_context = SystemContext::new(
+        public_key,
+        private_key,
+        node_id,
+        config,
+        memberships,
+        network,
+        initializer,
+        ConsensusMetricsValue::default(),
+        storage,
+        marketplace_config,
+    );
+
+    let system_context_handle = system_context.create_lean_test_handle();
+
+    tracing::info!("Successfully created system handle for node {}", node_id);
+    Ok(system_context_handle)
+}
+
+/// create certificate
+/// # Panics
+/// if we fail to sign the data
+pub fn build_da_cert<
+    TYPES: NodeType<SignatureKey = BLSPubKey>,
+    DATAType: Committable + Clone + Eq + Hash + Serialize + Debug + 'static,
+    VOTE: Vote<TYPES, Commitment = DATAType>,
+    CERT: Certificate<TYPES, Voteable = VOTE::Commitment>,
+>(
+    data: DATAType,
+    membership: &TYPES::Membership,
+    view: TYPES::Time,
+    public_key: &TYPES::SignatureKey,
+    private_key: &<TYPES::SignatureKey as SignatureKey>::PrivateKey,
+) -> CERT {
+    let real_qc_sig =
+        build_da_assembled_sig::<TYPES, VOTE, CERT, DATAType>(&data, membership, view);
+
+    let vote =
+        SimpleVote::<TYPES, DATAType>::create_signed_vote(data, view, public_key, private_key)
+            .expect("Failed to sign data!");
+    CERT::create_signed_certificate(
+        vote.date_commitment(),
+        vote.date().clone(),
+        real_qc_sig,
+        vote.view_number(),
+    )
+}
+
 /// create certificate
 /// # Panics
 /// if we fail to sign the data
@@ -169,6 +274,46 @@ pub fn vid_share<TYPES: NodeType>(
         .first()
         .expect("No VID for key")
         .clone()
+}
+
+/// create DA signature
+/// # Panics
+/// if fails to convert node id into keypair
+pub fn build_da_assembled_sig<TYPES, VOTE, CERT, DATAType>(
+    data: &DATAType,
+    membership: &TYPES::Membership,
+    view: TYPES::Time,
+) -> <TYPES::SignatureKey as SignatureKey>::QcType
+where
+    TYPES: NodeType<SignatureKey = BLSPubKey>,
+    VOTE: Vote<TYPES>,
+    CERT: Certificate<TYPES, Voteable = VOTE::Commitment>,
+    DATAType: Committable + Clone + Eq + Hash + Serialize + Debug + 'static,
+{
+    let stake_table = membership.committee_qc_stake_table();
+    let total_nodes = stake_table.len();
+    let threshold = CERT::threshold(membership) as usize;
+    let real_qc_pp =
+        TYPES::SignatureKey::public_parameter(stake_table.clone(), U256::from(threshold as u64));
+
+    let mut signers = bitvec![0; total_nodes];
+    let sig_lists: Vec<_> = (0..threshold)
+        .map(|node_id| {
+            let (private_key, public_key) = key_pair_for_id(node_id as u64);
+            let vote = SimpleVote::<TYPES, DATAType>::create_signed_vote(
+                data.clone(),
+                view,
+                &public_key,
+                &private_key,
+            )
+            .expect("Failed to sign data");
+
+            signers.set(node_id, true);
+            vote.signature()
+        })
+        .collect();
+
+    TYPES::SignatureKey::assemble(&real_qc_pp, signers.as_bitslice(), &sig_lists)
 }
 
 /// create signature
@@ -330,7 +475,7 @@ pub fn build_da_certificate(
         payload_commit: da_payload_commitment,
     };
 
-    build_cert::<TestTypes, DaData, DaVote<TestTypes>, DaCertificate<TestTypes>>(
+    build_da_cert::<TestTypes, DaData, DaVote<TestTypes>, DaCertificate<TestTypes>>(
         da_data,
         da_membership,
         view_number,
@@ -391,5 +536,42 @@ pub fn build_fake_view_with_leaf_and_state(
             state: state.into(),
             delta: None,
         },
+    }
+}
+
+pub async fn check_external_events<TYPES: NodeType, S: StreamExt<Item = Event<TYPES>> + Unpin>(
+    mut output_stream: S,
+    expectations: &[ExternalEventsExpectations<TYPES>],
+    timeout: Duration,
+) -> Result<(), String> {
+    let mut external_event_expectations_met = vec![false; expectations.len()];
+
+    while let Ok(Some(ext_event_received_output)) =
+        async_timeout(timeout, output_stream.next()).await
+    {
+        tracing::debug!("Test received Ext Event: {:?}", ext_event_received_output);
+        for (index, expectation) in expectations.iter().enumerate() {
+            if !external_event_expectations_met[index] {
+                for predicate in &expectation.output_asserts {
+                    if predicate
+                        .evaluate(&Arc::new(ext_event_received_output.clone()))
+                        .await
+                        == PredicateResult::Pass
+                    {
+                        external_event_expectations_met[index] = true;
+                        break;
+                    }
+                }
+            }
+        }
+        if external_event_expectations_met.iter().all(|&x| x) {
+            return Ok(());
+        }
+    }
+
+    if external_event_expectations_met.iter().all(|&x| x) {
+        Ok(())
+    } else {
+        Err("Not all external event expectations were met".to_string())
     }
 }

--- a/crates/testing/src/predicates/event.rs
+++ b/crates/testing/src/predicates/event.rs
@@ -11,10 +11,14 @@ use async_trait::async_trait;
 use hotshot_task_impls::events::{HotShotEvent, HotShotEvent::*};
 use hotshot_types::{
     data::null_block,
+    event::Event,
     traits::{block_contents::BlockHeader, node_implementation::NodeType},
 };
 
-use crate::predicates::{Predicate, PredicateResult};
+use crate::{
+    predicates::{Predicate, PredicateResult},
+    script::ExternalEventsExpectations,
+};
 
 type EventCallback<TYPES> = Arc<dyn Fn(Arc<HotShotEvent<TYPES>>) -> bool + Send + Sync>;
 
@@ -293,4 +297,48 @@ where
         matches!(e.as_ref(), ValidatedStateUpdated(..))
     });
     Box::new(EventPredicate { check, info })
+}
+
+// New predicate type for EventType
+type ExternalEventCheckFn<TYPES> = dyn Fn(&Event<TYPES>) -> bool + Send + Sync;
+
+pub struct ExternalEventPredicate<TYPES: NodeType> {
+    check: Arc<ExternalEventCheckFn<TYPES>>,
+    info: String,
+}
+
+impl<TYPES: NodeType> std::fmt::Debug for ExternalEventPredicate<TYPES> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.info)
+    }
+}
+
+#[async_trait]
+impl<TYPES: NodeType + Send + Sync + 'static> Predicate<Arc<Event<TYPES>>>
+    for ExternalEventPredicate<TYPES>
+{
+    async fn evaluate(&self, input: &Arc<Event<TYPES>>) -> PredicateResult {
+        PredicateResult::from((self.check)(input))
+    }
+
+    async fn info(&self) -> String {
+        self.info.clone()
+    }
+}
+
+pub fn ext_event_exact<TYPES: NodeType>(
+    event: Event<TYPES>,
+) -> Box<dyn Predicate<Arc<Event<TYPES>>>> {
+    let info = format!("{:?}", event);
+    let check = Arc::new(move |e: &Event<TYPES>| {
+        e.event == event.event && e.view_number == event.view_number
+    });
+
+    Box::new(ExternalEventPredicate { check, info })
+}
+
+pub fn expect_external_events<TYPES: NodeType>(
+    predicates: Vec<Box<dyn Predicate<Arc<Event<TYPES>>>>>,
+) -> ExternalEventsExpectations<TYPES> {
+    ExternalEventsExpectations::from_outputs(predicates)
 }

--- a/crates/testing/src/script.rs
+++ b/crates/testing/src/script.rs
@@ -7,7 +7,7 @@
 use std::{sync::Arc, time::Duration};
 
 use hotshot_task_impls::events::HotShotEvent;
-use hotshot_types::traits::node_implementation::NodeType;
+use hotshot_types::{event::Event, traits::node_implementation::NodeType};
 
 use crate::predicates::{Predicate, PredicateResult};
 
@@ -63,6 +63,16 @@ impl<TYPES: NodeType, S> Expectations<TYPES, S> {
             output_asserts,
             task_state_asserts,
         }
+    }
+}
+
+pub struct ExternalEventsExpectations<TYPES: NodeType> {
+    pub output_asserts: Vec<Box<dyn Predicate<Arc<Event<TYPES>>>>>,
+}
+
+impl<TYPES: NodeType> ExternalEventsExpectations<TYPES> {
+    pub fn from_outputs(output_asserts: Vec<Box<dyn Predicate<Arc<Event<TYPES>>>>>) -> Self {
+        Self { output_asserts }
     }
 }
 

--- a/crates/testing/tests/tests_cx_hardening.rs
+++ b/crates/testing/tests/tests_cx_hardening.rs
@@ -1,0 +1,3 @@
+mod tests_cx_hardening {
+    automod::dir!("tests/tests_cx_hardening");
+}

--- a/crates/testing/tests/tests_cx_hardening/cxh_da_task.rs
+++ b/crates/testing/tests/tests_cx_hardening/cxh_da_task.rs
@@ -1,0 +1,564 @@
+use std::{sync::Arc, time::Duration};
+
+use futures::StreamExt;
+use hotshot::tasks::task_state::CreateTaskState;
+use hotshot_example_types::{
+    block_types::TestTransaction,
+    node_types::{MemoryImpl, TestTypes, TestVersions},
+};
+use hotshot_macros::{run_test, test_scripts};
+use hotshot_task_impls::{da::DaTaskState, events::HotShotEvent};
+use hotshot_testing::{
+    helpers::{build_system_handle_from_launcher, check_external_events},
+    predicates::event::{exact, expect_external_events, ext_event_exact},
+    script::{Expectations, InputOrder, TaskScript},
+    serial,
+    test_builder::TestDescription,
+    view_generator::TestViewGenerator,
+};
+use hotshot_types::{
+    data::ViewNumber,
+    event::{Event, EventType},
+    simple_vote::DaData,
+    traits::{
+        block_contents::precompute_vid_commitment, election::Membership,
+        node_implementation::ConsensusTime,
+    },
+};
+
+
+/// Test the DA Task for handling an outdated proposal.
+/// 
+/// This test checks that when an outdated DA proposal is received, it doesn't produce 
+/// any output, while a current proposal triggers appropriate actions (validation and voting).
+#[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
+#[cfg_attr(async_executor_impl = "async-std", async_std::test)]
+async fn test_da_task_outdated_proposal() {
+    // Setup logging and backtrace for debugging
+    async_compatibility_layer::logging::setup_logging();
+    async_compatibility_layer::logging::setup_backtrace();
+
+    // Parameters for the test
+    let node_id: u64 = 2;
+    let num_nodes: usize = 10;
+    let da_committee_size: usize = 7;
+
+    // Initialize test description with node and committee details
+    let test_description = TestDescription {
+        num_nodes_with_stake: num_nodes,
+        da_staked_committee_size: da_committee_size,
+        start_nodes: num_nodes,
+        ..TestDescription::default()
+    };
+
+    // Generate a launcher for the test system with a custom configuration
+    let launcher = test_description
+        .gen_launcher(node_id)
+        .modify_default_config(|config| {
+            config.next_view_timeout = 1000;
+            config.timeout_ratio = (12, 10);
+            config.da_staked_committee_size = da_committee_size;
+        });
+
+    // Build the system handle using the launcher configuration
+    let handle =
+        build_system_handle_from_launcher::<TestTypes, MemoryImpl, TestVersions>(node_id, launcher, None)
+            .await
+            .expect("Failed to initialize HotShot");
+
+    // Prepare empty transactions and compute a commitment for later use
+    let transactions = vec![TestTransaction::new(vec![0])];
+    let encoded_transactions = Arc::from(TestTransaction::encode(&transactions));
+    let (payload_commit, _precompute) = precompute_vid_commitment(
+        &encoded_transactions,
+        handle.hotshot.memberships.quorum_membership.total_nodes(),
+    );
+
+    // Initialize a view generator using the current memberships
+    let mut view_generator = TestViewGenerator::generate(
+        handle.hotshot.memberships.quorum_membership.clone(),
+        handle.hotshot.memberships.da_membership.clone(),
+    );
+
+    // Generate views for the test
+    let view1 = view_generator.next().await.unwrap();
+    let _view2 = view_generator.next().await.unwrap();
+    view_generator.add_transactions(transactions);
+    let view3 = view_generator.next().await.unwrap();
+
+    // Define input events for the test:
+    // 1. Three view changes and an outdated proposal for view 1 when in view 3
+    // 2. A current proposal for view 3
+    let inputs = vec![
+        serial![
+            HotShotEvent::ViewChange(ViewNumber::new(1)),
+            HotShotEvent::ViewChange(ViewNumber::new(2)),
+            HotShotEvent::ViewChange(ViewNumber::new(3)),
+            // Send an outdated proposal (view 1) when we're in view 3
+            HotShotEvent::DaProposalRecv(view1.da_proposal.clone(), view1.leader_public_key),
+        ],
+        serial![
+            // Send a current proposal (view 3)
+            HotShotEvent::DaProposalRecv(view3.da_proposal.clone(), view3.leader_public_key),
+        ],
+    ];
+
+    // Define expectations:
+    // 1. No output for the outdated proposal
+    // 2. Validation and voting actions for the current proposal
+    let expectations = vec![
+        Expectations::from_outputs(vec![]),
+        Expectations::from_outputs(vec![
+            exact(HotShotEvent::DaProposalValidated(
+                view3.da_proposal.clone(),
+                view3.leader_public_key,
+            )),
+            exact(HotShotEvent::DaVoteSend(view3.create_da_vote(
+                DaData {
+                    payload_commit,
+                },
+                &handle,
+            ))),
+        ]),
+    ];
+
+    // Define expectations for external events triggered by the system
+    let external_event_expectations = vec![expect_external_events(vec![ext_event_exact(Event {
+        view_number: view3.view_number,
+        event: EventType::DaProposal {
+            proposal: view3.da_proposal.clone(),
+            sender: view3.leader_public_key,
+        },
+    })])];
+
+    // Create DA task state and script for the test
+    let da_state = DaTaskState::<TestTypes, MemoryImpl>::create_from(&handle).await;
+    let mut da_script = TaskScript {
+        timeout: Duration::from_millis(100),
+        state: da_state,
+        expectations,
+    };
+
+    // Run the test with the inputs and check the resulting events
+    let output_event_stream_recv = handle.event_stream();
+    run_test![inputs, da_script].await;
+
+    // Validate the external events against expectations
+    let result = check_external_events(
+        output_event_stream_recv,
+        &external_event_expectations,
+        da_script.timeout,
+    )
+    .await;
+    assert!(result.is_ok(), "{}", result.err().unwrap());
+}
+
+/// Test the DA Task for handling duplicate votes.
+///
+/// This test ensures that when duplicate votes are received in the DA Task,
+/// they are correctly ignored without producing any output. The original
+/// proposal and vote are processed as expected, validating the proposal
+/// and sending the first vote, while the duplicate vote is disregarded.
+#[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
+#[cfg_attr(async_executor_impl = "async-std", async_std::test)]
+async fn test_da_task_duplicate_votes() {
+    // Setup logging and backtrace for debugging
+    async_compatibility_layer::logging::setup_logging();
+    async_compatibility_layer::logging::setup_backtrace();
+
+    // Parameters for the test
+    let node_id: u64 = 2;
+    let num_nodes: usize = 10;
+    let da_committee_size: usize = 7;
+
+    // Initialize test description with node and committee details
+    let test_description = TestDescription {
+        num_nodes_with_stake: num_nodes,
+        da_staked_committee_size: da_committee_size,
+        start_nodes: num_nodes,
+        ..TestDescription::default()
+    };
+
+    // Generate a launcher for the test system with a custom configuration
+    let launcher = test_description
+        .gen_launcher(node_id)
+        .modify_default_config(|config| {
+            config.next_view_timeout = 1000;
+            config.timeout_ratio = (12, 10);
+            config.da_staked_committee_size = da_committee_size;
+        });
+
+    // Build the system handle using the launcher configuration
+    let handle =
+        build_system_handle_from_launcher::<TestTypes, MemoryImpl, TestVersions>(node_id, launcher, None)
+            .await
+            .expect("Failed to initialize HotShot");
+
+    // Prepare empty transactions and compute a commitment for later use
+    let transactions = vec![TestTransaction::new(vec![0])];
+    let encoded_transactions = Arc::from(TestTransaction::encode(&transactions));
+    let (payload_commit, _precompute) = precompute_vid_commitment(
+        &encoded_transactions,
+        handle.hotshot.memberships.quorum_membership.total_nodes(),
+    );
+
+    // Initialize a view generator using the current memberships
+    let mut view_generator = TestViewGenerator::generate(
+        handle.hotshot.memberships.quorum_membership.clone(),
+        handle.hotshot.memberships.da_membership.clone(),
+    );
+
+    // Generate views for the test
+    let _view1 = view_generator.next().await.unwrap();
+    view_generator.add_transactions(transactions);
+    let view2 = view_generator.next().await.unwrap();
+
+    // Create a duplicate vote
+    let duplicate_vote = view2.create_da_vote(
+        DaData {
+            payload_commit,
+        },
+        &handle,
+    );
+
+    let inputs = vec![
+        serial![
+            HotShotEvent::ViewChange(ViewNumber::new(1)),
+            HotShotEvent::ViewChange(ViewNumber::new(2)),
+            HotShotEvent::DaProposalRecv(view2.da_proposal.clone(), view2.leader_public_key),
+        ],
+        serial![
+            // Send the original vote
+            HotShotEvent::DaVoteRecv(duplicate_vote.clone()),
+            // Send the duplicate vote
+            HotShotEvent::DaVoteRecv(duplicate_vote.clone()),
+        ],
+    ];
+
+    // We expect the task to process the proposal and the first vote, but ignore the duplicate
+    let expectations = vec![
+        Expectations::from_outputs(vec![
+            exact(HotShotEvent::DaProposalValidated(
+                view2.da_proposal.clone(),
+                view2.leader_public_key,
+            )),
+            exact(HotShotEvent::DaVoteSend(duplicate_vote.clone())),
+        ]),
+        Expectations::from_outputs(vec![
+            // No output expected for the duplicate vote
+        ]),
+    ];
+
+    // We expect to see an external event for the proposal, but not for individual votes
+    let external_event_expectations = vec![expect_external_events(vec![ext_event_exact(Event {
+        view_number: view2.view_number,
+        event: EventType::DaProposal {
+            proposal: view2.da_proposal.clone(),
+            sender: view2.leader_public_key,
+        },
+    })])];
+
+    // Create DA task state and script for the test
+    let da_state = DaTaskState::<TestTypes, MemoryImpl>::create_from(&handle).await;
+    let mut da_script = TaskScript {
+        timeout: Duration::from_millis(100),
+        state: da_state,
+        expectations,
+    };
+
+    // Run the test with the inputs and check the resulting events
+    let output_event_stream_recv = handle.event_stream();
+    run_test![inputs, da_script].await;
+
+    // Validate the external events against expectations
+    let result = check_external_events(
+        output_event_stream_recv,
+        &external_event_expectations,
+        da_script.timeout,
+    )
+    .await;
+    assert!(result.is_ok(), "{}", result.err().unwrap());
+}
+
+/// Tests the DA Task for collecting and processing valid votes.
+///
+/// This test verifies that the DA Task correctly handles the proposal and votes
+/// from DA committee members. It does the following:
+///
+/// 1. Initializes a test environment with multiple nodes, configuring one as the leader.
+/// 2. Creates and sends a DA proposal followed by valid votes from the committee.
+/// 3. Asserts that the proposal is validated and a vote is sent in response by the leader.
+///
+/// The test ensures that only the intended vote is processed.
+#[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
+#[cfg_attr(async_executor_impl = "async-std", async_std::test)]
+async fn test_da_task_vote_collection() {
+    // Initialize logging and backtrace for debugging
+    async_compatibility_layer::logging::setup_logging();
+    async_compatibility_layer::logging::setup_backtrace();
+
+    // Setup: Create system handles for multiple nodes (at least 5 for DA committee)
+    let leader_node_id: usize = 4;
+    let num_nodes: usize = 6;
+    let da_committee_size: usize = 5;
+
+    let test_description = TestDescription {
+        num_nodes_with_stake: num_nodes,
+        da_staked_committee_size: da_committee_size,
+        start_nodes: num_nodes,
+        ..TestDescription::default()
+    };
+
+    // Create handles and view generators for all nodes
+    let mut handles = Vec::new();
+    let mut view_generators = Vec::new();
+
+    for node_id in 0..num_nodes as u64 {
+        let launcher = test_description
+            .clone()
+            .gen_launcher(node_id)
+            .modify_default_config(|config| {
+                config.next_view_timeout = 1000;
+                config.timeout_ratio = (12, 10);
+                config.da_staked_committee_size = da_committee_size;
+            });
+
+        let handle =
+            build_system_handle_from_launcher::<TestTypes, MemoryImpl, TestVersions>(node_id, launcher, None)
+                .await
+                .expect("Failed to initialize HotShot");
+
+        // Create the scenario with necessary views
+        let view_generator = TestViewGenerator::generate(
+            handle.hotshot.memberships.quorum_membership.clone(),
+            handle.hotshot.memberships.da_membership.clone(),
+        );
+
+        handles.push(handle);
+        view_generators.push(view_generator);
+    }
+
+    // Prepare empty transactions and compute a commitment for later use
+    let transactions = vec![TestTransaction::new(vec![0])];
+    let encoded_transactions = Arc::from(TestTransaction::encode(&transactions));
+    let (payload_commit, _precompute) = precompute_vid_commitment(
+        &encoded_transactions,
+        handles[leader_node_id]
+            .hotshot
+            .memberships
+            .quorum_membership
+            .total_nodes(),
+    );
+
+    let _view1 = view_generators[leader_node_id].next().await.unwrap();
+    let _view2 = view_generators[leader_node_id].next().await.unwrap();
+    let _view3 = view_generators[leader_node_id].next().await.unwrap();
+    view_generators[leader_node_id].add_transactions(transactions);
+    let view4 = view_generators[leader_node_id].next().await.unwrap();
+
+    // Create votes for all nodes
+    let votes: Vec<_> = handles
+        .iter()
+        .map(|handle| view4.create_da_vote(DaData { payload_commit }, handle))
+        .collect();
+
+    // Simulate sending valid votes
+    let inputs = vec![
+        serial![
+            HotShotEvent::ViewChange(ViewNumber::new(1)),
+            HotShotEvent::ViewChange(ViewNumber::new(2)),
+            HotShotEvent::ViewChange(ViewNumber::new(3)),
+            HotShotEvent::ViewChange(ViewNumber::new(4)),
+            HotShotEvent::DaProposalRecv(view4.da_proposal.clone(), view4.leader_public_key),
+        ],
+        serial![
+            // Send votes from the DA committee members
+            HotShotEvent::DaVoteRecv(votes[0].clone()),
+            HotShotEvent::DaVoteRecv(votes[1].clone()),
+            HotShotEvent::DaVoteRecv(votes[2].clone()),
+            HotShotEvent::DaVoteRecv(votes[3].clone()),
+        ],
+    ];
+
+    // Assert the outcome
+    let expectations = vec![
+        Expectations::from_outputs(vec![
+            exact(HotShotEvent::DaProposalValidated(
+                view4.da_proposal.clone(),
+                view4.leader_public_key,
+            )),
+            exact(HotShotEvent::DaVoteSend(votes[leader_node_id].clone())),
+        ]),
+        Expectations::from_outputs(vec![exact(HotShotEvent::DacSend(
+            view4.da_certificate,
+            view4.leader_public_key,
+        ))]),
+    ];
+
+    // Create DA task state and script
+    let da_state =
+        DaTaskState::<TestTypes, MemoryImpl>::create_from(&handles[leader_node_id]).await;
+    let mut da_script = TaskScript {
+        timeout: Duration::from_millis(100),
+        state: da_state,
+        expectations,
+    };
+
+    // Run the test
+    let output_event_stream_recv = handles[leader_node_id].event_stream();
+    run_test![inputs, da_script].await;
+
+    // Check for DacSend event in the output stream
+    let result = check_external_events(
+        output_event_stream_recv,
+        &[expect_external_events(vec![ext_event_exact(Event {
+            view_number: view4.view_number,
+            event: EventType::DaProposal {
+                proposal: view4.da_proposal.clone(),
+                sender: view4.leader_public_key,
+            },
+        })])],
+        da_script.timeout,
+    )
+    .await;
+    assert!(result.is_ok(), "{}", result.err().unwrap());
+}
+
+/// Test that non-leader nodes correctly handle DA (Data Availability) votes and
+/// ignore the certificate event when the node is not the leader during the voting process.
+///
+/// This test sets up a scenario where a specific node (not the leader) processes
+/// multiple views and receives votes from DA committee members. The test checks
+/// that the expected outcome occurs, verifying that a `DacSend` event is not
+/// generated since the node is not the leader.
+#[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
+#[cfg_attr(async_executor_impl = "async-std", async_std::test)]
+async fn test_da_task_non_leader_vote_collection_ignore() {
+    // Initialize logging and backtrace for debugging
+    async_compatibility_layer::logging::setup_logging();
+    async_compatibility_layer::logging::setup_backtrace();
+
+    // Setup: Create system handles for multiple nodes (at least 5 for DA committee)
+    let leader_node_id: usize = 3;
+    let num_nodes: usize = 6;
+    let da_committee_size: usize = 5;
+
+    let test_description = TestDescription {
+        num_nodes_with_stake: num_nodes,
+        da_staked_committee_size: da_committee_size,
+        start_nodes: num_nodes,
+        ..TestDescription::default()
+    };
+
+    // Create handles and view generators for all nodes
+    let mut handles = Vec::new();
+    let mut view_generators = Vec::new();
+
+    for node_id in 0..num_nodes as u64 {
+        let launcher = test_description
+            .clone()
+            .gen_launcher(node_id)
+            .modify_default_config(|config| {
+                config.next_view_timeout = 1000;
+                config.timeout_ratio = (12, 10);
+                config.da_staked_committee_size = da_committee_size;
+            });
+
+        let handle =
+            build_system_handle_from_launcher::<TestTypes, MemoryImpl, TestVersions>(node_id, launcher, None)
+                .await
+                .expect("Failed to initialize HotShot");
+
+        // Create the scenario with necessary views
+        let view_generator = TestViewGenerator::generate(
+            handle.hotshot.memberships.quorum_membership.clone(),
+            handle.hotshot.memberships.da_membership.clone(),
+        );
+
+        handles.push(handle);
+        view_generators.push(view_generator);
+    }
+
+    // Prepare empty transactions and compute a commitment for later use
+    let transactions = vec![TestTransaction::new(vec![0])];
+    let encoded_transactions = Arc::from(TestTransaction::encode(&transactions));
+    let (payload_commit, _precompute) = precompute_vid_commitment(
+        &encoded_transactions,
+        handles[leader_node_id]
+            .hotshot
+            .memberships
+            .quorum_membership
+            .total_nodes(),
+    );
+
+    // Generate multiple views and add transactions for the leader node
+    let _view1 = view_generators[leader_node_id].next().await.unwrap();
+    let _view2 = view_generators[leader_node_id].next().await.unwrap();
+    let _view3 = view_generators[leader_node_id].next().await.unwrap();
+    view_generators[leader_node_id].add_transactions(transactions);
+    let view4 = view_generators[leader_node_id].next().await.unwrap();
+
+    // Create votes for all nodes
+    let votes: Vec<_> = handles
+        .iter()
+        .map(|handle| view4.create_da_vote(DaData { payload_commit }, handle))
+        .collect();
+
+    // Simulate sending valid votes and a proposal to the DA committee
+    let inputs = vec![
+        serial![
+            HotShotEvent::ViewChange(ViewNumber::new(1)),
+            HotShotEvent::ViewChange(ViewNumber::new(2)),
+            HotShotEvent::ViewChange(ViewNumber::new(3)),
+            HotShotEvent::ViewChange(ViewNumber::new(4)),
+            HotShotEvent::DaProposalRecv(view4.da_proposal.clone(), view4.leader_public_key),
+        ],
+        serial![
+            // Send votes from the DA committee members
+            HotShotEvent::DaVoteRecv(votes[0].clone()),
+            HotShotEvent::DaVoteRecv(votes[1].clone()),
+            HotShotEvent::DaVoteRecv(votes[2].clone()),
+            HotShotEvent::DaVoteRecv(votes[3].clone()),
+        ],
+    ];
+
+    // Define the expected outcome for the non-leader node
+    let expectations = vec![
+        Expectations::from_outputs(vec![
+            exact(HotShotEvent::DaProposalValidated(
+                view4.da_proposal.clone(),
+                view4.leader_public_key,
+            )),
+            exact(HotShotEvent::DaVoteSend(votes[leader_node_id].clone())),
+        ]),
+        Expectations::from_outputs(vec![]),
+    ];
+
+    // Create DA task state and script for the test
+    let da_state =
+        DaTaskState::<TestTypes, MemoryImpl>::create_from(&handles[leader_node_id]).await;
+    let mut da_script = TaskScript {
+        timeout: Duration::from_millis(100),
+        state: da_state,
+        expectations,
+    };
+
+    // Run the test with the prepared inputs and script
+    let output_event_stream_recv = handles[leader_node_id].event_stream();
+    run_test![inputs, da_script].await;
+
+    // Verify that the non-leader node did not generate the DacSend event
+    let result = check_external_events(
+        output_event_stream_recv,
+        &[expect_external_events(vec![ext_event_exact(Event {
+            view_number: view4.view_number,
+            event: EventType::DaProposal {
+                proposal: view4.da_proposal.clone(),
+                sender: view4.leader_public_key,
+            },
+        })])],
+        da_script.timeout,
+    )
+    .await;
+    assert!(result.is_ok(), "{}", result.err().unwrap());
+}

--- a/crates/types/src/event.rs
+++ b/crates/types/src/event.rs
@@ -173,6 +173,70 @@ pub enum EventType<TYPES: NodeType> {
     /// A message destined for external listeners was received
     ExternalMessageReceived(Vec<u8>),
 }
+
+// Implement Eq as well, since EventType should have reflexive equality
+impl<TYPES: NodeType> Eq for EventType<TYPES> {}
+
+impl<TYPES: NodeType> PartialEq for EventType<TYPES> {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (
+                EventType::DaProposal {
+                    proposal: p1,
+                    sender: s1,
+                },
+                EventType::DaProposal {
+                    proposal: p2,
+                    sender: s2,
+                },
+            ) => p1 == p2 && s1 == s2,
+            (
+                EventType::ReplicaViewTimeout { view_number: v1 },
+                EventType::ReplicaViewTimeout { view_number: v2 },
+            )
+            | (
+                EventType::ViewFinished { view_number: v1 },
+                EventType::ViewFinished { view_number: v2 },
+            )
+            | (
+                EventType::ViewTimeout { view_number: v1 },
+                EventType::ViewTimeout { view_number: v2 },
+            ) => v1 == v2,
+            (
+                EventType::Transactions { transactions: t1 },
+                EventType::Transactions { transactions: t2 },
+            ) => t1 == t2,
+            (
+                EventType::QuorumProposal {
+                    proposal: p1,
+                    sender: s1,
+                },
+                EventType::QuorumProposal {
+                    proposal: p2,
+                    sender: s2,
+                },
+            ) => p1 == p2 && s1 == s2,
+            (
+                EventType::UpgradeProposal {
+                    proposal: p1,
+                    sender: s1,
+                },
+                EventType::UpgradeProposal {
+                    proposal: p2,
+                    sender: s2,
+                },
+            ) => p1 == p2 && s1 == s2,
+            (EventType::ExternalMessageReceived(m1), EventType::ExternalMessageReceived(m2)) => {
+                m1 == m2
+            }
+            (event_v1, _event_v2) => unreachable!(
+                "TODO: PartialEq not yet implemented for this EventType variant {:#?}",
+                event_v1
+            ),
+        }
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 /// A list of actions that we track for nodes
 pub enum HotShotAction {


### PR DESCRIPTION
## This PR:

This PR partially addresses issue [#3160](https://github.com/EspressoSystems/HotShot/issues/3160) by adding test cases for the following scenarios:

- Handling outdated proposals.
- Detecting duplicate votes.
- Validating vote collection and processing.
- Ensuring non-leader nodes correctly handle DA votes.

## Key Changes

1. Added a new test file: `crates/testing/tests/tests_cx_hardening/cxh_da_task.rs`.
2. Introduced the `create_lean_test_handle()` function to create a lightweight system handle for task state testing.
3. Fixed a bug in the `build_da_cert<>` function located in `HotShot/crates/testing/src/helpers.rs`.
4. Enhanced test functionality to verify external events on `output_event_stream`.

**This PR does not:**

- Introduce any other changes beyond the mentioned test cases and bug fixes.

**Key Areas to Review:**

1. All files committed as part of this PR.