### PR TITLE
Don't auto-assign people to draft PRs

### DIFF
--- a/.github/workflows/assign-reviewers.yml
+++ b/.github/workflows/assign-reviewers.yml
@@ -17,7 +17,7 @@ jobs:
 
           chosen=$(perl \
             -e 'use List::Util qw(shuffle head);' \
-            -e 'my @assignees = grep { "${{ github.event.actor }}" ne $_ } shuffle split /\s+/, $ENV{ASSIGNEES};' \
+            -e 'my @assignees = grep { "${{ github.event.sender }}" ne $_ } shuffle split /\s+/, $ENV{ASSIGNEES};' \
             -e 'print join ",", head $ENV{NUM_ASSIGNEES}, @assignees' \
           )
 

--- a/.github/workflows/assign-reviewers.yml
+++ b/.github/workflows/assign-reviewers.yml
@@ -6,14 +6,21 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
     steps:
       - name: Choose random assignees
         run: |
+          # Skip PRs that have assignees already
+          gh pr view ${{ github.event.number }} --repo ${{ github.repository }} --json assignees \
+            | jq '.assignees | length > 0' -e && \
+            exit 0
+
           chosen=$(perl \
             -e 'use List::Util qw(shuffle head);' \
             -e 'my @assignees = grep { "${{ github.event.actor }}" ne $_ } shuffle split /\s+/, $ENV{ASSIGNEES};' \
             -e 'print join ",", head $ENV{NUM_ASSIGNEES}, @assignees' \
           )
+
           gh pr edit ${{ github.event.number }} --add-assignee $chosen --repo ${{ github.repository }}
     env:
       GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Closes #<ISSUE_NUMBER>
<!-- See here for keywords in Github -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

### This PR: 
<!-- Describe what this PR adds to HotSHot -->
<!-- E.g. -->
<!-- * Implements feature 1 -->
<!-- * Implements feature 2 -->
<!-- * Fixes bug 3 -->

### This PR does not: 
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->

### Key places to review: 
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
