### PR TITLE
Timeout slow tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,5 +1,5 @@
 [profile.ci]
 retries = 2
-slow-timeout = "3m"
+slow-timeout = { period = "1m", terminate-after = 3 }
 final-status-level = "flaky"
 threads-required = "num-test-threads"


### PR DESCRIPTION
Didn't read the documentation thoroughly. This fixes the slow-timeout setting so that slow tests (>3m) are actually terminated (which should allow them to be retried).