### PR TITLE
Remove slow operations from critical path

### DIFF
--- a/crates/task-impls/src/helpers.rs
+++ b/crates/task-impls/src/helpers.rs
@@ -370,25 +370,6 @@ pub(crate) async fn parent_leaf_and_state<TYPES: NodeType, V: Versions>(
         "Somehow we formed a QC but are not the leader for the next view {next_proposal_view_number:?}",
     );
     let parent_view_number = consensus.read().await.high_qc().view_number();
-    if !consensus
-        .read()
-        .await
-        .validated_state_map()
-        .contains_key(&parent_view_number)
-    {
-        let _ = fetch_proposal(
-            parent_view_number,
-            event_sender.clone(),
-            event_receiver.clone(),
-            quorum_membership,
-            consensus.clone(),
-            public_key.clone(),
-            private_key.clone(),
-            upgrade_lock,
-        )
-        .await
-        .context("Failed to fetch proposal")?;
-    }
     let consensus_reader = consensus.read().await;
     let parent_view_number = consensus_reader.high_qc().view_number();
     let parent_view = consensus_reader.validated_state_map().get(&parent_view_number).context(

--- a/crates/task-impls/src/helpers.rs
+++ b/crates/task-impls/src/helpers.rs
@@ -31,7 +31,6 @@ use hotshot_types::{
         election::Membership,
         node_implementation::{ConsensusTime, NodeImplementation, NodeType, Versions},
         signature_key::SignatureKey,
-        storage::Storage,
         BlockPayload, ValidatedState,
     },
     utils::{Terminator, View, ViewInner},
@@ -552,15 +551,6 @@ pub async fn validate_proposal_safety_and_liveness<
         });
     }
 
-    // Update our persistent storage of the proposal. If we cannot store the proposal reutrn
-    // and error so we don't vote
-    task_state
-        .storage
-        .write()
-        .await
-        .append_proposal(&proposal)
-        .await?;
-
     // We accept the proposal, notify the application layer
     broadcast_event(
         Event {
@@ -577,7 +567,7 @@ pub async fn validate_proposal_safety_and_liveness<
     // Notify other tasks
     broadcast_event(
         Arc::new(HotShotEvent::QuorumProposalValidated(
-            proposal.data.clone(),
+            proposal.clone(),
             parent_leaf,
         )),
         &event_stream,

--- a/crates/task-impls/src/helpers.rs
+++ b/crates/task-impls/src/helpers.rs
@@ -370,6 +370,25 @@ pub(crate) async fn parent_leaf_and_state<TYPES: NodeType, V: Versions>(
         "Somehow we formed a QC but are not the leader for the next view {next_proposal_view_number:?}",
     );
     let parent_view_number = consensus.read().await.high_qc().view_number();
+    if !consensus
+        .read()
+        .await
+        .validated_state_map()
+        .contains_key(&parent_view_number)
+    {
+        let _ = fetch_proposal(
+            parent_view_number,
+            event_sender.clone(),
+            event_receiver.clone(),
+            quorum_membership,
+            consensus.clone(),
+            public_key.clone(),
+            private_key.clone(),
+            upgrade_lock,
+        )
+        .await
+        .context("Failed to fetch proposal")?;
+    }
     let consensus_reader = consensus.read().await;
     let parent_view_number = consensus_reader.high_qc().view_number();
     let parent_view = consensus_reader.validated_state_map().get(&parent_view_number).context(

--- a/crates/task-impls/src/helpers.rs
+++ b/crates/task-impls/src/helpers.rs
@@ -118,6 +118,9 @@ pub(crate) async fn fetch_proposal<TYPES: NodeType, V: Versions>(
                         }
 
                     }
+                } else {
+                    // If the dep returns early return none
+                    return None;
                 }
             }
 

--- a/crates/task-impls/src/quorum_proposal_recv/handlers.rs
+++ b/crates/task-impls/src/quorum_proposal_recv/handlers.rs
@@ -213,7 +213,7 @@ pub(crate) async fn handle_quorum_proposal_recv<
 
     let parent = match parent_leaf {
         Some(leaf) => {
-            if let (Some(state), _) = consensus_reader.state_and_delta(leaf.view_number()) {
+            if let (Some(state), _) = consensus_read.state_and_delta(leaf.view_number()) {
                 Some((leaf, Arc::clone(&state)))
             } else {
                 bail!("Parent state not found! Consensus internally inconsistent");
@@ -222,7 +222,7 @@ pub(crate) async fn handle_quorum_proposal_recv<
         None => None,
     };
 
-    if justify_qc.view_number() > consensus_reader.high_qc().view_number {
+    if justify_qc.view_number() > consensus_read.high_qc().view_number {
         if let Err(e) = task_state
             .storage
             .write()
@@ -233,7 +233,7 @@ pub(crate) async fn handle_quorum_proposal_recv<
             bail!("Failed to store High QC, not voting; error = {:?}", e);
         }
     }
-    drop(consensus_reader);
+    drop(consensus_read);
 
     let mut consensus_writer = task_state.consensus.write().await;
     if let Err(e) = consensus_writer.update_high_qc(justify_qc.clone()) {

--- a/crates/task-impls/src/quorum_proposal_recv/handlers.rs
+++ b/crates/task-impls/src/quorum_proposal_recv/handlers.rs
@@ -209,11 +209,11 @@ pub(crate) async fn handle_quorum_proposal_recv<
             task_state.upgrade_lock.clone(),
         );
     }
-    let consensus_read = task_state.consensus.read().await;
+    let consensus_reader = task_state.consensus.read().await;
 
     let parent = match parent_leaf {
         Some(leaf) => {
-            if let (Some(state), _) = consensus_read.state_and_delta(leaf.view_number()) {
+            if let (Some(state), _) = consensus_reader.state_and_delta(leaf.view_number()) {
                 Some((leaf, Arc::clone(&state)))
             } else {
                 bail!("Parent state not found! Consensus internally inconsistent");
@@ -222,7 +222,7 @@ pub(crate) async fn handle_quorum_proposal_recv<
         None => None,
     };
 
-    if justify_qc.view_number() > consensus_read.high_qc().view_number {
+    if justify_qc.view_number() > consensus_reader.high_qc().view_number {
         if let Err(e) = task_state
             .storage
             .write()
@@ -233,7 +233,7 @@ pub(crate) async fn handle_quorum_proposal_recv<
             bail!("Failed to store High QC, not voting; error = {:?}", e);
         }
     }
-    drop(consensus_read);
+    drop(consensus_reader);
 
     let mut consensus_writer = task_state.consensus.write().await;
     if let Err(e) = consensus_writer.update_high_qc(justify_qc.clone()) {

--- a/crates/task-impls/src/quorum_proposal_recv/mod.rs
+++ b/crates/task-impls/src/quorum_proposal_recv/mod.rs
@@ -129,15 +129,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions>
         event_receiver: Receiver<Arc<HotShotEvent<TYPES>>>,
     ) {
         if let HotShotEvent::QuorumProposalRecv(proposal, sender) = event.as_ref() {
-            match handle_quorum_proposal_recv(
-                proposal,
-                sender,
-                &event_sender,
-                &event_receiver,
-                self,
-            )
-            .await
-            {
+            match handle_quorum_proposal_recv(proposal, sender, &event_sender, self).await {
                 Ok(()) => {
                     self.cancel_tasks(proposal.data.view_number()).await;
                 }

--- a/crates/task-impls/src/quorum_proposal_recv/mod.rs
+++ b/crates/task-impls/src/quorum_proposal_recv/mod.rs
@@ -129,7 +129,15 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions>
         event_receiver: Receiver<Arc<HotShotEvent<TYPES>>>,
     ) {
         if let HotShotEvent::QuorumProposalRecv(proposal, sender) = event.as_ref() {
-            match handle_quorum_proposal_recv(proposal, sender, &event_sender, self).await {
+            match handle_quorum_proposal_recv(
+                proposal,
+                sender,
+                &event_sender,
+                &event_receiver,
+                self,
+            )
+            .await
+            {
                 Ok(()) => {
                     self.cancel_tasks(proposal.data.view_number()).await;
                 }

--- a/crates/task-impls/src/quorum_vote/mod.rs
+++ b/crates/task-impls/src/quorum_vote/mod.rs
@@ -280,7 +280,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static, V: Versions> Handl
             match event.as_ref() {
                 #[allow(unused_assignments)]
                 HotShotEvent::QuorumProposalValidated(proposal, parent_leaf) => {
-                    let proposal_payload_comm = proposal.block_header.payload_commitment();
+                    let proposal_payload_comm = proposal.data.block_header.payload_commitment();
                     if let Some(comm) = payload_commitment {
                         if proposal_payload_comm != comm {
                             error!("Quorum proposal has inconsistent payload commitment with DAC or VID.");
@@ -290,9 +290,15 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static, V: Versions> Handl
                         payload_commitment = Some(proposal_payload_comm);
                     }
                     let parent_commitment = parent_leaf.commit(&self.upgrade_lock).await;
-                    let proposed_leaf = Leaf::from_quorum_proposal(proposal);
+                    let proposed_leaf = Leaf::from_quorum_proposal(&proposal.data);
                     if proposed_leaf.parent_commitment() != parent_commitment {
                         warn!("Proposed leaf parent commitment does not match parent leaf payload commitment. Aborting vote.");
+                        return;
+                    }
+                    // Update our persistent storage of the proposal. If we cannot store the proposal reutrn
+                    // and error so we don't vote
+                    if let Err(e) = self.storage.write().await.append_proposal(proposal).await {
+                        error!("failed to store proposal, not voting.  error = {e:#}");
                         return;
                     }
                     leaf = Some(proposed_leaf);
@@ -419,7 +425,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> QuorumVoteTaskS
                 let event_view = match dependency_type {
                     VoteDependency::QuorumProposal => {
                         if let HotShotEvent::QuorumProposalValidated(proposal, _) = event {
-                            proposal.view_number
+                            proposal.data.view_number
                         } else {
                             return false;
                         }
@@ -543,17 +549,20 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> QuorumVoteTaskS
         let current_epoch = self.consensus.read().await.cur_epoch();
         match event.as_ref() {
             HotShotEvent::QuorumProposalValidated(proposal, _leaf) => {
-                trace!("Received Proposal for view {}", *proposal.view_number());
+                trace!(
+                    "Received Proposal for view {}",
+                    *proposal.data.view_number()
+                );
 
                 // Handle the event before creating the dependency task.
                 if let Err(e) =
-                    handle_quorum_proposal_validated(proposal, &event_sender, self).await
+                    handle_quorum_proposal_validated(&proposal.data, &event_sender, self).await
                 {
                     debug!("Failed to handle QuorumProposalValidated event; error = {e:#}");
                 }
 
                 self.create_dependency_task_if_new(
-                    proposal.view_number,
+                    proposal.data.view_number,
                     current_epoch,
                     event_receiver,
                     &event_sender,

--- a/crates/task-impls/src/request.rs
+++ b/crates/task-impls/src/request.rs
@@ -96,7 +96,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> TaskState for NetworkRequest
     ) -> Result<()> {
         match event.as_ref() {
             HotShotEvent::QuorumProposalValidated(proposal, _) => {
-                let prop_view = proposal.view_number();
+                let prop_view = proposal.data.view_number();
                 let current_epoch = self.state.read().await.cur_epoch();
 
                 // If we already have the VID shares for the next view, do nothing.

--- a/crates/testing/src/byzantine/byzantine_behaviour.rs
+++ b/crates/testing/src/byzantine/byzantine_behaviour.rs
@@ -186,7 +186,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES> + std::fmt::Debug, V: Version
                 ];
             }
             HotShotEvent::QuorumProposalValidated(proposal, _) => {
-                self.validated_proposals.push(proposal.clone());
+                self.validated_proposals.push(proposal.data.clone());
             }
             _ => {}
         }

--- a/crates/testing/tests/tests_1/quorum_proposal_recv_task.rs
+++ b/crates/testing/tests/tests_1/quorum_proposal_recv_task.rs
@@ -111,7 +111,7 @@ async fn test_quorum_proposal_recv_task() {
             .await,
         )),
         exact(QuorumProposalValidated(
-            proposals[1].data.clone(),
+            proposals[1].clone(),
             leaves[0].clone(),
         )),
         exact(ViewChange(ViewNumber::new(2))),

--- a/crates/testing/tests/tests_1/quorum_proposal_recv_task.rs
+++ b/crates/testing/tests/tests_1/quorum_proposal_recv_task.rs
@@ -208,17 +208,6 @@ async fn test_quorum_proposal_recv_task_liveness_check() {
         leaders[2]
     )]];
 
-    // make the request payload
-    let req = ProposalRequestPayload {
-        view_number: ViewNumber::new(2),
-        key: handle.public_key(),
-    };
-
-    // make the signed commitment
-    let signature =
-        <TestTypes as NodeType>::SignatureKey::sign(handle.private_key(), req.commit().as_ref())
-            .unwrap();
-
     let expectations = vec![Expectations::from_outputs(all_predicates![
         exact(QuorumProposalPreliminarilyValidated(proposals[2].clone())),
         exact(ViewChange(ViewNumber::new(3))),
@@ -233,7 +222,6 @@ async fn test_quorum_proposal_recv_task_liveness_check() {
             )
             .await,
         )),
-        exact(QuorumProposalRequestSend(req, signature)),
         exact(HighQcUpdated(proposals[2].data.justify_qc.clone())),
     ])];
 

--- a/crates/testing/tests/tests_1/quorum_proposal_recv_task.rs
+++ b/crates/testing/tests/tests_1/quorum_proposal_recv_task.rs
@@ -208,6 +208,17 @@ async fn test_quorum_proposal_recv_task_liveness_check() {
         leaders[2]
     )]];
 
+    // make the request payload
+    let req = ProposalRequestPayload {
+        view_number: ViewNumber::new(2),
+        key: handle.public_key(),
+    };
+
+    // make the signed commitment
+    let signature =
+        <TestTypes as NodeType>::SignatureKey::sign(handle.private_key(), req.commit().as_ref())
+            .unwrap();
+
     let expectations = vec![Expectations::from_outputs(all_predicates![
         exact(QuorumProposalPreliminarilyValidated(proposals[2].clone())),
         exact(ViewChange(ViewNumber::new(3))),
@@ -222,6 +233,7 @@ async fn test_quorum_proposal_recv_task_liveness_check() {
             )
             .await,
         )),
+        exact(QuorumProposalRequestSend(req, signature)),
         exact(HighQcUpdated(proposals[2].data.justify_qc.clone())),
     ])];
 

--- a/crates/testing/tests/tests_1/quorum_vote_task.rs
+++ b/crates/testing/tests/tests_1/quorum_vote_task.rs
@@ -75,7 +75,7 @@ async fn test_quorum_vote_task_success() {
     // Send the quorum proposal, DAC, VID share data, and validated state, in which case a dummy
     // vote can be formed and the view number will be updated.
     let inputs = vec![random![
-        QuorumProposalValidated(proposals[1].data.clone(), leaves[0].clone()),
+        QuorumProposalValidated(proposals[1].clone(), leaves[0].clone()),
         DaCertificateRecv(dacs[1].clone()),
         VidShareRecv(leaders[1], vids[1].0[0].clone()),
     ]];
@@ -150,11 +150,11 @@ async fn test_quorum_vote_task_miss_dependency() {
     // Send two of quorum proposal, DAC, VID share data, in which case there's no vote.
     let inputs = vec![
         random![
-            QuorumProposalValidated(proposals[1].data.clone(), leaves[0].clone()),
+            QuorumProposalValidated(proposals[1].clone(), leaves[0].clone()),
             VidShareRecv(leaders[1], vid_share(&vids[1].0, handle.public_key())),
         ],
         random![
-            QuorumProposalValidated(proposals[2].data.clone(), leaves[1].clone()),
+            QuorumProposalValidated(proposals[2].clone(), leaves[1].clone()),
             DaCertificateRecv(dacs[2].clone()),
         ],
         random![
@@ -223,7 +223,7 @@ async fn test_quorum_vote_task_incorrect_dependency() {
 
     // Send the correct quorum proposal and DAC, and incorrect VID share data.
     let inputs = vec![random![
-        QuorumProposalValidated(proposals[1].data.clone(), leaves[0].clone()),
+        QuorumProposalValidated(proposals[1].clone(), leaves[0].clone()),
         DaCertificateRecv(dacs[1].clone()),
         VidShareRecv(leaders[0], vids[0].0[0].clone()),
     ]];

--- a/crates/testing/tests/tests_1/upgrade_task_with_vote.rs
+++ b/crates/testing/tests/tests_1/upgrade_task_with_vote.rs
@@ -108,27 +108,27 @@ async fn test_upgrade_task_with_vote() {
 
     let inputs = vec![
         random![
-            QuorumProposalValidated(proposals[1].data.clone(), leaves[0].clone()),
+            QuorumProposalValidated(proposals[1].clone(), leaves[0].clone()),
             DaCertificateRecv(dacs[1].clone()),
             VidShareRecv(leaders[1], vids[1].0[0].clone()),
         ],
         random![
-            QuorumProposalValidated(proposals[2].data.clone(), leaves[1].clone()),
+            QuorumProposalValidated(proposals[2].clone(), leaves[1].clone()),
             DaCertificateRecv(dacs[2].clone()),
             VidShareRecv(leaders[2], vids[2].0[0].clone()),
         ],
         random![
-            QuorumProposalValidated(proposals[3].data.clone(), leaves[2].clone()),
+            QuorumProposalValidated(proposals[3].clone(), leaves[2].clone()),
             DaCertificateRecv(dacs[3].clone()),
             VidShareRecv(leaders[3], vids[3].0[0].clone()),
         ],
         random![
-            QuorumProposalValidated(proposals[4].data.clone(), leaves[3].clone()),
+            QuorumProposalValidated(proposals[4].clone(), leaves[3].clone()),
             DaCertificateRecv(dacs[4].clone()),
             VidShareRecv(leaders[4], vids[4].0[0].clone()),
         ],
         random![QuorumProposalValidated(
-            proposals[5].data.clone(),
+            proposals[5].clone(),
             leaves[5].clone()
         ),],
     ];

--- a/crates/testing/tests/tests_1/vote_dependency_handle.rs
+++ b/crates/testing/tests/tests_1/vote_dependency_handle.rs
@@ -70,7 +70,7 @@ async fn test_vote_dependency_handle() {
     // the dependency handles do not (yet) work with the existing test suite.
     let all_inputs = vec![
         DaCertificateValidated(dacs[1].clone()),
-        QuorumProposalValidated(proposals[1].data.clone(), leaves[0].clone()),
+        QuorumProposalValidated(proposals[1].clone(), leaves[0].clone()),
         VidShareValidated(vids[1].0[0].clone()),
     ]
     .into_iter()


### PR DESCRIPTION
Closes #<ISSUE_NUMBER>
<!-- See here for keywords in Github -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

### This PR: 
 Moves 2 things off the critical path

- Storing the proposal
- Fetching a previous proposal

For storing the proposal we just do this at the end of the voting procedure before sending a vote.  This only blocks sending a vote
For fetching past proposal there was already logic to do this in both the voting and proposing code path after the other dependencies are fulfilled.  We still spawn a task to do the fetch so we can vote on future proposals referencing that view, this is critical for cases where all nodes restart.

I want to make a larger fix where `handle_quorum_proposal_recv` is moved to a separate task I'll follow up with that.  In the meantime this should significantly improve the Decaf situation

### This PR does not: 
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->

### Key places to review: 
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
