### PR TITLE
Fix a scenario where we were unable to manually start the orchestrator

### DIFF
--- a/crates/orchestrator/src/lib.rs
+++ b/crates/orchestrator/src/lib.rs
@@ -504,7 +504,6 @@ where
             });
         }
 
-        self.manual_start_allowed = false;
         Ok(self.config.clone())
     }
 
@@ -595,6 +594,7 @@ where
         self.accepting_new_keys = false;
         self.manual_start_allowed = false;
         self.peer_pub_ready = true;
+        self.start = true;
 
         Ok(())
     }

--- a/crates/task-impls/src/consensus2/mod.rs
+++ b/crates/task-impls/src/consensus2/mod.rs
@@ -6,11 +6,6 @@
 
 use std::sync::Arc;
 
-use self::handlers::{
-    handle_quorum_vote_recv, handle_timeout, handle_timeout_vote_recv, handle_view_change,
-};
-use crate::helpers::broadcast_event;
-use crate::{events::HotShotEvent, vote_collection::VoteCollectorsMap};
 use anyhow::Result;
 use async_broadcast::{Receiver, Sender};
 use async_lock::RwLock;
@@ -33,6 +28,11 @@ use hotshot_types::{
 #[cfg(async_executor_impl = "tokio")]
 use tokio::task::JoinHandle;
 use tracing::instrument;
+
+use self::handlers::{
+    handle_quorum_vote_recv, handle_timeout, handle_timeout_vote_recv, handle_view_change,
+};
+use crate::{events::HotShotEvent, helpers::broadcast_event, vote_collection::VoteCollectorsMap};
 
 /// Event handlers for use in the `handle` method.
 mod handlers;

--- a/crates/types/src/vid.rs
+++ b/crates/types/src/vid.rs
@@ -35,7 +35,8 @@ use serde::{Deserialize, Serialize};
 use sha2::Sha256;
 
 use crate::{
-    constants::SRS_DEGREE, data::VidDisperse as HotShotVidDisperse, data::VidDisperseShare,
+    constants::SRS_DEGREE,
+    data::{VidDisperse as HotShotVidDisperse, VidDisperseShare},
     message::Proposal,
 };
 


### PR DESCRIPTION
- We no longer disable manual starting after peer configs are distributed -- I don't think this added any real safety, but please leave a comment if I'm missing something.
- We now actually set `self.start` when manually starting.
