### PR TITLE
[Easy] Remove TYPES from Libp2pNetwork::from_config

### DIFF
--- a/crates/examples/infra/mod.rs
+++ b/crates/examples/infra/mod.rs
@@ -760,7 +760,7 @@ where
             derive_libp2p_multiaddr(&bind_address).expect("failed to derive bind address");
 
         // Create the Libp2p network
-        let libp2p_network = Libp2pNetwork::from_config::<TYPES>(
+        let libp2p_network = Libp2pNetwork::from_config(
             config.clone(),
             GossipConfig::default(),
             bind_address,

--- a/crates/hotshot/src/traits/networking/libp2p_network.rs
+++ b/crates/hotshot/src/traits/networking/libp2p_network.rs
@@ -408,7 +408,7 @@ impl<K: SignatureKey + 'static> Libp2pNetwork<K> {
     ///
     /// # Panics
     /// If we are unable to calculate the replication factor
-    pub async fn from_config<TYPES: NodeType>(
+    pub async fn from_config(
         mut config: NetworkConfig<K>,
         gossip_config: GossipConfig,
         bind_address: Multiaddr,


### PR DESCRIPTION
Closes #<ISSUE_NUMBER>
<!-- See here for keywords in Github -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

### This PR: 
This doesn't need to be there, and it makes using the type more difficult.

### This PR does not: 
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->

### Key places to review: 
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
