### PR TITLE
[LIBP2P] Parameterize the DHT timeout

### DIFF
--- a/crates/hotshot/src/traits/networking/libp2p_network.rs
+++ b/crates/hotshot/src/traits/networking/libp2p_network.rs
@@ -553,7 +553,7 @@ impl<K: SignatureKey + 'static> Libp2pNetwork<K> {
                 is_ready: Arc::new(AtomicBool::new(false)),
                 // This is optimal for 10-30 nodes. TODO: parameterize this for both tests and examples
                 // https://github.com/EspressoSystems/HotShot/issues/2088
-                dht_timeout: Duration::from_secs(120),
+                dht_timeout: config.dht_timeout.unwrap_or(Duration::from_secs(120)),
                 is_bootstrapped: Arc::new(AtomicBool::new(false)),
                 metrics,
                 subscribed_topics,

--- a/crates/libp2p-networking/src/network/node/config.rs
+++ b/crates/libp2p-networking/src/network/node/config.rs
@@ -51,6 +51,10 @@ pub struct NetworkNodeConfig<K: SignatureKey + 'static> {
     /// If not supplied we will not send an authentication message during the handshake
     #[builder(default)]
     pub auth_message: Option<Vec<u8>>,
+
+    #[builder(default)]
+    /// The timeout for DHT lookups.
+    pub dht_timeout: Option<Duration>,
 }
 
 /// Configuration for Libp2p's Gossipsub


### PR DESCRIPTION
Closes #2088 
<!-- See here for keywords in Github -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

### This PR: 
Right now, the DHT timeout as specified in the Libp2p network is hardcoded and optimal for 10-30 nodes. We want to parameterize this so we can change it based on the number of actual nodes in the run. This is especially helpful for testing purposes.

This PR adds this feature via the `NetworkNodeConfig`.

### This PR does not: 
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->

### Key places to review: 
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
