### PR TITLE
Allow Proposal requesting from any DA node

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3076,7 +3076,7 @@ dependencies = [
 
 [[package]]
 name = "hotshot"
-version = "0.5.71"
+version = "0.5.72"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -3142,7 +3142,7 @@ dependencies = [
 
 [[package]]
 name = "hotshot-example-types"
-version = "0.5.71"
+version = "0.5.72"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -3174,7 +3174,7 @@ dependencies = [
 
 [[package]]
 name = "hotshot-examples"
-version = "0.5.71"
+version = "0.5.72"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -3224,7 +3224,7 @@ dependencies = [
 
 [[package]]
 name = "hotshot-fakeapi"
-version = "0.5.71"
+version = "0.5.72"
 dependencies = [
  "anyhow",
  "async-lock 2.8.0",
@@ -3242,7 +3242,7 @@ dependencies = [
 
 [[package]]
 name = "hotshot-macros"
-version = "0.5.71"
+version = "0.5.72"
 dependencies = [
  "derive_builder",
  "proc-macro2",
@@ -3252,7 +3252,7 @@ dependencies = [
 
 [[package]]
 name = "hotshot-orchestrator"
-version = "0.5.71"
+version = "0.5.72"
 dependencies = [
  "anyhow",
  "async-compatibility-layer",
@@ -3281,7 +3281,7 @@ dependencies = [
 
 [[package]]
 name = "hotshot-stake-table"
-version = "0.5.71"
+version = "0.5.72"
 dependencies = [
  "ark-bn254",
  "ark-ed-on-bn254",
@@ -3302,7 +3302,7 @@ dependencies = [
 
 [[package]]
 name = "hotshot-task"
-version = "0.5.71"
+version = "0.5.72"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -3316,7 +3316,7 @@ dependencies = [
 
 [[package]]
 name = "hotshot-task-impls"
-version = "0.5.71"
+version = "0.5.72"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -3352,7 +3352,7 @@ dependencies = [
 
 [[package]]
 name = "hotshot-testing"
-version = "0.5.71"
+version = "0.5.72"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -4513,7 +4513,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-networking"
-version = "0.5.71"
+version = "0.5.72"
 dependencies = [
  "anyhow",
  "async-compatibility-layer",

--- a/crates/task-impls/src/consensus/handlers.rs
+++ b/crates/task-impls/src/consensus/handlers.rs
@@ -137,11 +137,6 @@ pub async fn create_and_send_proposal<TYPES: NodeType, V: Versions>(
         proposed_leaf.view_number(),
     );
 
-    consensus
-        .write()
-        .await
-        .update_last_proposed_view(message.clone())?;
-
     async_sleep(Duration::from_millis(round_start_delay)).await;
 
     broadcast_event(

--- a/crates/task-impls/src/consensus/handlers.rs
+++ b/crates/task-impls/src/consensus/handlers.rs
@@ -518,7 +518,7 @@ pub(crate) async fn handle_quorum_proposal_recv<
         .entry(proposal.data.view_number())
         .or_default()
         .push(async_spawn(
-            validate_proposal_safety_and_liveness(
+            validate_proposal_safety_and_liveness::<TYPES, I, V>(
                 proposal.clone(),
                 parent_leaf,
                 OuterConsensus::new(Arc::clone(&task_state.consensus.inner_consensus)),
@@ -529,6 +529,7 @@ pub(crate) async fn handle_quorum_proposal_recv<
                 task_state.output_event_stream.clone(),
                 task_state.id,
                 task_state.upgrade_lock.clone(),
+                Arc::clone(&task_state.storage),
             )
             .map(AnyhowTracing::err_as_debug),
         ));

--- a/crates/task-impls/src/consensus/mod.rs
+++ b/crates/task-impls/src/consensus/mod.rs
@@ -420,7 +420,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> ConsensusTaskSt
                     }
 
                     if let Err(e) = self.consensus.write().await.update_high_qc(qc.clone()) {
-                        tracing::error!("{e:?}");
+                        tracing::trace!("{e:?}");
                     }
                     debug!(
                         "Attempting to publish proposal after forming a QC for view {}",

--- a/crates/task-impls/src/helpers.rs
+++ b/crates/task-impls/src/helpers.rs
@@ -29,8 +29,9 @@ use hotshot_types::{
     traits::{
         block_contents::BlockHeader,
         election::Membership,
-        node_implementation::{ConsensusTime, NodeType, Versions},
+        node_implementation::{ConsensusTime, NodeImplementation, NodeType, Versions},
         signature_key::SignatureKey,
+        storage::Storage,
         BlockPayload, ValidatedState,
     },
     utils::{Terminator, View, ViewInner},
@@ -438,7 +439,11 @@ pub(crate) async fn parent_leaf_and_state<TYPES: NodeType, V: Versions>(
 #[allow(clippy::too_many_arguments)]
 #[allow(clippy::too_many_lines)]
 #[instrument(skip_all, fields(id = id, view = *proposal.data.view_number()))]
-pub async fn validate_proposal_safety_and_liveness<TYPES: NodeType, V: Versions>(
+pub async fn validate_proposal_safety_and_liveness<
+    TYPES: NodeType,
+    I: NodeImplementation<TYPES>,
+    V: Versions,
+>(
     proposal: Proposal<TYPES, QuorumProposal<TYPES>>,
     parent_leaf: Leaf<TYPES>,
     consensus: OuterConsensus<TYPES>,
@@ -449,6 +454,7 @@ pub async fn validate_proposal_safety_and_liveness<TYPES: NodeType, V: Versions>
     event_sender: Sender<Event<TYPES>>,
     id: u64,
     upgrade_lock: UpgradeLock<TYPES, V>,
+    storage: Arc<RwLock<I::Storage>>,
 ) -> Result<()> {
     let view_number = proposal.data.view_number();
 
@@ -480,6 +486,13 @@ pub async fn validate_proposal_safety_and_liveness<TYPES: NodeType, V: Versions>
         // we swallow this error and just log if it occurs.
         if let Err(e) = consensus_write.update_last_proposed_view(proposal.clone()) {
             tracing::debug!("Internal proposal update failed; error = {e:#}");
+        };
+
+        // Update our persistent storage of the proposal. We also itentionally swallow
+        // this error as it should not affect consensus and would, instead, imply an
+        // issue on the sequencer side.
+        if let Err(e) = storage.write().await.append_proposal(&proposal).await {
+            tracing::debug!("Persisting the proposal update failed; error = {e:#}");
         };
 
         // Broadcast that we've updated our consensus state so that other tasks know it's safe to grab.

--- a/crates/task-impls/src/network.rs
+++ b/crates/task-impls/src/network.rs
@@ -315,7 +315,7 @@ impl<
                     MessageKind::<TYPES>::from_consensus_message(SequencingMessage::General(
                         GeneralConsensusMessage::ProposalRequested(req.clone(), signature),
                     )),
-                    TransmitType::DaCommitteeBroadcastAndLeader(membership.leader(req.view_number)),
+                    TransmitType::DaCommitteeAndLeaderBroadcast(membership.leader(req.view_number)),
                 ),
                 HotShotEvent::QuorumProposalResponseSend(sender_key, proposal) => (
                     sender_key.clone(),
@@ -494,7 +494,7 @@ impl<
                     net.da_broadcast_message(serialized_message, committee, broadcast_delay)
                         .await
                 }
-                TransmitType::DaCommitteeBroadcastAndLeader(recipient) => {
+                TransmitType::DaCommitteeAndLeaderBroadcast(recipient) => {
                     // Short-circuit exit from this call if we get an error during the direct leader broadcast.
                     // NOTE: An improvement to this is to check if the leader is in the DA committee but it's
                     // just a single extra message to the leader, so it's not an optimization that we need now.

--- a/crates/task-impls/src/network.rs
+++ b/crates/task-impls/src/network.rs
@@ -464,6 +464,7 @@ impl<
             {
                 return;
             }
+
             if let MessageKind::Consensus(SequencingMessage::General(
                 GeneralConsensusMessage::Proposal(prop),
             )) = &message.kind

--- a/crates/task-impls/src/network.rs
+++ b/crates/task-impls/src/network.rs
@@ -39,8 +39,6 @@ pub fn quorum_filter<TYPES: NodeType>(event: &Arc<HotShotEvent<TYPES>>) -> bool 
     !matches!(
         event.as_ref(),
         HotShotEvent::QuorumProposalSend(_, _)
-            | HotShotEvent::QuorumProposalRequestSend(..)
-            | HotShotEvent::QuorumProposalResponseSend(..)
             | HotShotEvent::QuorumVoteSend(_)
             | HotShotEvent::DacSend(_, _)
             | HotShotEvent::TimeoutVoteSend(_)
@@ -63,6 +61,8 @@ pub fn da_filter<TYPES: NodeType>(event: &Arc<HotShotEvent<TYPES>>) -> bool {
     !matches!(
         event.as_ref(),
         HotShotEvent::DaProposalSend(_, _)
+            | HotShotEvent::QuorumProposalRequestSend(..)
+            | HotShotEvent::QuorumProposalResponseSend(..)
             | HotShotEvent::DaVoteSend(_)
             | HotShotEvent::ViewChange(_)
     )
@@ -315,7 +315,7 @@ impl<
                     MessageKind::<TYPES>::from_consensus_message(SequencingMessage::General(
                         GeneralConsensusMessage::ProposalRequested(req.clone(), signature),
                     )),
-                    TransmitType::DaCommitteeBroadcast,
+                    TransmitType::DaCommitteeBroadcastAndLeader(membership.leader(req.view_number)),
                 ),
                 HotShotEvent::QuorumProposalResponseSend(sender_key, proposal) => (
                     sender_key.clone(),
@@ -491,6 +491,22 @@ impl<
                         .await
                 }
                 TransmitType::DaCommitteeBroadcast => {
+                    net.da_broadcast_message(serialized_message, committee, broadcast_delay)
+                        .await
+                }
+                TransmitType::DaCommitteeBroadcastAndLeader(recipient) => {
+                    // Short-circuit exit from this call if we get an error during the direct leader broadcast.
+                    // NOTE: An improvement to this is to check if the leader is in the DA committee but it's
+                    // just a single extra message to the leader, so it's not an optimization that we need now.
+                    if let Err(e) = net
+                        .direct_message(serialized_message.clone(), recipient)
+                        .await
+                    {
+                        error!("Failed to send message from network task: {e:?}");
+                        return;
+                    }
+
+                    // Otherwise, send the next message.
                     net.da_broadcast_message(serialized_message, committee, broadcast_delay)
                         .await
                 }

--- a/crates/task-impls/src/network.rs
+++ b/crates/task-impls/src/network.rs
@@ -315,7 +315,7 @@ impl<
                     MessageKind::<TYPES>::from_consensus_message(SequencingMessage::General(
                         GeneralConsensusMessage::ProposalRequested(req.clone(), signature),
                     )),
-                    TransmitType::Direct(membership.leader(req.view_number)),
+                    TransmitType::DaCommitteeBroadcast,
                 ),
                 HotShotEvent::QuorumProposalResponseSend(sender_key, proposal) => (
                     sender_key.clone(),

--- a/crates/task-impls/src/quorum_proposal/handlers.rs
+++ b/crates/task-impls/src/quorum_proposal/handlers.rs
@@ -229,10 +229,6 @@ impl<TYPES: NodeType, V: Versions> ProposalDependencyHandle<TYPES, V> {
             proposed_leaf.view_number(),
         );
 
-        self.consensus
-            .write()
-            .await
-            .update_last_proposed_view(message.clone())?;
         async_sleep(Duration::from_millis(self.round_start_delay)).await;
         broadcast_event(
             Arc::new(HotShotEvent::QuorumProposalSend(

--- a/crates/task-impls/src/quorum_proposal_recv/handlers.rs
+++ b/crates/task-impls/src/quorum_proposal_recv/handlers.rs
@@ -246,7 +246,7 @@ pub(crate) async fn handle_quorum_proposal_recv<
     };
 
     // Validate the proposal
-    validate_proposal_safety_and_liveness(
+    validate_proposal_safety_and_liveness::<TYPES, I, V>(
         proposal.clone(),
         parent_leaf,
         OuterConsensus::new(Arc::clone(&task_state.consensus.inner_consensus)),
@@ -257,6 +257,7 @@ pub(crate) async fn handle_quorum_proposal_recv<
         task_state.output_event_stream.clone(),
         task_state.id,
         task_state.upgrade_lock.clone(),
+        Arc::clone(&task_state.storage),
     )
     .await?;
 

--- a/crates/task-impls/src/request.rs
+++ b/crates/task-impls/src/request.rs
@@ -88,6 +88,7 @@ type Signature<TYPES> =
 impl<TYPES: NodeType, I: NodeImplementation<TYPES>> TaskState for NetworkRequestState<TYPES, I> {
     type Event = HotShotEvent<TYPES>;
 
+    #[instrument(skip_all, target = "NetworkRequestState", fields(id = self.id))]
     async fn handle_event(
         &mut self,
         event: Arc<Self::Event>,

--- a/crates/testing/tests/tests_2/catchup.rs
+++ b/crates/testing/tests/tests_2/catchup.rs
@@ -421,3 +421,68 @@ async fn test_all_restart_cdn() {
         .run_test::<SimpleBuilderImplementation>()
         .await;
 }
+
+#[cfg(test)]
+#[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
+#[cfg_attr(async_executor_impl = "async-std", async_std::test)]
+async fn test_all_restart_one_da() {
+    use std::time::Duration;
+
+    use hotshot_example_types::node_types::{CombinedImpl, TestTypes, TestVersions};
+    use hotshot_testing::{
+        block_builder::SimpleBuilderImplementation,
+        completion_task::{CompletionTaskDescription, TimeBasedCompletionTaskDescription},
+        overall_safety_task::OverallSafetyPropertiesDescription,
+        spinning_task::{ChangeNode, SpinningTaskDescription, UpDown},
+        test_builder::{TestDescription, TimingData},
+    };
+
+    async_compatibility_layer::logging::setup_logging();
+    async_compatibility_layer::logging::setup_backtrace();
+    let timing_data = TimingData {
+        next_view_timeout: 2000,
+        ..Default::default()
+    };
+    let mut metadata: TestDescription<TestTypes, CombinedImpl, TestVersions> =
+        TestDescription::default();
+    let mut catchup_nodes = vec![];
+    for i in 1..20 {
+        catchup_nodes.push(ChangeNode {
+            idx: i,
+            updown: UpDown::Restart,
+        })
+    }
+
+    metadata.timing_data = timing_data;
+    metadata.start_nodes = 20;
+    metadata.num_nodes_with_stake = 20;
+
+    // Explitily make the DA tiny to exaggerate a missing proposal.
+    // metadata.da_staked_committee_size = 9;
+
+    metadata.spinning_properties = SpinningTaskDescription {
+        // Restart all the nodes in view 13
+        node_changes: vec![(13, catchup_nodes)],
+    };
+    metadata.view_sync_properties =
+        hotshot_testing::view_sync_task::ViewSyncTaskDescription::Threshold(0, 20);
+
+    metadata.completion_task_description =
+        CompletionTaskDescription::TimeBasedCompletionTaskBuilder(
+            TimeBasedCompletionTaskDescription {
+                duration: Duration::from_secs(60),
+            },
+        );
+    metadata.overall_safety_properties = OverallSafetyPropertiesDescription {
+        // Make sure we keep committing rounds after the catchup, but not the full 50.
+        num_successful_views: 22,
+        num_failed_views: 15,
+        ..Default::default()
+    };
+
+    metadata
+        .gen_launcher(0)
+        .launch()
+        .run_test::<SimpleBuilderImplementation>()
+        .await;
+}

--- a/crates/testing/tests/tests_2/catchup.rs
+++ b/crates/testing/tests/tests_2/catchup.rs
@@ -422,6 +422,10 @@ async fn test_all_restart_cdn() {
         .await;
 }
 
+/// This test case ensures that proposals persist off of a restart. We demonstrate this by
+/// artificially removing node 0 (the only DA committee member) from the candidate pool,
+/// meaning that the entire DA also does not have the proposal, but we're still able to
+/// move on because the *leader* does have the proposal.
 #[cfg(test)]
 #[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
@@ -445,6 +449,11 @@ async fn test_all_restart_one_da() {
     };
     let mut metadata: TestDescription<TestTypes, CombinedImpl, TestVersions> =
         TestDescription::default();
+
+    let node_0_down = vec![ChangeNode {
+        idx: 0,
+        updown: UpDown::Restart,
+    }];
     let mut catchup_nodes = vec![];
     for i in 1..20 {
         catchup_nodes.push(ChangeNode {
@@ -457,12 +466,12 @@ async fn test_all_restart_one_da() {
     metadata.start_nodes = 20;
     metadata.num_nodes_with_stake = 20;
 
-    // Explitily make the DA tiny to exaggerate a missing proposal.
-    // metadata.da_staked_committee_size = 9;
+    // Explicitly make the DA tiny to exaggerate a missing proposal.
+    metadata.da_staked_committee_size = 1;
 
     metadata.spinning_properties = SpinningTaskDescription {
         // Restart all the nodes in view 13
-        node_changes: vec![(13, catchup_nodes)],
+        node_changes: vec![(12, node_0_down), (13, catchup_nodes)],
     };
     metadata.view_sync_properties =
         hotshot_testing::view_sync_task::ViewSyncTaskDescription::Threshold(0, 20);

--- a/crates/types/src/traits/network.rs
+++ b/crates/types/src/traits/network.rs
@@ -84,6 +84,8 @@ pub enum TransmitType<TYPES: NodeType> {
     Broadcast,
     /// broadcast to DA committee
     DaCommitteeBroadcast,
+    /// broadcast to the leader and the DA
+    DaCommitteeBroadcastAndLeader(TYPES::SignatureKey),
 }
 
 /// Error type for networking

--- a/crates/types/src/traits/network.rs
+++ b/crates/types/src/traits/network.rs
@@ -85,7 +85,7 @@ pub enum TransmitType<TYPES: NodeType> {
     /// broadcast to DA committee
     DaCommitteeBroadcast,
     /// broadcast to the leader and the DA
-    DaCommitteeBroadcastAndLeader(TYPES::SignatureKey),
+    DaCommitteeAndLeaderBroadcast(TYPES::SignatureKey),
 }
 
 /// Error type for networking


### PR DESCRIPTION
Closes #3603 
<!-- See here for keywords in Github -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

### This PR: 
Lets the requester of a proposal broadcast to the entire DA committee to receive a proposal on a first-come, first-served basis. 

### This PR does not: 
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->

### Key places to review: 
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
