### PR TITLE
Generic-array should not be an explicit dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3426,7 +3426,6 @@ dependencies = [
  "espresso-systems-common",
  "ethereum-types",
  "futures",
- "generic-array",
  "jf-pcs",
  "jf-signature",
  "jf-utils",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.5.75" # same as `hotshot`, but workspace subcrate can also release its own version
+version = "0.5.75"                                        # same as `hotshot`, but workspace subcrate can also release its own version
 authors = ["Espresso Systems <hello@espressosys.com>"]
 edition = "2021"
 rust-version = "1.76.0"
@@ -57,11 +57,8 @@ espresso-systems-common = { git = "https://github.com/espressosystems/espresso-s
 ethereum-types = { version = "0.14", default-features = false, features = [
   "serialize",
 ] }
-derive_more = { version = "1.0", features = [ "from" ]  }
+derive_more = { version = "1.0", features = ["from"] }
 futures = { version = "0.3", default-features = false }
-# TODO generic-array should not be a direct dependency
-# https://github.com/EspressoSystems/HotShot/issues/1850
-generic-array = { version = "0.14.7", features = ["serde"] }
 jf-crhf = { version = "0.1.0", git = "https://github.com/EspressoSystems/jellyfish", tag = "0.4.5" }
 jf-vid = { version = "0.1.0", git = "https://github.com/EspressoSystems/jellyfish", tag = "0.4.5" }
 jf-signature = { version = "0.1.0", git = "https://github.com/EspressoSystems/jellyfish", tag = "0.4.5" }

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -29,10 +29,6 @@ futures = { workspace = true }
 cdn-proto = { workspace = true }
 reqwest = { workspace = true }
 
-generic-array = { workspace = true }
-
-# TODO generic-array should not be a direct dependency
-# https://github.com/EspressoSystems/HotShot/issues/1850
 lazy_static = { workspace = true }
 memoize = { workspace = true }
 rand = { workspace = true }

--- a/crates/types/src/qc.rs
+++ b/crates/types/src/qc.rs
@@ -16,8 +16,8 @@ use ark_std::{
     vec::Vec,
 };
 use bitvec::prelude::*;
+use digest::generic_array::GenericArray;
 use ethereum_types::U256;
-use generic_array::GenericArray;
 use jf_signature::{AggregateableSignatureSchemes, SignatureError};
 use serde::{Deserialize, Serialize};
 use typenum::U32;

--- a/crates/types/src/signature_key.rs
+++ b/crates/types/src/signature_key.rs
@@ -8,8 +8,8 @@
 
 use ark_serialize::SerializationError;
 use bitvec::{slice::BitSlice, vec::BitVec};
+use digest::generic_array::GenericArray;
 use ethereum_types::U256;
-use generic_array::GenericArray;
 use jf_signature::{
     bls_over_bn254::{BLSOverBN254CurveSignatureScheme, KeyPair, SignKey, VerKey},
     SignatureError, SignatureScheme,

--- a/crates/types/src/traits/qc.rs
+++ b/crates/types/src/traits/qc.rs
@@ -12,7 +12,7 @@ use ark_std::{
     vec::Vec,
 };
 use bitvec::prelude::*;
-use generic_array::{ArrayLength, GenericArray};
+use digest::generic_array::{ArrayLength, GenericArray};
 use jf_signature::{AggregateableSignatureSchemes, SignatureError};
 use serde::{Deserialize, Serialize};
 


### PR DESCRIPTION
Closes #<ISSUE_NUMBER>
<!-- See here for keywords in Github -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

### This PR: 
From the ticket:

> Currently generic-array is an explicit direct dependency. All our use of generic-array is inherited from upstream RustCrypto crates such as blake3, sha3, digest, etc. Thus, the version of generic-array that we use should be whatever's used by these upstream crates. Thus, we should not list it as an explicit direct dependency.
> 
> Unfortunately, we need serde for generic-array and I don't know how to get it without listing generic-array as an explicit dependency. This is an insidious hack because it means that we must take care to always keep the version of generic-array we list in Cargo.toml consistent with whatever's used upstream.

This PR removes the `generic-array` dependency and instead gets it from `digest` which re-exports it.

### This PR does not: 
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->

### Key places to review: 
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
