### PR TITLE
Add anyhow replacement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8383,6 +8383,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
+name = "utils"
+version = "0.5.78"
+dependencies = [
+ "tracing",
+]
+
+[[package]]
 name = "uuid"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ members = [
   "crates/types",
   "crates/builder-api",
   "crates/fakeapi",
+  "crates/utils"
 ]
 resolver = "2"
 

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "utils"
+version = { workspace = true }
+edition = { workspace = true }
+description = "Utils"
+
+[dependencies]
+tracing = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/utils/src/anytrace.rs
+++ b/crates/utils/src/anytrace.rs
@@ -1,0 +1,191 @@
+use std::{cmp::max, fmt::Display};
+
+/// Macros
+mod macros;
+#[allow(unused_imports)]
+pub use macros::*;
+
+/// Default log level for the crate
+pub const DEFAULT_LOG_LEVEL: Level = Level::Info;
+
+/// Trait for logging errors
+pub trait Log {
+    /// Log an error via `tracing` utilities, printing it.
+    fn log(&self);
+}
+
+impl Log for Error {
+    fn log(&self) {
+        let mut error_level = self.level;
+        if error_level == Level::Unspecified {
+            error_level = DEFAULT_LOG_LEVEL;
+        }
+
+        match error_level {
+            Level::Trace => {
+                tracing::trace!("{}", self.message);
+            }
+            Level::Debug => {
+                tracing::debug!("{}", self.message);
+            }
+            Level::Info => {
+                tracing::info!("{}", self.message);
+            }
+            Level::Warn => {
+                tracing::warn!("{}", self.message);
+            }
+            Level::Error => {
+                tracing::error!("{}", self.message);
+            }
+            // impossible
+            Level::Unspecified => {}
+        }
+    }
+}
+
+impl<T> Log for Result<T> {
+    fn log(&self) {
+        let error = match self {
+            Ok(_) => {
+                return;
+            }
+            Err(e) => e,
+        };
+
+        let mut error_level = error.level;
+        if error_level == Level::Unspecified {
+            error_level = DEFAULT_LOG_LEVEL;
+        }
+
+        match error_level {
+            Level::Trace => {
+                tracing::trace!("{}", error.message);
+            }
+            Level::Debug => {
+                tracing::debug!("{}", error.message);
+            }
+            Level::Info => {
+                tracing::info!("{}", error.message);
+            }
+            Level::Warn => {
+                tracing::warn!("{}", error.message);
+            }
+            Level::Error => {
+                tracing::error!("{}", error.message);
+            }
+            // impossible
+            Level::Unspecified => {}
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+#[must_use]
+/// main error type
+pub struct Error {
+    /// level
+    pub level: Level,
+    /// message
+    pub message: String,
+}
+
+impl std::error::Error for Error {}
+
+/// Trait for a `std::result::Result` that can be wrapped into a `Result`
+pub trait Wrap<T> {
+    /// Wrap the value into a `Result`
+    ///
+    /// # Errors
+    /// Propagates errors from `self`
+    fn wrap(self) -> Result<T>;
+}
+
+impl<T, E> Wrap<T> for std::result::Result<T, E>
+where
+    E: Display,
+{
+    fn wrap(self) -> Result<T> {
+        match self {
+            Ok(t) => Ok(t),
+            Err(e) => Err(Error {
+                level: Level::Unspecified,
+                message: format!("{e}"),
+            }),
+        }
+    }
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+/// Alias for the main `Result` type used by the crate.
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[derive(PartialEq, Eq, PartialOrd, Ord, Debug, Clone, Copy)]
+/// Possible log levels
+pub enum Level {
+    /// Unspecified log level
+    Unspecified,
+    /// TRACE
+    Trace,
+    /// DEBUG
+    Debug,
+    /// INFO
+    Info,
+    /// WARN
+    Warn,
+    /// ERROR
+    Error,
+}
+
+/// Prepend an error to its cause
+fn concatenate(error: &String, cause: &String) -> String {
+    format!("{error}\ncaused by: {cause}")
+}
+
+/// Trait for converting error types to a `Result<T>`.
+pub trait Context<T> {
+    /// Attach context to the given error.
+    ///
+    /// # Errors
+    /// Propagates errors from `self`
+    fn context(self, error: Error) -> Result<T>;
+}
+
+impl<T> Context<T> for Result<T> {
+    fn context(self, error: Error) -> Result<T> {
+        match self {
+            Ok(t) => Ok(t),
+            Err(cause) => Err(Error {
+                level: max(error.level, cause.level),
+                message: concatenate(&error.message, &format!("{cause}")),
+            }),
+        }
+    }
+}
+
+impl<T> Context<T> for Option<T> {
+    fn context(self, error: Error) -> Result<T> {
+        match self {
+            Some(t) => Ok(t),
+            None => Err(error),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn ordering() {
+        assert!(Level::Trace < Level::Debug);
+        assert!(Level::Debug < Level::Info);
+        assert!(Level::Info < Level::Warn);
+        assert!(Level::Warn < Level::Error);
+        assert!(max(Level::Trace, Level::Error) == Level::Error);
+    }
+}

--- a/crates/utils/src/anytrace/macros.rs
+++ b/crates/utils/src/anytrace/macros.rs
@@ -1,0 +1,293 @@
+#[macro_export]
+/// Print the file and line number of the location this macro is invoked
+macro_rules! line_info {
+    () => {
+        format!("{}:{}", file!(), line!())
+    };
+}
+pub use line_info;
+
+#[macro_export]
+/// Create an error at the trace level.
+///
+/// The argument can be either:
+///   - an expression implementing `Display`
+///   - a string literal
+///   - a format string, similar to the `format!()` macro
+macro_rules! trace {
+  ($error:expr) => {
+      Error {
+        level: Level::Trace,
+        message: format!("{}: {}", line_info!(), $error)
+      }
+  };
+  ($message:literal) => {
+      Error {
+        level: Level::Trace,
+        message: format!("{}: {}", line_info!(), $message)
+      }
+  };
+  ($fmt:expr, $($arg:tt)*) => {
+      Error {
+        level: Level::Trace,
+        message: format!("{}: {}", line_info!(), format!($fmt, $($arg)*))
+      }
+  };
+}
+pub use trace;
+
+#[macro_export]
+/// Create an error at the debug level.
+///
+/// The argument can be either:
+///   - an expression implementing `Display`
+///   - a string literal
+///   - a format string, similar to the `format!()` macro
+macro_rules! debug {
+  ($error:expr) => {
+      Error {
+        level: Level::Debug,
+        message: format!("{}: {}", line_info!(), $error)
+      }
+  };
+  ($message:literal) => {
+      Error {
+        level: Level::Debug,
+        message: format!("{}: {}", line_info!(), $message)
+      }
+  };
+  ($fmt:expr, $($arg:tt)*) => {
+      Error {
+        level: Level::Debug,
+        message: format!("{}: {}", line_info!(), format!($fmt, $($arg)*))
+      }
+  };
+}
+pub use debug;
+
+#[macro_export]
+/// Create an error at the info level.
+///
+/// The argument can be either:
+///   - an expression implementing `Display`
+///   - a string literal
+///   - a format string, similar to the `format!()` macro
+macro_rules! info {
+  ($error:expr) => {
+      Error {
+        level: Level::Info,
+        message: format!("{}: {}", line_info!(), $error)
+      }
+  };
+  ($message:literal) => {
+      Error {
+        level: Level::Info,
+        message: format!("{}: {}", line_info!(), $message)
+      }
+  };
+  ($fmt:expr, $($arg:tt)*) => {
+      Error {
+        level: Level::Info,
+        message: format!("{}: {}", line_info!(), format!($fmt, $($arg)*))
+      }
+  };
+}
+pub use info;
+
+#[macro_export]
+/// Create an error at the warn level.
+///
+/// The argument can be either:
+///   - an expression implementing `Display`
+///   - a string literal
+///   - a format string, similar to the `format!()` macro
+macro_rules! warn {
+  ($error:expr) => {
+      Error {
+        level: Level::Warn,
+        message: format!("{}: {}", line_info!(), $error)
+      }
+  };
+  ($message:literal) => {
+      Error {
+        level: Level::Warn,
+        message: format!("{}: {}", line_info!(), $message)
+      }
+  };
+  ($fmt:expr, $($arg:tt)*) => {
+      Error {
+        level: Level::Warn,
+        message: format!("{}: {}", line_info!(), format!($fmt, $($arg)*))
+      }
+  };
+}
+pub use crate::warn;
+
+#[macro_export]
+/// Create an error at the error level.
+///
+/// The argument can be either:
+///   - an expression implementing `Display`
+///   - a string literal
+///   - a format string, similar to the `format!()` macro
+macro_rules! error {
+  ($error:expr) => {
+      Error {
+        level: Level::Error,
+        message: format!("{}: {}", line_info!(), $error)
+      }
+  };
+  ($message:literal) => {
+      Error {
+        level: Level::Error,
+        message: format!("{}: {}", line_info!(), $message)
+      }
+  };
+  ($fmt:expr, $($arg:tt)*) => {
+      Error {
+        level: Level::Error,
+        message: format!("{}: {}", line_info!(), format!($fmt, $($arg)*))
+      }
+  };
+}
+pub use error;
+
+#[macro_export]
+/// Log a `anytrace::Error` at the corresponding level.
+macro_rules! log {
+    ($result:expr) => {
+        if let Err(ref error) = $result {
+            let mut error_level = error.level;
+            if error_level == Level::Unspecified {
+                error_level = DEFAULT_LOG_LEVEL;
+            }
+
+            match error_level {
+                Level::Trace => {
+                    tracing::trace!("{}", error.message);
+                }
+                Level::Debug => {
+                    tracing::debug!("{}", error.message);
+                }
+                Level::Info => {
+                    tracing::info!("{}", error.message);
+                }
+                Level::Warn => {
+                    tracing::warn!("{}", error.message);
+                }
+                Level::Error => {
+                    tracing::error!("{}", error.message);
+                }
+                // impossible
+                Level::Unspecified => {}
+            }
+        }
+    };
+}
+pub use log;
+
+#[macro_export]
+/// Check that the given condition holds, otherwise return an error.
+///
+/// The argument can be either:
+///   - a condition, in which case a generic error is logged at the `Unspecified` level.
+///   - a condition and a string literal, in which case the provided literal is logged at the `Unspecified` level.
+///   - a condition and a format expression, in which case the message is formatted and logged at the `Unspecified` level.
+///   - a condition and an `Error`, in which case the given error is logged unchanged.
+macro_rules! ensure {
+  ($condition:expr) => {
+      if !$condition {
+        let result = Err(Error {
+          level: Level::Unspecified,
+          message: format!("{}: condition '{}' failed.", line_info!(), stringify!($condition))
+        });
+
+        log!(result);
+
+        return result;
+     }
+  };
+  ($condition:expr, $message:literal) => {
+      if !$condition {
+        let result = Err(Error {
+          level: Level::Unspecified,
+          message: format!("{}: {}", line_info!(), $message)
+        });
+
+        log!(result);
+
+        return result;
+      }
+  };
+  ($condition:expr, $fmt:expr, $($arg:tt)*) => {
+      if !$condition {
+        let result = Err(Error {
+          level: Level::Unspecified,
+          message: format!("{}: {}", line_info!(), format!($fmt, $($arg)*))
+        });
+
+        log!(result);
+
+        return result;
+      }
+  };
+  ($condition:expr, $error:expr) => {
+      if !$condition {
+        let result = Err($error);
+
+        log!(result);
+
+        return result;
+      }
+  };
+}
+pub use ensure;
+
+#[macro_export]
+/// Return an error.
+///
+/// The argument can be either:
+///   - nothing, in which case a generic message is logged at the `Unspecified` level.
+///   - a string literal, in which case the provided literal is logged at the `Unspecified` level.
+///   - a format expression, in which case the message is formatted and logged at the `Unspecified` level.
+///   - an `Error`, in which case the given error is logged unchanged.
+macro_rules! bail {
+  () => {
+      let result = Err(Error {
+        level: Level::Unspecified,
+        message: format!("{}: bailed.", line_info!()),
+      });
+
+      log!(result);
+
+      return result;
+  };
+  ($message:literal) => {
+      let result = Err(Error {
+        level: Level::Unspecified,
+        message: format!("{}: {}", line_info!(), $message)
+      });
+
+      log!(result);
+
+      return result;
+  };
+  ($fmt:expr, $($arg:tt)*) => {
+      let result = Err(Error {
+        level: Level::Unspecified,
+        message: format!("{}: {}", line_info!(), format!($fmt, $($arg)*))
+      });
+
+      log!(result);
+
+      return result;
+  };
+  ($error:expr) => {
+      let result = Err($error);
+
+      log!(result);
+
+      return result;
+  };
+}
+pub use bail;

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -1,0 +1,4 @@
+//! General (not HotShot-specific) utilities
+
+/// Error utilities, intended to function as a replacement to `anyhow`.
+pub mod anytrace;


### PR DESCRIPTION
### This PR: 
Adds a replacement for `anyhow` that logs like tracing.

Currently, the crate propagates an error to the top level. `ensure!` and `bail!` macro also log the error in-place at the given level, allowing for instrumentation.

This is used in #3738, to allow some more tasks to return a `Result<()>`.

### This PR does not: 

### Key places to review: 
I think the implementation is relatively flexible and we can adjust to log centrally and/or log at the `ensure!` statements. I think the main thing to do would be to take a quick look at #3738 and see that the usage there is reasonable
