### PR TITLE
Use pre-defined stake-table in orchestrator

### DIFF
--- a/crates/examples/infra/mod.rs
+++ b/crates/examples/infra/mod.rs
@@ -880,8 +880,8 @@ pub async fn main_entry_point<
     let my_own_validator_config =
         NetworkConfig::<TYPES::SignatureKey>::generate_init_validator_config(
             &orchestrator_client,
-            // This is false for now, we only use it to generate the keypair
-            false,
+            // we assign nodes to the DA committee by default
+            true,
         )
         .await;
 

--- a/crates/orchestrator/run-config.toml
+++ b/crates/orchestrator/run-config.toml
@@ -3,40 +3,7 @@ indexed_da = true
 transactions_per_round = 10
 transaction_size = 1000
 node_index = 0
-seed = [
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-]
+seed = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
 start_delay_seconds = 0
 cdn_marshal_address = "127.0.0.1:9000"
 public_keys = [
@@ -60,7 +27,6 @@ public_keys = [
 
     { stake_table_key = "BLS_VER_KEY~PAAQNgOYfj3GiVX7LxSlkXfOCDSnNKZDqPVYQ_jBMxKzOCn0PXbqQ62kKPenWOmCxiCE7X158s-VenBna6MjHJgf61eBAO-3-OyTP5NWVx49RTgHhQf2iMTKk2iqK2gjnjZimBU135YU4lQFtrG-ZgRezwqkC5vy8V-q46fschIG", state_ver_key = "SCHNORR_VER_KEY~APKGX39-mOmApq6jMdIEiuuyddJ_k8xFeIwU1Zs2zShH1rI--eZR180Us5vqNWmK3zAidScvVcW4bAsOMHB3LPg", stake = 1, da = true }
 ]
-enable_registration_verification = true
 
 [config]
 num_nodes_with_stake = 10

--- a/crates/orchestrator/run-config.toml
+++ b/crates/orchestrator/run-config.toml
@@ -59,7 +59,6 @@ public_keys = [
     { stake_table_key = "BLS_VER_KEY~IUPSdnsNUHgNx_74ZhBPrICcDZ9Bp_DAt-6kFz8vSwJES2Vy1Ws8NJ1mxb9XGE1u13sw0FRe8kn5Ib3p2stbEtR_1Qgbuif6aoLrGaSUzy0MvwrO58u9kHZk3rXIuSAN7n4ok3-KKk2CmnBfx7fchFoqT56FXCd1EJ7XRrYj8wTh", state_ver_key = "SCHNORR_VER_KEY~qLqeTM1ZT1ecLEpzHwmlr-GeMUOest-kAm5nKOnKnB-W_TRj4IL77lnmamYvUdXR_ddQp24wQh2IlOIdp5jKEgw", stake = 1, da = true },
 
     { stake_table_key = "BLS_VER_KEY~PAAQNgOYfj3GiVX7LxSlkXfOCDSnNKZDqPVYQ_jBMxKzOCn0PXbqQ62kKPenWOmCxiCE7X158s-VenBna6MjHJgf61eBAO-3-OyTP5NWVx49RTgHhQf2iMTKk2iqK2gjnjZimBU135YU4lQFtrG-ZgRezwqkC5vy8V-q46fschIG", state_ver_key = "SCHNORR_VER_KEY~APKGX39-mOmApq6jMdIEiuuyddJ_k8xFeIwU1Zs2zShH1rI--eZR180Us5vqNWmK3zAidScvVcW4bAsOMHB3LPg", stake = 1, da = true }
-
 ]
 enable_registration_verification = true
 

--- a/crates/orchestrator/run-config.toml
+++ b/crates/orchestrator/run-config.toml
@@ -40,47 +40,25 @@ seed = [
 start_delay_seconds = 0
 cdn_marshal_address = "127.0.0.1:9000"
 public_keys = [
-    { stake_table_key = "BLS_VER_KEY~bQszS-QKYvUij2g20VqS8asttGSb95NrTu2PUj0uMh1CBUxNy1FqyPDjZqB29M7ZbjWqj79QkEOWkpga84AmDYUeTuWmy-0P1AdKHD3ehc-dKvei78BDj5USwXPJiDUlCxvYs_9rWYhagaq-5_LXENr78xel17spftNd5MA1Mw5U", state_ver_key = "SCHNORR_VER_KEY~lJqDaVZyM0hWP2Br52IX5FeE-dCAIC-dPX7bL5-qUx-vjbunwe-ENOeZxj6FuOyvDCFzoGeP7yZ0fM995qF-CRE", stake = 1 },
+    { stake_table_key = "BLS_VER_KEY~bQszS-QKYvUij2g20VqS8asttGSb95NrTu2PUj0uMh1CBUxNy1FqyPDjZqB29M7ZbjWqj79QkEOWkpga84AmDYUeTuWmy-0P1AdKHD3ehc-dKvei78BDj5USwXPJiDUlCxvYs_9rWYhagaq-5_LXENr78xel17spftNd5MA1Mw5U", state_ver_key = "SCHNORR_VER_KEY~lJqDaVZyM0hWP2Br52IX5FeE-dCAIC-dPX7bL5-qUx-vjbunwe-ENOeZxj6FuOyvDCFzoGeP7yZ0fM995qF-CRE", stake = 1, da = true },
 
-    { stake_table_key = "BLS_VER_KEY~IBRoz_Q1EXvcm1pNZcmVlyYZU8hZ7qmy337ePAjEMhz8Hl2q8vWPFOd3BaLwgRS1UzAPW3z4E-XIgRDGcRBTAMZX9b_0lKYjlyTlNF2EZfNnKmvv-xJ0yurkfjiveeYEsD2l5d8q_rJJbH1iZdXy-yPEbwI0SIvQfwdlcaKw9po4", state_ver_key = "SCHNORR_VER_KEY~tyuplKrHzvjODsjPKMHVFYfoMcgklQsMye-2aSCktBcbW_CIzLOq3wZXRIPBbw3FiV6_QoUXYAlpZ5up0zG_ANY", stake = 1 },
+    { stake_table_key = "BLS_VER_KEY~IBRoz_Q1EXvcm1pNZcmVlyYZU8hZ7qmy337ePAjEMhz8Hl2q8vWPFOd3BaLwgRS1UzAPW3z4E-XIgRDGcRBTAMZX9b_0lKYjlyTlNF2EZfNnKmvv-xJ0yurkfjiveeYEsD2l5d8q_rJJbH1iZdXy-yPEbwI0SIvQfwdlcaKw9po4", state_ver_key = "SCHNORR_VER_KEY~tyuplKrHzvjODsjPKMHVFYfoMcgklQsMye-2aSCktBcbW_CIzLOq3wZXRIPBbw3FiV6_QoUXYAlpZ5up0zG_ANY", stake = 1, da = true },
 
-    { stake_table_key = "BLS_VER_KEY~4zQnaCOFJ7m95OjxeNls0QOOwWbz4rfxaL3NwmN2zSdnf8t5Nw_dfmMHq05ee8jCegw6Bn5T8inmrnGGAsQJMMWLv77nd7FJziz2ViAbXg-XGGF7o4HyzELCmypDOIYF3X2UWferFE_n72ZX0iQkUhOvYZZ7cfXToXxRTtb_mwRR", state_ver_key = "SCHNORR_VER_KEY~qQAC373HPv4s0mTTpdmSaynfUXC4SfPCuGD2fbeigSpexFB2ycCeXV9UAjuR86CC9udPhopgMsFLyD29VO2iJSg", stake = 1 },
+    { stake_table_key = "BLS_VER_KEY~4zQnaCOFJ7m95OjxeNls0QOOwWbz4rfxaL3NwmN2zSdnf8t5Nw_dfmMHq05ee8jCegw6Bn5T8inmrnGGAsQJMMWLv77nd7FJziz2ViAbXg-XGGF7o4HyzELCmypDOIYF3X2UWferFE_n72ZX0iQkUhOvYZZ7cfXToXxRTtb_mwRR", state_ver_key = "SCHNORR_VER_KEY~qQAC373HPv4s0mTTpdmSaynfUXC4SfPCuGD2fbeigSpexFB2ycCeXV9UAjuR86CC9udPhopgMsFLyD29VO2iJSg", stake = 1, da = true},
 
-    { stake_table_key = "BLS_VER_KEY~rO2PIjyY30HGfapFcloFe3mNDKMIFi6JlOLkH5ZWBSYoRm5fE2-Rm6Lp3EvmAcB5r7KFJ0c1Uor308x78r04EY_sfjcsDCWt7RSJdL4cJoD_4fSTCv_bisO8k98hs_8BtqQt8BHlPeJohpUXvcfnK8suXJETiJ6Er97pfxRbzgAL", state_ver_key = "SCHNORR_VER_KEY~le6RHdTasbBsTcbMqArt0XWFwfIJTY7RbUwaCvdxswL8LpXpO3eb86iyYUr63dtv4GGa5fIJaRH97nCd1lV9H8g", stake = 1 },
+    { stake_table_key = "BLS_VER_KEY~rO2PIjyY30HGfapFcloFe3mNDKMIFi6JlOLkH5ZWBSYoRm5fE2-Rm6Lp3EvmAcB5r7KFJ0c1Uor308x78r04EY_sfjcsDCWt7RSJdL4cJoD_4fSTCv_bisO8k98hs_8BtqQt8BHlPeJohpUXvcfnK8suXJETiJ6Er97pfxRbzgAL", state_ver_key = "SCHNORR_VER_KEY~le6RHdTasbBsTcbMqArt0XWFwfIJTY7RbUwaCvdxswL8LpXpO3eb86iyYUr63dtv4GGa5fIJaRH97nCd1lV9H8g", stake = 1, da = true },
 
-    { stake_table_key = "BLS_VER_KEY~r6b-Cwzp-b3czlt0MHmYPJIow5kMsXbrNmZsLSYg9RV49oCCO4WEeCRFR02x9bqLCa_sgNFMrIeNdEa11qNiBAohApYFIvrSa-zP5QGj3xbZaMOCrshxYit6E2TR-XsWvv6gjOrypmugjyTAth-iqQzTboSfmO9DD1-gjJIdCaD7", state_ver_key = "SCHNORR_VER_KEY~LfL6fFJQ8UZWR1Jro6LHtKm_y5-VQZBapO0XhcB8ABAmsVght9B8k7NntrgniffAMD8_OJ6Zjg8XUklhbb42CIw", stake = 1 },
+    { stake_table_key = "BLS_VER_KEY~r6b-Cwzp-b3czlt0MHmYPJIow5kMsXbrNmZsLSYg9RV49oCCO4WEeCRFR02x9bqLCa_sgNFMrIeNdEa11qNiBAohApYFIvrSa-zP5QGj3xbZaMOCrshxYit6E2TR-XsWvv6gjOrypmugjyTAth-iqQzTboSfmO9DD1-gjJIdCaD7", state_ver_key = "SCHNORR_VER_KEY~LfL6fFJQ8UZWR1Jro6LHtKm_y5-VQZBapO0XhcB8ABAmsVght9B8k7NntrgniffAMD8_OJ6Zjg8XUklhbb42CIw", stake = 1, da = true },
 
-    { stake_table_key = "BLS_VER_KEY~kEUEUJFBtCXl68fM_2roQw856wQlu1ZoDmPn8uu4bQgeZwyb5oz5_kMl-oAJ_OtbYV1serjWE--eXB_qYIpQLZka42-cML6WjCQjNl1hGSejtoBDkExNeUNcweFQBbEsaDiIy3-sgHTrfYpFd1icKeAVihLRn5_RtSU_RUu1TQqR", state_ver_key = "SCHNORR_VER_KEY~qKOggsQMNIIvmiIPM3smiGk40kYGXCVupsmgIrf3RgMmua683F3vUwzWcx0s7mxdzLXJwPAB06LD96cxip7JLJM", stake = 1 },
+    { stake_table_key = "BLS_VER_KEY~kEUEUJFBtCXl68fM_2roQw856wQlu1ZoDmPn8uu4bQgeZwyb5oz5_kMl-oAJ_OtbYV1serjWE--eXB_qYIpQLZka42-cML6WjCQjNl1hGSejtoBDkExNeUNcweFQBbEsaDiIy3-sgHTrfYpFd1icKeAVihLRn5_RtSU_RUu1TQqR", state_ver_key = "SCHNORR_VER_KEY~qKOggsQMNIIvmiIPM3smiGk40kYGXCVupsmgIrf3RgMmua683F3vUwzWcx0s7mxdzLXJwPAB06LD96cxip7JLJM", stake = 1, da = true },
 
-    { stake_table_key = "BLS_VER_KEY~96hAcdFZxQT8CEHcyV8j2ILJRsXagquENPkc9AwLSx3u6AE_uMupIKGbNJRiM99oFneK2vI5g1u61HidWeuTLRPM2537xAXeaO8e-wJYx4FaPKw_xTcLPrIm0OZT7SsLAMwFuqfMbDdKM71-RyrLwhff5517xXBKEk5Tg9iT9Qrr", state_ver_key = "SCHNORR_VER_KEY~y0nltwKyKSpwO3ki9Czu5asjAt5g1Ya3XmAywcerOSUg__FuZOcYq6tKxMsnsjE7ylpWLZv8R5W4-6WkP0DWI94", stake = 1 },
+    { stake_table_key = "BLS_VER_KEY~96hAcdFZxQT8CEHcyV8j2ILJRsXagquENPkc9AwLSx3u6AE_uMupIKGbNJRiM99oFneK2vI5g1u61HidWeuTLRPM2537xAXeaO8e-wJYx4FaPKw_xTcLPrIm0OZT7SsLAMwFuqfMbDdKM71-RyrLwhff5517xXBKEk5Tg9iT9Qrr", state_ver_key = "SCHNORR_VER_KEY~y0nltwKyKSpwO3ki9Czu5asjAt5g1Ya3XmAywcerOSUg__FuZOcYq6tKxMsnsjE7ylpWLZv8R5W4-6WkP0DWI94", stake = 1, da = true },
 
-    { stake_table_key = "BLS_VER_KEY~-pVi7j6TEBeG7ABata4uWWDRM2SrY8wWotWsGnTpIhnOVYJI_lNWyig6VJUuFmBsMS8rLMU7nDxDm8SbObxyA-SLFcr_jCkZqsbx8GcVQrnBAfjNRWuPZP0xcTDMu2IkQqtc3L0OpzbMEgGRGE8Wj09pNqouzl-xhPoYjTmD06Bw", state_ver_key = "SCHNORR_VER_KEY~6rPZ_plXxp8Uoh-E8VPb37csDRLND66zAorA3crYOhf9ARJapk8151RRVXWHe5Q2uF_RmQQmOCAov6tIpJ4yHz0", stake = 1 },
+    { stake_table_key = "BLS_VER_KEY~-pVi7j6TEBeG7ABata4uWWDRM2SrY8wWotWsGnTpIhnOVYJI_lNWyig6VJUuFmBsMS8rLMU7nDxDm8SbObxyA-SLFcr_jCkZqsbx8GcVQrnBAfjNRWuPZP0xcTDMu2IkQqtc3L0OpzbMEgGRGE8Wj09pNqouzl-xhPoYjTmD06Bw", state_ver_key = "SCHNORR_VER_KEY~6rPZ_plXxp8Uoh-E8VPb37csDRLND66zAorA3crYOhf9ARJapk8151RRVXWHe5Q2uF_RmQQmOCAov6tIpJ4yHz0", stake = 1, da = true },
 
-    { stake_table_key = "BLS_VER_KEY~IUPSdnsNUHgNx_74ZhBPrICcDZ9Bp_DAt-6kFz8vSwJES2Vy1Ws8NJ1mxb9XGE1u13sw0FRe8kn5Ib3p2stbEtR_1Qgbuif6aoLrGaSUzy0MvwrO58u9kHZk3rXIuSAN7n4ok3-KKk2CmnBfx7fchFoqT56FXCd1EJ7XRrYj8wTh", state_ver_key = "SCHNORR_VER_KEY~qLqeTM1ZT1ecLEpzHwmlr-GeMUOest-kAm5nKOnKnB-W_TRj4IL77lnmamYvUdXR_ddQp24wQh2IlOIdp5jKEgw", stake = 1 },
+    { stake_table_key = "BLS_VER_KEY~IUPSdnsNUHgNx_74ZhBPrICcDZ9Bp_DAt-6kFz8vSwJES2Vy1Ws8NJ1mxb9XGE1u13sw0FRe8kn5Ib3p2stbEtR_1Qgbuif6aoLrGaSUzy0MvwrO58u9kHZk3rXIuSAN7n4ok3-KKk2CmnBfx7fchFoqT56FXCd1EJ7XRrYj8wTh", state_ver_key = "SCHNORR_VER_KEY~qLqeTM1ZT1ecLEpzHwmlr-GeMUOest-kAm5nKOnKnB-W_TRj4IL77lnmamYvUdXR_ddQp24wQh2IlOIdp5jKEgw", stake = 1, da = true },
 
-    { stake_table_key = "BLS_VER_KEY~PAAQNgOYfj3GiVX7LxSlkXfOCDSnNKZDqPVYQ_jBMxKzOCn0PXbqQ62kKPenWOmCxiCE7X158s-VenBna6MjHJgf61eBAO-3-OyTP5NWVx49RTgHhQf2iMTKk2iqK2gjnjZimBU135YU4lQFtrG-ZgRezwqkC5vy8V-q46fschIG", state_ver_key = "SCHNORR_VER_KEY~APKGX39-mOmApq6jMdIEiuuyddJ_k8xFeIwU1Zs2zShH1rI--eZR180Us5vqNWmK3zAidScvVcW4bAsOMHB3LPg", stake = 1 }
-
-]
-da_public_keys = [
-    { stake_table_key = "BLS_VER_KEY~bQszS-QKYvUij2g20VqS8asttGSb95NrTu2PUj0uMh1CBUxNy1FqyPDjZqB29M7ZbjWqj79QkEOWkpga84AmDYUeTuWmy-0P1AdKHD3ehc-dKvei78BDj5USwXPJiDUlCxvYs_9rWYhagaq-5_LXENr78xel17spftNd5MA1Mw5U", state_ver_key = "SCHNORR_VER_KEY~lJqDaVZyM0hWP2Br52IX5FeE-dCAIC-dPX7bL5-qUx-vjbunwe-ENOeZxj6FuOyvDCFzoGeP7yZ0fM995qF-CRE", stake = 1 },
-
-    { stake_table_key = "BLS_VER_KEY~IBRoz_Q1EXvcm1pNZcmVlyYZU8hZ7qmy337ePAjEMhz8Hl2q8vWPFOd3BaLwgRS1UzAPW3z4E-XIgRDGcRBTAMZX9b_0lKYjlyTlNF2EZfNnKmvv-xJ0yurkfjiveeYEsD2l5d8q_rJJbH1iZdXy-yPEbwI0SIvQfwdlcaKw9po4", state_ver_key = "SCHNORR_VER_KEY~tyuplKrHzvjODsjPKMHVFYfoMcgklQsMye-2aSCktBcbW_CIzLOq3wZXRIPBbw3FiV6_QoUXYAlpZ5up0zG_ANY", stake = 1 },
-
-    { stake_table_key = "BLS_VER_KEY~4zQnaCOFJ7m95OjxeNls0QOOwWbz4rfxaL3NwmN2zSdnf8t5Nw_dfmMHq05ee8jCegw6Bn5T8inmrnGGAsQJMMWLv77nd7FJziz2ViAbXg-XGGF7o4HyzELCmypDOIYF3X2UWferFE_n72ZX0iQkUhOvYZZ7cfXToXxRTtb_mwRR", state_ver_key = "SCHNORR_VER_KEY~qQAC373HPv4s0mTTpdmSaynfUXC4SfPCuGD2fbeigSpexFB2ycCeXV9UAjuR86CC9udPhopgMsFLyD29VO2iJSg", stake = 1 },
-
-    { stake_table_key = "BLS_VER_KEY~rO2PIjyY30HGfapFcloFe3mNDKMIFi6JlOLkH5ZWBSYoRm5fE2-Rm6Lp3EvmAcB5r7KFJ0c1Uor308x78r04EY_sfjcsDCWt7RSJdL4cJoD_4fSTCv_bisO8k98hs_8BtqQt8BHlPeJohpUXvcfnK8suXJETiJ6Er97pfxRbzgAL", state_ver_key = "SCHNORR_VER_KEY~le6RHdTasbBsTcbMqArt0XWFwfIJTY7RbUwaCvdxswL8LpXpO3eb86iyYUr63dtv4GGa5fIJaRH97nCd1lV9H8g", stake = 1 },
-
-    { stake_table_key = "BLS_VER_KEY~r6b-Cwzp-b3czlt0MHmYPJIow5kMsXbrNmZsLSYg9RV49oCCO4WEeCRFR02x9bqLCa_sgNFMrIeNdEa11qNiBAohApYFIvrSa-zP5QGj3xbZaMOCrshxYit6E2TR-XsWvv6gjOrypmugjyTAth-iqQzTboSfmO9DD1-gjJIdCaD7", state_ver_key = "SCHNORR_VER_KEY~LfL6fFJQ8UZWR1Jro6LHtKm_y5-VQZBapO0XhcB8ABAmsVght9B8k7NntrgniffAMD8_OJ6Zjg8XUklhbb42CIw", stake = 1 },
-
-    { stake_table_key = "BLS_VER_KEY~kEUEUJFBtCXl68fM_2roQw856wQlu1ZoDmPn8uu4bQgeZwyb5oz5_kMl-oAJ_OtbYV1serjWE--eXB_qYIpQLZka42-cML6WjCQjNl1hGSejtoBDkExNeUNcweFQBbEsaDiIy3-sgHTrfYpFd1icKeAVihLRn5_RtSU_RUu1TQqR", state_ver_key = "SCHNORR_VER_KEY~qKOggsQMNIIvmiIPM3smiGk40kYGXCVupsmgIrf3RgMmua683F3vUwzWcx0s7mxdzLXJwPAB06LD96cxip7JLJM", stake = 1 },
-
-    { stake_table_key = "BLS_VER_KEY~96hAcdFZxQT8CEHcyV8j2ILJRsXagquENPkc9AwLSx3u6AE_uMupIKGbNJRiM99oFneK2vI5g1u61HidWeuTLRPM2537xAXeaO8e-wJYx4FaPKw_xTcLPrIm0OZT7SsLAMwFuqfMbDdKM71-RyrLwhff5517xXBKEk5Tg9iT9Qrr", state_ver_key = "SCHNORR_VER_KEY~y0nltwKyKSpwO3ki9Czu5asjAt5g1Ya3XmAywcerOSUg__FuZOcYq6tKxMsnsjE7ylpWLZv8R5W4-6WkP0DWI94", stake = 1 },
-
-    { stake_table_key = "BLS_VER_KEY~-pVi7j6TEBeG7ABata4uWWDRM2SrY8wWotWsGnTpIhnOVYJI_lNWyig6VJUuFmBsMS8rLMU7nDxDm8SbObxyA-SLFcr_jCkZqsbx8GcVQrnBAfjNRWuPZP0xcTDMu2IkQqtc3L0OpzbMEgGRGE8Wj09pNqouzl-xhPoYjTmD06Bw", state_ver_key = "SCHNORR_VER_KEY~6rPZ_plXxp8Uoh-E8VPb37csDRLND66zAorA3crYOhf9ARJapk8151RRVXWHe5Q2uF_RmQQmOCAov6tIpJ4yHz0", stake = 1 },
-
-    { stake_table_key = "BLS_VER_KEY~IUPSdnsNUHgNx_74ZhBPrICcDZ9Bp_DAt-6kFz8vSwJES2Vy1Ws8NJ1mxb9XGE1u13sw0FRe8kn5Ib3p2stbEtR_1Qgbuif6aoLrGaSUzy0MvwrO58u9kHZk3rXIuSAN7n4ok3-KKk2CmnBfx7fchFoqT56FXCd1EJ7XRrYj8wTh", state_ver_key = "SCHNORR_VER_KEY~qLqeTM1ZT1ecLEpzHwmlr-GeMUOest-kAm5nKOnKnB-W_TRj4IL77lnmamYvUdXR_ddQp24wQh2IlOIdp5jKEgw", stake = 1 },
-
-    { stake_table_key = "BLS_VER_KEY~PAAQNgOYfj3GiVX7LxSlkXfOCDSnNKZDqPVYQ_jBMxKzOCn0PXbqQ62kKPenWOmCxiCE7X158s-VenBna6MjHJgf61eBAO-3-OyTP5NWVx49RTgHhQf2iMTKk2iqK2gjnjZimBU135YU4lQFtrG-ZgRezwqkC5vy8V-q46fschIG", state_ver_key = "SCHNORR_VER_KEY~APKGX39-mOmApq6jMdIEiuuyddJ_k8xFeIwU1Zs2zShH1rI--eZR180Us5vqNWmK3zAidScvVcW4bAsOMHB3LPg", stake = 1 }
+    { stake_table_key = "BLS_VER_KEY~PAAQNgOYfj3GiVX7LxSlkXfOCDSnNKZDqPVYQ_jBMxKzOCn0PXbqQ62kKPenWOmCxiCE7X158s-VenBna6MjHJgf61eBAO-3-OyTP5NWVx49RTgHhQf2iMTKk2iqK2gjnjZimBU135YU4lQFtrG-ZgRezwqkC5vy8V-q46fschIG", state_ver_key = "SCHNORR_VER_KEY~APKGX39-mOmApq6jMdIEiuuyddJ_k8xFeIwU1Zs2zShH1rI--eZR180Us5vqNWmK3zAidScvVcW4bAsOMHB3LPg", stake = 1, da = true }
 
 ]
 enable_registration_verification = true

--- a/crates/orchestrator/run-config.toml
+++ b/crates/orchestrator/run-config.toml
@@ -40,17 +40,48 @@ seed = [
 start_delay_seconds = 0
 cdn_marshal_address = "127.0.0.1:9000"
 public_keys = [
-    "BLS_VER_KEY~p-JKk1VvO1RoMrDrqyjz0P1VGwtOaEjF5jLjpOZbJi5O747fvYEOg0OvCl_CLe4shh7vsqeG9uMF9RssM12sLSuaiVJkCClxEI5mRLV4qff1UjZAZJIBgeL1_hRhRUkpqC0Trm1qtvXtZ8FwOCIzYXv8c300Au824k7FxjjcWLBL",
-    "BLS_VER_KEY~bQszS-QKYvUij2g20VqS8asttGSb95NrTu2PUj0uMh1CBUxNy1FqyPDjZqB29M7ZbjWqj79QkEOWkpga84AmDYUeTuWmy-0P1AdKHD3ehc-dKvei78BDj5USwXPJiDUlCxvYs_9rWYhagaq-5_LXENr78xel17spftNd5MA1Mw5U",
-    "BLS_VER_KEY~4zQnaCOFJ7m95OjxeNls0QOOwWbz4rfxaL3NwmN2zSdnf8t5Nw_dfmMHq05ee8jCegw6Bn5T8inmrnGGAsQJMMWLv77nd7FJziz2ViAbXg-XGGF7o4HyzELCmypDOIYF3X2UWferFE_n72ZX0iQkUhOvYZZ7cfXToXxRTtb_mwRR",
-    "BLS_VER_KEY~rO2PIjyY30HGfapFcloFe3mNDKMIFi6JlOLkH5ZWBSYoRm5fE2-Rm6Lp3EvmAcB5r7KFJ0c1Uor308x78r04EY_sfjcsDCWt7RSJdL4cJoD_4fSTCv_bisO8k98hs_8BtqQt8BHlPeJohpUXvcfnK8suXJETiJ6Er97pfxRbzgAL",
-    "BLS_VER_KEY~r6b-Cwzp-b3czlt0MHmYPJIow5kMsXbrNmZsLSYg9RV49oCCO4WEeCRFR02x9bqLCa_sgNFMrIeNdEa11qNiBAohApYFIvrSa-zP5QGj3xbZaMOCrshxYit6E2TR-XsWvv6gjOrypmugjyTAth-iqQzTboSfmO9DD1-gjJIdCaD7",
-    "BLS_VER_KEY~IBRoz_Q1EXvcm1pNZcmVlyYZU8hZ7qmy337ePAjEMhz8Hl2q8vWPFOd3BaLwgRS1UzAPW3z4E-XIgRDGcRBTAMZX9b_0lKYjlyTlNF2EZfNnKmvv-xJ0yurkfjiveeYEsD2l5d8q_rJJbH1iZdXy-yPEbwI0SIvQfwdlcaKw9po4",
-    "BLS_VER_KEY~kEUEUJFBtCXl68fM_2roQw856wQlu1ZoDmPn8uu4bQgeZwyb5oz5_kMl-oAJ_OtbYV1serjWE--eXB_qYIpQLZka42-cML6WjCQjNl1hGSejtoBDkExNeUNcweFQBbEsaDiIy3-sgHTrfYpFd1icKeAVihLRn5_RtSU_RUu1TQqR",
-    "BLS_VER_KEY~PAAQNgOYfj3GiVX7LxSlkXfOCDSnNKZDqPVYQ_jBMxKzOCn0PXbqQ62kKPenWOmCxiCE7X158s-VenBna6MjHJgf61eBAO-3-OyTP5NWVx49RTgHhQf2iMTKk2iqK2gjnjZimBU135YU4lQFtrG-ZgRezwqkC5vy8V-q46fschIG",
-    "BLS_VER_KEY~96hAcdFZxQT8CEHcyV8j2ILJRsXagquENPkc9AwLSx3u6AE_uMupIKGbNJRiM99oFneK2vI5g1u61HidWeuTLRPM2537xAXeaO8e-wJYx4FaPKw_xTcLPrIm0OZT7SsLAMwFuqfMbDdKM71-RyrLwhff5517xXBKEk5Tg9iT9Qrr",
-    "BLS_VER_KEY~-pVi7j6TEBeG7ABata4uWWDRM2SrY8wWotWsGnTpIhnOVYJI_lNWyig6VJUuFmBsMS8rLMU7nDxDm8SbObxyA-SLFcr_jCkZqsbx8GcVQrnBAfjNRWuPZP0xcTDMu2IkQqtc3L0OpzbMEgGRGE8Wj09pNqouzl-xhPoYjTmD06Bw",
-    "BLS_VER_KEY~IUPSdnsNUHgNx_74ZhBPrICcDZ9Bp_DAt-6kFz8vSwJES2Vy1Ws8NJ1mxb9XGE1u13sw0FRe8kn5Ib3p2stbEtR_1Qgbuif6aoLrGaSUzy0MvwrO58u9kHZk3rXIuSAN7n4ok3-KKk2CmnBfx7fchFoqT56FXCd1EJ7XRrYj8wTh",
+    { stake_table_key = "BLS_VER_KEY~bQszS-QKYvUij2g20VqS8asttGSb95NrTu2PUj0uMh1CBUxNy1FqyPDjZqB29M7ZbjWqj79QkEOWkpga84AmDYUeTuWmy-0P1AdKHD3ehc-dKvei78BDj5USwXPJiDUlCxvYs_9rWYhagaq-5_LXENr78xel17spftNd5MA1Mw5U", state_ver_key = "SCHNORR_VER_KEY~lJqDaVZyM0hWP2Br52IX5FeE-dCAIC-dPX7bL5-qUx-vjbunwe-ENOeZxj6FuOyvDCFzoGeP7yZ0fM995qF-CRE", stake = 1 },
+
+    { stake_table_key = "BLS_VER_KEY~IBRoz_Q1EXvcm1pNZcmVlyYZU8hZ7qmy337ePAjEMhz8Hl2q8vWPFOd3BaLwgRS1UzAPW3z4E-XIgRDGcRBTAMZX9b_0lKYjlyTlNF2EZfNnKmvv-xJ0yurkfjiveeYEsD2l5d8q_rJJbH1iZdXy-yPEbwI0SIvQfwdlcaKw9po4", state_ver_key = "SCHNORR_VER_KEY~tyuplKrHzvjODsjPKMHVFYfoMcgklQsMye-2aSCktBcbW_CIzLOq3wZXRIPBbw3FiV6_QoUXYAlpZ5up0zG_ANY", stake = 1 },
+
+    { stake_table_key = "BLS_VER_KEY~4zQnaCOFJ7m95OjxeNls0QOOwWbz4rfxaL3NwmN2zSdnf8t5Nw_dfmMHq05ee8jCegw6Bn5T8inmrnGGAsQJMMWLv77nd7FJziz2ViAbXg-XGGF7o4HyzELCmypDOIYF3X2UWferFE_n72ZX0iQkUhOvYZZ7cfXToXxRTtb_mwRR", state_ver_key = "SCHNORR_VER_KEY~qQAC373HPv4s0mTTpdmSaynfUXC4SfPCuGD2fbeigSpexFB2ycCeXV9UAjuR86CC9udPhopgMsFLyD29VO2iJSg", stake = 1 },
+
+    { stake_table_key = "BLS_VER_KEY~rO2PIjyY30HGfapFcloFe3mNDKMIFi6JlOLkH5ZWBSYoRm5fE2-Rm6Lp3EvmAcB5r7KFJ0c1Uor308x78r04EY_sfjcsDCWt7RSJdL4cJoD_4fSTCv_bisO8k98hs_8BtqQt8BHlPeJohpUXvcfnK8suXJETiJ6Er97pfxRbzgAL", state_ver_key = "SCHNORR_VER_KEY~le6RHdTasbBsTcbMqArt0XWFwfIJTY7RbUwaCvdxswL8LpXpO3eb86iyYUr63dtv4GGa5fIJaRH97nCd1lV9H8g", stake = 1 },
+
+    { stake_table_key = "BLS_VER_KEY~r6b-Cwzp-b3czlt0MHmYPJIow5kMsXbrNmZsLSYg9RV49oCCO4WEeCRFR02x9bqLCa_sgNFMrIeNdEa11qNiBAohApYFIvrSa-zP5QGj3xbZaMOCrshxYit6E2TR-XsWvv6gjOrypmugjyTAth-iqQzTboSfmO9DD1-gjJIdCaD7", state_ver_key = "SCHNORR_VER_KEY~LfL6fFJQ8UZWR1Jro6LHtKm_y5-VQZBapO0XhcB8ABAmsVght9B8k7NntrgniffAMD8_OJ6Zjg8XUklhbb42CIw", stake = 1 },
+
+    { stake_table_key = "BLS_VER_KEY~kEUEUJFBtCXl68fM_2roQw856wQlu1ZoDmPn8uu4bQgeZwyb5oz5_kMl-oAJ_OtbYV1serjWE--eXB_qYIpQLZka42-cML6WjCQjNl1hGSejtoBDkExNeUNcweFQBbEsaDiIy3-sgHTrfYpFd1icKeAVihLRn5_RtSU_RUu1TQqR", state_ver_key = "SCHNORR_VER_KEY~qKOggsQMNIIvmiIPM3smiGk40kYGXCVupsmgIrf3RgMmua683F3vUwzWcx0s7mxdzLXJwPAB06LD96cxip7JLJM", stake = 1 },
+
+    { stake_table_key = "BLS_VER_KEY~96hAcdFZxQT8CEHcyV8j2ILJRsXagquENPkc9AwLSx3u6AE_uMupIKGbNJRiM99oFneK2vI5g1u61HidWeuTLRPM2537xAXeaO8e-wJYx4FaPKw_xTcLPrIm0OZT7SsLAMwFuqfMbDdKM71-RyrLwhff5517xXBKEk5Tg9iT9Qrr", state_ver_key = "SCHNORR_VER_KEY~y0nltwKyKSpwO3ki9Czu5asjAt5g1Ya3XmAywcerOSUg__FuZOcYq6tKxMsnsjE7ylpWLZv8R5W4-6WkP0DWI94", stake = 1 },
+
+    { stake_table_key = "BLS_VER_KEY~-pVi7j6TEBeG7ABata4uWWDRM2SrY8wWotWsGnTpIhnOVYJI_lNWyig6VJUuFmBsMS8rLMU7nDxDm8SbObxyA-SLFcr_jCkZqsbx8GcVQrnBAfjNRWuPZP0xcTDMu2IkQqtc3L0OpzbMEgGRGE8Wj09pNqouzl-xhPoYjTmD06Bw", state_ver_key = "SCHNORR_VER_KEY~6rPZ_plXxp8Uoh-E8VPb37csDRLND66zAorA3crYOhf9ARJapk8151RRVXWHe5Q2uF_RmQQmOCAov6tIpJ4yHz0", stake = 1 },
+
+    { stake_table_key = "BLS_VER_KEY~IUPSdnsNUHgNx_74ZhBPrICcDZ9Bp_DAt-6kFz8vSwJES2Vy1Ws8NJ1mxb9XGE1u13sw0FRe8kn5Ib3p2stbEtR_1Qgbuif6aoLrGaSUzy0MvwrO58u9kHZk3rXIuSAN7n4ok3-KKk2CmnBfx7fchFoqT56FXCd1EJ7XRrYj8wTh", state_ver_key = "SCHNORR_VER_KEY~qLqeTM1ZT1ecLEpzHwmlr-GeMUOest-kAm5nKOnKnB-W_TRj4IL77lnmamYvUdXR_ddQp24wQh2IlOIdp5jKEgw", stake = 1 },
+
+    { stake_table_key = "BLS_VER_KEY~PAAQNgOYfj3GiVX7LxSlkXfOCDSnNKZDqPVYQ_jBMxKzOCn0PXbqQ62kKPenWOmCxiCE7X158s-VenBna6MjHJgf61eBAO-3-OyTP5NWVx49RTgHhQf2iMTKk2iqK2gjnjZimBU135YU4lQFtrG-ZgRezwqkC5vy8V-q46fschIG", state_ver_key = "SCHNORR_VER_KEY~APKGX39-mOmApq6jMdIEiuuyddJ_k8xFeIwU1Zs2zShH1rI--eZR180Us5vqNWmK3zAidScvVcW4bAsOMHB3LPg", stake = 1 }
+
+]
+da_public_keys = [
+    { stake_table_key = "BLS_VER_KEY~bQszS-QKYvUij2g20VqS8asttGSb95NrTu2PUj0uMh1CBUxNy1FqyPDjZqB29M7ZbjWqj79QkEOWkpga84AmDYUeTuWmy-0P1AdKHD3ehc-dKvei78BDj5USwXPJiDUlCxvYs_9rWYhagaq-5_LXENr78xel17spftNd5MA1Mw5U", state_ver_key = "SCHNORR_VER_KEY~lJqDaVZyM0hWP2Br52IX5FeE-dCAIC-dPX7bL5-qUx-vjbunwe-ENOeZxj6FuOyvDCFzoGeP7yZ0fM995qF-CRE", stake = 1 },
+
+    { stake_table_key = "BLS_VER_KEY~IBRoz_Q1EXvcm1pNZcmVlyYZU8hZ7qmy337ePAjEMhz8Hl2q8vWPFOd3BaLwgRS1UzAPW3z4E-XIgRDGcRBTAMZX9b_0lKYjlyTlNF2EZfNnKmvv-xJ0yurkfjiveeYEsD2l5d8q_rJJbH1iZdXy-yPEbwI0SIvQfwdlcaKw9po4", state_ver_key = "SCHNORR_VER_KEY~tyuplKrHzvjODsjPKMHVFYfoMcgklQsMye-2aSCktBcbW_CIzLOq3wZXRIPBbw3FiV6_QoUXYAlpZ5up0zG_ANY", stake = 1 },
+
+    { stake_table_key = "BLS_VER_KEY~4zQnaCOFJ7m95OjxeNls0QOOwWbz4rfxaL3NwmN2zSdnf8t5Nw_dfmMHq05ee8jCegw6Bn5T8inmrnGGAsQJMMWLv77nd7FJziz2ViAbXg-XGGF7o4HyzELCmypDOIYF3X2UWferFE_n72ZX0iQkUhOvYZZ7cfXToXxRTtb_mwRR", state_ver_key = "SCHNORR_VER_KEY~qQAC373HPv4s0mTTpdmSaynfUXC4SfPCuGD2fbeigSpexFB2ycCeXV9UAjuR86CC9udPhopgMsFLyD29VO2iJSg", stake = 1 },
+
+    { stake_table_key = "BLS_VER_KEY~rO2PIjyY30HGfapFcloFe3mNDKMIFi6JlOLkH5ZWBSYoRm5fE2-Rm6Lp3EvmAcB5r7KFJ0c1Uor308x78r04EY_sfjcsDCWt7RSJdL4cJoD_4fSTCv_bisO8k98hs_8BtqQt8BHlPeJohpUXvcfnK8suXJETiJ6Er97pfxRbzgAL", state_ver_key = "SCHNORR_VER_KEY~le6RHdTasbBsTcbMqArt0XWFwfIJTY7RbUwaCvdxswL8LpXpO3eb86iyYUr63dtv4GGa5fIJaRH97nCd1lV9H8g", stake = 1 },
+
+    { stake_table_key = "BLS_VER_KEY~r6b-Cwzp-b3czlt0MHmYPJIow5kMsXbrNmZsLSYg9RV49oCCO4WEeCRFR02x9bqLCa_sgNFMrIeNdEa11qNiBAohApYFIvrSa-zP5QGj3xbZaMOCrshxYit6E2TR-XsWvv6gjOrypmugjyTAth-iqQzTboSfmO9DD1-gjJIdCaD7", state_ver_key = "SCHNORR_VER_KEY~LfL6fFJQ8UZWR1Jro6LHtKm_y5-VQZBapO0XhcB8ABAmsVght9B8k7NntrgniffAMD8_OJ6Zjg8XUklhbb42CIw", stake = 1 },
+
+    { stake_table_key = "BLS_VER_KEY~kEUEUJFBtCXl68fM_2roQw856wQlu1ZoDmPn8uu4bQgeZwyb5oz5_kMl-oAJ_OtbYV1serjWE--eXB_qYIpQLZka42-cML6WjCQjNl1hGSejtoBDkExNeUNcweFQBbEsaDiIy3-sgHTrfYpFd1icKeAVihLRn5_RtSU_RUu1TQqR", state_ver_key = "SCHNORR_VER_KEY~qKOggsQMNIIvmiIPM3smiGk40kYGXCVupsmgIrf3RgMmua683F3vUwzWcx0s7mxdzLXJwPAB06LD96cxip7JLJM", stake = 1 },
+
+    { stake_table_key = "BLS_VER_KEY~96hAcdFZxQT8CEHcyV8j2ILJRsXagquENPkc9AwLSx3u6AE_uMupIKGbNJRiM99oFneK2vI5g1u61HidWeuTLRPM2537xAXeaO8e-wJYx4FaPKw_xTcLPrIm0OZT7SsLAMwFuqfMbDdKM71-RyrLwhff5517xXBKEk5Tg9iT9Qrr", state_ver_key = "SCHNORR_VER_KEY~y0nltwKyKSpwO3ki9Czu5asjAt5g1Ya3XmAywcerOSUg__FuZOcYq6tKxMsnsjE7ylpWLZv8R5W4-6WkP0DWI94", stake = 1 },
+
+    { stake_table_key = "BLS_VER_KEY~-pVi7j6TEBeG7ABata4uWWDRM2SrY8wWotWsGnTpIhnOVYJI_lNWyig6VJUuFmBsMS8rLMU7nDxDm8SbObxyA-SLFcr_jCkZqsbx8GcVQrnBAfjNRWuPZP0xcTDMu2IkQqtc3L0OpzbMEgGRGE8Wj09pNqouzl-xhPoYjTmD06Bw", state_ver_key = "SCHNORR_VER_KEY~6rPZ_plXxp8Uoh-E8VPb37csDRLND66zAorA3crYOhf9ARJapk8151RRVXWHe5Q2uF_RmQQmOCAov6tIpJ4yHz0", stake = 1 },
+
+    { stake_table_key = "BLS_VER_KEY~IUPSdnsNUHgNx_74ZhBPrICcDZ9Bp_DAt-6kFz8vSwJES2Vy1Ws8NJ1mxb9XGE1u13sw0FRe8kn5Ib3p2stbEtR_1Qgbuif6aoLrGaSUzy0MvwrO58u9kHZk3rXIuSAN7n4ok3-KKk2CmnBfx7fchFoqT56FXCd1EJ7XRrYj8wTh", state_ver_key = "SCHNORR_VER_KEY~qLqeTM1ZT1ecLEpzHwmlr-GeMUOest-kAm5nKOnKnB-W_TRj4IL77lnmamYvUdXR_ddQp24wQh2IlOIdp5jKEgw", stake = 1 },
+
+    { stake_table_key = "BLS_VER_KEY~PAAQNgOYfj3GiVX7LxSlkXfOCDSnNKZDqPVYQ_jBMxKzOCn0PXbqQ62kKPenWOmCxiCE7X158s-VenBna6MjHJgf61eBAO-3-OyTP5NWVx49RTgHhQf2iMTKk2iqK2gjnjZimBU135YU4lQFtrG-ZgRezwqkC5vy8V-q46fschIG", state_ver_key = "SCHNORR_VER_KEY~APKGX39-mOmApq6jMdIEiuuyddJ_k8xFeIwU1Zs2zShH1rI--eZR180Us5vqNWmK3zAidScvVcW4bAsOMHB3LPg", stake = 1 }
+
 ]
 enable_registration_verification = true
 

--- a/crates/orchestrator/src/config.rs
+++ b/crates/orchestrator/src/config.rs
@@ -171,8 +171,6 @@ pub struct NetworkConfig<KEY: SignatureKey> {
     pub random_builder: Option<RandomBuilderConfig>,
     /// The list of public keys that are allowed to connect to the orchestrator
     pub public_keys: Vec<PeerConfigKeys<KEY>>,
-    /// Whether or not to disable registration verification.
-    pub enable_registration_verification: bool,
 }
 
 /// the source of the network config
@@ -405,7 +403,6 @@ impl<K: SignatureKey> Default for NetworkConfig<K> {
             builder: BuilderType::default(),
             random_builder: None,
             public_keys: vec![],
-            enable_registration_verification: true,
         }
     }
 }
@@ -456,11 +453,10 @@ pub struct NetworkConfigFile<KEY: SignatureKey> {
     #[serde(default)]
     pub random_builder: Option<RandomBuilderConfig>,
     /// The list of public keys that are allowed to connect to the orchestrator
+    ///
+    /// If nonempty, this list becomes the stake table and is used to determine DA membership (ignoring the node's request).
     #[serde(default)]
     pub public_keys: Vec<PeerConfigKeys<KEY>>,
-    /// Whether or not to disable registration verification.
-    #[serde(default)]
-    pub enable_registration_verification: bool,
 }
 
 impl<K: SignatureKey> From<NetworkConfigFile<K>> for NetworkConfig<K> {
@@ -493,7 +489,6 @@ impl<K: SignatureKey> From<NetworkConfigFile<K>> for NetworkConfig<K> {
             builder: val.builder,
             random_builder: val.random_builder,
             public_keys: val.public_keys,
-            enable_registration_verification: val.enable_registration_verification,
         }
     }
 }

--- a/crates/orchestrator/src/config.rs
+++ b/crates/orchestrator/src/config.rs
@@ -95,6 +95,8 @@ pub struct PeerConfigKeys<KEY: SignatureKey> {
     pub state_ver_key: StateVerKey,
     /// the peer's stake
     pub stake: u64,
+    /// whether the node is a DA node
+    pub da: bool,
 }
 
 /// Options controlling how the random builder generates blocks
@@ -169,8 +171,6 @@ pub struct NetworkConfig<KEY: SignatureKey> {
     pub random_builder: Option<RandomBuilderConfig>,
     /// The list of public keys that are allowed to connect to the orchestrator
     pub public_keys: Vec<PeerConfigKeys<KEY>>,
-    /// The list of public keys that are DA nodes
-    pub da_public_keys: Vec<PeerConfigKeys<KEY>>,
     /// Whether or not to disable registration verification.
     pub enable_registration_verification: bool,
 }
@@ -405,7 +405,6 @@ impl<K: SignatureKey> Default for NetworkConfig<K> {
             builder: BuilderType::default(),
             random_builder: None,
             public_keys: vec![],
-            da_public_keys: vec![],
             enable_registration_verification: true,
         }
     }
@@ -459,9 +458,6 @@ pub struct NetworkConfigFile<KEY: SignatureKey> {
     /// The list of public keys that are allowed to connect to the orchestrator
     #[serde(default)]
     pub public_keys: Vec<PeerConfigKeys<KEY>>,
-    #[serde(default)]
-    /// The list of public keys that are DA nodes
-    pub da_public_keys: Vec<PeerConfigKeys<KEY>>,
     /// Whether or not to disable registration verification.
     #[serde(default)]
     pub enable_registration_verification: bool,
@@ -497,7 +493,6 @@ impl<K: SignatureKey> From<NetworkConfigFile<K>> for NetworkConfig<K> {
             builder: val.builder,
             random_builder: val.random_builder,
             public_keys: val.public_keys,
-            da_public_keys: val.da_public_keys,
             enable_registration_verification: val.enable_registration_verification,
         }
     }

--- a/crates/orchestrator/src/config.rs
+++ b/crates/orchestrator/src/config.rs
@@ -5,7 +5,6 @@
 // along with the HotShot repository. If not, see <https://mit-license.org/>.
 
 use std::{
-    collections::HashSet,
     env, fs,
     net::SocketAddr,
     num::NonZeroUsize,
@@ -17,8 +16,8 @@ use std::{
 
 use clap::ValueEnum;
 use hotshot_types::{
-    constants::REQUEST_DATA_DELAY, traits::signature_key::SignatureKey, ExecutionType,
-    HotShotConfig, PeerConfig, ValidatorConfig,
+    constants::REQUEST_DATA_DELAY, light_client::StateVerKey, traits::signature_key::SignatureKey,
+    ExecutionType, HotShotConfig, PeerConfig, ValidatorConfig,
 };
 use libp2p::{Multiaddr, PeerId};
 use serde_inline_default::serde_inline_default;
@@ -84,6 +83,18 @@ pub enum BuilderType {
     Simple,
     /// Random integrated builder will be started and used by each hotshot node
     Random,
+}
+
+/// Node PeerConfig keys
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
+#[serde(bound(deserialize = ""))]
+pub struct PeerConfigKeys<KEY: SignatureKey> {
+    /// The peer's public key
+    pub stake_table_key: KEY,
+    /// the peer's state public key
+    pub state_ver_key: StateVerKey,
+    /// the peer's stake
+    pub stake: u64,
 }
 
 /// Options controlling how the random builder generates blocks
@@ -157,7 +168,9 @@ pub struct NetworkConfig<KEY: SignatureKey> {
     /// random builder config
     pub random_builder: Option<RandomBuilderConfig>,
     /// The list of public keys that are allowed to connect to the orchestrator
-    pub public_keys: HashSet<KEY>,
+    pub public_keys: Vec<PeerConfigKeys<KEY>>,
+    /// The list of public keys that are DA nodes
+    pub da_public_keys: Vec<PeerConfigKeys<KEY>>,
     /// Whether or not to disable registration verification.
     pub enable_registration_verification: bool,
 }
@@ -391,7 +404,8 @@ impl<K: SignatureKey> Default for NetworkConfig<K> {
             commit_sha: String::new(),
             builder: BuilderType::default(),
             random_builder: None,
-            public_keys: HashSet::new(),
+            public_keys: vec![],
+            da_public_keys: vec![],
             enable_registration_verification: true,
         }
     }
@@ -444,7 +458,10 @@ pub struct NetworkConfigFile<KEY: SignatureKey> {
     pub random_builder: Option<RandomBuilderConfig>,
     /// The list of public keys that are allowed to connect to the orchestrator
     #[serde(default)]
-    pub public_keys: HashSet<KEY>,
+    pub public_keys: Vec<PeerConfigKeys<KEY>>,
+    #[serde(default)]
+    /// The list of public keys that are DA nodes
+    pub da_public_keys: Vec<PeerConfigKeys<KEY>>,
     /// Whether or not to disable registration verification.
     #[serde(default)]
     pub enable_registration_verification: bool,
@@ -480,6 +497,7 @@ impl<K: SignatureKey> From<NetworkConfigFile<K>> for NetworkConfig<K> {
             builder: val.builder,
             random_builder: val.random_builder,
             public_keys: val.public_keys,
+            da_public_keys: val.da_public_keys,
             enable_registration_verification: val.enable_registration_verification,
         }
     }

--- a/crates/orchestrator/src/lib.rs
+++ b/crates/orchestrator/src/lib.rs
@@ -106,6 +106,12 @@ struct OrchestratorState<KEY: SignatureKey> {
 impl<KEY: SignatureKey + 'static> OrchestratorState<KEY> {
     /// create a new [`OrchestratorState`]
     pub fn new(network_config: NetworkConfig<KEY>) -> Self {
+        let mut peer_pub_ready = false;
+
+        if network_config.enable_registration_verification {
+            peer_pub_ready = true;
+        }
+
         let builders = if matches!(network_config.builder, BuilderType::External) {
             network_config.config.builder_urls.clone().into()
         } else {
@@ -115,7 +121,7 @@ impl<KEY: SignatureKey + 'static> OrchestratorState<KEY> {
             latest_index: 0,
             tmp_latest_index: 0,
             config: network_config,
-            peer_pub_ready: false,
+            peer_pub_ready,
             pub_posted: HashMap::new(),
             nodes_connected: 0,
             start: false,
@@ -246,6 +252,144 @@ pub trait OrchestratorApi<KEY: SignatureKey> {
     fn get_builders(&self) -> Result<Vec<Url>, ServerError>;
 }
 
+impl<KEY> OrchestratorState<KEY>
+where
+    KEY: serde::Serialize + Clone + SignatureKey + 'static,
+{
+    fn register_unknown(
+        &mut self,
+        pubkey: &mut Vec<u8>,
+        da_requested: bool,
+        libp2p_address: Option<Multiaddr>,
+        libp2p_public_key: Option<PeerId>,
+    ) -> Result<(u64, bool), ServerError> {
+        if let Some((node_index, is_da)) = self.pub_posted.get(pubkey) {
+            return Ok((*node_index, *is_da));
+        }
+
+        if !self.accepting_new_keys {
+            return Err(ServerError {
+                status: tide_disco::StatusCode::FORBIDDEN,
+                message:
+                    "Network has been started manually, and is no longer registering new keys."
+                        .to_string(),
+            });
+        }
+
+        let node_index = self.pub_posted.len() as u64;
+
+        // Deserialize the public key
+        let staked_pubkey = PeerConfig::<KEY>::from_bytes(pubkey).unwrap();
+
+        self.config
+            .config
+            .known_nodes_with_stake
+            .push(staked_pubkey.clone());
+
+        let mut added_to_da = false;
+
+        let da_full =
+            self.config.config.known_da_nodes.len() >= self.config.config.da_staked_committee_size;
+
+        #[allow(clippy::nonminimal_bool)]
+        // We add the node to the DA committee depending on either its node index or whether it requested membership.
+        //
+        // Since we issue `node_index` incrementally, if we are deciding DA membership by node_index
+        // we only need to check that the DA committee is not yet full.
+        //
+        // Note: this logically simplifies to (self.config.indexed_da || da_requested) && !da_full,
+        // but writing it that way makes it a little less clear to me.
+        if (self.config.indexed_da || (!self.config.indexed_da && da_requested)) && !da_full {
+            self.config.config.known_da_nodes.push(staked_pubkey);
+            added_to_da = true;
+        }
+
+        self.pub_posted
+            .insert(pubkey.clone(), (node_index, added_to_da));
+
+        // If the orchestrator is set up for libp2p and we have supplied the proper
+        // Libp2p data, add our node to the list of bootstrap nodes.
+        if self.config.libp2p_config.clone().is_some() {
+            if let (Some(libp2p_public_key), Some(libp2p_address)) =
+                (libp2p_public_key, libp2p_address)
+            {
+                // Push to our bootstrap nodes
+                self.config
+                    .libp2p_config
+                    .as_mut()
+                    .unwrap()
+                    .bootstrap_nodes
+                    .push((libp2p_public_key, libp2p_address));
+            }
+        }
+
+        tracing::error!("Posted public key for node_index {node_index}");
+
+        // node_index starts at 0, so once it matches `num_nodes_with_stake`
+        // we will have registered one node too many. hence, we want `node_index + 1`.
+        if node_index + 1 >= (self.config.config.num_nodes_with_stake.get() as u64) {
+            self.peer_pub_ready = true;
+            self.accepting_new_keys = false;
+        }
+        Ok((node_index, added_to_da))
+    }
+
+    fn register_from_list(
+        &mut self,
+        pubkey: &mut Vec<u8>,
+        _da_requested: bool,
+        libp2p_address: Option<Multiaddr>,
+        libp2p_public_key: Option<PeerId>,
+    ) -> Result<(u64, bool), ServerError> {
+        // if we've already registered this node before, we just retrieve its info from `pub_posted`
+        if let Some((node_index, is_da)) = self.pub_posted.get(pubkey) {
+            return Ok((*node_index, *is_da));
+        }
+
+        // Deserialize the public key
+        let staked_pubkey = PeerConfig::<KEY>::from_bytes(pubkey).unwrap();
+
+        // Check if the node is allowed to connect, returning its index if so.
+        let Some(node_index) = self
+            .config
+            .config
+            .known_nodes_with_stake
+            .iter()
+            .position(|pubkey| *pubkey == staked_pubkey)
+        else {
+            return Err(ServerError {
+                status: tide_disco::StatusCode::FORBIDDEN,
+                message: "You are unauthorized to register with the orchestrator".to_string(),
+            });
+        };
+
+        let added_to_da = self.config.config.known_da_nodes.contains(&staked_pubkey);
+
+        self.pub_posted
+            .insert(pubkey.clone(), (node_index as u64, added_to_da));
+
+        // If the orchestrator is set up for libp2p and we have supplied the proper
+        // Libp2p data, add our node to the list of bootstrap nodes.
+        if self.config.libp2p_config.clone().is_some() {
+            if let (Some(libp2p_public_key), Some(libp2p_address)) =
+                (libp2p_public_key, libp2p_address)
+            {
+                // Push to our bootstrap nodes
+                self.config
+                    .libp2p_config
+                    .as_mut()
+                    .unwrap()
+                    .bootstrap_nodes
+                    .push((libp2p_public_key, libp2p_address));
+            }
+        }
+
+        tracing::error!("Node {node_index} has registered.");
+
+        Ok((node_index as u64, added_to_da))
+    }
+}
+
 impl<KEY> OrchestratorApi<KEY> for OrchestratorState<KEY>
 where
     KEY: serde::Serialize + Clone + SignatureKey + 'static,
@@ -316,88 +460,11 @@ where
         libp2p_address: Option<Multiaddr>,
         libp2p_public_key: Option<PeerId>,
     ) -> Result<(u64, bool), ServerError> {
-        if let Some((node_index, is_da)) = self.pub_posted.get(pubkey) {
-            return Ok((*node_index, *is_da));
+        if self.config.enable_registration_verification {
+            self.register_from_list(pubkey, da_requested, libp2p_address, libp2p_public_key)
+        } else {
+            self.register_unknown(pubkey, da_requested, libp2p_address, libp2p_public_key)
         }
-
-        if !self.accepting_new_keys {
-            return Err(ServerError {
-                status: tide_disco::StatusCode::FORBIDDEN,
-                message:
-                    "Network has been started manually, and is no longer registering new keys."
-                        .to_string(),
-            });
-        }
-
-        let node_index = self.pub_posted.len() as u64;
-
-        // Deserialize the public key
-        let staked_pubkey = PeerConfig::<KEY>::from_bytes(pubkey).unwrap();
-
-        // Check if the node is allowed to connect
-        if self.config.enable_registration_verification
-            && !self
-                .config
-                .public_keys
-                .contains(&staked_pubkey.stake_table_entry.public_key())
-        {
-            return Err(ServerError {
-                status: tide_disco::StatusCode::FORBIDDEN,
-                message: "You are unauthorized to register with the orchestrator".to_string(),
-            });
-        }
-
-        self.config
-            .config
-            .known_nodes_with_stake
-            .push(staked_pubkey.clone());
-
-        let mut added_to_da = false;
-
-        let da_full =
-            self.config.config.known_da_nodes.len() >= self.config.config.da_staked_committee_size;
-
-        #[allow(clippy::nonminimal_bool)]
-        // We add the node to the DA committee depending on either its node index or whether it requested membership.
-        //
-        // Since we issue `node_index` incrementally, if we are deciding DA membership by node_index
-        // we only need to check that the DA committee is not yet full.
-        //
-        // Note: this logically simplifies to (self.config.indexed_da || da_requested) && !da_full,
-        // but writing it that way makes it a little less clear to me.
-        if (self.config.indexed_da || (!self.config.indexed_da && da_requested)) && !da_full {
-            self.config.config.known_da_nodes.push(staked_pubkey);
-            added_to_da = true;
-        }
-
-        self.pub_posted
-            .insert(pubkey.clone(), (node_index, added_to_da));
-
-        // If the orchestrator is set up for libp2p and we have supplied the proper
-        // Libp2p data, add our node to the list of bootstrap nodes.
-        if self.config.libp2p_config.clone().is_some() {
-            if let (Some(libp2p_public_key), Some(libp2p_address)) =
-                (libp2p_public_key, libp2p_address)
-            {
-                // Push to our bootstrap nodes
-                self.config
-                    .libp2p_config
-                    .as_mut()
-                    .unwrap()
-                    .bootstrap_nodes
-                    .push((libp2p_public_key, libp2p_address));
-            }
-        }
-
-        tracing::error!("Posted public key for node_index {node_index}");
-
-        // node_index starts at 0, so once it matches `num_nodes_with_stake`
-        // we will have registered one node too many. hence, we want `node_index + 1`.
-        if node_index + 1 >= (self.config.config.num_nodes_with_stake.get() as u64) {
-            self.peer_pub_ready = true;
-            self.accepting_new_keys = false;
-        }
-        Ok((node_index, added_to_da))
     }
 
     fn peer_pub_ready(&self) -> Result<bool, ServerError> {
@@ -768,8 +835,29 @@ where
         network_config.manual_start_password = env_password.ok();
     }
 
-    network_config.config.known_nodes_with_stake = vec![];
-    network_config.config.known_da_nodes = vec![];
+    if network_config.enable_registration_verification {
+        network_config.config.known_nodes_with_stake = network_config
+            .public_keys
+            .iter()
+            .map(|keys| PeerConfig {
+                stake_table_entry: keys.stake_table_key.stake_table_entry(keys.stake),
+                state_ver_key: keys.state_ver_key.clone(),
+            })
+            .collect();
+
+        network_config.config.known_da_nodes = network_config
+            .da_public_keys
+            .iter()
+            .map(|keys| PeerConfig {
+                //stake_table_entry: <KEY as SignatureKey>::StakeTableEntry::public_key(&keys.stake_table_key),
+                stake_table_entry: keys.stake_table_key.stake_table_entry(keys.stake),
+                state_ver_key: keys.state_ver_key.clone(),
+            })
+            .collect();
+    } else {
+        network_config.config.known_nodes_with_stake = vec![];
+        network_config.config.known_da_nodes = vec![];
+    }
 
     if !network_config.enable_registration_verification {
         tracing::error!("REGISTRATION VERIFICATION IS TURNED OFF");


### PR DESCRIPTION
### This PR: 
Updates the orchestrator's verification mode to now use the given stake table and pre-defined DA committee. In this mode, `run-config.toml` must provide:

- the stake table key
- the light client `state_ver_key`
- the node's stake
- whether the node is a DA node

before startup. Note that this replaces the previous verification mode, meaning the previous behaviour of allowing nodes from a whitelist (but not necessarily requiring the whole list) no longer exists.

One (welcome?) side-effect is that each node's index is now just its position in `run-config.toml`.


### This PR does not: 

### Key places to review: 
