### PR TITLE
Move task startup into `start_consensus`

### DIFF
--- a/crates/examples/infra/mod.rs
+++ b/crates/examples/infra/mod.rs
@@ -434,7 +434,7 @@ pub trait RunDa<
     #[allow(clippy::too_many_lines)]
     async fn run_hotshot(
         &self,
-        context: SystemContextHandle<TYPES, NODE, V>,
+        mut context: SystemContextHandle<TYPES, NODE, V>,
         transactions: &mut Vec<TestTransaction>,
         transactions_to_send_per_round: u64,
         transaction_size_in_bytes: u64,
@@ -463,7 +463,7 @@ pub trait RunDa<
         let mut anchor_view: TYPES::Time = <TYPES::Time as ConsensusTime>::genesis();
         let mut num_successful_commits = 0;
 
-        context.hotshot.start_consensus().await;
+        context.start_consensus().await;
 
         loop {
             match event_stream.next().await {

--- a/crates/hotshot/src/lib.rs
+++ b/crates/hotshot/src/lib.rs
@@ -34,7 +34,7 @@ use std::{
 };
 
 use async_broadcast::{broadcast, InactiveReceiver, Receiver, Sender};
-use async_compatibility_layer::art::{async_spawn};
+use async_compatibility_layer::art::async_spawn;
 use async_lock::RwLock;
 use async_trait::async_trait;
 use futures::join;

--- a/crates/task-impls/src/consensus2/mod.rs
+++ b/crates/task-impls/src/consensus2/mod.rs
@@ -6,11 +6,6 @@
 
 use std::sync::Arc;
 
-use self::handlers::{
-    handle_quorum_vote_recv, handle_timeout, handle_timeout_vote_recv, handle_view_change,
-};
-use crate::helpers::broadcast_event;
-use crate::{events::HotShotEvent, vote_collection::VoteCollectorsMap};
 use anyhow::Result;
 use async_broadcast::{Receiver, Sender};
 use async_lock::RwLock;
@@ -33,6 +28,11 @@ use hotshot_types::{
 #[cfg(async_executor_impl = "tokio")]
 use tokio::task::JoinHandle;
 use tracing::instrument;
+
+use self::handlers::{
+    handle_quorum_vote_recv, handle_timeout, handle_timeout_vote_recv, handle_view_change,
+};
+use crate::{events::HotShotEvent, helpers::broadcast_event, vote_collection::VoteCollectorsMap};
 
 /// Event handlers for use in the `handle` method.
 mod handlers;

--- a/crates/testing/src/spinning_task.rs
+++ b/crates/testing/src/spinning_task.rs
@@ -184,17 +184,17 @@ where
                                     }
                                 };
 
-                                let handle = context.run_tasks().await;
+                                let handle = context.setup_handle();
 
                                 // Create the node and add it to the state, so we can shut them
                                 // down properly later to avoid the overflow error in the overall
                                 // safety task.
-                                let node = Node {
+                                let mut node = Node {
                                     node_id,
                                     network: node.network,
                                     handle,
                                 };
-                                node.handle.hotshot.start_consensus().await;
+                                node.handle.start_consensus().await;
 
                                 self.handles.write().await.push(node);
                             }
@@ -322,17 +322,17 @@ where
                 let handles = self.handles.clone();
                 let fut = async move {
                     tracing::info!("Starting node {} back up", id);
-                    let handle = node.run_tasks().await;
+                    let handle = node.setup_handle();
 
                     // Create the node and add it to the state, so we can shut them
                     // down properly later to avoid the overflow error in the overall
                     // safety task.
-                    let node = Node {
+                    let mut node = Node {
                         node_id: id.try_into().unwrap(),
                         network: node.network.clone(),
                         handle,
                     };
-                    node.handle.hotshot.start_consensus().await;
+                    node.handle.start_consensus().await;
 
                     handles.write().await[id] = node;
                 };

--- a/crates/testing/src/test_builder.rs
+++ b/crates/testing/src/test_builder.rs
@@ -252,7 +252,7 @@ pub async fn create_test_handle<
             )
             .await;
 
-            hotshot.run_tasks().await
+            hotshot.setup_handle()
         }
     }
 }

--- a/crates/testing/src/test_runner.rs
+++ b/crates/testing/src/test_runner.rs
@@ -243,7 +243,7 @@ where
             test_receiver.clone(),
         );
 
-        let nodes = handles.read().await;
+        let mut nodes = handles.write().await;
 
         // wait for networks to be ready
         for node in &*nodes {
@@ -251,9 +251,9 @@ where
         }
 
         // Start hotshot
-        for node in &*nodes {
+        for node in &mut *nodes {
             if !late_start_nodes.contains(&node.node_id) {
-                node.handle.hotshot.start_consensus().await;
+                node.handle.start_consensus().await;
             }
         }
 

--- a/crates/types/src/vid.rs
+++ b/crates/types/src/vid.rs
@@ -35,7 +35,8 @@ use serde::{Deserialize, Serialize};
 use sha2::Sha256;
 
 use crate::{
-    constants::SRS_DEGREE, data::VidDisperse as HotShotVidDisperse, data::VidDisperseShare,
+    constants::SRS_DEGREE,
+    data::{VidDisperse as HotShotVidDisperse, VidDisperseShare},
     message::Proposal,
 };
 


### PR DESCRIPTION
### This PR: 
Moves task startup into `start_consensus`. As a consequence, `start_consensus` is now a method on `SystemContextHandle` and not `SystemContext`.

### This PR does not: 

### Key places to review: 
