### PR TITLE
use nextest for CI

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,3 @@
+[profile.ci]
+retries=2
+final-status-level = "flaky"

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,4 +1,4 @@
 [profile.ci]
 retries = 2
 final-status-level = "flaky"
-num-test-threads = 1
+threads-required = "num-test-threads"

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,3 +1,4 @@
 [profile.ci]
-retries=2
+retries = 2
 final-status-level = "flaky"
+num-test-threads = 1

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -51,6 +51,8 @@ jobs:
           tar -vxf just-1.14.0-x86_64-unknown-linux-musl.tar.gz just
           sudo cp just /usr/bin/just
 
+      - uses: taiki-e/install-action@nextest
+
       - name: Unit and integration tests for all crates in workspace
         run: |
           just ${{ matrix.just_variants }} ${{ matrix.test_suites }}
@@ -92,6 +94,8 @@ jobs:
           wget https://github.com/casey/just/releases/download/1.14.0/just-1.14.0-x86_64-unknown-linux-musl.tar.gz
           tar -vxf just-1.14.0-x86_64-unknown-linux-musl.tar.gz just
           sudo cp just /usr/bin/just
+
+      - uses: taiki-e/install-action@nextest
 
       - name: Unit and integration tests for all crates in workspace
         run: |

--- a/justfile
+++ b/justfile
@@ -57,7 +57,7 @@ test-ci *ARGS:
 
 test-ci-rest *ARGS:
   echo Testing {{ARGS}}
-  RUST_LOG=info cargo nextest run --profile ci --lib --bins --tests --benches --workspace --no-fail-fast {{ARGS}} -- --skip tests_1 --skip tests_2 --skip tests_3 --skip tests_4 --skip tests_5
+  RUST_LOG=info cargo nextest run -E 'not (test(tests_1) | test(tests_2) | test(tests_3) | test(tests_4) | test(tests_5))' --profile ci --lib --bins --tests --benches --workspace --no-fail-fast {{ARGS}}
 
 test-ci-1 *ARGS:
   echo Testing {{ARGS}}

--- a/justfile
+++ b/justfile
@@ -53,31 +53,31 @@ test *ARGS:
 
 test-ci *ARGS:
   echo Testing {{ARGS}}
-  RUST_LOG=info cargo test --lib --bins --tests --benches --workspace --no-fail-fast {{ARGS}} -- --test-threads=1
+  RUST_LOG=info cargo nextest run --profile ci tests_1 --lib --bins --tests --benches --workspace --no-fail-fast {{ARGS}}
 
 test-ci-rest *ARGS:
   echo Testing {{ARGS}}
-  RUST_LOG=info cargo test --lib --bins --tests --benches --workspace --no-fail-fast {{ARGS}} -- --skip tests_1 --skip tests_2 --skip tests_3 --skip tests_4 --skip tests_5 --test-threads=1
+  RUST_LOG=info cargo nextest run --profile ci --lib --bins --tests --benches --workspace --no-fail-fast {{ARGS}} -- --skip tests_1 --skip tests_2 --skip tests_3 --skip tests_4 --skip tests_5
 
 test-ci-1 *ARGS:
   echo Testing {{ARGS}}
-  RUST_LOG=info cargo test tests_1 --lib --bins --tests --benches --workspace --no-fail-fast {{ARGS}} -- --test-threads=1
+  RUST_LOG=info cargo nextest run --profile ci tests_1 --lib --bins --tests --benches --workspace --no-fail-fast {{ARGS}}
 
 test-ci-2 *ARGS:
   echo Testing {{ARGS}}
-  RUST_LOG=info cargo test tests_2 --lib --bins --tests --benches --workspace --no-fail-fast {{ARGS}} -- --test-threads=1
+  RUST_LOG=info cargo nextest run --profile ci tests_2 --lib --bins --tests --benches --workspace --no-fail-fast {{ARGS}}
 
 test-ci-3 *ARGS:
   echo Testing {{ARGS}}
-  RUST_LOG=info cargo test tests_3 --lib --bins --tests --benches --workspace --no-fail-fast {{ARGS}} -- --test-threads=1
+  RUST_LOG=info cargo nextest run --profile ci tests_3 --lib --bins --tests --benches --workspace --no-fail-fast {{ARGS}}
 
 test-ci-4 *ARGS:
   echo Testing {{ARGS}}
-  RUST_LOG=info cargo test tests_4 --lib --bins --tests --benches --workspace --no-fail-fast {{ARGS}} -- --test-threads=1
+  RUST_LOG=info cargo nextest run --profile ci tests_4 --lib --bins --tests --benches --workspace --no-fail-fast {{ARGS}}
 
 test-ci-5 *ARGS:
   echo Testing {{ARGS}}
-  RUST_LOG=info cargo test tests_5 --lib --bins --tests --benches --workspace --no-fail-fast {{ARGS}} -- --test-threads=1
+  RUST_LOG=info cargo nextest run --profile ci tests_5 --lib --bins --tests --benches --workspace --no-fail-fast {{ARGS}}
 
 test_basic: test_success test_with_failures test_network_task test_consensus_task test_da_task test_vid_task test_view_sync_task
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 channel = "1.78"
-components = [ "cargo", "clippy", "rust-src", "rustc", "rustfmt", "llvm-tools-preview" ]
+components = [ "cargo", "clippy", "rust-src", "rustc", "rustfmt", "llvm-tools-preview", "nextest" ]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 channel = "1.78"
-components = [ "cargo", "clippy", "rust-src", "rustc", "rustfmt", "llvm-tools-preview", "nextest" ]
+components = [ "cargo", "clippy", "rust-src", "rustc", "rustfmt", "llvm-tools-preview", "cargo-nextest" ]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 channel = "1.78"
-components = [ "cargo", "clippy", "rust-src", "rustc", "rustfmt", "llvm-tools-preview", "cargo-nextest" ]
+components = [ "cargo", "clippy", "rust-src", "rustc", "rustfmt", "llvm-tools-preview" ]


### PR DESCRIPTION
### This PR: 
Makes CI use `cargo nextest` with automatic retries. Currently configured to try flaky tests up to 3 times total.

### This PR does not: 

### Key places to review:
This makes it harder to tell when tests are flaky because CI might not fail, but it should reduce the back-and-forth from manually retrying CI workflows

Worth looking at the logs too, which seem much nicer and (personally) easier to read
