### PR TITLE
Break task loops when channel closes

### DIFF
--- a/crates/hotshot/src/tasks/mod.rs
+++ b/crates/hotshot/src/tasks/mod.rs
@@ -10,7 +10,7 @@
 pub mod task_state;
 use std::{fmt::Debug, sync::Arc};
 
-use async_broadcast::broadcast;
+use async_broadcast::{broadcast, RecvError};
 use async_compatibility_layer::art::async_spawn;
 use async_lock::RwLock;
 use async_trait::async_trait;
@@ -260,6 +260,9 @@ pub fn create_shutdown_event_monitor<TYPES: NodeType, I: NodeImplementation<TYPE
                     if matches!(event.as_ref(), HotShotEvent::Shutdown) {
                         return;
                     }
+                }
+                Err(RecvError::Closed) => {
+                    return;
                 }
                 Err(e) => {
                     tracing::error!("Shutdown event monitor channel recv error: {}", e);

--- a/crates/task-impls/src/consensus2/mod.rs
+++ b/crates/task-impls/src/consensus2/mod.rs
@@ -6,11 +6,6 @@
 
 use std::sync::Arc;
 
-use self::handlers::{
-    handle_quorum_vote_recv, handle_timeout, handle_timeout_vote_recv, handle_view_change,
-};
-use crate::helpers::broadcast_event;
-use crate::{events::HotShotEvent, vote_collection::VoteCollectorsMap};
 use anyhow::Result;
 use async_broadcast::{Receiver, Sender};
 use async_lock::RwLock;
@@ -33,6 +28,11 @@ use hotshot_types::{
 #[cfg(async_executor_impl = "tokio")]
 use tokio::task::JoinHandle;
 use tracing::instrument;
+
+use self::handlers::{
+    handle_quorum_vote_recv, handle_timeout, handle_timeout_vote_recv, handle_view_change,
+};
+use crate::{events::HotShotEvent, helpers::broadcast_event, vote_collection::VoteCollectorsMap};
 
 /// Event handlers for use in the `handle` method.
 mod handlers;

--- a/crates/types/src/vid.rs
+++ b/crates/types/src/vid.rs
@@ -35,7 +35,8 @@ use serde::{Deserialize, Serialize};
 use sha2::Sha256;
 
 use crate::{
-    constants::SRS_DEGREE, data::VidDisperse as HotShotVidDisperse, data::VidDisperseShare,
+    constants::SRS_DEGREE,
+    data::{VidDisperse as HotShotVidDisperse, VidDisperseShare},
     message::Proposal,
 };
 


### PR DESCRIPTION
### This PR: 
Breaks task loops when the channel closes in a few places

### This PR does not: 
I don't know if this necessarily fixes anything, but I think it makes the behaviour more correct

### Key places to review: 
