### PR TITLE
[Libp2p] Use native Libp2p multiaddresses

### DIFF
--- a/crates/examples/combined/all.rs
+++ b/crates/examples/combined/all.rs
@@ -151,7 +151,7 @@ async fn main() {
             infra::main_entry_point::<TestTypes, Network, NodeImpl, TestVersions, ThisRun>(
                 ValidatorArgs {
                     url: orchestrator_url,
-                    advertise_address: Some(advertise_address),
+                    advertise_address: Some(advertise_address.to_string()),
                     builder_address: Some(builder_address),
                     network_config_file: None,
                 },

--- a/crates/examples/combined/validator.rs
+++ b/crates/examples/combined/validator.rs
@@ -5,7 +5,6 @@
 // along with the HotShot repository. If not, see <https://mit-license.org/>.
 
 //! A validator using both the web server and libp2p
-use std::{net::SocketAddr, str::FromStr};
 
 use async_compatibility_layer::logging::{setup_backtrace, setup_logging};
 use clap::Parser;
@@ -34,12 +33,7 @@ async fn main() {
 
     // If we did not set the advertise address, use our local IP and port 8000
     let local_ip = local_ip().expect("failed to get local IP");
-    args.advertise_address = Some(
-        args.advertise_address.unwrap_or(
-            SocketAddr::from_str(&format!("{local_ip}:8000"))
-                .expect("failed to convert local IP to socket address"),
-        ),
-    );
+    args.advertise_address = Some(args.advertise_address.unwrap_or(format!("{local_ip}:8000")));
 
     debug!("connecting to orchestrator at {:?}", args.url);
     infra::main_entry_point::<TestTypes, Network, NodeImpl, TestVersions, ThisRun>(args).await;

--- a/crates/examples/infra/mod.rs
+++ b/crates/examples/infra/mod.rs
@@ -908,7 +908,9 @@ pub async fn main_entry_point<
 
     // Derive the advertise multiaddress from the supplied string
     let advertise_multiaddress = if let Some(advertise_address) = args.advertise_address.clone() {
-        Some(derive_libp2p_multiaddr(&advertise_address).expect("failed to derive Libp2p multiaddr"))
+        Some(
+            derive_libp2p_multiaddr(&advertise_address).expect("failed to derive Libp2p multiaddr"),
+        )
     } else {
         None
     };

--- a/crates/examples/infra/mod.rs
+++ b/crates/examples/infra/mod.rs
@@ -885,7 +885,7 @@ pub async fn main_entry_point<
 
     info!("Starting validator");
 
-    let orchestrator_client: OrchestratorClient = OrchestratorClient::new(args.clone());
+    let orchestrator_client: OrchestratorClient = OrchestratorClient::new(args.url.clone());
 
     // We assume one node will not call this twice to generate two validator_config-s with same identity.
     let my_own_validator_config =

--- a/crates/examples/infra/mod.rs
+++ b/crates/examples/infra/mod.rs
@@ -9,7 +9,7 @@ use std::{
     collections::HashMap,
     fmt::Debug,
     fs,
-    net::{IpAddr, Ipv4Addr, SocketAddr},
+    net::{IpAddr, Ipv4Addr, SocketAddr, SocketAddrV4},
     num::NonZeroUsize,
     sync::Arc,
     time::{Duration, Instant},
@@ -27,8 +27,9 @@ use futures::StreamExt;
 use hotshot::{
     traits::{
         implementations::{
-            derive_libp2p_peer_id, CdnMetricsValue, CdnTopic, CombinedNetworks, Libp2pMetricsValue,
-            Libp2pNetwork, PushCdnNetwork, WrappedSignatureKey,
+            derive_libp2p_multiaddr, derive_libp2p_peer_id, CdnMetricsValue, CdnTopic,
+            CombinedNetworks, Libp2pMetricsValue, Libp2pNetwork, PushCdnNetwork,
+            WrappedSignatureKey,
         },
         BlockPayload, NodeImplementation,
     },
@@ -359,7 +360,7 @@ pub trait RunDa<
     /// Initializes networking, returns self
     async fn initialize_networking(
         config: NetworkConfig<TYPES::SignatureKey>,
-        libp2p_advertise_address: Option<SocketAddr>,
+        libp2p_advertise_address: Option<String>,
     ) -> Self;
 
     /// Initializes the genesis state and HotShot instance; does not start HotShot consensus
@@ -633,7 +634,7 @@ where
 {
     async fn initialize_networking(
         config: NetworkConfig<TYPES::SignatureKey>,
-        _libp2p_advertise_address: Option<SocketAddr>,
+        _libp2p_advertise_address: Option<String>,
     ) -> PushCdnDaRun<TYPES> {
         // Get our own key
         let key = config.config.my_own_validator_config.clone();
@@ -711,7 +712,7 @@ where
 {
     async fn initialize_networking(
         config: NetworkConfig<TYPES::SignatureKey>,
-        libp2p_advertise_address: Option<SocketAddr>,
+        libp2p_advertise_address: Option<String>,
     ) -> Libp2pDaRun<TYPES> {
         // Extrapolate keys for ease of use
         let keys = config.clone().config.my_own_validator_config;
@@ -721,11 +722,16 @@ where
         // In an example, we can calculate the libp2p bind address as a function
         // of the advertise address.
         let bind_address = if let Some(libp2p_advertise_address) = libp2p_advertise_address {
+            let libp2p_advertise_address: SocketAddrV4 = libp2p_advertise_address
+                .parse()
+                .expect("failed to parse advertise address");
+
             // If we have supplied one, use it
             SocketAddr::new(
                 IpAddr::V4(Ipv4Addr::UNSPECIFIED),
                 libp2p_advertise_address.port(),
             )
+            .to_string()
         } else {
             // If not, index a base port with our node index
             SocketAddr::new(
@@ -733,7 +739,12 @@ where
                 8000 + (u16::try_from(config.node_index)
                     .expect("failed to create advertise address")),
             )
+            .to_string()
         };
+
+        // Derive the bind address
+        let bind_address =
+            derive_libp2p_multiaddr(bind_address).expect("failed to derive bind address");
 
         // Create the Libp2p network
         let libp2p_network = Libp2pNetwork::from_config::<TYPES>(
@@ -799,7 +810,7 @@ where
 {
     async fn initialize_networking(
         config: NetworkConfig<TYPES::SignatureKey>,
-        libp2p_advertise_address: Option<SocketAddr>,
+        libp2p_advertise_address: Option<String>,
     ) -> CombinedDaRun<TYPES> {
         // Initialize our Libp2p network
         let libp2p_network: Libp2pDaRun<TYPES> =
@@ -808,7 +819,7 @@ where
                 Libp2pNetwork<TYPES::SignatureKey>,
                 Libp2pImpl,
                 V,
-            >>::initialize_networking(config.clone(), libp2p_advertise_address)
+            >>::initialize_networking(config.clone(), libp2p_advertise_address.clone())
             .await;
 
         // Initialize our CDN network
@@ -895,6 +906,13 @@ pub async fn main_entry_point<
         PeerConfig::<TYPES::SignatureKey>::to_bytes(&my_own_validator_config.public_config())
             .clone();
 
+    // Derive the advertise multiaddress from the supplied string
+    let advertise_multiaddress = if let Some(advertise_address) = args.advertise_address.clone() {
+        Some(derive_libp2p_multiaddr(advertise_address).expect("failed to derive Libp2p multiaddr"))
+    } else {
+        None
+    };
+
     // conditionally save/load config from file or orchestrator
     // This is a function that will return correct complete config from orchestrator.
     // It takes in a valid args.network_config_file when loading from file, or valid validator_config when loading from orchestrator, the invalid one will be ignored.
@@ -904,7 +922,7 @@ pub async fn main_entry_point<
     let (mut run_config, source) = NetworkConfig::<TYPES::SignatureKey>::get_complete_config(
         &orchestrator_client,
         my_own_validator_config,
-        args.advertise_address,
+        advertise_multiaddress,
         Some(libp2p_public_key),
     )
     .await

--- a/crates/examples/infra/mod.rs
+++ b/crates/examples/infra/mod.rs
@@ -744,7 +744,7 @@ where
 
         // Derive the bind address
         let bind_address =
-            derive_libp2p_multiaddr(bind_address).expect("failed to derive bind address");
+            derive_libp2p_multiaddr(&bind_address).expect("failed to derive bind address");
 
         // Create the Libp2p network
         let libp2p_network = Libp2pNetwork::from_config::<TYPES>(
@@ -908,7 +908,7 @@ pub async fn main_entry_point<
 
     // Derive the advertise multiaddress from the supplied string
     let advertise_multiaddress = if let Some(advertise_address) = args.advertise_address.clone() {
-        Some(derive_libp2p_multiaddr(advertise_address).expect("failed to derive Libp2p multiaddr"))
+        Some(derive_libp2p_multiaddr(&advertise_address).expect("failed to derive Libp2p multiaddr"))
     } else {
         None
     };

--- a/crates/examples/infra/mod.rs
+++ b/crates/examples/infra/mod.rs
@@ -907,13 +907,9 @@ pub async fn main_entry_point<
             .clone();
 
     // Derive the advertise multiaddress from the supplied string
-    let advertise_multiaddress = if let Some(advertise_address) = args.advertise_address.clone() {
-        Some(
-            derive_libp2p_multiaddr(&advertise_address).expect("failed to derive Libp2p multiaddr"),
-        )
-    } else {
-        None
-    };
+    let advertise_multiaddress = args.advertise_address.clone().map(|advertise_address| {
+        derive_libp2p_multiaddr(&advertise_address).expect("failed to derive Libp2p multiaddr")
+    });
 
     // conditionally save/load config from file or orchestrator
     // This is a function that will return correct complete config from orchestrator.

--- a/crates/examples/libp2p/all.rs
+++ b/crates/examples/libp2p/all.rs
@@ -54,7 +54,7 @@ async fn main() {
             infra::main_entry_point::<TestTypes, Network, NodeImpl, TestVersions, ThisRun>(
                 ValidatorArgs {
                     url: orchestrator_url,
-                    advertise_address: Some(advertise_address),
+                    advertise_address: Some(advertise_address.to_string()),
                     builder_address: Some(builder_address),
                     network_config_file: None,
                 },

--- a/crates/examples/libp2p/validator.rs
+++ b/crates/examples/libp2p/validator.rs
@@ -5,7 +5,6 @@
 // along with the HotShot repository. If not, see <https://mit-license.org/>.
 
 //! A validator using libp2p
-use std::{net::SocketAddr, str::FromStr};
 
 use async_compatibility_layer::logging::{setup_backtrace, setup_logging};
 use clap::Parser;
@@ -33,12 +32,7 @@ async fn main() {
 
     // If we did not set the advertise address, use our local IP and port 8000
     let local_ip = local_ip().expect("failed to get local IP");
-    args.advertise_address = Some(
-        args.advertise_address.unwrap_or(
-            SocketAddr::from_str(&format!("{local_ip}:8000"))
-                .expect("failed to convert local IP to socket address"),
-        ),
-    );
+    args.advertise_address = Some(args.advertise_address.unwrap_or(format!("{local_ip}:8000")));
 
     debug!("connecting to orchestrator at {:?}", args.url);
     infra::main_entry_point::<TestTypes, Network, NodeImpl, TestVersions, ThisRun>(args).await;

--- a/crates/examples/push-cdn/whitelist-adapter.rs
+++ b/crates/examples/push-cdn/whitelist-adapter.rs
@@ -14,10 +14,7 @@ use anyhow::{Context, Result};
 use cdn_broker::reexports::discovery::{DiscoveryClient, Embedded, Redis};
 use clap::Parser;
 use hotshot_example_types::node_types::TestTypes;
-use hotshot_orchestrator::{
-    client::{OrchestratorClient, ValidatorArgs},
-    config::NetworkConfig,
-};
+use hotshot_orchestrator::{client::OrchestratorClient, config::NetworkConfig};
 use hotshot_types::traits::{node_implementation::NodeType, signature_key::SignatureKey};
 use surf_disco::Url;
 
@@ -50,12 +47,9 @@ async fn main() -> Result<()> {
     tracing_subscriber::fmt::init();
 
     // Create a new `OrchestratorClient` from the supplied URL
-    let orchestrator_client = OrchestratorClient::new(ValidatorArgs {
-        url: Url::from_str(&args.orchestrator_url).with_context(|| "Invalid URL")?,
-        advertise_address: None,
-        builder_address: None,
-        network_config_file: None,
-    });
+    let orchestrator_client = OrchestratorClient::new(
+        Url::from_str(&args.orchestrator_url).with_context(|| "Invalid URL")?,
+    );
 
     // Attempt to get the config from the orchestrator.
     // Loops internally until the config is received.

--- a/crates/hotshot/src/traits.rs
+++ b/crates/hotshot/src/traits.rs
@@ -19,8 +19,8 @@ pub mod implementations {
     pub use super::networking::{
         combined_network::{CombinedNetworks, UnderlyingCombinedNetworks},
         libp2p_network::{
-            derive_libp2p_keypair, derive_libp2p_peer_id, GossipConfig, Libp2pMetricsValue,
-            Libp2pNetwork, PeerInfoVec,
+            derive_libp2p_keypair, derive_libp2p_multiaddr, derive_libp2p_peer_id, GossipConfig,
+            Libp2pMetricsValue, Libp2pNetwork, PeerInfoVec,
         },
         memory_network::{MasterMap, MemoryNetwork},
         push_cdn_network::{

--- a/crates/hotshot/src/traits/networking/libp2p_network.rs
+++ b/crates/hotshot/src/traits/networking/libp2p_network.rs
@@ -1142,7 +1142,6 @@ impl<K: SignatureKey + 'static> ConnectedNetwork<K> for Libp2pNetwork<K> {
     }
 }
 
-
 #[cfg(test)]
 mod test {
     use std::net::Ipv6Addr;

--- a/crates/hotshot/src/traits/networking/libp2p_network.rs
+++ b/crates/hotshot/src/traits/networking/libp2p_network.rs
@@ -405,90 +405,6 @@ pub fn derive_libp2p_multiaddr(addr: &String) -> anyhow::Result<Multiaddr> {
     })
 }
 
-#[cfg(test)]
-mod test {
-    use std::net::Ipv6Addr;
-
-    use super::*;
-
-    /// Test derivation of a valid IPv4 address -> Multiaddr
-    #[test]
-    fn test_derive_multiaddr_v4_valid() {
-        // Derive a multiaddr from a valid IPv4 address
-        let addr = "1.1.1.1:8080".to_string();
-        let multiaddr =
-            derive_libp2p_multiaddr(&addr).expect("Failed to derive valid multiaddr, {}");
-
-        // Make sure it's the correct (quic) multiaddr
-        assert_eq!(multiaddr.to_string(), "/ip4/1.1.1.1/udp/8080/quic-v1");
-    }
-
-    /// Test derivation of a valid IPv6 address -> Multiaddr
-    #[test]
-    fn test_derive_multiaddr_v6_valid() {
-        // Derive a multiaddr from a valid IPv6 address
-        let ipv6_addr = Ipv6Addr::new(1, 2, 3, 4, 5, 6, 7, 8);
-        let addr = format!("{}:8080", ipv6_addr);
-        let multiaddr =
-            derive_libp2p_multiaddr(&addr).expect("Failed to derive valid multiaddr, {}");
-
-        // Make sure it's the correct (quic) multiaddr
-        assert_eq!(
-            multiaddr.to_string(),
-            format!("/ip6/{}/udp/8080/quic-v1", ipv6_addr)
-        );
-    }
-
-    /// Test that an invalid address fails to derive to a Multiaddr
-    #[test]
-    fn test_no_port() {
-        // Derive a multiaddr from an invalid port
-        let addr = "1.1.1.1".to_string();
-        let multiaddr = derive_libp2p_multiaddr(&addr);
-
-        // Make sure it fails
-        assert!(multiaddr.is_err());
-    }
-
-    /// Test that an existing domain name resolves to a Multiaddr
-    #[test]
-    fn test_fqdn_exists() {
-        // Derive a multiaddr from a valid FQDN
-        let addr = "example.com:8080".to_string();
-        let multiaddr =
-            derive_libp2p_multiaddr(&addr).expect("Failed to derive valid multiaddr, {}");
-
-        // Make sure it's the correct (quic) multiaddr
-        assert_eq!(multiaddr.to_string(), "/dns/example.com/udp/8080/quic-v1");
-    }
-
-    /// Test that a non-existent domain name still resolves to a Multiaddr
-    #[test]
-    fn test_fqdn_does_not_exist() {
-        // Derive a multiaddr from an invalid FQDN
-        let addr = "libp2p.example.com:8080".to_string();
-        let multiaddr =
-            derive_libp2p_multiaddr(&addr).expect("Failed to derive valid multiaddr, {}");
-
-        // Make sure it still worked
-        assert_eq!(
-            multiaddr.to_string(),
-            "/dns/libp2p.example.com/udp/8080/quic-v1"
-        );
-    }
-
-    /// Test that a domain name without a port fails to derive to a Multiaddr
-    #[test]
-    fn test_fqdn_no_port() {
-        // Derive a multiaddr from an invalid port
-        let addr = "example.com".to_string();
-        let multiaddr = derive_libp2p_multiaddr(&addr);
-
-        // Make sure it fails
-        assert!(multiaddr.is_err());
-    }
-}
-
 impl<K: SignatureKey + 'static> Libp2pNetwork<K> {
     /// Create and return a Libp2p network from a network config file
     /// and various other configuration-specific values.
@@ -1223,5 +1139,90 @@ impl<K: SignatureKey + 'static> ConnectedNetwork<K> for Libp2pNetwork<K> {
         let _ = self
             .queue_node_lookup(ViewNumber::new(*future_view), future_leader)
             .map_err(|err| tracing::warn!("failed to process node lookup request: {err}"));
+    }
+}
+
+
+#[cfg(test)]
+mod test {
+    use std::net::Ipv6Addr;
+
+    use super::*;
+
+    /// Test derivation of a valid IPv4 address -> Multiaddr
+    #[test]
+    fn test_derive_multiaddr_v4_valid() {
+        // Derive a multiaddr from a valid IPv4 address
+        let addr = "1.1.1.1:8080".to_string();
+        let multiaddr =
+            derive_libp2p_multiaddr(&addr).expect("Failed to derive valid multiaddr, {}");
+
+        // Make sure it's the correct (quic) multiaddr
+        assert_eq!(multiaddr.to_string(), "/ip4/1.1.1.1/udp/8080/quic-v1");
+    }
+
+    /// Test derivation of a valid IPv6 address -> Multiaddr
+    #[test]
+    fn test_derive_multiaddr_v6_valid() {
+        // Derive a multiaddr from a valid IPv6 address
+        let ipv6_addr = Ipv6Addr::new(1, 2, 3, 4, 5, 6, 7, 8);
+        let addr = format!("{ipv6_addr}:8080");
+        let multiaddr =
+            derive_libp2p_multiaddr(&addr).expect("Failed to derive valid multiaddr, {}");
+
+        // Make sure it's the correct (quic) multiaddr
+        assert_eq!(
+            multiaddr.to_string(),
+            format!("/ip6/{ipv6_addr}/udp/8080/quic-v1")
+        );
+    }
+
+    /// Test that an invalid address fails to derive to a Multiaddr
+    #[test]
+    fn test_no_port() {
+        // Derive a multiaddr from an invalid port
+        let addr = "1.1.1.1".to_string();
+        let multiaddr = derive_libp2p_multiaddr(&addr);
+
+        // Make sure it fails
+        assert!(multiaddr.is_err());
+    }
+
+    /// Test that an existing domain name resolves to a Multiaddr
+    #[test]
+    fn test_fqdn_exists() {
+        // Derive a multiaddr from a valid FQDN
+        let addr = "example.com:8080".to_string();
+        let multiaddr =
+            derive_libp2p_multiaddr(&addr).expect("Failed to derive valid multiaddr, {}");
+
+        // Make sure it's the correct (quic) multiaddr
+        assert_eq!(multiaddr.to_string(), "/dns/example.com/udp/8080/quic-v1");
+    }
+
+    /// Test that a non-existent domain name still resolves to a Multiaddr
+    #[test]
+    fn test_fqdn_does_not_exist() {
+        // Derive a multiaddr from an invalid FQDN
+        let addr = "libp2p.example.com:8080".to_string();
+        let multiaddr =
+            derive_libp2p_multiaddr(&addr).expect("Failed to derive valid multiaddr, {}");
+
+        // Make sure it still worked
+        assert_eq!(
+            multiaddr.to_string(),
+            "/dns/libp2p.example.com/udp/8080/quic-v1"
+        );
+    }
+
+    /// Test that a domain name without a port fails to derive to a Multiaddr
+    #[test]
+    fn test_fqdn_no_port() {
+        // Derive a multiaddr from an invalid port
+        let addr = "example.com".to_string();
+        let multiaddr = derive_libp2p_multiaddr(&addr);
+
+        // Make sure it fails
+        assert!(multiaddr.is_err());
     }
 }

--- a/crates/hotshot/src/traits/networking/libp2p_network.rs
+++ b/crates/hotshot/src/traits/networking/libp2p_network.rs
@@ -361,7 +361,7 @@ pub fn derive_libp2p_peer_id<K: SignatureKey>(
 ///
 /// This borrows from Rust's implementation of `to_socket_addrs` but will only warn if the domain
 /// does not yet resolve.
-pub fn derive_libp2p_multiaddr(addr: String) -> anyhow::Result<Multiaddr> {
+pub fn derive_libp2p_multiaddr(addr: &String) -> anyhow::Result<Multiaddr> {
     // Split the address into the host and port parts
     let (host, port) = match addr.rfind(':') {
         Some(idx) => (&addr[..idx], &addr[idx + 1..]),

--- a/crates/hotshot/src/traits/networking/libp2p_network.rs
+++ b/crates/hotshot/src/traits/networking/libp2p_network.rs
@@ -1144,84 +1144,85 @@ impl<K: SignatureKey + 'static> ConnectedNetwork<K> for Libp2pNetwork<K> {
 
 #[cfg(test)]
 mod test {
-    use std::net::Ipv6Addr;
+    mod derive_multiaddr {
+        use super::super::*;
+        use std::net::Ipv6Addr;
 
-    use super::*;
+        /// Test derivation of a valid IPv4 address -> Multiaddr
+        #[test]
+        fn test_v4_valid() {
+            // Derive a multiaddr from a valid IPv4 address
+            let addr = "1.1.1.1:8080".to_string();
+            let multiaddr =
+                derive_libp2p_multiaddr(&addr).expect("Failed to derive valid multiaddr, {}");
 
-    /// Test derivation of a valid IPv4 address -> Multiaddr
-    #[test]
-    fn test_derive_multiaddr_v4_valid() {
-        // Derive a multiaddr from a valid IPv4 address
-        let addr = "1.1.1.1:8080".to_string();
-        let multiaddr =
-            derive_libp2p_multiaddr(&addr).expect("Failed to derive valid multiaddr, {}");
+            // Make sure it's the correct (quic) multiaddr
+            assert_eq!(multiaddr.to_string(), "/ip4/1.1.1.1/udp/8080/quic-v1");
+        }
 
-        // Make sure it's the correct (quic) multiaddr
-        assert_eq!(multiaddr.to_string(), "/ip4/1.1.1.1/udp/8080/quic-v1");
-    }
+        /// Test derivation of a valid IPv6 address -> Multiaddr
+        #[test]
+        fn test_v6_valid() {
+            // Derive a multiaddr from a valid IPv6 address
+            let ipv6_addr = Ipv6Addr::new(1, 2, 3, 4, 5, 6, 7, 8);
+            let addr = format!("{ipv6_addr}:8080");
+            let multiaddr =
+                derive_libp2p_multiaddr(&addr).expect("Failed to derive valid multiaddr, {}");
 
-    /// Test derivation of a valid IPv6 address -> Multiaddr
-    #[test]
-    fn test_derive_multiaddr_v6_valid() {
-        // Derive a multiaddr from a valid IPv6 address
-        let ipv6_addr = Ipv6Addr::new(1, 2, 3, 4, 5, 6, 7, 8);
-        let addr = format!("{ipv6_addr}:8080");
-        let multiaddr =
-            derive_libp2p_multiaddr(&addr).expect("Failed to derive valid multiaddr, {}");
+            // Make sure it's the correct (quic) multiaddr
+            assert_eq!(
+                multiaddr.to_string(),
+                format!("/ip6/{ipv6_addr}/udp/8080/quic-v1")
+            );
+        }
 
-        // Make sure it's the correct (quic) multiaddr
-        assert_eq!(
-            multiaddr.to_string(),
-            format!("/ip6/{ipv6_addr}/udp/8080/quic-v1")
-        );
-    }
+        /// Test that an invalid address fails to derive to a Multiaddr
+        #[test]
+        fn test_no_port() {
+            // Derive a multiaddr from an invalid port
+            let addr = "1.1.1.1".to_string();
+            let multiaddr = derive_libp2p_multiaddr(&addr);
 
-    /// Test that an invalid address fails to derive to a Multiaddr
-    #[test]
-    fn test_no_port() {
-        // Derive a multiaddr from an invalid port
-        let addr = "1.1.1.1".to_string();
-        let multiaddr = derive_libp2p_multiaddr(&addr);
+            // Make sure it fails
+            assert!(multiaddr.is_err());
+        }
 
-        // Make sure it fails
-        assert!(multiaddr.is_err());
-    }
+        /// Test that an existing domain name resolves to a Multiaddr
+        #[test]
+        fn test_fqdn_exists() {
+            // Derive a multiaddr from a valid FQDN
+            let addr = "example.com:8080".to_string();
+            let multiaddr =
+                derive_libp2p_multiaddr(&addr).expect("Failed to derive valid multiaddr, {}");
 
-    /// Test that an existing domain name resolves to a Multiaddr
-    #[test]
-    fn test_fqdn_exists() {
-        // Derive a multiaddr from a valid FQDN
-        let addr = "example.com:8080".to_string();
-        let multiaddr =
-            derive_libp2p_multiaddr(&addr).expect("Failed to derive valid multiaddr, {}");
+            // Make sure it's the correct (quic) multiaddr
+            assert_eq!(multiaddr.to_string(), "/dns/example.com/udp/8080/quic-v1");
+        }
 
-        // Make sure it's the correct (quic) multiaddr
-        assert_eq!(multiaddr.to_string(), "/dns/example.com/udp/8080/quic-v1");
-    }
+        /// Test that a non-existent domain name still resolves to a Multiaddr
+        #[test]
+        fn test_fqdn_does_not_exist() {
+            // Derive a multiaddr from an invalid FQDN
+            let addr = "libp2p.example.com:8080".to_string();
+            let multiaddr =
+                derive_libp2p_multiaddr(&addr).expect("Failed to derive valid multiaddr, {}");
 
-    /// Test that a non-existent domain name still resolves to a Multiaddr
-    #[test]
-    fn test_fqdn_does_not_exist() {
-        // Derive a multiaddr from an invalid FQDN
-        let addr = "libp2p.example.com:8080".to_string();
-        let multiaddr =
-            derive_libp2p_multiaddr(&addr).expect("Failed to derive valid multiaddr, {}");
+            // Make sure it still worked
+            assert_eq!(
+                multiaddr.to_string(),
+                "/dns/libp2p.example.com/udp/8080/quic-v1"
+            );
+        }
 
-        // Make sure it still worked
-        assert_eq!(
-            multiaddr.to_string(),
-            "/dns/libp2p.example.com/udp/8080/quic-v1"
-        );
-    }
+        /// Test that a domain name without a port fails to derive to a Multiaddr
+        #[test]
+        fn test_fqdn_no_port() {
+            // Derive a multiaddr from an invalid port
+            let addr = "example.com".to_string();
+            let multiaddr = derive_libp2p_multiaddr(&addr);
 
-    /// Test that a domain name without a port fails to derive to a Multiaddr
-    #[test]
-    fn test_fqdn_no_port() {
-        // Derive a multiaddr from an invalid port
-        let addr = "example.com".to_string();
-        let multiaddr = derive_libp2p_multiaddr(&addr);
-
-        // Make sure it fails
-        assert!(multiaddr.is_err());
+            // Make sure it fails
+            assert!(multiaddr.is_err());
+        }
     }
 }

--- a/crates/hotshot/src/traits/networking/libp2p_network.rs
+++ b/crates/hotshot/src/traits/networking/libp2p_network.rs
@@ -405,6 +405,90 @@ pub fn derive_libp2p_multiaddr(addr: &String) -> anyhow::Result<Multiaddr> {
     })
 }
 
+#[cfg(test)]
+mod test {
+    use std::net::Ipv6Addr;
+
+    use super::*;
+
+    /// Test derivation of a valid IPv4 address -> Multiaddr
+    #[test]
+    fn test_derive_multiaddr_v4_valid() {
+        // Derive a multiaddr from a valid IPv4 address
+        let addr = "1.1.1.1:8080".to_string();
+        let multiaddr =
+            derive_libp2p_multiaddr(&addr).expect("Failed to derive valid multiaddr, {}");
+
+        // Make sure it's the correct (quic) multiaddr
+        assert_eq!(multiaddr.to_string(), "/ip4/1.1.1.1/udp/8080/quic-v1");
+    }
+
+    /// Test derivation of a valid IPv6 address -> Multiaddr
+    #[test]
+    fn test_derive_multiaddr_v6_valid() {
+        // Derive a multiaddr from a valid IPv6 address
+        let ipv6_addr = Ipv6Addr::new(1, 2, 3, 4, 5, 6, 7, 8);
+        let addr = format!("{}:8080", ipv6_addr);
+        let multiaddr =
+            derive_libp2p_multiaddr(&addr).expect("Failed to derive valid multiaddr, {}");
+
+        // Make sure it's the correct (quic) multiaddr
+        assert_eq!(
+            multiaddr.to_string(),
+            format!("/ip6/{}/udp/8080/quic-v1", ipv6_addr)
+        );
+    }
+
+    /// Test that an invalid address fails to derive to a Multiaddr
+    #[test]
+    fn test_no_port() {
+        // Derive a multiaddr from an invalid port
+        let addr = "1.1.1.1".to_string();
+        let multiaddr = derive_libp2p_multiaddr(&addr);
+
+        // Make sure it fails
+        assert!(multiaddr.is_err());
+    }
+
+    /// Test that an existing domain name resolves to a Multiaddr
+    #[test]
+    fn test_fqdn_exists() {
+        // Derive a multiaddr from a valid FQDN
+        let addr = "example.com:8080".to_string();
+        let multiaddr =
+            derive_libp2p_multiaddr(&addr).expect("Failed to derive valid multiaddr, {}");
+
+        // Make sure it's the correct (quic) multiaddr
+        assert_eq!(multiaddr.to_string(), "/dns/example.com/udp/8080/quic-v1");
+    }
+
+    /// Test that a non-existent domain name still resolves to a Multiaddr
+    #[test]
+    fn test_fqdn_does_not_exist() {
+        // Derive a multiaddr from an invalid FQDN
+        let addr = "libp2p.example.com:8080".to_string();
+        let multiaddr =
+            derive_libp2p_multiaddr(&addr).expect("Failed to derive valid multiaddr, {}");
+
+        // Make sure it still worked
+        assert_eq!(
+            multiaddr.to_string(),
+            "/dns/libp2p.example.com/udp/8080/quic-v1"
+        );
+    }
+
+    /// Test that a domain name without a port fails to derive to a Multiaddr
+    #[test]
+    fn test_fqdn_no_port() {
+        // Derive a multiaddr from an invalid port
+        let addr = "example.com".to_string();
+        let multiaddr = derive_libp2p_multiaddr(&addr);
+
+        // Make sure it fails
+        assert!(multiaddr.is_err());
+    }
+}
+
 impl<K: SignatureKey + 'static> Libp2pNetwork<K> {
     /// Create and return a Libp2p network from a network config file
     /// and various other configuration-specific values.

--- a/crates/orchestrator/src/client.rs
+++ b/crates/orchestrator/src/client.rs
@@ -129,7 +129,7 @@ pub struct ValidatorArgs {
     /// The address the orchestrator runs on
     pub url: Url,
     /// The optional advertise address to use for Libp2p
-    pub advertise_address: Option<SocketAddr>,
+    pub advertise_address: Option<String>,
     /// Optional address to run builder on. Address must be accessible by other nodes
     pub builder_address: Option<SocketAddr>,
     /// An optional network config file to save to/load from
@@ -146,7 +146,7 @@ pub struct MultiValidatorArgs {
     /// The address the orchestrator runs on
     pub url: Url,
     /// The optional advertise address to use for Libp2p
-    pub advertise_address: Option<SocketAddr>,
+    pub advertise_address: Option<String>,
     /// An optional network config file to save to/load from
     /// Allows for rejoining the network on a complete state loss
     #[arg(short, long)]
@@ -370,20 +370,9 @@ impl OrchestratorClient {
     pub async fn post_and_wait_all_public_keys<K: SignatureKey>(
         &self,
         mut validator_config: ValidatorConfig<K>,
-        libp2p_address: Option<SocketAddr>,
+        libp2p_address: Option<Multiaddr>,
         libp2p_public_key: Option<PeerId>,
     ) -> NetworkConfig<K> {
-        // Get the (possible) Libp2p advertise address from our args
-        let libp2p_address: Option<Multiaddr> = libp2p_address.map(|f| {
-            Multiaddr::try_from(format!(
-                "/{}/{}/udp/{}/quic-v1",
-                if f.is_ipv4() { "ip4" } else { "ip6" },
-                f.ip(),
-                f.port()
-            ))
-            .expect("failed to create multiaddress")
-        });
-
         let pubkey: Vec<u8> = PeerConfig::<K>::to_bytes(&validator_config.public_config()).clone();
         let da_requested: bool = validator_config.is_da;
 

--- a/crates/orchestrator/src/client.rs
+++ b/crates/orchestrator/src/client.rs
@@ -359,7 +359,7 @@ impl OrchestratorClient {
     pub async fn post_and_wait_all_public_keys<K: SignatureKey>(
         &self,
         mut validator_config: ValidatorConfig<K>,
-        libp2p_address: Option<Multiaddr>,
+        libp2p_advertise_address: Option<Multiaddr>,
         libp2p_public_key: Option<PeerId>,
     ) -> NetworkConfig<K> {
         let pubkey: Vec<u8> = PeerConfig::<K>::to_bytes(&validator_config.public_config()).clone();
@@ -368,7 +368,7 @@ impl OrchestratorClient {
         // Serialize our (possible) libp2p-specific data
         let request_body = vbs::Serializer::<OrchestratorVersion>::serialize(&(
             pubkey,
-            libp2p_address,
+            libp2p_advertise_address,
             libp2p_public_key,
         ))
         .expect("failed to serialize request");

--- a/crates/orchestrator/src/client.rs
+++ b/crates/orchestrator/src/client.rs
@@ -212,23 +212,12 @@ impl OrchestratorClient {
     #[allow(clippy::type_complexity)]
     pub async fn get_config_without_peer<K: SignatureKey>(
         &self,
-        libp2p_address: Option<SocketAddr>,
+        libp2p_advertise_address: Option<Multiaddr>,
         libp2p_public_key: Option<PeerId>,
     ) -> anyhow::Result<NetworkConfig<K>> {
-        // Get the (possible) Libp2p advertise address from our args
-        let libp2p_address = libp2p_address.map(|f| {
-            Multiaddr::try_from(format!(
-                "/{}/{}/udp/{}/quic-v1",
-                if f.is_ipv4() { "ip4" } else { "ip6" },
-                f.ip(),
-                f.port()
-            ))
-            .expect("failed to create multiaddress")
-        });
-
         // Serialize our (possible) libp2p-specific data
         let request_body = vbs::Serializer::<OrchestratorVersion>::serialize(&(
-            libp2p_address,
+            libp2p_advertise_address,
             libp2p_public_key,
         ))?;
 

--- a/crates/orchestrator/src/client.rs
+++ b/crates/orchestrator/src/client.rs
@@ -193,8 +193,8 @@ impl ValidatorArgs {
 impl OrchestratorClient {
     /// Creates the client that will connect to the orchestrator
     #[must_use]
-    pub fn new(args: ValidatorArgs) -> Self {
-        let client = surf_disco::Client::<ClientError, OrchestratorVersion>::new(args.url);
+    pub fn new(url: Url) -> Self {
+        let client = surf_disco::Client::<ClientError, OrchestratorVersion>::new(url);
         // TODO ED: Add healthcheck wait here
         OrchestratorClient { client }
     }

--- a/crates/orchestrator/src/config.rs
+++ b/crates/orchestrator/src/config.rs
@@ -266,7 +266,7 @@ impl<K: SignatureKey> NetworkConfig<K> {
     pub async fn get_complete_config(
         client: &OrchestratorClient,
         my_own_validator_config: ValidatorConfig<K>,
-        libp2p_address: Option<SocketAddr>,
+        libp2p_address: Option<Multiaddr>,
         libp2p_public_key: Option<PeerId>,
     ) -> anyhow::Result<(NetworkConfig<K>, NetworkConfigSource)> {
         // get the configuration from the orchestrator

--- a/crates/orchestrator/src/config.rs
+++ b/crates/orchestrator/src/config.rs
@@ -6,7 +6,6 @@
 
 use std::{
     env, fs,
-    net::SocketAddr,
     num::NonZeroUsize,
     ops::Range,
     path::{Path, PathBuf},
@@ -210,7 +209,7 @@ impl<K: SignatureKey> NetworkConfig<K> {
     pub async fn from_file_or_orchestrator(
         client: &OrchestratorClient,
         file: Option<String>,
-        libp2p_address: Option<SocketAddr>,
+        libp2p_advertise_address: Option<Multiaddr>,
         libp2p_public_key: Option<PeerId>,
     ) -> anyhow::Result<(NetworkConfig<K>, NetworkConfigSource)> {
         if let Some(file) = file {
@@ -223,7 +222,7 @@ impl<K: SignatureKey> NetworkConfig<K> {
                     error!("{e}, falling back to orchestrator");
 
                     let config = client
-                        .get_config_without_peer(libp2p_address, libp2p_public_key)
+                        .get_config_without_peer(libp2p_advertise_address, libp2p_public_key)
                         .await?;
 
                     // save to file if we fell back
@@ -240,7 +239,7 @@ impl<K: SignatureKey> NetworkConfig<K> {
             // otherwise just get from orchestrator
             Ok((
                 client
-                    .get_config_without_peer(libp2p_address, libp2p_public_key)
+                    .get_config_without_peer(libp2p_advertise_address, libp2p_public_key)
                     .await?,
                 NetworkConfigSource::Orchestrator,
             ))

--- a/crates/orchestrator/src/config.rs
+++ b/crates/orchestrator/src/config.rs
@@ -265,14 +265,14 @@ impl<K: SignatureKey> NetworkConfig<K> {
     pub async fn get_complete_config(
         client: &OrchestratorClient,
         my_own_validator_config: ValidatorConfig<K>,
-        libp2p_address: Option<Multiaddr>,
+        libp2p_advertise_address: Option<Multiaddr>,
         libp2p_public_key: Option<PeerId>,
     ) -> anyhow::Result<(NetworkConfig<K>, NetworkConfigSource)> {
         // get the configuration from the orchestrator
         let run_config: NetworkConfig<K> = client
             .post_and_wait_all_public_keys::<K>(
                 my_own_validator_config,
-                libp2p_address,
+                libp2p_advertise_address,
                 libp2p_public_key,
             )
             .await;


### PR DESCRIPTION
### This PR: 
<!-- Describe what this PR adds to HotSHot -->
<!-- E.g. -->
<!-- * Implements feature 1 -->
<!-- * Implements feature 2 -->
<!-- * Fixes bug 3 -->

Changes Libp2p to use native multiaddressing. This allows us to use DNS and IPv6 entries directly instead of (for DNS) resolving it at runtime and using the resolved address.

This prevents the node from failing to start if the DNS entry does not yet exist, and also prevents the local resolution of a cloud address causing issues (e.g. `espresso.node` resolving to some AWS-local IP). It also allows for node addresses to be automatically updated through just changing the DNS entry.

To do this, we introduce the function `derive_libp2p_multiaddress` which derives the proper Multiaddress from a string. It supports IPv4, IPv6, and FQDNs. In the event that the configured FQDN does not exist, it will warn the user but still allow the node to start. It also includes testing for expected functionality.

Also does some cleanup, like removing the need for an orchestrator client to be created from `ValidatorArgs`

### This PR does not: 
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->
Make any protocol-breaking changes 

### Key places to review: 
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->
`derive_libp2p_multiaddress`

### How to test this PR:
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->
I have already tested this in the sequencer and it works as expected

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
