### PR TITLE
[Networking] Add a hook for application messages

### DIFF
--- a/crates/hotshot/src/tasks/mod.rs
+++ b/crates/hotshot/src/tasks/mod.rs
@@ -107,6 +107,7 @@ pub fn add_network_message_task<
     let network_state: NetworkMessageTaskState<_> = NetworkMessageTaskState {
         internal_event_stream: handle.internal_event_stream.0.clone(),
         external_event_stream: handle.output_event_stream.0.clone(),
+        public_key: handle.public_key().clone(),
     };
 
     let upgrade_lock = handle.hotshot.upgrade_lock.clone();

--- a/crates/hotshot/src/traits/networking/combined_network.rs
+++ b/crates/hotshot/src/traits/networking/combined_network.rs
@@ -7,7 +7,7 @@
 //! Networking Implementation that has a primary and a fallback network.  If the primary
 //! Errors we will use the backup to send or receive
 use std::{
-    collections::{hash_map::DefaultHasher, BTreeMap, BTreeSet, HashMap},
+    collections::{hash_map::DefaultHasher, BTreeMap, HashMap},
     future::Future,
     hash::{Hash, Hasher},
     num::NonZeroUsize,
@@ -391,7 +391,7 @@ impl<TYPES: NodeType> ConnectedNetwork<TYPES::SignatureKey> for CombinedNetworks
     async fn da_broadcast_message(
         &self,
         message: Vec<u8>,
-        recipients: BTreeSet<TYPES::SignatureKey>,
+        recipients: Vec<TYPES::SignatureKey>,
         broadcast_delay: BroadcastDelay,
     ) -> Result<(), NetworkError> {
         let primary = self.primary().clone();

--- a/crates/hotshot/src/traits/networking/libp2p_network.rs
+++ b/crates/hotshot/src/traits/networking/libp2p_network.rs
@@ -885,7 +885,7 @@ impl<K: SignatureKey + 'static> ConnectedNetwork<K> for Libp2pNetwork<K> {
     async fn da_broadcast_message(
         &self,
         message: Vec<u8>,
-        recipients: BTreeSet<K>,
+        recipients: Vec<K>,
         _broadcast_delay: BroadcastDelay,
     ) -> Result<(), NetworkError> {
         // If we're not ready, return an error

--- a/crates/hotshot/src/traits/networking/memory_network.rs
+++ b/crates/hotshot/src/traits/networking/memory_network.rs
@@ -11,7 +11,6 @@
 
 use core::time::Duration;
 use std::{
-    collections::BTreeSet,
     fmt::Debug,
     sync::{
         atomic::{AtomicUsize, Ordering},
@@ -305,7 +304,7 @@ impl<K: SignatureKey + 'static> ConnectedNetwork<K> for MemoryNetwork<K> {
     async fn da_broadcast_message(
         &self,
         message: Vec<u8>,
-        recipients: BTreeSet<K>,
+        recipients: Vec<K>,
         broadcast_delay: BroadcastDelay,
     ) -> Result<(), NetworkError> {
         // Iterate over all topics, compare to recipients, and get the `Topic`

--- a/crates/hotshot/src/traits/networking/memory_network.rs
+++ b/crates/hotshot/src/traits/networking/memory_network.rs
@@ -360,10 +360,9 @@ impl<K: SignatureKey + 'static> ConnectedNetwork<K> for MemoryNetwork<K> {
                 }
             }
         } else {
-            Err(NetworkError::MessageSendError(format!(
-                "node does not exist {:?}\n\n\n {:?}",
-                recipient, self.inner.master_map.map
-            )))
+            Err(NetworkError::MessageSendError(
+                "node does not exist".to_string(),
+            ))
         }
     }
 

--- a/crates/hotshot/src/traits/networking/memory_network.rs
+++ b/crates/hotshot/src/traits/networking/memory_network.rs
@@ -360,9 +360,10 @@ impl<K: SignatureKey + 'static> ConnectedNetwork<K> for MemoryNetwork<K> {
                 }
             }
         } else {
-            Err(NetworkError::MessageSendError(
-                "node does not exist".to_string(),
-            ))
+            Err(NetworkError::MessageSendError(format!(
+                "node does not exist {:?}\n\n\n {:?}",
+                recipient, self.inner.master_map.map
+            )))
         }
     }
 

--- a/crates/hotshot/src/traits/networking/push_cdn_network.rs
+++ b/crates/hotshot/src/traits/networking/push_cdn_network.rs
@@ -6,7 +6,7 @@
 
 #[cfg(feature = "hotshot-testing")]
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::{collections::BTreeSet, marker::PhantomData, sync::Arc};
+use std::{marker::PhantomData, sync::Arc};
 #[cfg(feature = "hotshot-testing")]
 use std::{path::Path, time::Duration};
 
@@ -487,7 +487,7 @@ impl<K: SignatureKey + 'static> ConnectedNetwork<K> for PushCdnNetwork<K> {
     async fn da_broadcast_message(
         &self,
         message: Vec<u8>,
-        _recipients: BTreeSet<K>,
+        _recipients: Vec<K>,
         _broadcast_delay: BroadcastDelay,
     ) -> Result<(), NetworkError> {
         self.broadcast_message(message, Topic::Da)

--- a/crates/hotshot/src/types/handle.rs
+++ b/crates/hotshot/src/types/handle.rs
@@ -22,11 +22,14 @@ use hotshot_types::{
     consensus::Consensus,
     data::{Leaf, QuorumProposal},
     error::HotShotError,
-    message::Proposal,
+    message::{Message, MessageKind, Proposal, RecipientList},
     request_response::ProposalRequestPayload,
     traits::{
-        consensus_api::ConsensusApi, election::Membership, network::ConnectedNetwork,
-        node_implementation::NodeType, signature_key::SignatureKey,
+        consensus_api::ConsensusApi,
+        election::Membership,
+        network::{BroadcastDelay, ConnectedNetwork, Topic},
+        node_implementation::NodeType,
+        signature_key::SignatureKey,
     },
     vote::HasViewNumber,
 };
@@ -86,6 +89,43 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static, V: Versions>
     /// obtains a stream to expose to the user
     pub fn event_stream(&self) -> impl Stream<Item = Event<TYPES>> {
         self.output_event_stream.1.activate_cloned()
+    }
+
+    /// Message other participents with a serialized message from the application
+    /// Receivers of this message will get an `Event::ExternalMessageReceived` via
+    /// the event stream.
+    ///
+    /// # Errors
+    /// Errors if serializing the request fails, or the request fails to be sent
+    pub async fn send_external_message(
+        &self,
+        msg: Vec<u8>,
+        recipients: RecipientList<TYPES::SignatureKey>,
+    ) -> Result<()> {
+        let message = Message {
+            sender: self.public_key().clone(),
+            kind: MessageKind::External(msg),
+        };
+        let serialized_message = self.hotshot.upgrade_lock.serialize(&message).await?;
+
+        match recipients {
+            RecipientList::Broadcast => {
+                self.network
+                    .broadcast_message(serialized_message, Topic::Global, BroadcastDelay::None)
+                    .await?;
+            }
+            RecipientList::Direct(recipient) => {
+                self.network
+                    .direct_message(serialized_message, recipient)
+                    .await?;
+            }
+            RecipientList::Many(recipients) => {
+                self.network
+                    .da_broadcast_message(serialized_message, recipients, BroadcastDelay::None)
+                    .await?;
+            }
+        }
+        Ok(())
     }
 
     /// Request a proposal from the all other nodes.  Will block until some node

--- a/crates/task-impls/src/network.rs
+++ b/crates/task-impls/src/network.rs
@@ -577,8 +577,12 @@ impl<
                         .await
                 }
                 TransmitType::DaCommitteeBroadcast => {
-                    net.da_broadcast_message(serialized_message, da_committee, broadcast_delay)
-                        .await
+                    net.da_broadcast_message(
+                        serialized_message,
+                        da_committee.iter().cloned().collect(),
+                        broadcast_delay,
+                    )
+                    .await
                 }
             };
 

--- a/crates/task-impls/src/network.rs
+++ b/crates/task-impls/src/network.rs
@@ -46,6 +46,9 @@ pub struct NetworkMessageTaskState<TYPES: NodeType> {
 
     /// Sender to send external events this task generates to the event stream
     pub external_event_stream: Sender<Event<TYPES>>,
+
+    /// This nodes public key
+    pub public_key: TYPES::SignatureKey,
 }
 
 impl<TYPES: NodeType> NetworkMessageTaskState<TYPES> {
@@ -160,11 +163,14 @@ impl<TYPES: NodeType> NetworkMessageTaskState<TYPES> {
 
             // Handle external messages
             MessageKind::External(data) => {
+                if sender == self.public_key {
+                    return;
+                }
                 // Send the external message to the external event stream so it can be processed
                 broadcast_event(
                     Event {
                         view_number: TYPES::Time::new(1),
-                        event: EventType::ExternalMessageReceived(data),
+                        event: EventType::ExternalMessageReceived { sender, data },
                     },
                     &self.external_event_stream,
                 )
@@ -571,18 +577,6 @@ impl<
                         .await
                 }
                 TransmitType::DaCommitteeBroadcast => {
-                    net.da_broadcast_message(serialized_message, da_committee, broadcast_delay)
-                        .await
-                }
-                TransmitType::DaCommitteeAndLeaderBroadcast(recipient) => {
-                    if let Err(e) = net
-                        .direct_message(serialized_message.clone(), recipient)
-                        .await
-                    {
-                        warn!("Failed to send message: {e:?}");
-                    }
-
-                    // Otherwise, send the next message.
                     net.da_broadcast_message(serialized_message, da_committee, broadcast_delay)
                         .await
                 }

--- a/crates/testing/src/test_task.rs
+++ b/crates/testing/src/test_task.rs
@@ -124,11 +124,13 @@ pub async fn add_network_message_test_task<
     external_event_stream: Sender<Event<TYPES>>,
     upgrade_lock: UpgradeLock<TYPES, V>,
     channel: Arc<NET>,
+    public_key: TYPES::SignatureKey,
 ) -> JoinHandle<()> {
     let net = Arc::clone(&channel);
     let network_state: NetworkMessageTaskState<_> = NetworkMessageTaskState {
         internal_event_stream: internal_event_stream.clone(),
         external_event_stream: external_event_stream.clone(),
+        public_key,
     };
 
     let network = Arc::clone(&net);

--- a/crates/testing/tests/tests_1/network_task.rs
+++ b/crates/testing/tests/tests_1/network_task.rs
@@ -84,6 +84,7 @@ async fn test_network_task() {
         out_tx_external.clone(),
         upgrade_lock,
         network.clone(),
+        public_key,
     )
     .await;
 
@@ -102,6 +103,110 @@ async fn test_network_task() {
         res.as_ref(),
         HotShotEvent::QuorumProposalRecv(_, _)
     ));
+}
+
+#[cfg(test)]
+#[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
+#[cfg_attr(async_executor_impl = "async-std", async_std::test)]
+async fn test_network_external_mnessages() {
+    use async_std::stream::StreamExt;
+    use hotshot::types::EventType;
+    use hotshot_testing::helpers::build_system_handle_from_launcher;
+    use hotshot_types::message::RecipientList;
+
+    async_compatibility_layer::logging::setup_logging();
+    async_compatibility_layer::logging::setup_backtrace();
+
+    let builder: TestDescription<TestTypes, MemoryImpl, TestVersions> =
+        TestDescription::default_multiple_rounds();
+
+    let launcher = builder.gen_launcher(0);
+
+    let mut handles = vec![];
+    let mut event_streams = vec![];
+    for i in 0..launcher.metadata.num_nodes_with_stake {
+        let handle = build_system_handle_from_launcher::<TestTypes, MemoryImpl, TestVersions>(
+            i.try_into().unwrap(),
+            &launcher,
+        )
+        .await
+        .0;
+        event_streams.push(handle.event_stream_known_impl());
+        handles.push(handle);
+    }
+
+    // Send a message from 1 -> 2
+    handles[1]
+        .send_external_message(vec![1, 2], RecipientList::Direct(handles[2].public_key()))
+        .await
+        .unwrap();
+    let event = async_compatibility_layer::art::async_timeout(
+        Duration::from_millis(100),
+        event_streams[2].next(),
+    )
+    .await
+    .unwrap()
+    .unwrap()
+    .event;
+
+    // check that 2 received the message
+    assert!(matches!(
+        event,
+        EventType::ExternalMessageReceived {
+            sender,
+            data,
+        } if sender == handles[1].public_key() && data == vec![1, 2]
+    ));
+
+    // Send a message from 2 -> 1
+    handles[2]
+        .send_external_message(vec![2, 1], RecipientList::Direct(handles[1].public_key()))
+        .await
+        .unwrap();
+    let event = async_compatibility_layer::art::async_timeout(
+        Duration::from_millis(100),
+        event_streams[1].next(),
+    )
+    .await
+    .unwrap()
+    .unwrap()
+    .event;
+
+    // check that 1 received the message
+    assert!(matches!(
+        event,
+        EventType::ExternalMessageReceived {
+            sender,
+            data,
+        } if sender == handles[2].public_key() && data == vec![2,1]
+    ));
+
+    // Check broadcast works
+    handles[0]
+        .send_external_message(vec![0, 0, 0], RecipientList::Broadcast)
+        .await
+        .unwrap();
+    // All other nodes get the broadcast
+    for stream in event_streams.iter_mut().skip(1) {
+        let event = async_compatibility_layer::art::async_timeout(
+            Duration::from_millis(100),
+            stream.next(),
+        )
+        .await
+        .unwrap()
+        .unwrap()
+        .event;
+        assert!(matches!(
+            event,
+            EventType::ExternalMessageReceived {
+                sender,
+                data,
+            } if sender == handles[0].public_key() && data == vec![0,0,0]
+        ));
+    }
+    // No event on 0 even after short sleep
+    async_compatibility_layer::art::async_sleep(Duration::from_millis(2)).await;
+    assert!(event_streams[0].is_empty());
 }
 
 #[cfg(test)]
@@ -161,6 +266,7 @@ async fn test_network_storage_fail() {
         out_tx_external.clone(),
         upgrade_lock,
         network.clone(),
+        public_key,
     )
     .await;
 

--- a/crates/testing/tests/tests_1/network_task.rs
+++ b/crates/testing/tests/tests_1/network_task.rs
@@ -109,7 +109,6 @@ async fn test_network_task() {
 #[cfg_attr(async_executor_impl = "tokio", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
 async fn test_network_external_mnessages() {
-    use async_std::stream::StreamExt;
     use hotshot::types::EventType;
     use hotshot_testing::helpers::build_system_handle_from_launcher;
     use hotshot_types::message::RecipientList;

--- a/crates/testing/tests/tests_1/network_task.rs
+++ b/crates/testing/tests/tests_1/network_task.rs
@@ -190,7 +190,7 @@ async fn test_network_external_mnessages() {
     for stream in event_streams.iter_mut().skip(1) {
         let event = async_compatibility_layer::art::async_timeout(
             Duration::from_millis(100),
-            stream.next(),
+            stream.recv(),
         )
         .await
         .unwrap()

--- a/crates/testing/tests/tests_1/network_task.rs
+++ b/crates/testing/tests/tests_1/network_task.rs
@@ -142,7 +142,7 @@ async fn test_network_external_mnessages() {
         .unwrap();
     let event = async_compatibility_layer::art::async_timeout(
         Duration::from_millis(100),
-        event_streams[2].next(),
+        event_streams[2].recv(),
     )
     .await
     .unwrap()
@@ -165,7 +165,7 @@ async fn test_network_external_mnessages() {
         .unwrap();
     let event = async_compatibility_layer::art::async_timeout(
         Duration::from_millis(100),
-        event_streams[1].next(),
+        event_streams[1].recv(),
     )
     .await
     .unwrap()

--- a/crates/types/src/event.rs
+++ b/crates/types/src/event.rs
@@ -92,6 +92,7 @@ pub mod error_adaptor {
         Ok(Arc::new(HotShotError::FailedToDeserialize(str)))
     }
 }
+
 /// The type and contents of a status event emitted by a `HotShot` instance
 ///
 /// This enum does not include metadata shared among all variants, such as the stage and view
@@ -171,7 +172,12 @@ pub enum EventType<TYPES: NodeType> {
     },
 
     /// A message destined for external listeners was received
-    ExternalMessageReceived(Vec<u8>),
+    ExternalMessageReceived {
+        /// Public Key of the message sender
+        sender: TYPES::SignatureKey,
+        /// Serialized data of the message
+        data: Vec<u8>,
+    },
 }
 #[derive(Debug, Serialize, Deserialize, Clone, Copy)]
 /// A list of actions that we track for nodes

--- a/crates/types/src/message.rs
+++ b/crates/types/src/message.rs
@@ -9,7 +9,12 @@
 //! This module contains types used to represent the various types of messages that
 //! `HotShot` nodes can send among themselves.
 
-use std::{fmt, fmt::Debug, marker::PhantomData, sync::Arc};
+use std::{
+    collections::BTreeSet,
+    fmt::{self, Debug},
+    marker::PhantomData,
+    sync::Arc,
+};
 
 use anyhow::{bail, ensure, Context, Result};
 use async_lock::RwLock;
@@ -115,6 +120,16 @@ pub enum MessageKind<TYPES: NodeType> {
     Data(DataMessage<TYPES>),
     /// A (still serialized) message to be passed through to external listeners
     External(Vec<u8>),
+}
+
+/// List of keys to send a message to, or broadcast to all known keys
+pub enum RecipientList<K: SignatureKey> {
+    /// Broadcast to all
+    Broadcast,
+    /// Send a message directly to a key
+    Direct(K),
+    /// Send a message directly to many keys
+    Many(BTreeSet<K>),
 }
 
 impl<TYPES: NodeType> MessageKind<TYPES> {

--- a/crates/types/src/message.rs
+++ b/crates/types/src/message.rs
@@ -10,7 +10,6 @@
 //! `HotShot` nodes can send among themselves.
 
 use std::{
-    collections::BTreeSet,
     fmt::{self, Debug},
     marker::PhantomData,
     sync::Arc,
@@ -129,7 +128,7 @@ pub enum RecipientList<K: SignatureKey> {
     /// Send a message directly to a key
     Direct(K),
     /// Send a message directly to many keys
-    Many(BTreeSet<K>),
+    Many(Vec<K>),
 }
 
 impl<TYPES: NodeType> MessageKind<TYPES> {

--- a/crates/types/src/traits/network.rs
+++ b/crates/types/src/traits/network.rs
@@ -54,8 +54,6 @@ pub enum TransmitType<TYPES: NodeType> {
     Broadcast,
     /// broadcast to DA committee
     DaCommitteeBroadcast,
-    /// broadcast to the leader and the DA
-    DaCommitteeAndLeaderBroadcast(TYPES::SignatureKey),
 }
 
 /// Errors that can occur in the network
@@ -120,17 +118,6 @@ pub enum NetworkError {
     /// Failed to look up a node on the network
     #[error("Node lookup failed: {0}")]
     LookupError(String),
-}
-
-/// common traits we would like our network messages to implement
-pub trait NetworkMsg:
-    Serialize + for<'a> Deserialize<'a> + Clone + Sync + Send + Debug + 'static
-{
-}
-
-impl<T> NetworkMsg for T where
-    T: Serialize + for<'a> Deserialize<'a> + Clone + Sync + Send + Debug + 'static
-{
 }
 
 /// Trait that bundles what we need from a request ID

--- a/crates/types/src/traits/network.rs
+++ b/crates/types/src/traits/network.rs
@@ -17,7 +17,7 @@ use thiserror::Error;
 #[cfg(not(any(async_executor_impl = "async-std", async_executor_impl = "tokio")))]
 compile_error! {"Either config option \"async-std\" or \"tokio\" must be enabled for this crate."}
 use std::{
-    collections::{BTreeSet, HashMap},
+    collections::HashMap,
     fmt::{Debug, Display},
     hash::Hash,
     pin::Pin,
@@ -217,7 +217,7 @@ pub trait ConnectedNetwork<K: SignatureKey + 'static>: Clone + Send + Sync + 'st
     async fn da_broadcast_message(
         &self,
         message: Vec<u8>,
-        recipients: BTreeSet<K>,
+        recipients: Vec<K>,
         broadcast_delay: BroadcastDelay,
     ) -> Result<(), NetworkError>;
 


### PR DESCRIPTION


### This PR: 

This adds a way for the application layer to send arbitrary messages to other participants via the HotShot networking layer.  It's not perfect as it'll do double de/serialization and all messages are fire and forget within hotshot.  
### This PR does not: 
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->

### Key places to review: 

Changes to `SystemContextHandle`
Test added to the newtorking tests

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
