### PR TITLE
push task_state as QuorumProposalRecv task state into helper function…

### DIFF
--- a/crates/hotshot/src/lib.rs
+++ b/crates/hotshot/src/lib.rs
@@ -350,8 +350,6 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> SystemContext<T
     /// Panics if sending genesis fails
     #[instrument(skip_all, target = "SystemContext", fields(id = self.id))]
     pub async fn start_consensus(&self) {
-        tracing::error!("HotShot is running with the dependency tasks feature enabled!!");
-
         #[cfg(all(feature = "rewind", not(debug_assertions)))]
         compile_error!("Cannot run rewind in production builds!");
 

--- a/crates/hotshot/src/tasks/mod.rs
+++ b/crates/hotshot/src/tasks/mod.rs
@@ -217,14 +217,14 @@ pub async fn add_consensus_tasks<TYPES: NodeType, I: NodeImplementation<TYPES>, 
 
     {
         use hotshot_task_impls::{
-            consensus2::Consensus2TaskState, quorum_proposal::QuorumProposalTaskState,
+            consensus::ConsensusTaskState, quorum_proposal::QuorumProposalTaskState,
             quorum_proposal_recv::QuorumProposalRecvTaskState, quorum_vote::QuorumVoteTaskState,
         };
 
         handle.add_task(QuorumProposalTaskState::<TYPES, I, V>::create_from(handle).await);
         handle.add_task(QuorumVoteTaskState::<TYPES, I, V>::create_from(handle).await);
         handle.add_task(QuorumProposalRecvTaskState::<TYPES, I, V>::create_from(handle).await);
-        handle.add_task(Consensus2TaskState::<TYPES, I, V>::create_from(handle).await);
+        handle.add_task(ConsensusTaskState::<TYPES, I, V>::create_from(handle).await);
     }
 
     #[cfg(feature = "rewind")]

--- a/crates/hotshot/src/tasks/task_state.rs
+++ b/crates/hotshot/src/tasks/task_state.rs
@@ -13,7 +13,7 @@ use async_compatibility_layer::art::async_spawn;
 use async_trait::async_trait;
 use chrono::Utc;
 use hotshot_task_impls::{
-    builder::BuilderClient, consensus2::Consensus2TaskState, da::DaTaskState,
+    builder::BuilderClient, consensus::ConsensusTaskState, da::DaTaskState,
     quorum_proposal::QuorumProposalTaskState, quorum_proposal_recv::QuorumProposalRecvTaskState,
     quorum_vote::QuorumVoteTaskState, request::NetworkRequestState, rewind::RewindTaskState,
     transactions::TransactionTaskState, upgrade::UpgradeTaskState, vid::VidTaskState,
@@ -299,7 +299,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> CreateTaskState
 
 #[async_trait]
 impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> CreateTaskState<TYPES, I, V>
-    for Consensus2TaskState<TYPES, I, V>
+    for ConsensusTaskState<TYPES, I, V>
 {
     async fn create_from(handle: &SystemContextHandle<TYPES, I, V>) -> Self {
         let consensus = handle.hotshot.consensus();

--- a/crates/task-impls/src/consensus/handlers.rs
+++ b/crates/task-impls/src/consensus/handlers.rs
@@ -21,9 +21,9 @@ use hotshot_types::{
 };
 use tracing::{debug, error, instrument};
 
-use super::Consensus2TaskState;
+use super::ConsensusTaskState;
 use crate::{
-    consensus2::Versions,
+    consensus::Versions,
     events::HotShotEvent,
     helpers::{broadcast_event, cancel_task},
     vote_collection::handle_vote,
@@ -38,7 +38,7 @@ pub(crate) async fn handle_quorum_vote_recv<
     vote: &QuorumVote<TYPES>,
     event: Arc<HotShotEvent<TYPES>>,
     sender: &Sender<Arc<HotShotEvent<TYPES>>>,
-    task_state: &mut Consensus2TaskState<TYPES, I, V>,
+    task_state: &mut ConsensusTaskState<TYPES, I, V>,
 ) -> Result<()> {
     // Are we the leader for this view?
     ensure!(
@@ -73,7 +73,7 @@ pub(crate) async fn handle_timeout_vote_recv<
     vote: &TimeoutVote<TYPES>,
     event: Arc<HotShotEvent<TYPES>>,
     sender: &Sender<Arc<HotShotEvent<TYPES>>>,
-    task_state: &mut Consensus2TaskState<TYPES, I, V>,
+    task_state: &mut ConsensusTaskState<TYPES, I, V>,
 ) -> Result<()> {
     // Are we the leader for this view?
     ensure!(
@@ -108,7 +108,7 @@ pub(crate) async fn handle_view_change<
 >(
     new_view_number: TYPES::Time,
     sender: &Sender<Arc<HotShotEvent<TYPES>>>,
-    task_state: &mut Consensus2TaskState<TYPES, I, V>,
+    task_state: &mut ConsensusTaskState<TYPES, I, V>,
 ) -> Result<()> {
     ensure!(
         new_view_number > task_state.cur_view,
@@ -205,7 +205,7 @@ pub(crate) async fn handle_view_change<
 pub(crate) async fn handle_timeout<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions>(
     view_number: TYPES::Time,
     sender: &Sender<Arc<HotShotEvent<TYPES>>>,
-    task_state: &mut Consensus2TaskState<TYPES, I, V>,
+    task_state: &mut ConsensusTaskState<TYPES, I, V>,
 ) -> Result<()> {
     ensure!(
         task_state.cur_view < view_number,

--- a/crates/task-impls/src/consensus/mod.rs
+++ b/crates/task-impls/src/consensus/mod.rs
@@ -37,7 +37,7 @@ use crate::{events::HotShotEvent, vote_collection::VoteCollectorsMap};
 mod handlers;
 
 /// Task state for the Consensus task.
-pub struct Consensus2TaskState<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> {
+pub struct ConsensusTaskState<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> {
     /// Our public key
     pub public_key: TYPES::SignatureKey,
 
@@ -96,9 +96,9 @@ pub struct Consensus2TaskState<TYPES: NodeType, I: NodeImplementation<TYPES>, V:
     /// Lock for a decided upgrade
     pub upgrade_lock: UpgradeLock<TYPES, V>,
 }
-impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> Consensus2TaskState<TYPES, I, V> {
+impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> ConsensusTaskState<TYPES, I, V> {
     /// Handles a consensus event received on the event stream
-    #[instrument(skip_all, fields(id = self.id, cur_view = *self.cur_view, last_decided_view = *self.last_decided_view), name = "Consensus replica task", level = "error", target = "Consensus2TaskState")]
+    #[instrument(skip_all, fields(id = self.id, cur_view = *self.cur_view, last_decided_view = *self.last_decided_view), name = "Consensus replica task", level = "error", target = "ConsensusTaskState")]
     pub async fn handle(
         &mut self,
         event: Arc<HotShotEvent<TYPES>>,
@@ -151,7 +151,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> Consensus2TaskS
 
 #[async_trait]
 impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> TaskState
-    for Consensus2TaskState<TYPES, I, V>
+    for ConsensusTaskState<TYPES, I, V>
 {
     type Event = HotShotEvent<TYPES>;
 

--- a/crates/task-impls/src/lib.rs
+++ b/crates/task-impls/src/lib.rs
@@ -8,7 +8,7 @@
 //! consensus in an event driven way
 
 /// The task which implements the core state logic of consensus.
-pub mod consensus2;
+pub mod consensus;
 
 /// The task which handles the logic for the quorum vote.
 pub mod quorum_vote;

--- a/crates/testing/src/view_generator.rs
+++ b/crates/testing/src/view_generator.rs
@@ -63,7 +63,7 @@ pub struct TestView {
     pub da_certificate: DaCertificate<TestTypes>,
     pub transactions: Vec<TestTransaction>,
     upgrade_data: Option<UpgradeProposalData<TestTypes>>,
-    pub formed_upgrade_certificate: Option<UpgradeCertificate<TestTypes>>,
+    formed_upgrade_certificate: Option<UpgradeCertificate<TestTypes>>,
     view_sync_finalize_data: Option<ViewSyncFinalizeData<TestTypes>>,
     timeout_cert_data: Option<TimeoutData<TestTypes>>,
     upgrade_lock: UpgradeLock<TestTypes, TestVersions>,

--- a/crates/testing/tests/tests_1/test_success.rs
+++ b/crates/testing/tests/tests_1/test_success.rs
@@ -6,12 +6,12 @@
 
 use std::time::Duration;
 
-use hotshot_example_types::node_types::{
-    Libp2pImpl, MemoryImpl, PushCdnImpl, TestConsecutiveLeaderTypes, TestTypes,
-    TestTypesRandomizedLeader, TestVersions,
-};
-use hotshot_example_types::testable_delay::{
-    DelayConfig, DelayOptions, DelaySettings, SupportedTraitTypesForAsyncDelay,
+use hotshot_example_types::{
+    node_types::{
+        Libp2pImpl, MemoryImpl, PushCdnImpl, TestConsecutiveLeaderTypes, TestTypes,
+        TestTypesRandomizedLeader, TestVersions,
+    },
+    testable_delay::{DelayConfig, DelayOptions, DelaySettings, SupportedTraitTypesForAsyncDelay},
 };
 use hotshot_macros::cross_tests;
 use hotshot_testing::{

--- a/crates/testing/tests/tests_1/upgrade_task_with_proposal.rs
+++ b/crates/testing/tests/tests_1/upgrade_task_with_proposal.rs
@@ -17,7 +17,7 @@ use hotshot_example_types::{
 };
 use hotshot_macros::{run_test, test_scripts};
 use hotshot_task_impls::{
-    consensus2::Consensus2TaskState, events::HotShotEvent::*,
+    consensus::ConsensusTaskState, events::HotShotEvent::*,
     quorum_proposal::QuorumProposalTaskState, upgrade::UpgradeTaskState,
 };
 use hotshot_testing::{

--- a/crates/testing/tests/tests_1/upgrade_task_with_vote.rs
+++ b/crates/testing/tests/tests_1/upgrade_task_with_vote.rs
@@ -17,7 +17,7 @@ use hotshot_example_types::{
 };
 use hotshot_macros::{run_test, test_scripts};
 use hotshot_task_impls::{
-    consensus2::Consensus2TaskState, events::HotShotEvent::*, quorum_vote::QuorumVoteTaskState,
+    consensus::ConsensusTaskState, events::HotShotEvent::*, quorum_vote::QuorumVoteTaskState,
     upgrade::UpgradeTaskState,
 };
 use hotshot_testing::{

--- a/justfile
+++ b/justfile
@@ -145,7 +145,7 @@ test_quorum_proposal_recv_task:
   cargo test --lib --bins --tests --benches --workspace --no-fail-fast test_quorum_proposal_recv_task -- --test-threads=1 --nocapture
 
 test_upgrade_task:
-  echo Testing the upgrade task without dependency tasks
+  echo Testing the upgrade task
   cargo test --lib --bins --tests --benches --workspace --no-fail-fast test_upgrade_task -- --test-threads=1 --nocapture
 
 test_pkg := "hotshot"


### PR DESCRIPTION
…s, rename consensus2

Closes #3640 
<!-- See here for keywords in Github -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

### This PR: 
<!-- Describe what this PR adds to HotSHot -->
<!-- E.g. -->
<!-- * Implements feature 1 -->
<!-- * Implements feature 2 -->
<!-- * Fixes bug 3 -->
Finishes the rest of #3640 by pushing task_state into helper functions instead of copying the component parts; this is no longer necessary as consensus has been removed in lieu of consensus2. Also renames consensus2->consensus, and cleans up some other bits of code.

### This PR does not: 
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->

### Key places to review: 
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->
In particular, check over the functions update_view and handle_quorum_proposal_recv. In at least one case, I was worried that a local copy of a mutable reference var was being copied locally to allow changing the pointed-to value while being able to access the previous value. I believe I got this correct but want an extra set of eyes to check it.

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
