### PR TITLE
Add `Error` type to `Membership` trait

### DIFF
--- a/crates/hotshot/src/traits/election/randomized_committee.rs
+++ b/crates/hotshot/src/traits/election/randomized_committee.rs
@@ -41,6 +41,8 @@ pub struct RandomizedCommittee<T: NodeType> {
 }
 
 impl<TYPES: NodeType> Membership<TYPES> for RandomizedCommittee<TYPES> {
+    type Error = utils::anytrace::Error;
+
     /// Create a new election
     fn new(
         eligible_leaders: Vec<PeerConfig<<TYPES as NodeType>::SignatureKey>>,
@@ -139,7 +141,7 @@ impl<TYPES: NodeType> Membership<TYPES> for RandomizedCommittee<TYPES> {
     }
 
     /// Index the vector of public keys with the current view number
-    fn leader(
+    fn lookup_leader(
         &self,
         view_number: TYPES::View,
         _epoch: <TYPES as NodeType>::Epoch,

--- a/crates/hotshot/src/traits/election/static_committee.rs
+++ b/crates/hotshot/src/traits/election/static_committee.rs
@@ -39,6 +39,8 @@ pub struct StaticCommittee<T: NodeType> {
 }
 
 impl<TYPES: NodeType> Membership<TYPES> for StaticCommittee<TYPES> {
+    type Error = utils::anytrace::Error;
+
     /// Create a new election
     fn new(
         eligible_leaders: Vec<PeerConfig<<TYPES as NodeType>::SignatureKey>>,
@@ -137,7 +139,7 @@ impl<TYPES: NodeType> Membership<TYPES> for StaticCommittee<TYPES> {
     }
 
     /// Index the vector of public keys with the current view number
-    fn leader(
+    fn lookup_leader(
         &self,
         view_number: TYPES::View,
         _epoch: <TYPES as NodeType>::Epoch,

--- a/crates/hotshot/src/traits/election/static_committee_leader_two_views.rs
+++ b/crates/hotshot/src/traits/election/static_committee_leader_two_views.rs
@@ -39,6 +39,8 @@ pub struct StaticCommitteeLeaderForTwoViews<T: NodeType> {
 }
 
 impl<TYPES: NodeType> Membership<TYPES> for StaticCommitteeLeaderForTwoViews<TYPES> {
+    type Error = utils::anytrace::Error;
+
     /// Create a new election
     fn new(
         eligible_leaders: Vec<PeerConfig<<TYPES as NodeType>::SignatureKey>>,
@@ -137,7 +139,7 @@ impl<TYPES: NodeType> Membership<TYPES> for StaticCommitteeLeaderForTwoViews<TYP
     }
 
     /// Index the vector of public keys with the current view number
-    fn leader(
+    fn lookup_leader(
         &self,
         view_number: TYPES::View,
         _epoch: <TYPES as NodeType>::Epoch,


### PR DESCRIPTION
### This PR: 
We are making the implementation of the `Membership` trait for proof-of-stake the responsibility of the sequencer.

This PR allows the `Membership` trait to be implemented with a custom error type (via `lookup_leader`), rather than forcing the sequencer to use `anyhow` or our own internal error type.

### This PR does not: 
The goal was to make a minimal change here (i.e. not have to touch any code in `task-impls`), so I added a new method with a different name rather than changing `leader`

### Key places to review: 
Is there a better naming convention?
