### PR TITLE
[CATCHUP] Init Consensus with 2 views to prevent Double Vote/Propose

### DIFF
--- a/crates/example-types/src/storage_types.rs
+++ b/crates/example-types/src/storage_types.rs
@@ -18,7 +18,10 @@ use hotshot_types::{
     event::HotShotAction,
     message::Proposal,
     simple_certificate::QuorumCertificate,
-    traits::{node_implementation::{NodeType, ConsensusTime}, storage::Storage},
+    traits::{
+        node_implementation::{ConsensusTime, NodeType},
+        storage::Storage,
+    },
     utils::View,
     vote::HasViewNumber,
 };
@@ -46,7 +49,7 @@ impl<TYPES: NodeType> Default for TestStorageState<TYPES> {
             das: HashMap::new(),
             proposals: BTreeMap::new(),
             high_qc: None,
-            action: TYPES::Time::genesis()
+            action: TYPES::Time::genesis(),
         }
     }
 }
@@ -144,10 +147,8 @@ impl<TYPES: NodeType> Storage<TYPES> for TestStorage<TYPES> {
             bail!("Failed to append Action to storage");
         }
         let mut inner = self.inner.write().await;
-        if view > inner.action {
-            if matches!(action, HotShotAction::Vote | HotShotAction::Propose) {
-                inner.action = view;
-            }
+        if view > inner.action && matches!(action, HotShotAction::Vote | HotShotAction::Propose) {
+            inner.action = view;
         }
         Self::run_delay_settings_from_config(&self.delay_config).await;
         Ok(())

--- a/crates/example-types/src/storage_types.rs
+++ b/crates/example-types/src/storage_types.rs
@@ -15,9 +15,10 @@ use async_trait::async_trait;
 use hotshot_types::{
     consensus::CommitmentMap,
     data::{DaProposal, Leaf, QuorumProposal, VidDisperseShare},
+    event::HotShotAction,
     message::Proposal,
     simple_certificate::QuorumCertificate,
-    traits::{node_implementation::NodeType, storage::Storage},
+    traits::{node_implementation::{NodeType, ConsensusTime}, storage::Storage},
     utils::View,
     vote::HasViewNumber,
 };
@@ -35,6 +36,7 @@ pub struct TestStorageState<TYPES: NodeType> {
     das: HashMap<TYPES::Time, Proposal<TYPES, DaProposal<TYPES>>>,
     proposals: BTreeMap<TYPES::Time, Proposal<TYPES, QuorumProposal<TYPES>>>,
     high_qc: Option<hotshot_types::simple_certificate::QuorumCertificate<TYPES>>,
+    action: TYPES::Time,
 }
 
 impl<TYPES: NodeType> Default for TestStorageState<TYPES> {
@@ -44,6 +46,7 @@ impl<TYPES: NodeType> Default for TestStorageState<TYPES> {
             das: HashMap::new(),
             proposals: BTreeMap::new(),
             high_qc: None,
+            action: TYPES::Time::genesis()
         }
     }
 }
@@ -84,6 +87,9 @@ impl<TYPES: NodeType> TestStorage<TYPES> {
     }
     pub async fn high_qc_cloned(&self) -> Option<QuorumCertificate<TYPES>> {
         self.inner.read().await.high_qc.clone()
+    }
+    pub async fn last_actioned_view(&self) -> TYPES::Time {
+        self.inner.read().await.action
     }
 }
 
@@ -131,11 +137,17 @@ impl<TYPES: NodeType> Storage<TYPES> for TestStorage<TYPES> {
 
     async fn record_action(
         &self,
-        _view: <TYPES as NodeType>::Time,
-        _action: hotshot_types::event::HotShotAction,
+        view: <TYPES as NodeType>::Time,
+        action: hotshot_types::event::HotShotAction,
     ) -> Result<()> {
         if self.should_return_err {
             bail!("Failed to append Action to storage");
+        }
+        let mut inner = self.inner.write().await;
+        if view > inner.action {
+            if matches!(action, HotShotAction::Vote | HotShotAction::Propose) {
+                inner.action = view;
+            }
         }
         Self::run_delay_settings_from_config(&self.delay_config).await;
         Ok(())

--- a/crates/hotshot/src/lib.rs
+++ b/crates/hotshot/src/lib.rs
@@ -951,8 +951,11 @@ pub struct HotShotInitializer<TYPES: NodeType> {
     /// If it's given, we'll use it to construct the `SystemContext`.
     state_delta: Option<Arc<<TYPES::ValidatedState as ValidatedState<TYPES>>::Delta>>,
 
-    /// Starting view number that we are confident won't lead to a double vote after restart.
+    /// Starting view number that should be equivelant to the view the node shut down with last.
     start_view: TYPES::Time,
+    /// The view we last performed an action in.  An action is Proposing or voting for 
+    /// Either the quorum or DA.
+    actioned_view: TYPES::Time,
     /// Highest QC that was seen, for genesis it's the genesis QC.  It should be for a view greater
     /// than `inner`s view number for the non genesis case because we must have seen higher QCs
     /// to decide on the leaf.
@@ -981,6 +984,7 @@ impl<TYPES: NodeType> HotShotInitializer<TYPES> {
             validated_state: Some(Arc::new(validated_state)),
             state_delta: Some(Arc::new(state_delta)),
             start_view: TYPES::Time::new(0),
+            actioned_view: TYPES::Time::new(0),
             saved_proposals: BTreeMap::new(),
             high_qc,
             undecided_leafs: Vec::new(),
@@ -1002,6 +1006,7 @@ impl<TYPES: NodeType> HotShotInitializer<TYPES> {
         instance_state: TYPES::InstanceState,
         validated_state: Option<Arc<TYPES::ValidatedState>>,
         start_view: TYPES::Time,
+        actioned_view: TYPES::Time,
         saved_proposals: BTreeMap<TYPES::Time, Proposal<TYPES, QuorumProposal<TYPES>>>,
         high_qc: QuorumCertificate<TYPES>,
         undecided_leafs: Vec<Leaf<TYPES>>,
@@ -1013,6 +1018,7 @@ impl<TYPES: NodeType> HotShotInitializer<TYPES> {
             validated_state,
             state_delta: None,
             start_view,
+            actioned_view,
             saved_proposals,
             high_qc,
             undecided_leafs,

--- a/crates/hotshot/src/lib.rs
+++ b/crates/hotshot/src/lib.rs
@@ -306,9 +306,8 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> SystemContext<T
             validated_state_map,
             anchored_leaf.view_number(),
             anchored_leaf.view_number(),
-            // TODO this is incorrect
-            // https://github.com/EspressoSystems/HotShot/issues/560
             anchored_leaf.view_number(),
+            initializer.actioned_view,
             initializer.saved_proposals,
             saved_leaves,
             saved_payloads,
@@ -953,7 +952,7 @@ pub struct HotShotInitializer<TYPES: NodeType> {
 
     /// Starting view number that should be equivelant to the view the node shut down with last.
     start_view: TYPES::Time,
-    /// The view we last performed an action in.  An action is Proposing or voting for 
+    /// The view we last performed an action in.  An action is Proposing or voting for
     /// Either the quorum or DA.
     actioned_view: TYPES::Time,
     /// Highest QC that was seen, for genesis it's the genesis QC.  It should be for a view greater

--- a/crates/hotshot/src/tasks/mod.rs
+++ b/crates/hotshot/src/tasks/mod.rs
@@ -386,7 +386,7 @@ where
         let public_key = handle.public_key().clone();
         let private_key = handle.private_key().clone();
         let upgrade_lock = handle.hotshot.upgrade_lock.clone();
-        let consensus = handle.hotshot.consensus().clone();
+        let consensus = Arc::clone(&handle.hotshot.consensus());
         let send_handle = async_spawn(async move {
             futures::pin_mut!(shutdown_signal);
 

--- a/crates/hotshot/src/tasks/mod.rs
+++ b/crates/hotshot/src/tasks/mod.rs
@@ -192,6 +192,7 @@ pub fn add_network_event_task<
         membership,
         filter,
         storage: Arc::clone(&handle.storage()),
+        consensus: Arc::clone(&handle.consensus()),
         upgrade_lock: handle.hotshot.upgrade_lock.clone(),
     };
     let task = Task::new(

--- a/crates/hotshot/src/tasks/mod.rs
+++ b/crates/hotshot/src/tasks/mod.rs
@@ -36,7 +36,7 @@ use hotshot_task_impls::{
     vid::VidTaskState,
     view_sync::ViewSyncTaskState,
 };
-use hotshot_types::message::UpgradeLock;
+use hotshot_types::{consensus::Consensus, message::UpgradeLock};
 use hotshot_types::{
     constants::EVENT_CHANNEL_SIZE,
     message::Messages,
@@ -289,6 +289,7 @@ where
         public_key: &TYPES::SignatureKey,
         private_key: &<TYPES::SignatureKey as SignatureKey>::PrivateKey,
         upgrade_lock: &UpgradeLock<TYPES, V>,
+        consensus: Arc<RwLock<Consensus<TYPES>>>,
     ) -> Vec<HotShotEvent<TYPES>>;
 
     #[allow(clippy::too_many_arguments)]
@@ -385,6 +386,7 @@ where
         let public_key = handle.public_key().clone();
         let private_key = handle.private_key().clone();
         let upgrade_lock = handle.hotshot.upgrade_lock.clone();
+        let consensus = handle.hotshot.consensus().clone();
         let send_handle = async_spawn(async move {
             futures::pin_mut!(shutdown_signal);
 
@@ -416,6 +418,7 @@ where
                                     &public_key,
                                     &private_key,
                                     &upgrade_lock,
+                                    Arc::clone(&consensus)
                                 ).await;
                                 results.reverse();
                                 while let Some(event) = results.pop() {

--- a/crates/task-impls/src/helpers.rs
+++ b/crates/task-impls/src/helpers.rs
@@ -484,7 +484,7 @@ pub async fn validate_proposal_safety_and_liveness<
 
         // Update our internal storage of the proposal. The proposal is valid, so
         // we swallow this error and just log if it occurs.
-        if let Err(e) = consensus_write.update_last_proposed_view(proposal.clone()) {
+        if let Err(e) = consensus_write.update_proposed_view(proposal.clone()) {
             tracing::debug!("Internal proposal update failed; error = {e:#}");
         };
 

--- a/crates/task-impls/src/network.rs
+++ b/crates/task-impls/src/network.rs
@@ -347,6 +347,7 @@ impl<
     ) -> Result<(), ()> {
         if let Some(action) = maybe_action {
             if !state.write().await.update_action(action, view) {
+                error!("Already actioned in this view");
                 return Err(());
             }
             match storage.write().await.record_action(view, action).await {

--- a/crates/task-impls/src/network.rs
+++ b/crates/task-impls/src/network.rs
@@ -346,15 +346,10 @@ impl<
         view: <TYPES as NodeType>::Time,
     ) -> Result<(), ()> {
         if let Some(action) = maybe_action {
-            if !state.write().await.update_action(action.clone(), view) {
+            if !state.write().await.update_action(action, view) {
                 return Err(());
             }
-            match storage
-                .write()
-                .await
-                .record_action(view, action.clone())
-                .await
-            {
+            match storage.write().await.record_action(view, action).await {
                 Ok(()) => Ok(()),
                 Err(e) => {
                     warn!("Not Sending {:?} because of storage error: {:?}", action, e);

--- a/crates/task-impls/src/network.rs
+++ b/crates/task-impls/src/network.rs
@@ -347,7 +347,7 @@ impl<
     ) -> Result<(), ()> {
         if let Some(action) = maybe_action {
             if !state.write().await.update_action(action, view) {
-                error!("Already actioned in this view");
+                warn!("Already actioned {:?} in view {:?}", action, view);
                 return Err(());
             }
             match storage.write().await.record_action(view, action).await {

--- a/crates/testing/src/byzantine/byzantine_behaviour.rs
+++ b/crates/testing/src/byzantine/byzantine_behaviour.rs
@@ -1,10 +1,12 @@
 use anyhow::Context;
+use async_lock::RwLock;
 use async_trait::async_trait;
 use hotshot::tasks::EventTransformerState;
 use hotshot::types::{SignatureKey, SystemContextHandle};
 use hotshot_task_impls::events::HotShotEvent;
 use hotshot_task_impls::network::test::{ModifierClosure, NetworkEventTaskStateModifier};
 use hotshot_task_impls::network::NetworkEventTaskState;
+use hotshot_types::consensus::Consensus;
 use hotshot_types::message::UpgradeLock;
 use hotshot_types::simple_vote::QuorumVote;
 use hotshot_types::traits::node_implementation::ConsensusTime;
@@ -39,12 +41,15 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> EventTransforme
         _public_key: &TYPES::SignatureKey,
         _private_key: &<TYPES::SignatureKey as SignatureKey>::PrivateKey,
         _upgrade_lock: &UpgradeLock<TYPES, V>,
+        consensus: Arc<RwLock<Consensus<TYPES>>>,
     ) -> Vec<HotShotEvent<TYPES>> {
         match event {
             HotShotEvent::QuorumProposalSend(proposal, signature) => {
                 let mut result = Vec::new();
 
                 for n in 0..self.multiplier {
+                    // reset last actioned view so we actually propose multiple times
+                    consensus.write().await.reset_actions();
                     let mut modified_proposal = proposal.clone();
 
                     modified_proposal.data.view_number += n * self.increment;
@@ -80,6 +85,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> EventTransforme
         _public_key: &TYPES::SignatureKey,
         _private_key: &<TYPES::SignatureKey as SignatureKey>::PrivateKey,
         _upgrade_lock: &UpgradeLock<TYPES, V>,
+        _consensus: Arc<RwLock<Consensus<TYPES>>>,
     ) -> Vec<HotShotEvent<TYPES>> {
         match event {
             HotShotEvent::QuorumProposalSend(_, _) | HotShotEvent::QuorumVoteSend(_) => {
@@ -155,6 +161,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES> + std::fmt::Debug, V: Version
         _public_key: &TYPES::SignatureKey,
         _private_key: &<TYPES::SignatureKey as SignatureKey>::PrivateKey,
         _upgrade_lock: &UpgradeLock<TYPES, V>,
+        _consensus: Arc<RwLock<Consensus<TYPES>>>,
     ) -> Vec<HotShotEvent<TYPES>> {
         match event {
             HotShotEvent::QuorumProposalSend(proposal, sender) => {
@@ -195,6 +202,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES> + std::fmt::Debug, V: Version
         _public_key: &TYPES::SignatureKey,
         _private_key: &<TYPES::SignatureKey as SignatureKey>::PrivateKey,
         _upgrade_lock: &UpgradeLock<TYPES, V>,
+        _consensus: Arc<RwLock<Consensus<TYPES>>>,
     ) -> Vec<HotShotEvent<TYPES>> {
         if let HotShotEvent::DacSend(cert, sender) = event {
             self.total_da_certs_sent_from_node += 1;
@@ -264,6 +272,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES> + std::fmt::Debug, V: Version
         _public_key: &TYPES::SignatureKey,
         _private_key: &<TYPES::SignatureKey as SignatureKey>::PrivateKey,
         _upgrade_lock: &UpgradeLock<TYPES, V>,
+        _consensus: Arc<RwLock<Consensus<TYPES>>>,
     ) -> Vec<HotShotEvent<TYPES>> {
         vec![event.clone()]
     }
@@ -291,6 +300,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES> + std::fmt::Debug, V: Version
         public_key: &TYPES::SignatureKey,
         private_key: &<TYPES::SignatureKey as SignatureKey>::PrivateKey,
         upgrade_lock: &UpgradeLock<TYPES, V>,
+        _consensus: Arc<RwLock<Consensus<TYPES>>>,
     ) -> Vec<HotShotEvent<TYPES>> {
         if let HotShotEvent::QuorumVoteSend(vote) = event {
             let new_view = vote.view_number + self.view_increment;

--- a/crates/testing/src/byzantine/byzantine_behaviour.rs
+++ b/crates/testing/src/byzantine/byzantine_behaviour.rs
@@ -323,6 +323,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES> + std::fmt::Debug, V: Version
             membership,
             filter,
             storage: Arc::clone(&handle.storage()),
+            consensus: Arc::clone(&handle.consensus()),
             upgrade_lock: handle.hotshot.upgrade_lock.clone(),
         };
         let modified_network_state = NetworkEventTaskStateModifier {

--- a/crates/testing/src/spinning_task.rs
+++ b/crates/testing/src/spinning_task.rs
@@ -14,13 +14,13 @@ use async_lock::RwLock;
 use async_trait::async_trait;
 use futures::future::join_all;
 use hotshot::{traits::TestableNodeImplementation, types::EventType, HotShotInitializer};
-use hotshot_types::traits::node_implementation::ConsensusTime;
 use hotshot_example_types::{
     auction_results_provider_types::TestAuctionResultsProvider,
     state_types::{TestInstanceState, TestValidatedState},
     storage_types::TestStorage,
     testable_delay::DelayConfig,
 };
+use hotshot_types::traits::node_implementation::ConsensusTime;
 use hotshot_types::{
     data::Leaf,
     event::Event,

--- a/crates/testing/src/spinning_task.rs
+++ b/crates/testing/src/spinning_task.rs
@@ -14,6 +14,7 @@ use async_lock::RwLock;
 use async_trait::async_trait;
 use futures::future::join_all;
 use hotshot::{traits::TestableNodeImplementation, types::EventType, HotShotInitializer};
+use hotshot_types::traits::node_implementation::ConsensusTime;
 use hotshot_example_types::{
     auction_results_provider_types::TestAuctionResultsProvider,
     state_types::{TestInstanceState, TestValidatedState},
@@ -134,7 +135,8 @@ where
                                             self.last_decided_leaf.clone(),
                                             TestInstanceState::new(self.async_delay_config.clone()),
                                             None,
-                                            view_number,
+                                            TYPES::Time::genesis(),
+                                            TYPES::Time::genesis(),
                                             BTreeMap::new(),
                                             self.high_qc.clone(),
                                             Vec::new(),
@@ -211,6 +213,7 @@ where
                                     self.last_decided_leaf.clone(),
                                     TestInstanceState::new(self.async_delay_config.clone()),
                                     None,
+                                    view_number,
                                     view_number,
                                     read_storage.proposals_cloned().await,
                                     read_storage.high_qc_cloned().await.unwrap_or(

--- a/crates/testing/src/spinning_task.rs
+++ b/crates/testing/src/spinning_task.rs
@@ -214,7 +214,7 @@ where
                                     TestInstanceState::new(self.async_delay_config.clone()),
                                     None,
                                     view_number,
-                                    view_number,
+                                    read_storage.last_actioned_view().await,
                                     read_storage.proposals_cloned().await,
                                     read_storage.high_qc_cloned().await.unwrap_or(
                                         QuorumCertificate::genesis(

--- a/crates/testing/tests/tests_1/network_task.rs
+++ b/crates/testing/tests/tests_1/network_task.rs
@@ -28,7 +28,7 @@ use hotshot_types::{
         node_implementation::{ConsensusTime, NodeType},
     },
 };
-
+use hotshot_testing::helpers::build_system_handle;
 // Test that the event task sends a message, and the message task receives it
 // and emits the proper event
 #[cfg(test)]
@@ -46,12 +46,15 @@ async fn test_network_task() {
         TestDescription::default_multiple_rounds();
     let upgrade_lock = UpgradeLock::<TestTypes, TestVersions>::new();
     let node_id = 1;
-
+    let handle = build_system_handle::<TestTypes, MemoryImpl, TestVersions>(node_id)
+        .await
+        .0;
     let launcher = builder.gen_launcher(node_id);
 
     let network = (launcher.resource_generator.channel_generator)(node_id).await;
 
     let storage = Arc::new(RwLock::new((launcher.resource_generator.storage)(node_id)));
+    let consensus = handle.hotshot.consensus();
     let config = launcher.resource_generator.config.clone();
     let public_key = config.my_own_validator_config.public_key;
     let known_nodes_with_stake = config.known_nodes_with_stake.clone();
@@ -70,6 +73,7 @@ async fn test_network_task() {
             filter: network::quorum_filter,
             upgrade_lock: upgrade_lock.clone(),
             storage,
+            consensus,
         };
     let (tx, rx) = async_broadcast::broadcast(10);
     let mut task_reg = ConsensusTaskRegistry::new();
@@ -120,11 +124,14 @@ async fn test_network_storage_fail() {
     let builder: TestDescription<TestTypes, MemoryImpl, TestVersions> =
         TestDescription::default_multiple_rounds();
     let node_id = 1;
-
+    let handle = build_system_handle::<TestTypes, MemoryImpl, TestVersions>(node_id)
+        .await
+        .0;
     let launcher = builder.gen_launcher(node_id);
 
     let network = (launcher.resource_generator.channel_generator)(node_id).await;
 
+    let consensus = handle.hotshot.consensus();
     let storage = Arc::new(RwLock::new((launcher.resource_generator.storage)(node_id)));
     storage.write().await.should_return_err = true;
     let config = launcher.resource_generator.config.clone();
@@ -146,6 +153,7 @@ async fn test_network_storage_fail() {
             filter: network::quorum_filter,
             upgrade_lock: upgrade_lock.clone(),
             storage,
+            consensus,
         };
     let (tx, rx) = async_broadcast::broadcast(10);
     let mut task_reg = ConsensusTaskRegistry::new();

--- a/crates/testing/tests/tests_1/network_task.rs
+++ b/crates/testing/tests/tests_1/network_task.rs
@@ -17,8 +17,8 @@ use hotshot_task_impls::{
     network::{self, NetworkEventTaskState},
 };
 use hotshot_testing::{
-    test_builder::TestDescription, test_task::add_network_message_test_task,
-    view_generator::TestViewGenerator,
+    helpers::build_system_handle, test_builder::TestDescription,
+    test_task::add_network_message_test_task, view_generator::TestViewGenerator,
 };
 use hotshot_types::{
     data::ViewNumber,
@@ -28,7 +28,6 @@ use hotshot_types::{
         node_implementation::{ConsensusTime, NodeType},
     },
 };
-use hotshot_testing::helpers::build_system_handle;
 // Test that the event task sends a message, and the message task receives it
 // and emits the proper event
 #[cfg(test)]

--- a/crates/types/src/consensus.rs
+++ b/crates/types/src/consensus.rs
@@ -244,6 +244,17 @@ struct HotShotActionViews<T: ConsensusTime> {
     da_vote: T,
 }
 
+impl<T: ConsensusTime> Default for HotShotActionViews<T> {
+    fn default() -> Self {
+        let genesis = T::genesis();
+        Self {
+            proposed: genesis,
+            voted: genesis,
+            da_proposed: genesis,
+            da_vote: genesis,
+        }
+    }
+}
 impl<T: ConsensusTime> HotShotActionViews<T> {
     /// Create HotShotActionViews from a view number
     fn from_view(view: T) -> Self {
@@ -490,6 +501,11 @@ impl<TYPES: NodeType> Consensus<TYPES> {
             return true;
         }
         false
+    }
+
+    /// reset last actions to genesis so we can resend events in tests
+    pub fn reset_actions(&mut self) {
+        self.last_actions = HotShotActionViews::default();
     }
 
     /// Update the last proposal.

--- a/crates/types/src/consensus.rs
+++ b/crates/types/src/consensus.rs
@@ -474,12 +474,15 @@ impl<TYPES: NodeType> Consensus<TYPES> {
             HotShotAction::Propose => &mut self.last_actions.proposed,
             HotShotAction::DaPropose => &mut self.last_actions.da_proposed,
             HotShotAction::DaVote => {
+                if view > self.last_actions.da_vote {
+                    self.last_actions.da_vote = view;
+                }
                 // TODO Add logic to prevent double voting.  For now the simple check if
                 // the last voted view is less than the view we are trying to vote doesn't work
                 // becuase the leader of view n + 1 may propose to the DA (and we would vote)
                 // before the leader of view n.
-                return  true;
-            },
+                return true;
+            }
             _ => return true,
         };
         if view > *old_view {

--- a/crates/types/src/consensus.rs
+++ b/crates/types/src/consensus.rs
@@ -473,7 +473,13 @@ impl<TYPES: NodeType> Consensus<TYPES> {
             HotShotAction::Vote => &mut self.last_actions.voted,
             HotShotAction::Propose => &mut self.last_actions.proposed,
             HotShotAction::DaPropose => &mut self.last_actions.da_proposed,
-            HotShotAction::DaVote => &mut self.last_actions.da_vote,
+            HotShotAction::DaVote => {
+                // TODO Add logic to prevent double voting.  For now the simple check if
+                // the last voted view is less than the view we are trying to vote doesn't work
+                // becuase the leader of view n + 1 may propose to the DA (and we would vote)
+                // before the leader of view n.
+                return  true;
+            },
             _ => return true,
         };
         if view > *old_view {

--- a/crates/types/src/consensus.rs
+++ b/crates/types/src/consensus.rs
@@ -459,17 +459,22 @@ impl<TYPES: NodeType> Consensus<TYPES> {
         Ok(())
     }
 
-    pub fn update_action(&mut self, action: HotShotAction, view: TYPES::Time) {
+    /// Update the last actioned view internally for votes and proposals
+    ///
+    /// Returns true if the action is for a newer view than the last action of that type
+    pub fn update_action(&mut self, action: HotShotAction, view: TYPES::Time) -> bool {
         let old_view = match action {
             HotShotAction::Vote => &mut self.last_actions.last_voted_view,
             HotShotAction::Propose => &mut self.last_actions.last_proposed_view,
             HotShotAction::DaPropose => &mut self.last_actions.last_da_proposed_view,
             HotShotAction::DaVote => &mut self.last_actions.last_da_vote_view,
-            _ => return,
+            _ => return true,
         };
         if view > *old_view {
             *old_view = view;
+            return true;
         }
+        false
     }
 
     /// Update the last proposal.

--- a/crates/types/src/event.rs
+++ b/crates/types/src/event.rs
@@ -173,7 +173,7 @@ pub enum EventType<TYPES: NodeType> {
     /// A message destined for external listeners was received
     ExternalMessageReceived(Vec<u8>),
 }
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, Copy)]
 /// A list of actions that we track for nodes
 pub enum HotShotAction {
     /// A quorum vote was sent


### PR DESCRIPTION
Closes #3626 
<!-- See here for keywords in Github -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

### This PR: 

This PR adds a new start parameter to consensus which is the view we last "actioned" in.  An action is voting or proposing for DA/Quorum.  The PR also enforces that we don't send double actions by checking in the network task if we've already sent something for the view we are about to transmit a vote/proposal to or a higher view.  This means if we propose in view 10 we can't then propose for view 9.  We should never want to do this.

The PR also adds the consensus shared state to the byzantine behaviors so that they can reset the last actioned view so their byzantine sends are not blocked.
### This PR does not: 
This PR doesn't apply to DA votes because after view sync we can often legitimately get a proposal for view n and n+1 in either order.  If we handle the n+1 view first we don't want to not vote for view n

### Key places to review: 
-Changes to the `HotshotInitializer`
- Changes in `network.rs`
- Changes to `Consensus` 

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
