### PR TITLE
Add test for verify_share return type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4130,6 +4130,7 @@ dependencies = [
 [[package]]
 name = "jf-vid"
 version = "0.1.0"
+source = "git+https://github.com/EspressoSystems/jellyfish?tag=0.4.5#7d71dbeff14f1a501b0b0dc391f1dffa1b8374fb"
 dependencies = [
  "anyhow",
  "ark-ec",
@@ -4226,7 +4227,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.5",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -6980,7 +6981,7 @@ version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38d1e02fca405f6280643174a50c942219f0bbf4dbf7d480f1dd864d6f211ae5"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.75",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4130,6 +4130,7 @@ dependencies = [
 [[package]]
 name = "jf-vid"
 version = "0.1.0"
+source = "git+https://github.com/EspressoSystems/jellyfish?tag=0.4.5#7d71dbeff14f1a501b0b0dc391f1dffa1b8374fb"
 dependencies = [
  "anyhow",
  "ark-ec",
@@ -4226,7 +4227,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -6980,7 +6981,7 @@ version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38d1e02fca405f6280643174a50c942219f0bbf4dbf7d480f1dd864d6f211ae5"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.75",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4130,7 +4130,6 @@ dependencies = [
 [[package]]
 name = "jf-vid"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/jellyfish?tag=0.4.5#7d71dbeff14f1a501b0b0dc391f1dffa1b8374fb"
 dependencies = [
  "anyhow",
  "ark-ec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -177,3 +177,6 @@ rust_2018_idioms = "warn"
 # TODO change to deny
 missing_docs = "warn"
 warnings = "warn"
+
+[patch."https://github.com/EspressoSystems/jellyfish"]
+jf-vid = { path = "../jellyfish/vid"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -177,6 +177,3 @@ rust_2018_idioms = "warn"
 # TODO change to deny
 missing_docs = "warn"
 warnings = "warn"
-
-[patch."https://github.com/EspressoSystems/jellyfish"]
-jf-vid = { path = "../jellyfish/vid"}

--- a/crates/task-impls/Cargo.toml
+++ b/crates/task-impls/Cargo.toml
@@ -10,6 +10,7 @@ example-upgrade = []
 gpu-vid = ["hotshot-types/gpu-vid"]
 dependency-tasks = []
 rewind = []
+test-srs = ["jf-vid/test-srs"]
 
 [dependencies]
 anyhow = { workspace = true }

--- a/crates/task-impls/src/consensus/mod.rs
+++ b/crates/task-impls/src/consensus/mod.rs
@@ -177,19 +177,16 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> ConsensusTaskSt
         }
 
         // Validate the VID share.
-        if vid_scheme(self.quorum_membership.total_nodes())
-            .verify_share(
-                &disperse.data.share,
-                &disperse.data.common,
-                &payload_commitment,
-            )
-            .is_err()
-        {
-            debug!("Invalid VID share.");
-            return false;
+        // NOTE: `verify_share` returns a nested `Result`, so we must check both the inner
+        // and outer results
+        match vid_scheme(self.quorum_membership.total_nodes()).verify_share(
+            &disperse.data.share,
+            &disperse.data.common,
+            &payload_commitment,
+        ) {
+            Ok(inner) => inner.is_ok(),
+            Err(_) => false,
         }
-
-        true
     }
 
     /// Publishes a proposal

--- a/crates/task-impls/src/consensus/mod.rs
+++ b/crates/task-impls/src/consensus/mod.rs
@@ -184,8 +184,8 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> ConsensusTaskSt
             &disperse.data.common,
             &payload_commitment,
         ) {
-            Ok(inner) => inner.is_ok(),
-            Err(_) => false,
+            Ok(Ok(_)) => true,
+            _ => false,
         }
     }
 

--- a/crates/task-impls/src/consensus/mod.rs
+++ b/crates/task-impls/src/consensus/mod.rs
@@ -179,14 +179,14 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> ConsensusTaskSt
         // Validate the VID share.
         // NOTE: `verify_share` returns a nested `Result`, so we must check both the inner
         // and outer results
-        match vid_scheme(self.quorum_membership.total_nodes()).verify_share(
-            &disperse.data.share,
-            &disperse.data.common,
-            &payload_commitment,
-        ) {
-            Ok(Ok(_)) => true,
-            _ => false,
-        }
+        matches!(
+            vid_scheme(self.quorum_membership.total_nodes()).verify_share(
+                &disperse.data.share,
+                &disperse.data.common,
+                &payload_commitment,
+            ),
+            Ok(Ok(()))
+        )
     }
 
     /// Publishes a proposal

--- a/crates/task-impls/src/quorum_vote/mod.rs
+++ b/crates/task-impls/src/quorum_vote/mod.rs
@@ -605,16 +605,19 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> QuorumVoteTaskS
                         return;
                     }
                 }
-                if vid_scheme(self.quorum_membership.total_nodes())
-                    .verify_share(
-                        &disperse.data.share,
-                        &disperse.data.common,
-                        &payload_commitment,
-                    )
-                    .is_err()
-                {
-                    debug!("Invalid VID share.");
-                    return;
+                // NOTE: `verify_share` returns a nested `Result`, so we must check both the inner
+                // and outer results
+                match vid_scheme(self.quorum_membership.total_nodes()).verify_share(
+                    &disperse.data.share,
+                    &disperse.data.common,
+                    &payload_commitment,
+                ) {
+                    Ok(inner) => {
+                        if inner.is_err() {
+                            return
+                        }
+                    }
+                    Err(_) => return
                 }
 
                 self.consensus

--- a/crates/task-impls/src/quorum_vote/mod.rs
+++ b/crates/task-impls/src/quorum_vote/mod.rs
@@ -607,15 +607,16 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> QuorumVoteTaskS
                 }
                 // NOTE: `verify_share` returns a nested `Result`, so we must check both the inner
                 // and outer results
+                #[allow(clippy::no_effect)]
                 match vid_scheme(self.quorum_membership.total_nodes()).verify_share(
                     &disperse.data.share,
                     &disperse.data.common,
                     &payload_commitment,
                 ) {
-                    Ok(Err(_)) | Err(_) => {
+                    Ok(Err(())) | Err(_) => {
                         return;
                     }
-                    Ok(Ok(_)) => {
+                    Ok(Ok(())) => {
                         ();
                     }
                 }

--- a/crates/task-impls/src/quorum_vote/mod.rs
+++ b/crates/task-impls/src/quorum_vote/mod.rs
@@ -614,10 +614,10 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> QuorumVoteTaskS
                 ) {
                     Ok(inner) => {
                         if inner.is_err() {
-                            return
+                            return;
                         }
                     }
-                    Err(_) => return
+                    Err(_) => return,
                 }
 
                 self.consensus

--- a/crates/task-impls/src/quorum_vote/mod.rs
+++ b/crates/task-impls/src/quorum_vote/mod.rs
@@ -612,12 +612,12 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> QuorumVoteTaskS
                     &disperse.data.common,
                     &payload_commitment,
                 ) {
-                    Ok(inner) => {
-                        if inner.is_err() {
-                            return;
-                        }
+                    Ok(Err(_)) | Err(_) => {
+                        return;
                     }
-                    Err(_) => return,
+                    Ok(Ok(_)) => {
+                        ();
+                    }
                 }
 
                 self.consensus

--- a/crates/testing/Cargo.toml
+++ b/crates/testing/Cargo.toml
@@ -12,6 +12,7 @@ slow-tests = []
 gpu-vid = ["hotshot-types/gpu-vid"]
 dependency-tasks = ["hotshot/dependency-tasks"]
 rewind = ["hotshot/rewind"]
+test-srs = ["jf-vid/test-srs"]
 
 [dependencies]
 automod = "1.0.14"

--- a/crates/testing/tests/tests_1/consensus_task.rs
+++ b/crates/testing/tests/tests_1/consensus_task.rs
@@ -609,7 +609,6 @@ async fn test_vid_disperse_storage_failure() {
 #[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 #[cfg(feature = "test-srs")]
-#[ignore]
 async fn test_invalid_vid_disperse() {
     use hotshot_testing::{
         helpers::{build_payload_commitment, build_vid_proposal},

--- a/crates/testing/tests/tests_1/consensus_task.rs
+++ b/crates/testing/tests/tests_1/consensus_task.rs
@@ -609,7 +609,8 @@ async fn test_vid_disperse_storage_failure() {
 #[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 #[cfg(feature = "test-srs")]
-async fn test_invalid_vid_disperse() {
+#[ignore]
+async fn () {
     use hotshot_testing::{
         helpers::{build_payload_commitment, build_vid_proposal},
         test_builder::TestDescription,

--- a/crates/testing/tests/tests_1/consensus_task.rs
+++ b/crates/testing/tests/tests_1/consensus_task.rs
@@ -610,7 +610,7 @@ async fn test_vid_disperse_storage_failure() {
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 #[cfg(feature = "test-srs")]
 #[ignore]
-async fn () {
+async fn test_invalid_vid_disperse() {
     use hotshot_testing::{
         helpers::{build_payload_commitment, build_vid_proposal},
         test_builder::TestDescription,

--- a/crates/types/src/vid.rs
+++ b/crates/types/src/vid.rs
@@ -231,6 +231,12 @@ impl VidScheme for VidSchemeType {
     fn get_multiplicity(common: &Self::Common) -> u32 {
         <Advz as VidScheme>::get_multiplicity(common)
     }
+
+    /// Helper function for testing only
+    #[cfg(feature = "test-srs")]
+    fn corrupt_share_index(&self, share: Self::Share) -> Self::Share {
+        self.0.corrupt_share_index(share)
+    }
 }
 
 impl PayloadProver<LargeRangeProofType> for VidSchemeType {


### PR DESCRIPTION
Closes #<ISSUE_NUMBER>
<!-- See here for keywords in Github -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

### This PR: 
This PR fixes a bug where an invalid vid share could be marked as valid.  Specifically, the `verify_share` function from jellyfish returns a nested `Result`.  Previously we were only checking the outer result.  This means that a call to `verify_share` that returned a result of `Ok(Err)` would be incorrectly return `true`.  This PR checks both the inner and outer results.  

### This PR does not: 
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->

### Key places to review: 
`task_impls/src/consensus/mod.rs`
`testing/test-1/consensus_task.rs`
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->

 ### How to test this PR: 
To test this PR, check out this branch.  Next, check out the following branch of jellyfish locally, `309fb5ba80a2b401dc7d5c355ff5cecece8fa412`.  This jellyfish branch contains a function to create a corrupt VID share in the exact way we were not covering before.  This commit in HotShot contains the `test_invalid_vid_disperse` test, but it is currently ignored.  To test that the test is doing what it is supposed to, revert the change in the `consensus/mod.rs` file to what it was previously.  The test will now fail.  

To run the test use the following command: 
`just tokio test test_invalid_vid_disperse --features=test-srs`

NOTE: This test is ignored in the final commit because the corresponding function in jellyfish will likely not be merged soon, if at all.  The test is gated by the `test-srs` feature to ensure it does not compile during normal testing.  The point is just to demonstrate the old bug and that it was fixed.  It might make sense to only merge the bug fixes and not the tests. 

Tagging @jparr721 in case we want to look for bugs of a similar class. 

<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
