### PR TITLE
Clean up Libp2p

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4533,6 +4533,7 @@ dependencies = [
  "libp2p-identity",
  "libp2p-swarm-derive",
  "pin-project",
+ "portpicker",
  "rand 0.8.5",
  "serde",
  "serde_bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3076,7 +3076,7 @@ dependencies = [
 
 [[package]]
 name = "hotshot"
-version = "0.5.71"
+version = "0.5.72"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -3142,7 +3142,7 @@ dependencies = [
 
 [[package]]
 name = "hotshot-example-types"
-version = "0.5.71"
+version = "0.5.72"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -3174,7 +3174,7 @@ dependencies = [
 
 [[package]]
 name = "hotshot-examples"
-version = "0.5.71"
+version = "0.5.72"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -3224,7 +3224,7 @@ dependencies = [
 
 [[package]]
 name = "hotshot-fakeapi"
-version = "0.5.71"
+version = "0.5.72"
 dependencies = [
  "anyhow",
  "async-lock 2.8.0",
@@ -3242,7 +3242,7 @@ dependencies = [
 
 [[package]]
 name = "hotshot-macros"
-version = "0.5.71"
+version = "0.5.72"
 dependencies = [
  "derive_builder",
  "proc-macro2",
@@ -3252,7 +3252,7 @@ dependencies = [
 
 [[package]]
 name = "hotshot-orchestrator"
-version = "0.5.71"
+version = "0.5.72"
 dependencies = [
  "anyhow",
  "async-compatibility-layer",
@@ -3281,7 +3281,7 @@ dependencies = [
 
 [[package]]
 name = "hotshot-stake-table"
-version = "0.5.71"
+version = "0.5.72"
 dependencies = [
  "ark-bn254",
  "ark-ed-on-bn254",
@@ -3302,7 +3302,7 @@ dependencies = [
 
 [[package]]
 name = "hotshot-task"
-version = "0.5.71"
+version = "0.5.72"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -3316,7 +3316,7 @@ dependencies = [
 
 [[package]]
 name = "hotshot-task-impls"
-version = "0.5.71"
+version = "0.5.72"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -3352,7 +3352,7 @@ dependencies = [
 
 [[package]]
 name = "hotshot-testing"
-version = "0.5.71"
+version = "0.5.72"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -4513,7 +4513,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-networking"
-version = "0.5.71"
+version = "0.5.72"
 dependencies = [
  "anyhow",
  "async-compatibility-layer",

--- a/crates/examples/Cargo.toml
+++ b/crates/examples/Cargo.toml
@@ -105,7 +105,7 @@ snafu = { workspace = true }
 surf-disco = { workspace = true }
 time = { workspace = true }
 derive_more = { workspace = true }
-portpicker = "0.1"
+portpicker.workspace = true
 lru.workspace = true
 hotshot-task = { path = "../task" }
 hotshot = { path = "../hotshot" }

--- a/crates/examples/infra/mod.rs
+++ b/crates/examples/infra/mod.rs
@@ -64,6 +64,7 @@ use hotshot_types::{
     },
     HotShotConfig, PeerConfig, ValidatorConfig,
 };
+use libp2p_networking::network::GossipConfig;
 use rand::{rngs::StdRng, SeedableRng};
 use surf_disco::Url;
 use tracing::{debug, error, info, warn};
@@ -735,6 +736,7 @@ where
         // Create the Libp2p network
         let libp2p_network = Libp2pNetwork::from_config::<TYPES>(
             config.clone(),
+            GossipConfig::default(),
             bind_address,
             &public_key,
             &private_key,

--- a/crates/hotshot/src/traits/networking/libp2p_network.rs
+++ b/crates/hotshot/src/traits/networking/libp2p_network.rs
@@ -267,8 +267,9 @@ impl<TYPES: NodeType> TestableNetworkingImplementation<TYPES>
                 )
                 .expect("Failed to sign DHT lookup record");
 
-                // We want 2/3 of the nodes to have any given record in the DHT
-                let replication_factor = NonZeroUsize::new(2 * expected_node_count / 3).unwrap();
+                // We want at least 2/3 of the nodes to have any given record in the DHT
+                let replication_factor =
+                    NonZeroUsize::new((2 * expected_node_count).div_ceil(3)).unwrap();
 
                 // Build the network node configuration
                 let config = NetworkNodeConfigBuilder::default()

--- a/crates/libp2p-networking/Cargo.toml
+++ b/crates/libp2p-networking/Cargo.toml
@@ -38,6 +38,7 @@ tracing = { workspace = true }
 void = "1"
 lazy_static = { workspace = true }
 pin-project = "1"
+portpicker.workspace = true
 
 [target.'cfg(all(async_executor_impl = "tokio"))'.dependencies]
 libp2p = { workspace = true, features = ["tokio"] }

--- a/crates/libp2p-networking/src/network/mod.rs
+++ b/crates/libp2p-networking/src/network/mod.rs
@@ -15,7 +15,7 @@ mod node;
 /// Alternative Libp2p transport implementations
 pub mod transport;
 
-use std::{collections::HashSet, fmt::Debug, str::FromStr};
+use std::{collections::HashSet, fmt::Debug};
 
 use futures::channel::oneshot::{self, Sender};
 use hotshot_types::{
@@ -41,7 +41,6 @@ use libp2p_identity::PeerId;
 use quic::async_std::Transport as QuicTransport;
 #[cfg(async_executor_impl = "tokio")]
 use quic::tokio::Transport as QuicTransport;
-use serde::{Deserialize, Serialize};
 use tracing::instrument;
 use transport::StakeTableAuthentication;
 
@@ -56,41 +55,6 @@ pub use self::{
 };
 #[cfg(not(any(async_executor_impl = "async-std", async_executor_impl = "tokio")))]
 compile_error! {"Either config option \"async-std\" or \"tokio\" must be enabled for this crate."}
-
-/// this is mostly to estimate how many network connections
-/// a node should allow
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Deserialize, Serialize)]
-pub enum NetworkNodeType {
-    /// bootstrap node accepts all connections
-    Bootstrap,
-    /// regular node has a limit to the
-    /// number of connections to accept
-    Regular,
-    /// conductor node is never pruned
-    Conductor,
-}
-
-impl FromStr for NetworkNodeType {
-    type Err = String;
-
-    fn from_str(input: &str) -> Result<NetworkNodeType, Self::Err> {
-        match input {
-            "Conductor" => Ok(NetworkNodeType::Conductor),
-            "Regular" => Ok(NetworkNodeType::Regular),
-            "Bootstrap" => Ok(NetworkNodeType::Bootstrap),
-            _ => Err(
-                "Couldn't parse node type. Must be one of Conductor, Bootstrap, Regular"
-                    .to_string(),
-            ),
-        }
-    }
-}
-
-impl Default for NetworkNodeType {
-    fn default() -> Self {
-        Self::Bootstrap
-    }
-}
 
 /// Actions to send from the client to the swarm
 #[derive(Debug)]

--- a/crates/libp2p-networking/src/network/mod.rs
+++ b/crates/libp2p-networking/src/network/mod.rs
@@ -48,9 +48,9 @@ pub use self::{
     def::NetworkDef,
     error::NetworkError,
     node::{
-        network_node_handle_error, spawn_network_node, MeshParams, NetworkNode, NetworkNodeConfig,
-        NetworkNodeConfigBuilder, NetworkNodeConfigBuilderError, NetworkNodeHandle,
-        NetworkNodeHandleError, NetworkNodeReceiver, DEFAULT_REPLICATION_FACTOR,
+        network_node_handle_error, spawn_network_node, GossipConfig, NetworkNode,
+        NetworkNodeConfig, NetworkNodeConfigBuilder, NetworkNodeConfigBuilderError,
+        NetworkNodeHandle, NetworkNodeHandleError, NetworkNodeReceiver, DEFAULT_REPLICATION_FACTOR,
     },
 };
 #[cfg(not(any(async_executor_impl = "async-std", async_executor_impl = "tokio")))]

--- a/crates/libp2p-networking/src/network/node.rs
+++ b/crates/libp2p-networking/src/network/node.rs
@@ -202,7 +202,7 @@ impl<K: SignatureKey + 'static> NetworkNode<K> {
             };
 
             // Use the default mesh parameters if none are provided
-            let mesh_params = config.clone().mesh_params.unwrap_or_default();
+            let mesh_params = config.mesh_params.clone().unwrap_or_default();
 
             // Create a custom gossipsub
             let gossipsub_config = GossipsubConfigBuilder::default()

--- a/crates/libp2p-networking/src/network/node.rs
+++ b/crates/libp2p-networking/src/network/node.rs
@@ -176,11 +176,10 @@ impl<K: SignatureKey + 'static> NetworkNode<K> {
     #[instrument]
     pub async fn new(config: NetworkNodeConfig<K>) -> Result<Self, NetworkError> {
         // Generate a random `KeyPair` if one is not specified
-        let keypair = config.keypair.clone().unwrap_or_else(Keypair::generate_ed25519);
-            kp.clone()
-        } else {
-            Keypair::generate_ed25519()
-        };
+        let keypair = config
+            .keypair
+            .clone()
+            .unwrap_or_else(Keypair::generate_ed25519);
 
         // Get the `PeerId` from the `KeyPair`
         let peer_id = PeerId::from(keypair.public());

--- a/crates/libp2p-networking/src/network/node.rs
+++ b/crates/libp2p-networking/src/network/node.rs
@@ -176,7 +176,7 @@ impl<K: SignatureKey + 'static> NetworkNode<K> {
     #[instrument]
     pub async fn new(config: NetworkNodeConfig<K>) -> Result<Self, NetworkError> {
         // Generate a random `KeyPair` if one is not specified
-        let keypair = if let Some(ref kp) = config.keypair {
+        let keypair = config.keypair.clone().unwrap_or_else(Keypair::generate_ed25519);
             kp.clone()
         } else {
             Keypair::generate_ed25519()

--- a/crates/libp2p-networking/src/network/node/config.rs
+++ b/crates/libp2p-networking/src/network/node/config.rs
@@ -20,9 +20,9 @@ pub struct NetworkNodeConfig<K: SignatureKey + 'static> {
     #[builder(setter(into, strip_option), default)]
     #[debug(skip)]
     pub keypair: Option<Keypair>,
-    /// address to bind to
+    /// The address to bind to
     #[builder(default)]
-    pub bound_addr: Option<Multiaddr>,
+    pub bind_address: Option<Multiaddr>,
     /// Replication factor for entries in the DHT
     #[builder(setter(into, strip_option), default = "DEFAULT_REPLICATION_FACTOR")]
     pub replication_factor: Option<NonZeroUsize>,

--- a/crates/libp2p-networking/src/network/node/handle.rs
+++ b/crates/libp2p-networking/src/network/node/handle.rs
@@ -91,7 +91,7 @@ pub async fn spawn_network_node<K: SignatureKey + 'static>(
         .context(NetworkSnafu)?;
     // randomly assigned port
     let listen_addr = config
-        .bound_addr
+        .bind_address
         .clone()
         .unwrap_or_else(|| gen_multiaddr(0));
     let peer_id = network.peer_id();

--- a/crates/libp2p-networking/tests/common/mod.rs
+++ b/crates/libp2p-networking/tests/common/mod.rs
@@ -198,7 +198,7 @@ pub async fn spin_up_swarms<S: Debug + Default + Send, K: SignatureKey + 'static
         let port = portpicker::pick_unused_port().expect("Failed to get an unused port");
 
         let addr =
-            Multiaddr::from_str(format!("/ip4/127.0.0.1/udp/{}/quic-v1", port).as_str()).unwrap();
+            Multiaddr::from_str(format!("/ip4/127.0.0.1/udp/{port}/quic-v1").as_str()).unwrap();
 
         let regular_node_config = NetworkNodeConfigBuilder::default()
             .replication_factor(replication_factor)

--- a/crates/libp2p-networking/tests/common/mod.rs
+++ b/crates/libp2p-networking/tests/common/mod.rs
@@ -188,7 +188,7 @@ pub async fn spin_up_swarms<S: Debug + Default + Send, K: SignatureKey + 'static
     timeout_len: Duration,
 ) -> Result<Vec<(HandleWithState<S, K>, NetworkNodeReceiver)>, TestError<S>> {
     let mut handles = Vec::new();
-    let mut bootstrap_addrs = Vec::<(PeerId, Multiaddr)>::new();
+    let mut node_addrs = Vec::<(PeerId, Multiaddr)>::new();
     let mut connecting_futs = Vec::new();
     // should never panic unless num_nodes is 0
     let replication_factor = NonZeroUsize::new(num_of_nodes - 1).unwrap();
@@ -211,8 +211,8 @@ pub async fn spin_up_swarms<S: Debug + Default + Send, K: SignatureKey + 'static
 
         let (rx, node) = spawn_network_node(config.clone(), i).await.unwrap();
 
-        // Add ourselves to the bootstrap list
-        bootstrap_addrs.push((node.peer_id(), addr));
+        // Add ourselves to the list of node addresses to connect to
+        node_addrs.push((node.peer_id(), addr));
 
         let node = Arc::new(node);
         connecting_futs.push({
@@ -231,7 +231,7 @@ pub async fn spin_up_swarms<S: Debug + Default + Send, K: SignatureKey + 'static
     }
 
     for (handle, _) in &handles[0..num_of_nodes] {
-        let to_share = bootstrap_addrs.clone();
+        let to_share = node_addrs.clone();
         handle
             .handle
             .add_known_peers(to_share)

--- a/crates/libp2p-networking/tests/common/mod.rs
+++ b/crates/libp2p-networking/tests/common/mod.rs
@@ -28,7 +28,7 @@ use libp2p_networking::network::{
     NetworkNodeConfigBuilder, NetworkNodeHandle, NetworkNodeHandleError, NetworkNodeReceiver,
 };
 use snafu::{ResultExt, Snafu};
-use tracing::{info, instrument, warn};
+use tracing::{instrument, warn};
 
 #[derive(Clone, Debug)]
 pub(crate) struct HandleWithState<S: Debug + Default + Send, K: SignatureKey + 'static> {
@@ -225,15 +225,6 @@ pub async fn spin_up_swarms<S: Debug + Default + Send, K: SignatureKey + 'static
         };
         handles.push((node_with_state, rx));
     }
-    info!("BSADDRS ARE: {:?}", bootstrap_addrs);
-
-    info!(
-        "known nodes: {:?}",
-        bootstrap_addrs
-            .iter()
-            .map(|(a, b)| (Some(*a), b.clone()))
-            .collect::<Vec<_>>()
-    );
 
     for (handle, _) in &handles[0..num_of_nodes] {
         let to_share = bootstrap_addrs.clone();

--- a/crates/libp2p-networking/tests/common/mod.rs
+++ b/crates/libp2p-networking/tests/common/mod.rs
@@ -197,19 +197,19 @@ pub async fn spin_up_swarms<S: Debug + Default + Send, K: SignatureKey + 'static
         // Get an unused port
         let port = portpicker::pick_unused_port().expect("Failed to get an unused port");
 
+        // Use the port to create a Multiaddr
         let addr =
             Multiaddr::from_str(format!("/ip4/127.0.0.1/udp/{port}/quic-v1").as_str()).unwrap();
 
-        let regular_node_config = NetworkNodeConfigBuilder::default()
+        let config = NetworkNodeConfigBuilder::default()
             .replication_factor(replication_factor)
             .bind_address(Some(addr.clone()))
             .to_connect_addrs(HashSet::default())
             .build()
             .context(NodeConfigSnafu)
             .context(HandleSnafu)?;
-        let (rx, node) = spawn_network_node(regular_node_config.clone(), i)
-            .await
-            .unwrap();
+
+        let (rx, node) = spawn_network_node(config.clone(), i).await.unwrap();
 
         // Add ourselves to the bootstrap list
         bootstrap_addrs.push((node.peer_id(), addr));

--- a/crates/libp2p-networking/tests/common/mod.rs
+++ b/crates/libp2p-networking/tests/common/mod.rs
@@ -194,7 +194,8 @@ pub async fn spin_up_swarms<S: Debug + Default + Send, K: SignatureKey + 'static
     let replication_factor = NonZeroUsize::new(num_of_nodes - 1).unwrap();
 
     for j in 0..num_of_nodes {
-        let addr = Multiaddr::from_str("/ip4/127.0.0.1/udp/0/quic-v1").unwrap();
+        let addr = Multiaddr::from_str(format!("/ip4/127.0.0.1/udp/{}/quic-v1", 2000 + j).as_str())
+            .unwrap();
 
         let regular_node_config = NetworkNodeConfigBuilder::default()
             .replication_factor(replication_factor)

--- a/crates/libp2p-networking/tests/common/mod.rs
+++ b/crates/libp2p-networking/tests/common/mod.rs
@@ -193,9 +193,12 @@ pub async fn spin_up_swarms<S: Debug + Default + Send, K: SignatureKey + 'static
     // should never panic unless num_nodes is 0
     let replication_factor = NonZeroUsize::new(num_of_nodes - 1).unwrap();
 
-    for j in 0..num_of_nodes {
-        let addr = Multiaddr::from_str(format!("/ip4/127.0.0.1/udp/{}/quic-v1", 2000 + j).as_str())
-            .unwrap();
+    for i in 0..num_of_nodes {
+        // Get an unused port
+        let port = portpicker::pick_unused_port().expect("Failed to get an unused port");
+
+        let addr =
+            Multiaddr::from_str(format!("/ip4/127.0.0.1/udp/{}/quic-v1", port).as_str()).unwrap();
 
         let regular_node_config = NetworkNodeConfigBuilder::default()
             .replication_factor(replication_factor)
@@ -204,7 +207,7 @@ pub async fn spin_up_swarms<S: Debug + Default + Send, K: SignatureKey + 'static
             .build()
             .context(NodeConfigSnafu)
             .context(HandleSnafu)?;
-        let (rx, node) = spawn_network_node(regular_node_config.clone(), j)
+        let (rx, node) = spawn_network_node(regular_node_config.clone(), i)
             .await
             .unwrap();
 

--- a/crates/libp2p-networking/tests/common/mod.rs
+++ b/crates/libp2p-networking/tests/common/mod.rs
@@ -198,7 +198,7 @@ pub async fn spin_up_swarms<S: Debug + Default + Send, K: SignatureKey + 'static
 
         let regular_node_config = NetworkNodeConfigBuilder::default()
             .replication_factor(replication_factor)
-            .bound_addr(Some(addr.clone()))
+            .bind_address(Some(addr.clone()))
             .to_connect_addrs(HashSet::default())
             .build()
             .context(NodeConfigSnafu)

--- a/crates/libp2p-networking/tests/common/mod.rs
+++ b/crates/libp2p-networking/tests/common/mod.rs
@@ -21,12 +21,11 @@ use async_compatibility_layer::{
 };
 use futures::{future::join_all, Future, FutureExt};
 use hotshot_types::traits::signature_key::SignatureKey;
-use libp2p::{identity::Keypair, Multiaddr};
+use libp2p::Multiaddr;
 use libp2p_identity::PeerId;
 use libp2p_networking::network::{
     network_node_handle_error::NodeConfigSnafu, spawn_network_node, NetworkEvent,
     NetworkNodeConfigBuilder, NetworkNodeHandle, NetworkNodeHandleError, NetworkNodeReceiver,
-    NetworkNodeType,
 };
 use snafu::{ResultExt, Snafu};
 use tracing::{info, instrument, warn};
@@ -109,7 +108,6 @@ pub async fn test_bed<
     run_test: F,
     client_handler: G,
     num_nodes: usize,
-    num_of_bootstrap: usize,
     timeout: Duration,
 ) where
     FutF: Future<Output = ()>,
@@ -123,9 +121,7 @@ pub async fn test_bed<
     let mut kill_switches = Vec::new();
     // NOTE we want this to panic if we can't spin up the swarms.
     // that amounts to a failed test.
-    let handles_and_receivers = spin_up_swarms::<S, K>(num_nodes, timeout, num_of_bootstrap)
-        .await
-        .unwrap();
+    let handles_and_receivers = spin_up_swarms::<S, K>(num_nodes, timeout).await.unwrap();
 
     let (handles, receivers): (Vec<_>, Vec<_>) = handles_and_receivers.into_iter().unzip();
     let mut handler_futures = Vec::new();
@@ -190,7 +186,6 @@ pub async fn print_connections<K: SignatureKey + 'static>(handles: &[Arc<Network
 pub async fn spin_up_swarms<S: Debug + Default + Send, K: SignatureKey + 'static>(
     num_of_nodes: usize,
     timeout_len: Duration,
-    num_bootstrap: usize,
 ) -> Result<Vec<(HandleWithState<S, K>, NetworkNodeReceiver)>, TestError<S>> {
     let mut handles = Vec::new();
     let mut bootstrap_addrs = Vec::<(PeerId, Multiaddr)>::new();
@@ -198,69 +193,22 @@ pub async fn spin_up_swarms<S: Debug + Default + Send, K: SignatureKey + 'static
     // should never panic unless num_nodes is 0
     let replication_factor = NonZeroUsize::new(num_of_nodes - 1).unwrap();
 
-    for i in 0..num_bootstrap {
-        let mut config = NetworkNodeConfigBuilder::default();
-        let identity = Keypair::generate_ed25519();
-        // let start_port = 5000;
-        // NOTE use this if testing locally and want human readable ports
-        // as opposed to random ports. These are harder to track
-        // especially since the "listener"/inbound connection sees a different
-        // port
-        // let addr = Multiaddr::from_str(&format!("/ip4/127.0.0.1/udp/{}/quic-v1", start_port + i)).unwrap();
-
+    for j in 0..num_of_nodes {
         let addr = Multiaddr::from_str("/ip4/127.0.0.1/udp/0/quic-v1").unwrap();
-        config
-            .identity(identity)
-            .replication_factor(replication_factor)
-            .node_type(NetworkNodeType::Bootstrap)
-            .to_connect_addrs(HashSet::default())
-            .bound_addr(Some(addr))
-            .ttl(None)
-            .republication_interval(None)
-            .server_mode(true);
-        let config = config
-            .build()
-            .context(NodeConfigSnafu)
-            .context(HandleSnafu)?;
-        let (rx, node) = spawn_network_node(config.clone(), i).await.unwrap();
-        let node = Arc::new(node);
-        let addr = node.listen_addr();
-        info!("listen addr for {} is {:?}", i, addr);
-        bootstrap_addrs.push((node.peer_id(), addr));
-        connecting_futs.push({
-            let node = Arc::clone(&node);
-            async move {
-                node.begin_bootstrap().await?;
-                node.lookup_pid(PeerId::random()).await
-            }
-            .boxed_local()
-        });
-        let node_with_state = HandleWithState {
-            handle: Arc::clone(&node),
-            state: Arc::default(),
-        };
-        handles.push((node_with_state, rx));
-    }
 
-    for j in 0..(num_of_nodes - num_bootstrap) {
-        let addr = Multiaddr::from_str("/ip4/127.0.0.1/udp/0/quic-v1").unwrap();
-        // NOTE use this if testing locally and want human readable ports
-        // let addr = Multiaddr::from_str(&format!(
-        //     "/ip4/127.0.0.1/udp/{}/quic-v1",
-        //     start_port + num_bootstrap + j
-        // )).unwrap();
         let regular_node_config = NetworkNodeConfigBuilder::default()
-            .node_type(NetworkNodeType::Regular)
             .replication_factor(replication_factor)
             .bound_addr(Some(addr.clone()))
             .to_connect_addrs(HashSet::default())
-            .server_mode(true)
             .build()
             .context(NodeConfigSnafu)
             .context(HandleSnafu)?;
-        let (rx, node) = spawn_network_node(regular_node_config.clone(), j + num_bootstrap)
+        let (rx, node) = spawn_network_node(regular_node_config.clone(), j)
             .await
             .unwrap();
+
+        // Add ourselves to the bootstrap list
+        bootstrap_addrs.push((node.peer_id(), addr));
 
         let node = Arc::new(node);
         connecting_futs.push({

--- a/crates/libp2p-networking/tests/counter.rs
+++ b/crates/libp2p-networking/tests/counter.rs
@@ -397,7 +397,7 @@ async fn run_dht_rounds<K: SignatureKey + 'static>(
         // Sign the value
         let value = RecordValue::new_signed(&key, value, &private_key).expect("signing failed");
 
-        // put the key
+        // Put the key
         msg_handle
             .handle
             .put_record(key.clone(), value.clone())

--- a/crates/libp2p-networking/tests/counter.rs
+++ b/crates/libp2p-networking/tests/counter.rs
@@ -35,11 +35,9 @@ pub type CounterState = u32;
 const NUM_ROUNDS: usize = 100;
 
 const TOTAL_NUM_PEERS_COVERAGE: usize = 10;
-const NUM_OF_BOOTSTRAP_COVERAGE: usize = 5;
 const TIMEOUT_COVERAGE: Duration = Duration::from_secs(120);
 
 const TOTAL_NUM_PEERS_STRESS: usize = 100;
-const NUM_OF_BOOTSTRAP_STRESS: usize = 25;
 const TIMEOUT_STRESS: Duration = Duration::from_secs(60);
 
 const DHT_KV_PADDING: usize = 1024;
@@ -529,7 +527,6 @@ async fn test_coverage_request_response_one_round() {
         run_request_response_one_round::<BLSPubKey>,
         counter_handle_network_event,
         TOTAL_NUM_PEERS_COVERAGE,
-        NUM_OF_BOOTSTRAP_COVERAGE,
         TIMEOUT_COVERAGE,
     ))
     .await;
@@ -544,7 +541,6 @@ async fn test_coverage_request_response_many_rounds() {
         run_request_response_many_rounds::<BLSPubKey>,
         counter_handle_network_event,
         TOTAL_NUM_PEERS_COVERAGE,
-        NUM_OF_BOOTSTRAP_COVERAGE,
         TIMEOUT_COVERAGE,
     ))
     .await;
@@ -559,7 +555,6 @@ async fn test_coverage_intersperse_many_rounds() {
         run_intersperse_many_rounds::<BLSPubKey>,
         counter_handle_network_event,
         TOTAL_NUM_PEERS_COVERAGE,
-        NUM_OF_BOOTSTRAP_COVERAGE,
         TIMEOUT_COVERAGE,
     ))
     .await;
@@ -574,7 +569,6 @@ async fn test_coverage_gossip_many_rounds() {
         run_gossip_many_rounds::<BLSPubKey>,
         counter_handle_network_event,
         TOTAL_NUM_PEERS_COVERAGE,
-        NUM_OF_BOOTSTRAP_COVERAGE,
         TIMEOUT_COVERAGE,
     ))
     .await;
@@ -589,7 +583,6 @@ async fn test_coverage_gossip_one_round() {
         run_gossip_one_round::<BLSPubKey>,
         counter_handle_network_event,
         TOTAL_NUM_PEERS_COVERAGE,
-        NUM_OF_BOOTSTRAP_COVERAGE,
         TIMEOUT_COVERAGE,
     ))
     .await;
@@ -605,7 +598,6 @@ async fn test_stress_request_response_one_round() {
         run_request_response_one_round::<BLSPubKey>,
         counter_handle_network_event,
         TOTAL_NUM_PEERS_STRESS,
-        NUM_OF_BOOTSTRAP_STRESS,
         TIMEOUT_STRESS,
     ))
     .await;
@@ -621,7 +613,6 @@ async fn test_stress_request_response_many_rounds() {
         run_request_response_many_rounds::<BLSPubKey>,
         counter_handle_network_event,
         TOTAL_NUM_PEERS_STRESS,
-        NUM_OF_BOOTSTRAP_STRESS,
         TIMEOUT_STRESS,
     ))
     .await;
@@ -637,7 +628,6 @@ async fn test_stress_intersperse_many_rounds() {
         run_intersperse_many_rounds::<BLSPubKey>,
         counter_handle_network_event,
         TOTAL_NUM_PEERS_STRESS,
-        NUM_OF_BOOTSTRAP_STRESS,
         TIMEOUT_STRESS,
     ))
     .await;
@@ -653,7 +643,6 @@ async fn test_stress_gossip_many_rounds() {
         run_gossip_many_rounds::<BLSPubKey>,
         counter_handle_network_event,
         TOTAL_NUM_PEERS_STRESS,
-        NUM_OF_BOOTSTRAP_STRESS,
         TIMEOUT_STRESS,
     ))
     .await;
@@ -669,7 +658,6 @@ async fn test_stress_gossip_one_round() {
         run_gossip_one_round::<BLSPubKey>,
         counter_handle_network_event,
         TOTAL_NUM_PEERS_STRESS,
-        NUM_OF_BOOTSTRAP_STRESS,
         TIMEOUT_STRESS,
     ))
     .await;
@@ -685,7 +673,6 @@ async fn test_stress_dht_one_round() {
         run_dht_one_round::<BLSPubKey>,
         counter_handle_network_event,
         TOTAL_NUM_PEERS_STRESS,
-        NUM_OF_BOOTSTRAP_STRESS,
         TIMEOUT_STRESS,
     ))
     .await;
@@ -701,7 +688,6 @@ async fn test_stress_dht_many_rounds() {
         run_dht_many_rounds::<BLSPubKey>,
         counter_handle_network_event,
         TOTAL_NUM_PEERS_STRESS,
-        NUM_OF_BOOTSTRAP_STRESS,
         TIMEOUT_STRESS,
     ))
     .await;
@@ -716,7 +702,6 @@ async fn test_coverage_dht_one_round() {
         run_dht_one_round::<BLSPubKey>,
         counter_handle_network_event,
         TOTAL_NUM_PEERS_COVERAGE,
-        NUM_OF_BOOTSTRAP_COVERAGE,
         TIMEOUT_COVERAGE,
     ))
     .await;
@@ -731,7 +716,6 @@ async fn test_coverage_dht_many_rounds() {
         run_dht_many_rounds::<BLSPubKey>,
         counter_handle_network_event,
         TOTAL_NUM_PEERS_COVERAGE,
-        NUM_OF_BOOTSTRAP_COVERAGE,
         TIMEOUT_COVERAGE,
     ))
     .await;

--- a/crates/orchestrator/run-config.toml
+++ b/crates/orchestrator/run-config.toml
@@ -59,12 +59,6 @@ round_start_delay = 1
 start_delay = 1
 num_bootstrap = 5
 
-[libp2p_config]
-mesh_n_high = 4
-mesh_n_low = 4
-mesh_outbound_min = 2
-mesh_n = 4
-
 [random_builder]
 txn_in_block = 100
 blocks_per_second = 1

--- a/crates/orchestrator/run-config.toml
+++ b/crates/orchestrator/run-config.toml
@@ -60,16 +60,10 @@ start_delay = 1
 num_bootstrap = 5
 
 [libp2p_config]
-bootstrap_mesh_n_high = 4
-bootstrap_mesh_n_low = 4
-bootstrap_mesh_outbound_min = 2
-bootstrap_mesh_n = 4
 mesh_n_high = 4
 mesh_n_low = 4
 mesh_outbound_min = 2
 mesh_n = 4
-online_time = 10
-server_mode = true
 
 [random_builder]
 txn_in_block = 100

--- a/crates/orchestrator/src/config.rs
+++ b/crates/orchestrator/src/config.rs
@@ -36,13 +36,6 @@ pub struct Libp2pConfig {
     pub bootstrap_nodes: Vec<(PeerId, Multiaddr)>,
 }
 
-/// configuration serialized into a file
-#[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
-pub struct Libp2pConfigFile {
-    /// The bootstrap nodes to connect to (multiaddress, serialized public key)
-    pub bootstrap_nodes: Vec<(PeerId, Multiaddr)>,
-}
-
 /// configuration for a web server
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
 pub struct WebServerConfig {
@@ -427,9 +420,6 @@ pub struct NetworkConfigFile<KEY: SignatureKey> {
     /// delay before beginning consensus
     #[serde_inline_default(ORCHESTRATOR_DEFAULT_START_DELAY_SECONDS)]
     pub start_delay_seconds: u64,
-    /// the libp2p config
-    #[serde(default)]
-    pub libp2p_config: Option<Libp2pConfigFile>,
     /// the hotshot config file
     #[serde(default)]
     pub config: HotShotConfigFile<KEY>,
@@ -465,8 +455,8 @@ impl<K: SignatureKey> From<NetworkConfigFile<K>> for NetworkConfig<K> {
                 .unwrap_or(Duration::from_millis(REQUEST_DATA_DELAY)),
             seed: val.seed,
             transaction_size: val.transaction_size,
-            libp2p_config: val.libp2p_config.map(|libp2p_config| Libp2pConfig {
-                bootstrap_nodes: libp2p_config.bootstrap_nodes,
+            libp2p_config: Some(Libp2pConfig {
+                bootstrap_nodes: Vec::new(),
             }),
             config: val.config.into(),
             key_type_name: std::any::type_name::<K>().to_string(),

--- a/crates/orchestrator/src/config.rs
+++ b/crates/orchestrator/src/config.rs
@@ -32,29 +32,15 @@ use crate::client::OrchestratorClient;
 /// Configuration describing a libp2p node
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
 pub struct Libp2pConfig {
-    /// bootstrap nodes (multiaddress, serialized public key)
+    /// The bootstrap nodes to connect to (multiaddress, serialized public key)
     pub bootstrap_nodes: Vec<(PeerId, Multiaddr)>,
-    /// The target number of peers in the mesh
-    pub mesh_n: usize,
-    /// The minimum number of peers in the mesh
-    pub mesh_n_low: usize,
-    /// The maximum number of peers in the mesh
-    pub mesh_n_high: usize,
-    /// The minimum number of mesh peers that must be outbound
-    pub mesh_outbound_min: usize,
 }
 
 /// configuration serialized into a file
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
 pub struct Libp2pConfigFile {
-    /// The target number of peers in the mesh
-    pub mesh_n: usize,
-    /// The minimum number of peers in the mesh
-    pub mesh_n_low: usize,
-    /// The maximum number of peers in the mesh
-    pub mesh_n_high: usize,
-    /// The minimum number of mesh peers that must be outbound
-    pub mesh_outbound_min: usize,
+    /// The bootstrap nodes to connect to (multiaddress, serialized public key)
+    pub bootstrap_nodes: Vec<(PeerId, Multiaddr)>,
 }
 
 /// configuration for a web server
@@ -480,11 +466,7 @@ impl<K: SignatureKey> From<NetworkConfigFile<K>> for NetworkConfig<K> {
             seed: val.seed,
             transaction_size: val.transaction_size,
             libp2p_config: val.libp2p_config.map(|libp2p_config| Libp2pConfig {
-                bootstrap_nodes: Vec::new(),
-                mesh_n_high: libp2p_config.mesh_n_high,
-                mesh_n_low: libp2p_config.mesh_n_low,
-                mesh_outbound_min: libp2p_config.mesh_outbound_min,
-                mesh_n: libp2p_config.mesh_n,
+                bootstrap_nodes: libp2p_config.bootstrap_nodes,
             }),
             config: val.config.into(),
             key_type_name: std::any::type_name::<K>().to_string(),

--- a/crates/orchestrator/src/config.rs
+++ b/crates/orchestrator/src/config.rs
@@ -34,59 +34,27 @@ use crate::client::OrchestratorClient;
 pub struct Libp2pConfig {
     /// bootstrap nodes (multiaddress, serialized public key)
     pub bootstrap_nodes: Vec<(PeerId, Multiaddr)>,
-    /// global index of node (for testing purposes a uid)
-    pub node_index: u64,
-    /// corresponds to libp2p DHT parameter of the same name for bootstrap nodes
-    pub bootstrap_mesh_n_high: usize,
-    /// corresponds to libp2p DHT parameter of the same name for bootstrap nodes
-    pub bootstrap_mesh_n_low: usize,
-    /// corresponds to libp2p DHT parameter of the same name for bootstrap nodes
-    pub bootstrap_mesh_outbound_min: usize,
-    /// corresponds to libp2p DHT parameter of the same name for bootstrap nodes
-    pub bootstrap_mesh_n: usize,
-    /// corresponds to libp2p DHT parameter of the same name
-    pub mesh_n_high: usize,
-    /// corresponds to libp2p DHT parameter of the same name
-    pub mesh_n_low: usize,
-    /// corresponds to libp2p DHT parameter of the same name
-    pub mesh_outbound_min: usize,
-    /// corresponds to libp2p DHT parameter of the same name
+    /// The target number of peers in the mesh
     pub mesh_n: usize,
-    /// timeout before starting the next view
-    pub next_view_timeout: u64,
-    /// The maximum amount of time a leader can wait to get a block from a builder
-    pub builder_timeout: Duration,
-    /// time node has been running
-    pub online_time: u64,
-    /// number of transactions per view
-    pub num_txn_per_round: usize,
-    /// whether to start in libp2p::kad::Mode::Server mode
-    pub server_mode: bool,
+    /// The minimum number of peers in the mesh
+    pub mesh_n_low: usize,
+    /// The maximum number of peers in the mesh
+    pub mesh_n_high: usize,
+    /// The minimum number of mesh peers that must be outbound
+    pub mesh_outbound_min: usize,
 }
 
 /// configuration serialized into a file
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
 pub struct Libp2pConfigFile {
-    /// corresponds to libp2p DHT parameter of the same name for bootstrap nodes
-    pub bootstrap_mesh_n_high: usize,
-    /// corresponds to libp2p DHT parameter of the same name for bootstrap nodes
-    pub bootstrap_mesh_n_low: usize,
-    /// corresponds to libp2p DHT parameter of the same name for bootstrap nodes
-    pub bootstrap_mesh_outbound_min: usize,
-    /// corresponds to libp2p DHT parameter of the same name for bootstrap nodes
-    pub bootstrap_mesh_n: usize,
-    /// corresponds to libp2p DHT parameter of the same name
-    pub mesh_n_high: usize,
-    /// corresponds to libp2p DHT parameter of the same name
-    pub mesh_n_low: usize,
-    /// corresponds to libp2p DHT parameter of the same name
-    pub mesh_outbound_min: usize,
-    /// corresponds to libp2p DHT parameter of the same name
+    /// The target number of peers in the mesh
     pub mesh_n: usize,
-    /// time node has been running
-    pub online_time: u64,
-    /// whether to start in libp2p::kad::Mode::Server mode
-    pub server_mode: bool,
+    /// The minimum number of peers in the mesh
+    pub mesh_n_low: usize,
+    /// The maximum number of peers in the mesh
+    pub mesh_n_high: usize,
+    /// The minimum number of mesh peers that must be outbound
+    pub mesh_outbound_min: usize,
 }
 
 /// configuration for a web server
@@ -513,20 +481,10 @@ impl<K: SignatureKey> From<NetworkConfigFile<K>> for NetworkConfig<K> {
             transaction_size: val.transaction_size,
             libp2p_config: val.libp2p_config.map(|libp2p_config| Libp2pConfig {
                 bootstrap_nodes: Vec::new(),
-                node_index: 0,
-                bootstrap_mesh_n_high: libp2p_config.bootstrap_mesh_n_high,
-                bootstrap_mesh_n_low: libp2p_config.bootstrap_mesh_n_low,
-                bootstrap_mesh_outbound_min: libp2p_config.bootstrap_mesh_outbound_min,
-                bootstrap_mesh_n: libp2p_config.bootstrap_mesh_n,
                 mesh_n_high: libp2p_config.mesh_n_high,
                 mesh_n_low: libp2p_config.mesh_n_low,
                 mesh_outbound_min: libp2p_config.mesh_outbound_min,
                 mesh_n: libp2p_config.mesh_n,
-                next_view_timeout: val.config.next_view_timeout,
-                builder_timeout: val.config.builder_timeout,
-                online_time: libp2p_config.online_time,
-                num_txn_per_round: val.transactions_per_round,
-                server_mode: libp2p_config.server_mode,
             }),
             config: val.config.into(),
             key_type_name: std::any::type_name::<K>().to_string(),

--- a/crates/orchestrator/staging-config.toml
+++ b/crates/orchestrator/staging-config.toml
@@ -42,17 +42,10 @@ start_delay_seconds = 10
 builder = "Simple"
 
 [libp2p_config]
-bootstrap_mesh_n_high = 4
-bootstrap_mesh_n_low = 4
-bootstrap_mesh_outbound_min = 2
-bootstrap_mesh_n = 4
 mesh_n_high = 4
 mesh_n_low = 4
 mesh_outbound_min = 2
 mesh_n = 4
-online_time = 10
-num_txn_per_round = 0
-server_mode = false
 
 [config]
 start_threshold = [ 8, 10 ]

--- a/crates/orchestrator/staging-config.toml
+++ b/crates/orchestrator/staging-config.toml
@@ -41,12 +41,6 @@ transaction_size = 100
 start_delay_seconds = 10
 builder = "Simple"
 
-[libp2p_config]
-mesh_n_high = 4
-mesh_n_low = 4
-mesh_outbound_min = 2
-mesh_n = 4
-
 [config]
 start_threshold = [ 8, 10 ]
 num_nodes_with_stake = 10


### PR DESCRIPTION
### This PR: 
<!-- Describe what this PR adds to HotSHot -->
<!-- E.g. -->
<!-- * Implements feature 1 -->
<!-- * Implements feature 2 -->
<!-- * Fixes bug 3 -->

#### 1. Gossipsub configuration
- Changes the parameters to use sane defaults
- Moves specification from the global network file to the function caller. This allows us to specify downstream in the sequencer.

#### 2. Miscellaneous
- Removes `NetworkNodeType` as we are treating most nodes as "bootstrap" nodes
- Removes a bunch of unused configuration parameters
- Changes terminology of `identity` to `keypair` to make it easier to understand
- Not sure why we have `Libp2pConfigFile`, but it was not pulling in the right `bootstrap_nodes`

### This PR does **not**:
Address any changes in the sequencer.

### Testing:
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->
I have tested that the gossip changes will not break config deserialization, as they are purely subtractive