### PR TITLE
[CLEANUP] - Remove `QuorumProposalRequestRecv` from Consensus Tasks

### DIFF
--- a/crates/task-impls/src/consensus/mod.rs
+++ b/crates/task-impls/src/consensus/mod.rs
@@ -310,31 +310,6 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> ConsensusTaskSt
                     warn!("Failed to handle QuorumProposalValidated event {e:#}");
                 }
             }
-            HotShotEvent::QuorumProposalRequestRecv(req, signature) => {
-                // Make sure that this request came from who we think it did
-                if !req.key.validate(signature, req.commit().as_ref()) {
-                    warn!("Invalid signature key on proposal request.");
-                    return;
-                }
-
-                if let Some(quorum_proposal) = self
-                    .consensus
-                    .read()
-                    .await
-                    .last_proposals()
-                    .get(&req.view_number)
-                {
-                    broadcast_event(
-                        HotShotEvent::QuorumProposalResponseSend(
-                            req.key.clone(),
-                            quorum_proposal.clone(),
-                        )
-                        .into(),
-                        &event_sender,
-                    )
-                    .await;
-                }
-            }
             HotShotEvent::QuorumVoteRecv(ref vote) => {
                 debug!("Received quorum vote: {:?}", vote.view_number());
                 if self.quorum_membership.leader(vote.view_number() + 1) != self.public_key {

--- a/crates/task-impls/src/consensus/mod.rs
+++ b/crates/task-impls/src/consensus/mod.rs
@@ -13,7 +13,6 @@ use async_lock::RwLock;
 #[cfg(async_executor_impl = "async-std")]
 use async_std::task::JoinHandle;
 use async_trait::async_trait;
-use committable::Committable;
 use futures::future::join_all;
 use handlers::publish_proposal_from_commitment_and_metadata;
 use hotshot_task::task::TaskState;

--- a/crates/task-impls/src/consensus2/mod.rs
+++ b/crates/task-impls/src/consensus2/mod.rs
@@ -12,7 +12,6 @@ use async_lock::RwLock;
 #[cfg(async_executor_impl = "async-std")]
 use async_std::task::JoinHandle;
 use async_trait::async_trait;
-use committable::Committable;
 use hotshot_task::task::TaskState;
 use hotshot_types::{
     consensus::OuterConsensus,
@@ -32,7 +31,7 @@ use tracing::instrument;
 use self::handlers::{
     handle_quorum_vote_recv, handle_timeout, handle_timeout_vote_recv, handle_view_change,
 };
-use crate::{events::HotShotEvent, helpers::broadcast_event, vote_collection::VoteCollectorsMap};
+use crate::{events::HotShotEvent, vote_collection::VoteCollectorsMap};
 
 /// Event handlers for use in the `handle` method.
 mod handlers;

--- a/crates/task-impls/src/consensus2/mod.rs
+++ b/crates/task-impls/src/consensus2/mod.rs
@@ -113,31 +113,6 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> Consensus2TaskS
                     tracing::debug!("Failed to handle QuorumVoteRecv event; error = {e}");
                 }
             }
-            HotShotEvent::QuorumProposalRequestRecv(req, signature) => {
-                // Make sure that this request came from who we think it did
-                if !req.key.validate(signature, req.commit().as_ref()) {
-                    tracing::warn!("Invalid signature key on proposal request.");
-                    return;
-                }
-
-                if let Some(quorum_proposal) = self
-                    .consensus
-                    .read()
-                    .await
-                    .last_proposals()
-                    .get(&req.view_number)
-                {
-                    broadcast_event(
-                        HotShotEvent::QuorumProposalResponseSend(
-                            req.key.clone(),
-                            quorum_proposal.clone(),
-                        )
-                        .into(),
-                        &sender,
-                    )
-                    .await;
-                }
-            }
             HotShotEvent::TimeoutVoteRecv(ref vote) => {
                 if let Err(e) =
                     handle_timeout_vote_recv(vote, Arc::clone(&event), &sender, self).await

--- a/crates/task-impls/src/request.rs
+++ b/crates/task-impls/src/request.rs
@@ -214,6 +214,11 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> NetworkRequestState<TYPES, I
             {
                 // Cycle da members we send the request to each time
                 if let Some(recipient) = recipients_it.next() {
+                    if *recipient == public_key {
+                        // no need to send a message to ourselves.
+                        // just check from start of loop in `cancel_vid_request_task`
+                        continue;
+                    }
                     // If we got the data after we make the request then we are done
                     if Self::handle_vid_request_task(
                         &sender,
@@ -229,6 +234,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> NetworkRequestState<TYPES, I
                         return;
                     }
                 } else {
+                    // This shouldnt be possible `recipients_it.next()` should clone original and start over if `None`
                     tracing::warn!(
                         "Sent VID request to all available DA members and got no reponse for view: {:?}",
                         view

--- a/crates/task-impls/src/request.rs
+++ b/crates/task-impls/src/request.rs
@@ -216,7 +216,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> NetworkRequestState<TYPES, I
                 if let Some(recipient) = recipients_it.next() {
                     if *recipient == public_key {
                         // no need to send a message to ourselves.
-                        // just check from start of loop in `cancel_vid_request_task`
+                        // just check for the data at start of loop in `cancel_vid_request_task`
                         continue;
                     }
                     // If we got the data after we make the request then we are done


### PR DESCRIPTION

<!-- See here for keywords in Github -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

### This PR: 
<!-- Describe what this PR adds to HotSHot -->
<!-- E.g. -->
<!-- * Implements feature 1 -->
<!-- * Implements feature 2 -->
<!-- * Fixes bug 3 -->
As part of this PR: https://github.com/EspressoSystems/HotShot/pull/3688 we refactored Request / Response task. So, now just remove some event matching in Consensus Task for `QuorumProposalRequestRecv` events. This is only needed in Response task now.

### This PR does not: 
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->

### Key places to review: 
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
