### PR TITLE
[AUDIT] Fix `post_identity` endpoint to not allow slot exhaustion

### DIFF
--- a/crates/orchestrator/src/lib.rs
+++ b/crates/orchestrator/src/lib.rs
@@ -75,7 +75,9 @@ pub fn libp2p_generate_indexed_identity(seed: [u8; 32], index: u64) -> Keypair {
 /// The state of the orchestrator
 #[derive(Default, Clone)]
 #[allow(clippy::struct_excessive_bools)]
-struct OrchestratorState<KEY: SignatureKey> {
+pub struct OrchestratorState<KEY: SignatureKey> {
+    /// Tracks the latest temporary index we have generated for init validator's key pair
+    tmp_latest_index: u16,
     /// The network configuration
     config: NetworkConfig<KEY>,
     /// Whether the network configuration has been updated with all the peer's public keys/configs
@@ -124,6 +126,7 @@ impl<KEY: SignatureKey + 'static> OrchestratorState<KEY> {
         };
 
         OrchestratorState {
+            tmp_latest_index: 0,
             config: network_config,
             peer_pub_ready,
             pub_posted: HashMap::new(),
@@ -439,7 +442,7 @@ where
                     .as_mut()
                     .unwrap()
                     .bootstrap_nodes
-                    .push((libp2p_public_key, libp2p_address));
+                    .push((libp2p_public_key.clone(), libp2p_address.clone()));
 
                 // Only identify the node if it is not already identified
                 if self
@@ -457,7 +460,7 @@ where
             }
         }
 
-        Ok(node_index)
+        Ok(node_index as u16)
     }
 
     // Assumes nodes will set their own index that they received from the

--- a/crates/orchestrator/src/lib.rs
+++ b/crates/orchestrator/src/lib.rs
@@ -164,6 +164,10 @@ impl<KEY: SignatureKey + 'static> OrchestratorState<KEY> {
     }
 
     /// Output the results to a csv file according to orchestrator state
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if the `scripts/benchmarks_results/results.csv` file cannot be opened for writing.
     pub fn output_to_csv(&self) {
         let output_csv = BenchResultsDownloadConfig {
             commit_sha: self.config.commit_sha.clone(),
@@ -442,7 +446,7 @@ where
                     .as_mut()
                     .unwrap()
                     .bootstrap_nodes
-                    .push((libp2p_public_key.clone(), libp2p_address.clone()));
+                    .push((libp2p_public_key, libp2p_address.clone()));
 
                 // Only identify the node if it is not already identified
                 if self
@@ -452,14 +456,14 @@ where
                     tracing::debug!("Node {node_index} has already posted to the orchestrator; Total nodes identified: {}", self.nodes_identified.len());
                     return Err(ServerError {
                         status: tide_disco::StatusCode::BAD_REQUEST,
-                        message: format!(
-                            "You have already posted your identity to the orchestrator."
-                        ),
+                        message: "You have already posted your identity to the orchestrator."
+                            .to_string(),
                     });
                 }
             }
         }
 
+        #[allow(clippy::cast_possible_truncation)]
         Ok(node_index as u16)
     }
 


### PR DESCRIPTION
Closes N/A
<!-- See here for keywords in Github -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

### This PR: 
Changes the `post_identity` method to utilize a new state variable to record the received (valid) node identifiers, and uses this map as the source of truth for the node_index field. It does not remove `tmp_node_index` as this is for testing and does not correlate with `node_index`.

### This PR does not: 
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->

### Key places to review: 
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
