### PR TITLE
Canonicalize some variable names, minor cleanup

### DIFF
--- a/crates/hotshot/src/tasks/task_state.rs
+++ b/crates/hotshot/src/tasks/task_state.rs
@@ -48,7 +48,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> CreateTaskState
     async fn create_from(handle: &SystemContextHandle<TYPES, I, V>) -> Self {
         Self {
             network: Arc::clone(&handle.hotshot.network),
-            state: OuterConsensus::new(handle.hotshot.consensus()),
+            consensus: OuterConsensus::new(handle.hotshot.consensus()),
             view: handle.cur_view().await,
             delay: handle.hotshot.config.data_request_delay,
             da_membership: handle.hotshot.memberships.da_membership.clone(),
@@ -162,9 +162,9 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> CreateTaskState
         let cur_view = handle.cur_view().await;
 
         Self {
-            current_view: cur_view,
+            cur_view,
             next_view: cur_view,
-            current_epoch: handle.cur_epoch().await,
+            cur_epoch: handle.cur_epoch().await,
             network: Arc::clone(&handle.hotshot.network),
             membership: handle.hotshot.memberships.quorum_membership.clone().into(),
             public_key: handle.public_key().clone(),

--- a/crates/task-impls/src/consensus/handlers.rs
+++ b/crates/task-impls/src/consensus/handlers.rs
@@ -169,8 +169,8 @@ pub(crate) async fn handle_view_change<
     ))
     .await;
 
-    let consensus = task_state.consensus.read().await;
-    consensus
+    let consensus_reader = task_state.consensus.read().await;
+    consensus_reader
         .metrics
         .current_view
         .set(usize::try_from(task_state.cur_view.u64()).unwrap());
@@ -181,7 +181,7 @@ pub(crate) async fn handle_view_change<
         == task_state.public_key
     {
         #[allow(clippy::cast_precision_loss)]
-        consensus
+        consensus_reader
             .metrics
             .view_duration_as_leader
             .add_point((cur_view_time - task_state.cur_view_time) as f64);
@@ -193,10 +193,13 @@ pub(crate) async fn handle_view_change<
     if usize::try_from(task_state.cur_view.u64()).unwrap()
         > usize::try_from(task_state.last_decided_view.u64()).unwrap()
     {
-        consensus.metrics.number_of_views_since_last_decide.set(
-            usize::try_from(task_state.cur_view.u64()).unwrap()
-                - usize::try_from(task_state.last_decided_view.u64()).unwrap(),
-        );
+        consensus_reader
+            .metrics
+            .number_of_views_since_last_decide
+            .set(
+                usize::try_from(task_state.cur_view.u64()).unwrap()
+                    - usize::try_from(task_state.last_decided_view.u64()).unwrap(),
+            );
     }
 
     broadcast_event(

--- a/crates/task-impls/src/quorum_proposal_recv/handlers.rs
+++ b/crates/task-impls/src/quorum_proposal_recv/handlers.rs
@@ -46,7 +46,7 @@ async fn validate_proposal_liveness<TYPES: NodeType, I: NodeImplementation<TYPES
     task_state: &mut QuorumProposalRecvTaskState<TYPES, I, V>,
 ) -> Result<()> {
     let view_number = proposal.data.view_number();
-    let mut consensus_write = task_state.consensus.write().await;
+    let mut consensus_writer = task_state.consensus.write().await;
 
     let leaf = Leaf::from_quorum_proposal(&proposal.data);
 
@@ -61,10 +61,10 @@ async fn validate_proposal_liveness<TYPES: NodeType, I: NodeImplementation<TYPES
         },
     };
 
-    if let Err(e) = consensus_write.update_validated_state_map(view_number, view.clone()) {
+    if let Err(e) = consensus_writer.update_validated_state_map(view_number, view.clone()) {
         tracing::trace!("{e:?}");
     }
-    consensus_write
+    consensus_writer
         .update_saved_leaves(leaf.clone(), &task_state.upgrade_lock)
         .await;
 
@@ -73,8 +73,8 @@ async fn validate_proposal_liveness<TYPES: NodeType, I: NodeImplementation<TYPES
         .write()
         .await
         .update_undecided_state(
-            consensus_write.saved_leaves().clone(),
-            consensus_write.validated_state_map().clone(),
+            consensus_writer.saved_leaves().clone(),
+            consensus_writer.validated_state_map().clone(),
         )
         .await
     {
@@ -82,9 +82,9 @@ async fn validate_proposal_liveness<TYPES: NodeType, I: NodeImplementation<TYPES
     }
 
     let liveness_check =
-        proposal.data.justify_qc.clone().view_number() > consensus_write.locked_view();
+        proposal.data.justify_qc.clone().view_number() > consensus_writer.locked_view();
 
-    drop(consensus_write);
+    drop(consensus_writer);
 
     // Broadcast that we've updated our consensus state so that other tasks know it's safe to grab.
     broadcast_event(
@@ -141,8 +141,8 @@ pub(crate) async fn handle_quorum_proposal_recv<
         )
         .await
     {
-        let consensus = task_state.consensus.read().await;
-        consensus.metrics.invalid_qc.update(1);
+        let consensus_reader = task_state.consensus.read().await;
+        consensus_reader.metrics.invalid_qc.update(1);
         bail!("Invalid justify_qc in proposal for view {}", *view_number);
     }
 
@@ -181,11 +181,11 @@ pub(crate) async fn handle_quorum_proposal_recv<
         .await
         .ok(),
     };
-    let consensus_read = task_state.consensus.read().await;
+    let consensus_reader = task_state.consensus.read().await;
 
     let parent = match parent_leaf {
         Some(leaf) => {
-            if let (Some(state), _) = consensus_read.state_and_delta(leaf.view_number()) {
+            if let (Some(state), _) = consensus_reader.state_and_delta(leaf.view_number()) {
                 Some((leaf, Arc::clone(&state)))
             } else {
                 bail!("Parent state not found! Consensus internally inconsistent");
@@ -194,7 +194,7 @@ pub(crate) async fn handle_quorum_proposal_recv<
         None => None,
     };
 
-    if justify_qc.view_number() > consensus_read.high_qc().view_number {
+    if justify_qc.view_number() > consensus_reader.high_qc().view_number {
         if let Err(e) = task_state
             .storage
             .write()
@@ -205,13 +205,13 @@ pub(crate) async fn handle_quorum_proposal_recv<
             bail!("Failed to store High QC, not voting; error = {:?}", e);
         }
     }
-    drop(consensus_read);
+    drop(consensus_reader);
 
-    let mut consensus_write = task_state.consensus.write().await;
-    if let Err(e) = consensus_write.update_high_qc(justify_qc.clone()) {
+    let mut consensus_writer = task_state.consensus.write().await;
+    if let Err(e) = consensus_writer.update_high_qc(justify_qc.clone()) {
         tracing::trace!("{e:?}");
     }
-    drop(consensus_write);
+    drop(consensus_writer);
 
     broadcast_event(
         HotShotEvent::HighQcUpdated(justify_qc.clone()).into(),

--- a/crates/task-impls/src/request.rs
+++ b/crates/task-impls/src/request.rs
@@ -54,7 +54,7 @@ pub struct NetworkRequestState<TYPES: NodeType, I: NodeImplementation<TYPES>> {
     pub network: Arc<I::Network>,
     /// Consensus shared state so we can check if we've gotten the information
     /// before sending a request
-    pub state: OuterConsensus<TYPES>,
+    pub consensus: OuterConsensus<TYPES>,
     /// Last seen view, we won't request for proposals before older than this view
     pub view: TYPES::View,
     /// Delay before requesting peers
@@ -97,18 +97,18 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> TaskState for NetworkRequest
         match event.as_ref() {
             HotShotEvent::QuorumProposalValidated(proposal, _) => {
                 let prop_view = proposal.view_number();
-                let current_epoch = self.state.read().await.cur_epoch();
+                let cur_epoch = self.consensus.read().await.cur_epoch();
 
                 // If we already have the VID shares for the next view, do nothing.
                 if prop_view >= self.view
                     && !self
-                        .state
+                        .consensus
                         .read()
                         .await
                         .vid_shares()
                         .contains_key(&prop_view)
                 {
-                    self.spawn_requests(prop_view, current_epoch, sender, receiver);
+                    self.spawn_requests(prop_view, cur_epoch, sender, receiver);
                 }
                 Ok(())
             }
@@ -176,7 +176,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> NetworkRequestState<TYPES, I
         view: TYPES::View,
         epoch: TYPES::Epoch,
     ) {
-        let state = OuterConsensus::new(Arc::clone(&self.state.inner_consensus));
+        let consensus = OuterConsensus::new(Arc::clone(&self.consensus.inner_consensus));
         let network = Arc::clone(&self.network);
         let shutdown_flag = Arc::clone(&self.shutdown_flag);
         let delay = self.delay;
@@ -208,7 +208,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> NetworkRequestState<TYPES, I
             let mut recipients_it = recipients.iter().cycle();
             // First check if we got the data before continuing
             while !Self::cancel_vid_request_task(
-                &state,
+                &consensus,
                 &sender,
                 &public_key,
                 &view,
@@ -327,19 +327,19 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> NetworkRequestState<TYPES, I
 
     /// Returns true if we got the data we wanted, a shutdown even was received, or the view has moved on.
     async fn cancel_vid_request_task(
-        state: &OuterConsensus<TYPES>,
+        consensus: &OuterConsensus<TYPES>,
         sender: &Sender<Arc<HotShotEvent<TYPES>>>,
         public_key: &<TYPES as NodeType>::SignatureKey,
         view: &TYPES::View,
         shutdown_flag: &Arc<AtomicBool>,
     ) -> bool {
-        let state = state.read().await;
+        let consensus_reader = consensus.read().await;
 
         let cancel = shutdown_flag.load(Ordering::Relaxed)
-            || state.vid_shares().contains_key(view)
-            || state.cur_view() > *view;
+            || consensus_reader.vid_shares().contains_key(view)
+            || consensus_reader.cur_view() > *view;
         if cancel {
-            if let Some(Some(vid_share)) = state
+            if let Some(Some(vid_share)) = consensus_reader
                 .vid_shares()
                 .get(view)
                 .map(|shares| shares.get(public_key).cloned())
@@ -356,7 +356,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> NetworkRequestState<TYPES, I
             tracing::debug!(
                 "Canceling vid request for view {:?}, cur view is {:?}",
                 view,
-                state.cur_view()
+                consensus_reader.cur_view()
             );
         }
         cancel

--- a/crates/task-impls/src/response.rs
+++ b/crates/task-impls/src/response.rs
@@ -151,13 +151,13 @@ impl<TYPES: NodeType> NetworkResponseState<TYPES> {
             .get(&view)
             .is_some_and(|m| m.contains_key(key));
         if !contained {
-            let current_epoch = self.consensus.read().await.cur_epoch();
+            let cur_epoch = self.consensus.read().await.cur_epoch();
             if Consensus::calculate_and_update_vid(
                 OuterConsensus::new(Arc::clone(&self.consensus)),
                 view,
                 Arc::clone(&self.quorum),
                 &self.private_key,
-                current_epoch,
+                cur_epoch,
             )
             .await
             .is_none()
@@ -169,7 +169,7 @@ impl<TYPES: NodeType> NetworkResponseState<TYPES> {
                     view,
                     Arc::clone(&self.quorum),
                     &self.private_key,
-                    current_epoch,
+                    cur_epoch,
                 )
                 .await?;
             }

--- a/crates/task-impls/src/transactions.rs
+++ b/crates/task-impls/src/transactions.rs
@@ -65,10 +65,13 @@ const RETRY_DELAY: Duration = Duration::from_millis(100);
 pub struct BuilderResponse<TYPES: NodeType> {
     /// Fee information
     pub fee: BuilderFee<TYPES>,
+
     /// Block payload
     pub block_payload: TYPES::BlockPayload,
+
     /// Block metadata
     pub metadata: <TYPES::BlockPayload as BlockPayload<TYPES>>::Metadata,
+
     /// Optional precomputed commitment
     pub precompute_data: Option<VidPrecomputeData>,
 }
@@ -101,16 +104,22 @@ pub struct TransactionTaskState<TYPES: NodeType, I: NodeImplementation<TYPES>, V
 
     /// This Nodes Public Key
     pub public_key: TYPES::SignatureKey,
+
     /// Our Private Key
     pub private_key: <TYPES::SignatureKey as SignatureKey>::PrivateKey,
+
     /// InstanceState
     pub instance_state: Arc<TYPES::InstanceState>,
+
     /// This state's ID
     pub id: u64,
+
     /// Lock for a decided upgrade
     pub upgrade_lock: UpgradeLock<TYPES, V>,
+
     /// auction results provider
     pub auction_results_provider: Arc<I::AuctionResultsProvider>,
+
     /// fallback builder url
     pub fallback_builder_url: Url,
 }
@@ -517,11 +526,11 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> TransactionTask
         &self,
         block_view: TYPES::View,
     ) -> Result<(TYPES::View, VidCommitment)> {
-        let consensus = self.consensus.read().await;
+        let consensus_reader = self.consensus.read().await;
         let mut target_view = TYPES::View::new(block_view.saturating_sub(1));
 
         loop {
-            let view_data = consensus
+            let view_data = consensus_reader
                 .validated_state_map()
                 .get(&target_view)
                 .context(info!(
@@ -536,7 +545,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> TransactionTask
                     leaf: leaf_commitment,
                     ..
                 } => {
-                    let leaf = consensus.saved_leaves().get(leaf_commitment).context
+                    let leaf = consensus_reader.saved_leaves().get(leaf_commitment).context
                         (info!("Missing leaf with commitment {leaf_commitment} for view {target_view} in saved_leaves"))?;
                     return Ok((target_view, leaf.payload_commitment()));
                 }

--- a/crates/types/src/consensus.rs
+++ b/crates/types/src/consensus.rs
@@ -827,10 +827,10 @@ impl<TYPES: NodeType> Consensus<TYPES> {
         let txns = Arc::clone(consensus.read().await.saved_payloads().get(&view)?);
         let vid = VidDisperse::calculate_vid_disperse(txns, &membership, view, epoch, None).await;
         let shares = VidDisperseShare::from_vid_disperse(vid);
-        let mut consensus = consensus.write().await;
+        let mut consensus_writer = consensus.write().await;
         for share in shares {
             if let Some(prop) = share.to_proposal(private_key) {
-                consensus.update_vid_shares(view, prop);
+                consensus_writer.update_vid_shares(view, prop);
             }
         }
         Some(())


### PR DESCRIPTION
Doesn't close any particular issue, but broke out from work on #3215.

Fixes up some variable names to make them consistent across tasks.

Closes #<ISSUE_NUMBER>
<!-- See here for keywords in Github -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

### This PR: 
<!-- Describe what this PR adds to HotSHot -->
<!-- E.g. -->
<!-- * Implements feature 1 -->
<!-- * Implements feature 2 -->
<!-- * Fixes bug 3 -->

### This PR does not: 
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->

### Key places to review: 
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
