### PR TITLE
Update builder marketplace API

### DIFF
--- a/crates/builder-api/api/v0_3/builder.toml
+++ b/crates/builder-api/api/v0_3/builder.toml
@@ -27,7 +27,9 @@ DESCRIPTION = ""
 FORMAT_VERSION = "0.1.0"
 
 [route.bundle]
-PATH = ["bundle/:view_number"]
+PATH = ["bundle/:parent_view/:parent_hash/:view_number"]
+":parent_view" = "Integer"
+":parent_hash" = "TaggedBase64"
 ":view_number" = "Integer"
 DOC = """
 Fetch the bundle from the builder for the specified view.

--- a/crates/libp2p-networking/src/network/def.rs
+++ b/crates/libp2p-networking/src/network/def.rs
@@ -4,6 +4,7 @@
 // You should have received a copy of the MIT License
 // along with the HotShot repository. If not, see <https://mit-license.org/>.
 
+use hotshot_types::request_response::{Request, Response};
 use libp2p::{
     autonat,
     gossipsub::{Behaviour as GossipBehaviour, Event as GossipEvent, IdentTopic},
@@ -17,7 +18,6 @@ use libp2p_swarm_derive::NetworkBehaviour;
 use tracing::{debug, error};
 
 use super::NetworkEventInternal;
-use hotshot_types::request_response::{Request, Response};
 
 /// Overarching network behaviour performing:
 /// - network topology discovoery

--- a/crates/task-impls/src/builder.rs
+++ b/crates/task-impls/src/builder.rs
@@ -203,7 +203,9 @@ pub mod v0_2 {
 /// Version 0.3: marketplace. Bundles.
 pub mod v0_3 {
     pub use hotshot_builder_api::v0_3::Version;
-    use hotshot_types::{bundle::Bundle, traits::node_implementation::NodeType};
+    use hotshot_types::{
+        bundle::Bundle, traits::node_implementation::NodeType, vid::VidCommitment,
+    };
     use vbs::version::StaticVersion;
 
     pub use super::BuilderClientError;
@@ -217,9 +219,14 @@ pub mod v0_3 {
         /// # Errors
         /// - [`BuilderClientError::NotFound`] if block isn't available
         /// - [`BuilderClientError::Api`] if API isn't responding or responds incorrectly
-        pub async fn bundle(&self, view_number: u64) -> Result<Bundle<TYPES>, BuilderClientError> {
+        pub async fn bundle(
+            &self,
+            parent_view: u64,
+            parent_hash: VidCommitment,
+            view_number: u64,
+        ) -> Result<Bundle<TYPES>, BuilderClientError> {
             self.inner
-                .get(&format!("bundle/{view_number}"))
+                .get(&format!("bundle/{parent_view}/{parent_hash}/{view_number}"))
                 .send()
                 .await
                 .map_err(Into::into)

--- a/crates/task-impls/src/transactions.rs
+++ b/crates/task-impls/src/transactions.rs
@@ -233,6 +233,10 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> TransactionTask
     }
 
     /// Produce a block by fetching auction results from the solver and bundles from builders.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the solver cannot be contacted, or if none of the builders respond.
     pub async fn produce_block_marketplace(
         &mut self,
         parent_view: TYPES::Time,
@@ -299,7 +303,8 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> TransactionTask
 
         let validated_state = self.consensus.read().await.decided_state();
 
-        let sequencing_fees = Vec1::try_from_vec(sequencing_fees)?;
+        let sequencing_fees = Vec1::try_from_vec(sequencing_fees)
+            .context("Failed to receive a bundle from any builder.")?;
         let (block_payload, metadata) = TYPES::BlockPayload::from_transactions(
             transactions,
             &validated_state,

--- a/crates/task-impls/src/transactions.rs
+++ b/crates/task-impls/src/transactions.rs
@@ -292,7 +292,14 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> TransactionTask
         for bundle in join_all(futures).await {
             match bundle {
                 Ok(Ok(b)) => bundles.push(b),
-                _ => continue,
+                Ok(Err(e)) => {
+                    tracing::debug!("Failed to retrieve bundle: {e}");
+                    continue;
+                }
+                Err(e) => {
+                    tracing::debug!("Failed to retrieve bundle: {e}");
+                    continue;
+                }
             }
         }
 

--- a/crates/types/src/request_response.rs
+++ b/crates/types/src/request_response.rs
@@ -7,11 +7,12 @@
 //! Types for the request/response implementations. This module incorporates all
 //! of the shared types for all of the network backends.
 
-use crate::traits::network::NetworkMsg;
 use async_lock::Mutex;
 use futures::channel::{mpsc::Receiver, oneshot};
 use libp2p::request_response::ResponseChannel;
 use serde::{Deserialize, Serialize};
+
+use crate::traits::network::NetworkMsg;
 
 /// Request for Consenus data
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]


### PR DESCRIPTION
### This PR: 
Changes the builder marketplace API to include a parent view and parent commitment.

This made the fallback logic for returning an empty block even more unwieldy, so this PR also includes some changes to the transactions task marketplace logic.

### This PR does not: 

### Key places to review: 
