### PR TITLE
Allow injecting custom tasks into testing harness

### DIFF
--- a/crates/testing/src/test_builder.rs
+++ b/crates/testing/src/test_builder.rs
@@ -33,6 +33,7 @@ use super::{
 use crate::{
     spinning_task::SpinningTaskDescription,
     test_launcher::{Network, ResourceGenerators, TestLauncher},
+    test_task::TestTaskStateSeed,
     view_sync_task::ViewSyncTaskDescription,
 };
 
@@ -444,8 +445,21 @@ where
     /// a [`TestLauncher`] that can be used to launch the test.
     /// # Panics
     /// if some of the the configuration values are zero
-    #[must_use]
     pub fn gen_launcher(self, node_id: u64) -> TestLauncher<TYPES, I, V> {
+        self.gen_launcher_with_tasks(node_id, vec![])
+    }
+
+    /// turn a description of a test (e.g. a [`TestDescription`]) into
+    /// a [`TestLauncher`] that can be used to launch the test, with
+    /// additional testing tasks to run in test harness
+    /// # Panics
+    /// if some of the the configuration values are zero
+    #[must_use]
+    pub fn gen_launcher_with_tasks(
+        self,
+        node_id: u64,
+        additional_test_tasks: Vec<Box<dyn TestTaskStateSeed<TYPES, I, V>>>,
+    ) -> TestLauncher<TYPES, I, V> {
         let TestDescription {
             num_nodes_with_stake,
             num_bootstrap_nodes,
@@ -561,6 +575,7 @@ where
                 }),
             },
             metadata: self,
+            additional_test_tasks,
         }
         .modify_default_config(mod_config)
     }

--- a/crates/testing/src/test_launcher.rs
+++ b/crates/testing/src/test_launcher.rs
@@ -20,6 +20,7 @@ use hotshot_types::{
 };
 
 use super::{test_builder::TestDescription, test_runner::TestRunner};
+use crate::test_task::TestTaskStateSeed;
 
 /// A type alias to help readability
 pub type Network<TYPES, I> = Arc<<I as NodeImplementation<TYPES>>::Network>;
@@ -45,6 +46,8 @@ pub struct TestLauncher<TYPES: NodeType, I: TestableNodeImplementation<TYPES>, V
     pub resource_generator: ResourceGenerators<TYPES, I>,
     /// metadata used for tasks
     pub metadata: TestDescription<TYPES, I, V>,
+    /// any additional test tasks to run
+    pub additional_test_tasks: Vec<Box<dyn TestTaskStateSeed<TYPES, I, V>>>,
 }
 
 impl<TYPES: NodeType, I: TestableNodeImplementation<TYPES>, V: Versions> TestLauncher<TYPES, I, V> {


### PR DESCRIPTION
Closes #0000
<!-- See here for keywords in Github -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

### This PR: 
Adds a list of additional test tasks to `TestLauncher`, which are then injected into the testing harness.
This enables us at `marketplace-builder-core` to make use of HotShot testing harness with custom validation logic that tests builder properties and custom transaction generation logic tailored for stressing the builder.

### This PR does not: 
Change any existing tests hotshot-side.

### Key places to review: 
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
