### PR TITLE
[TESTING] - Fix Startup / Restart Test Failures

### DIFF
--- a/crates/testing/src/overall_safety_task.rs
+++ b/crates/testing/src/overall_safety_task.rs
@@ -269,8 +269,9 @@ impl<TYPES: NodeType, I: TestableNodeImplementation<TYPES>, V: Versions> TestTas
         let views_count = self.ctx.failed_views.len() + self.ctx.successful_views.len();
         let results_count = self.ctx.round_results.len();
 
-        // This can cause tests to crash if we do the subtracting to get `num_incomplete_views` below, so throw an error instead
-        // Use this instead of saturating_sub as that could hide a real problem
+        // This can cause tests to crash if we do the subtracting to get `num_incomplete_views` below
+        // So lets fail return an error instead
+        // Use this check instead of saturating_sub as that could hide a real problem
         if views_count > results_count {
             return TestResult::Fail(Box::new(
                 OverallSafetyTaskErr::<TYPES>::NotEnoughRoundResults {
@@ -592,7 +593,7 @@ impl<TYPES: NodeType> RoundResult<TYPES> {
         }
 
         // check if no more failed nodes
-        if self.failed_nodes.is_empty() && failed_views.contains(view_number) {
+        if self.failed_nodes.is_empty() && failed_views.remove(view_number) {
             tracing::debug!(
                 "Removed view {:?} from failed views, all nodes have agreed upon view.",
                 view_number

--- a/crates/testing/src/overall_safety_task.rs
+++ b/crates/testing/src/overall_safety_task.rs
@@ -82,7 +82,7 @@ pub enum OverallSafetyTaskErr<TYPES: NodeType> {
         expected_failed_views: HashSet<TYPES::Time>,
         actual_failed_views: HashSet<TYPES::Time>,
     },
-    /// This is a case where we have too many failured + succesful views over round results
+    /// This is a case where we have too many failed + succesful views over round results
     /// This should never be the case and requires debugging if we see this get thrown
     NotEnoughRoundResults {
         results_count: usize,
@@ -274,12 +274,12 @@ impl<TYPES: NodeType, I: TestableNodeImplementation<TYPES>, V: Versions> TestTas
         if views_count > results_count {
             return TestResult::Fail(Box::new(
                 OverallSafetyTaskErr::<TYPES>::NotEnoughRoundResults {
-                    results_count: results_count,
-                    views_count: views_count,
+                    results_count,
+                    views_count,
                 },
             ));
         }
-        let num_incomplete_views = views_count - results_count;
+        let num_incomplete_views = results_count - views_count;
 
         if self.ctx.successful_views.len() < num_successful_views {
             return TestResult::Fail(Box::new(OverallSafetyTaskErr::<TYPES>::NotEnoughDecides {

--- a/crates/testing/tests/tests_2/catchup.rs
+++ b/crates/testing/tests/tests_2/catchup.rs
@@ -23,6 +23,9 @@ async fn test_catchup() {
     async_compatibility_layer::logging::setup_backtrace();
     let timing_data = TimingData {
         next_view_timeout: 2000,
+        // increase the round delay for this test
+        // TODO: remove this delay increase for test - https://github.com/EspressoSystems/HotShot/issues/3673
+        round_start_delay: 200,
         ..Default::default()
     };
     let mut metadata: TestDescription<TestTypes, MemoryImpl, TestVersions> =
@@ -41,7 +44,7 @@ async fn test_catchup() {
 
     metadata.spinning_properties = SpinningTaskDescription {
         // Start the nodes before their leadership.
-        node_changes: vec![(8, catchup_node)],
+        node_changes: vec![(13, catchup_node)],
     };
 
     metadata.completion_task_description =

--- a/crates/testing/tests/tests_2/catchup.rs
+++ b/crates/testing/tests/tests_2/catchup.rs
@@ -41,7 +41,7 @@ async fn test_catchup() {
 
     metadata.spinning_properties = SpinningTaskDescription {
         // Start the nodes before their leadership.
-        node_changes: vec![(13, catchup_node)],
+        node_changes: vec![(8, catchup_node)],
     };
 
     metadata.completion_task_description =


### PR DESCRIPTION
Closes (https://github.com/EspressoSystems/HotShot/issues/3651)
<!-- See here for keywords in Github -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

### This PR: 
<!-- Describe what this PR adds to HotShot -->
<!-- E.g. -->
<!-- * Implements feature 1 -->
<!-- * Implements feature 2 -->
<!-- * Fixes bug 3 -->
We noticed with certain flaky catchup tests that a node may come up before other nodes and wait for a proposal. The node wont receive the proposal in time then timeout the view, and add it to `failed_views` in our test harness. Later, the node will receive the proposal and decide upon the view, but in our test harness we never remove the previously timed out view from `failed_views`. So this PR will add some logic to do so.

### This PR does not: 
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->

### Key places to review: 
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
