### PR TITLE
Fix rust caching in CI

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,4 +1,5 @@
 [profile.ci]
 retries = 2
+slow-timeout = "3m"
 final-status-level = "flaky"
 threads-required = "num-test-threads"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -40,10 +40,10 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         name: Enable Rust Caching
         with:
-          shared-key: "build-and-test"
+          shared-key: "test"
           prefix-key: ${{ matrix.just_variants }}
           cache-on-failure: "true"
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+          save-if: ${{ matrix.test_suites == 'test-ci-rest' }}
 
       - name: Install Just
         run: |
@@ -84,10 +84,10 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         name: Enable Rust Caching
         with:
-          shared-key: "build-and-test"
+          shared-key: "test"
           prefix-key: ${{ matrix.just_variants }}
           cache-on-failure: "true"
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+          save-if: ${{ matrix.test_suites == 'test-ci-rest' }}
 
       - name: Install Just
         run: |
@@ -122,7 +122,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         name: Enable Rust Caching
         with:
-          shared-key: "build-and-test"
+          shared-key: "examples"
           prefix-key: ${{ matrix.just_variants }}
           cache-on-failure: "true"
           save-if: ${{ github.ref == 'refs/heads/main' }}
@@ -156,7 +156,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         name: Enable Rust Caching
         with:
-          shared-key: "build-and-test"
+          shared-key: "build-release"
           prefix-key: ${{ matrix.just_variants }}
           cache-on-failure: "true"
           save-if: ${{ github.ref == 'refs/heads/main' }}
@@ -201,7 +201,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         name: Enable Rust Caching
         with:
-          shared-key: "build-and-test"
+          shared-key: "build-arm-release"
           prefix-key: ${{ matrix.just_variants }}
           cache-on-failure: "true"
           save-if: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -43,7 +43,7 @@ jobs:
           shared-key: "test"
           prefix-key: ${{ matrix.just_variants }}
           cache-on-failure: "true"
-          save-if: ${{ matrix.test_suites == 'test-ci-rest' }}
+          save-if: ${{ github.ref == 'refs/heads/main' && matrix.test_suites == 'test-ci-rest' }}
 
       - name: Install Just
         run: |
@@ -87,7 +87,7 @@ jobs:
           shared-key: "test"
           prefix-key: ${{ matrix.just_variants }}
           cache-on-failure: "true"
-          save-if: ${{ matrix.test_suites == 'test-ci-rest' }}
+          save-if: ${{ github.ref == 'refs/heads/main' && matrix.test_suites == 'test-ci-rest' }}
 
       - name: Install Just
         run: |


### PR DESCRIPTION
Should fix a longstanding problem where we weren't caching builds for tests properly. I think the test and release build workflows were overwriting each other's caches previously, so neither had a usable cache. 

With this PR, CI times should be down by a flat 4-5 minutes or so across the board.