### PR TITLE
[TECH DEBT] Improve `ConnectedNetwork` - `recv_message`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3109,6 +3109,7 @@ dependencies = [
  "libp2p-networking",
  "lru 0.12.4",
  "num_enum",
+ "parking_lot",
  "portpicker",
  "rand 0.8.5",
  "serde",

--- a/crates/hotshot/Cargo.toml
+++ b/crates/hotshot/Cargo.toml
@@ -61,6 +61,7 @@ blake3.workspace = true
 sha2 = { workspace = true }
 url = { workspace = true }
 num_enum = "0.7"
+parking_lot = "0.12"
 
 [target.'cfg(all(async_executor_impl = "tokio"))'.dependencies]
 tokio = { workspace = true }

--- a/crates/hotshot/src/traits/networking/libp2p_network.rs
+++ b/crates/hotshot/src/traits/networking/libp2p_network.rs
@@ -1055,12 +1055,12 @@ impl<K: SignatureKey + 'static> ConnectedNetwork<K> for Libp2pNetwork<K> {
     ///
     /// # Errors
     /// If there is a network-related failure.
-    #[instrument(name = "Libp2pNetwork::recv_msgs", skip_all)]
-    async fn recv_msgs(&self) -> Result<Vec<Vec<u8>>, NetworkError> {
+    #[instrument(name = "Libp2pNetwork::recv_message", skip_all)]
+    async fn recv_message(&self) -> Result<Vec<u8>, NetworkError> {
         let result = self
             .inner
             .receiver
-            .drain_at_least_one()
+            .recv()
             .await
             .map_err(|_x| NetworkError::ShutDown)?;
 

--- a/crates/hotshot/src/traits/networking/memory_network.rs
+++ b/crates/hotshot/src/traits/networking/memory_network.rs
@@ -371,14 +371,14 @@ impl<K: SignatureKey + 'static> ConnectedNetwork<K> for MemoryNetwork<K> {
     ///
     /// # Errors
     /// If the other side of the channel is closed
-    #[instrument(name = "MemoryNetwork::recv_msgs", skip_all)]
-    async fn recv_msgs(&self) -> Result<Vec<Vec<u8>>, NetworkError> {
+    #[instrument(name = "MemoryNetwork::recv_messages", skip_all)]
+    async fn recv_message(&self) -> Result<Vec<u8>, NetworkError> {
         let ret = self
             .inner
             .output
             .lock()
             .await
-            .drain_at_least_one()
+            .recv()
             .await
             .map_err(|_x| NetworkError::ShutDown)?;
         self.inner

--- a/crates/hotshot/src/traits/networking/memory_network.rs
+++ b/crates/hotshot/src/traits/networking/memory_network.rs
@@ -383,7 +383,7 @@ impl<K: SignatureKey + 'static> ConnectedNetwork<K> for MemoryNetwork<K> {
             .map_err(|_x| NetworkError::ShutDown)?;
         self.inner
             .in_flight_message_count
-            .fetch_sub(ret.len(), Ordering::Relaxed);
+            .fetch_sub(1, Ordering::Relaxed);
         Ok(ret)
     }
 }

--- a/crates/hotshot/src/traits/networking/push_cdn_network.rs
+++ b/crates/hotshot/src/traits/networking/push_cdn_network.rs
@@ -546,7 +546,7 @@ impl<K: SignatureKey + 'static> ConnectedNetwork<K> for PushCdnNetwork<K> {
     ///
     /// # Errors
     /// - If we fail to receive messages. Will trigger a retry automatically.
-    async fn recv_msgs(&self) -> Result<Vec<Vec<u8>>, NetworkError> {
+    async fn recv_message(&self) -> Result<Vec<u8>, NetworkError> {
         // Receive a message
         let message = self.client.receive_message().await;
 
@@ -577,7 +577,7 @@ impl<K: SignatureKey + 'static> ConnectedNetwork<K> for PushCdnNetwork<K> {
             return Ok(vec![]);
         };
 
-        Ok(vec![message])
+        Ok(message)
     }
 
     /// Do nothing here, as we don't need to look up nodes.

--- a/crates/orchestrator/run-config.toml
+++ b/crates/orchestrator/run-config.toml
@@ -1,4 +1,4 @@
-rounds = 10000
+rounds = 100
 indexed_da = true
 transactions_per_round = 10
 transaction_size = 1000

--- a/crates/orchestrator/run-config.toml
+++ b/crates/orchestrator/run-config.toml
@@ -1,4 +1,4 @@
-rounds = 100
+rounds = 10000
 indexed_da = true
 transactions_per_round = 10
 transaction_size = 1000

--- a/crates/types/src/traits/network.rs
+++ b/crates/types/src/traits/network.rs
@@ -304,7 +304,7 @@ pub trait ConnectedNetwork<K: SignatureKey + 'static>: Clone + Send + Sync + 'st
     ///
     /// # Errors
     /// If there is a network-related failure.
-    async fn recv_msgs(&self) -> Result<Vec<Vec<u8>>, NetworkError>;
+    async fn recv_message(&self) -> Result<Vec<u8>, NetworkError>;
 
     /// Ask request the network for some data.  Returns the request ID for that data,
     /// The ID returned can be used for cancelling the request


### PR DESCRIPTION
Is part of #3672
Closes #2558 

## This PR: 
<!-- Describe what this PR adds to HotSHot -->
<!-- E.g. -->
<!-- * Implements feature 1 -->
<!-- * Implements feature 2 -->
<!-- * Fixes bug 3 -->

### 1. Changes `recv_msgs` to `recv_message`, allowing us to receive a single message for each call. 

This simplifies the receiving layer and allows us to remove the `async_sleep` that we were using.

### 2. Improves the message receiving loop

Doesn't do the unfold/pin/stream anymore. Instead, selects between the shutdown stream and our `recv_messages` future. 

### 3. Improves performance of the `combined_network` loop by:

Changing it to use a synchronous lock. It will also now keep going until it receives something deserializable, instead of returning an empty message

## This PR does not: 
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->

Make any further improvements to `ConnectedNetwork`

## Key places to review: 
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->
`combined_network.rs`
`network.rs` for `handle_message()`

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

## Testing
Running the examples locally I get a 10x speedup (only tested with `combined` so far) due to the rewrite of the loop and the removal of the sleep. Now, the `combined_network` loop will keep receiving until it receives an uncached message instead of sleeping

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
