### PR TITLE
[Combined Net] Remove optimistic VID

### DIFF
--- a/crates/task-impls/src/da.rs
+++ b/crates/task-impls/src/da.rs
@@ -7,14 +7,13 @@
 use std::{marker::PhantomData, sync::Arc};
 
 use async_broadcast::{Receiver, Sender};
-use async_compatibility_layer::art::async_spawn;
 use async_lock::RwLock;
 #[cfg(async_executor_impl = "async-std")]
 use async_std::task::spawn_blocking;
 use async_trait::async_trait;
 use hotshot_task::task::TaskState;
 use hotshot_types::{
-    consensus::{Consensus, OuterConsensus, View},
+    consensus::{OuterConsensus, View},
     data::{DaProposal, PackedBundle},
     event::{Event, EventType},
     message::{Proposal, UpgradeLock},
@@ -23,7 +22,6 @@ use hotshot_types::{
     traits::{
         block_contents::vid_commitment,
         election::Membership,
-        network::ConnectedNetwork,
         node_implementation::{ConsensusTime, NodeImplementation, NodeType, Versions},
         signature_key::SignatureKey,
         storage::Storage,

--- a/crates/types/src/consensus.rs
+++ b/crates/types/src/consensus.rs
@@ -825,9 +825,7 @@ impl<TYPES: NodeType> Consensus<TYPES> {
         epoch: TYPES::Epoch,
     ) -> Option<()> {
         let txns = Arc::clone(consensus.read().await.saved_payloads().get(&view)?);
-        let vid =
-            VidDisperse::calculate_vid_disperse(txns, &membership, view, epoch, None)
-                .await;
+        let vid = VidDisperse::calculate_vid_disperse(txns, &membership, view, epoch, None).await;
         let shares = VidDisperseShare::from_vid_disperse(vid);
         let mut consensus = consensus.write().await;
         for share in shares {

--- a/crates/types/src/consensus.rs
+++ b/crates/types/src/consensus.rs
@@ -824,13 +824,12 @@ impl<TYPES: NodeType> Consensus<TYPES> {
         private_key: &<TYPES::SignatureKey as SignatureKey>::PrivateKey,
         epoch: TYPES::Epoch,
     ) -> Option<()> {
-        let consensus = consensus.upgradable_read().await;
-        let txns = consensus.saved_payloads().get(&view)?;
+        let txns = Arc::clone(consensus.read().await.saved_payloads().get(&view)?);
         let vid =
-            VidDisperse::calculate_vid_disperse(Arc::clone(txns), &membership, view, epoch, None)
+            VidDisperse::calculate_vid_disperse(txns, &membership, view, epoch, None)
                 .await;
         let shares = VidDisperseShare::from_vid_disperse(vid);
-        let mut consensus = ConsensusUpgradableReadLockGuard::upgrade(consensus).await;
+        let mut consensus = consensus.write().await;
         for share in shares {
             if let Some(prop) = share.to_proposal(private_key) {
                 consensus.update_vid_shares(view, prop);


### PR DESCRIPTION
## This PR:
- Removes optimistic VID calculation when the primary network is down
- Reduces lock contention during VID calculation

Subsequent PRs will address the switching logic now that block times are == 8s due to the builder