### PR TITLE
Revert crates/types/src/vid.rs to 01ea0ab9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2187,7 +2187,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.85",
- "unicode-xid",
 ]
 
 [[package]]
@@ -3440,7 +3439,6 @@ dependencies = [
  "committable",
  "custom_debug",
  "derivative",
- "derive_more 1.0.0",
  "digest 0.10.7",
  "displaydoc",
  "dyn-clone 1.0.17 (git+https://github.com/dtolnay/dyn-clone?tag=1.0.17)",

--- a/crates/example-types/src/block_types.rs
+++ b/crates/example-types/src/block_types.rs
@@ -395,7 +395,9 @@ impl Committable for TestBlockHeader {
             )
             .constant_str("payload commitment")
             .fixed_size_bytes(
-                <TestBlockHeader as BlockHeader<TestTypes>>::payload_commitment(self).as_ref(),
+                <TestBlockHeader as BlockHeader<TestTypes>>::payload_commitment(self)
+                    .as_ref()
+                    .as_ref(),
             )
             .finalize()
     }

--- a/crates/example-types/src/block_types.rs
+++ b/crates/example-types/src/block_types.rs
@@ -370,7 +370,7 @@ impl<
     }
 
     fn payload_commitment(&self) -> VidCommitment {
-        self.payload_commitment.clone()
+        self.payload_commitment
     }
 
     fn metadata(&self) -> &<TYPES::BlockPayload as BlockPayload<TYPES>>::Metadata {

--- a/crates/task-impls/src/da.rs
+++ b/crates/task-impls/src/da.rs
@@ -200,7 +200,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> DaTaskState<TYP
                 // Generate and send vote
                 let vote = DaVote::create_signed_vote(
                     DaData {
-                        payload_commit: payload_commitment.clone(),
+                        payload_commit: payload_commitment,
                     },
                     view_number,
                     &self.public_key,

--- a/crates/task-impls/src/quorum_proposal/handlers.rs
+++ b/crates/task-impls/src/quorum_proposal/handlers.rs
@@ -311,7 +311,7 @@ impl<TYPES: NodeType, V: Versions> HandleDepOutput for ProposalDependencyHandle<
                     auction_result,
                 ) => {
                     commit_and_metadata = Some(CommitmentAndMetadata {
-                        commitment: payload_commitment.clone(),
+                        commitment: *payload_commitment,
                         builder_commitment: builder_commitment.clone(),
                         metadata: metadata.clone(),
                         fees: fees.clone(),

--- a/crates/task-impls/src/quorum_vote/mod.rs
+++ b/crates/task-impls/src/quorum_vote/mod.rs
@@ -310,7 +310,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static, V: Versions> Handl
                             return;
                         }
                     } else {
-                        payload_commitment = Some(cert_payload_comm.clone());
+                        payload_commitment = Some(*cert_payload_comm);
                     }
                 }
                 HotShotEvent::VidShareValidated(share) => {
@@ -322,7 +322,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static, V: Versions> Handl
                             return;
                         }
                     } else {
-                        payload_commitment = Some(vid_payload_commitment.clone());
+                        payload_commitment = Some(*vid_payload_commitment);
                     }
                 }
                 _ => {}

--- a/crates/task-impls/src/transactions.rs
+++ b/crates/task-impls/src/transactions.rs
@@ -298,7 +298,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> TransactionTask
                 async {
                     let client = BuilderClientMarketplace::new(url);
                     client
-                        .bundle(*parent_view, parent_hash.clone(), *block_view)
+                        .bundle(*parent_view, parent_hash, *block_view)
                         .await
                 },
             ));
@@ -539,7 +539,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> TransactionTask
 
             match &view_data.view_inner {
                 ViewInner::Da { payload_commitment } => {
-                    return Ok((target_view, payload_commitment.clone()))
+                    return Ok((target_view, *payload_commitment))
                 }
                 ViewInner::Leaf {
                     leaf: leaf_commitment,
@@ -590,7 +590,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> TransactionTask
             match async_timeout(
                 self.builder_timeout
                     .saturating_sub(task_start_time.elapsed()),
-                self.block_from_builder(parent_comm.clone(), parent_view, &parent_comm_sig),
+                self.block_from_builder(parent_comm, parent_view, &parent_comm_sig),
             )
             .await
             {
@@ -632,7 +632,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> TransactionTask
             .iter()
             .enumerate()
             .map(|(builder_idx, client)| {
-                let parent_comm = parent_comm.clone();
+                let parent_comm = parent_comm;
                 async move {
                     client
                         .available_blocks(

--- a/crates/task-impls/src/transactions.rs
+++ b/crates/task-impls/src/transactions.rs
@@ -297,9 +297,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> TransactionTask
                 self.builder_timeout.saturating_sub(start.elapsed()),
                 async {
                     let client = BuilderClientMarketplace::new(url);
-                    client
-                        .bundle(*parent_view, parent_hash, *block_view)
-                        .await
+                    client.bundle(*parent_view, parent_hash, *block_view).await
                 },
             ));
         }
@@ -631,23 +629,20 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> TransactionTask
             .builder_clients
             .iter()
             .enumerate()
-            .map(|(builder_idx, client)| {
-                let parent_comm = parent_comm;
-                async move {
-                    client
-                        .available_blocks(
-                            parent_comm,
-                            view_number.u64(),
-                            self.public_key.clone(),
-                            parent_comm_sig,
-                        )
-                        .await
-                        .map(move |blocks| {
-                            blocks
-                                .into_iter()
-                                .map(move |block_info| (block_info, builder_idx))
-                        })
-                }
+            .map(|(builder_idx, client)| async move {
+                client
+                    .available_blocks(
+                        parent_comm,
+                        view_number.u64(),
+                        self.public_key.clone(),
+                        parent_comm_sig,
+                    )
+                    .await
+                    .map(move |blocks| {
+                        blocks
+                            .into_iter()
+                            .map(move |block_info| (block_info, builder_idx))
+                    })
             })
             .collect::<FuturesUnordered<_>>();
         let mut results = Vec::with_capacity(self.builder_clients.len());

--- a/crates/task-impls/src/vid.rs
+++ b/crates/task-impls/src/vid.rs
@@ -87,7 +87,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> VidTaskState<TYPES, I> {
                     vid_precompute.clone(),
                 )
                 .await;
-                let payload_commitment = vid_disperse.payload_commitment.clone();
+                let payload_commitment = vid_disperse.payload_commitment;
                 let shares = VidDisperseShare::from_vid_disperse(vid_disperse.clone());
                 let mut consensus_writer = self.consensus.write().await;
                 for share in shares {

--- a/crates/testing/tests/tests_1/da_task.rs
+++ b/crates/testing/tests/tests_1/da_task.rs
@@ -71,7 +71,7 @@ async fn test_da_task() {
         votes.push(
             view.create_da_vote(
                 DaData {
-                    payload_commit: payload_commit.clone(),
+                    payload_commit: payload_commit,
                 },
                 &handle,
             )
@@ -89,7 +89,7 @@ async fn test_da_task() {
         votes.push(
             view.create_da_vote(
                 DaData {
-                    payload_commit: payload_commit.clone(),
+                    payload_commit: payload_commit,
                 },
                 &handle,
             )
@@ -182,7 +182,7 @@ async fn test_da_task_storage_failure() {
         votes.push(
             view.create_da_vote(
                 DaData {
-                    payload_commit: payload_commit.clone(),
+                    payload_commit: payload_commit,
                 },
                 &handle,
             )
@@ -200,7 +200,7 @@ async fn test_da_task_storage_failure() {
         votes.push(
             view.create_da_vote(
                 DaData {
-                    payload_commit: payload_commit.clone(),
+                    payload_commit: payload_commit,
                 },
                 &handle,
             )

--- a/crates/testing/tests/tests_1/da_task.rs
+++ b/crates/testing/tests/tests_1/da_task.rs
@@ -69,13 +69,8 @@ async fn test_da_task() {
         proposals.push(view.da_proposal.clone());
         leaders.push(view.leader_public_key);
         votes.push(
-            view.create_da_vote(
-                DaData {
-                    payload_commit,
-                },
-                &handle,
-            )
-            .await,
+            view.create_da_vote(DaData { payload_commit }, &handle)
+                .await,
         );
         dacs.push(view.da_certificate.clone());
         vids.push(view.vid_proposal.clone());
@@ -87,13 +82,8 @@ async fn test_da_task() {
         proposals.push(view.da_proposal.clone());
         leaders.push(view.leader_public_key);
         votes.push(
-            view.create_da_vote(
-                DaData {
-                    payload_commit,
-                },
-                &handle,
-            )
-            .await,
+            view.create_da_vote(DaData { payload_commit }, &handle)
+                .await,
         );
         dacs.push(view.da_certificate.clone());
         vids.push(view.vid_proposal.clone());
@@ -180,13 +170,8 @@ async fn test_da_task_storage_failure() {
         proposals.push(view.da_proposal.clone());
         leaders.push(view.leader_public_key);
         votes.push(
-            view.create_da_vote(
-                DaData {
-                    payload_commit,
-                },
-                &handle,
-            )
-            .await,
+            view.create_da_vote(DaData { payload_commit }, &handle)
+                .await,
         );
         dacs.push(view.da_certificate.clone());
         vids.push(view.vid_proposal.clone());
@@ -198,13 +183,8 @@ async fn test_da_task_storage_failure() {
         proposals.push(view.da_proposal.clone());
         leaders.push(view.leader_public_key);
         votes.push(
-            view.create_da_vote(
-                DaData {
-                    payload_commit,
-                },
-                &handle,
-            )
-            .await,
+            view.create_da_vote(DaData { payload_commit }, &handle)
+                .await,
         );
         dacs.push(view.da_certificate.clone());
         vids.push(view.vid_proposal.clone());

--- a/crates/testing/tests/tests_1/da_task.rs
+++ b/crates/testing/tests/tests_1/da_task.rs
@@ -71,7 +71,7 @@ async fn test_da_task() {
         votes.push(
             view.create_da_vote(
                 DaData {
-                    payload_commit: payload_commit,
+                    payload_commit,
                 },
                 &handle,
             )
@@ -89,7 +89,7 @@ async fn test_da_task() {
         votes.push(
             view.create_da_vote(
                 DaData {
-                    payload_commit: payload_commit,
+                    payload_commit,
                 },
                 &handle,
             )
@@ -182,7 +182,7 @@ async fn test_da_task_storage_failure() {
         votes.push(
             view.create_da_vote(
                 DaData {
-                    payload_commit: payload_commit,
+                    payload_commit,
                 },
                 &handle,
             )
@@ -200,7 +200,7 @@ async fn test_da_task_storage_failure() {
         votes.push(
             view.create_da_vote(
                 DaData {
-                    payload_commit: payload_commit,
+                    payload_commit,
                 },
                 &handle,
             )

--- a/crates/testing/tests/tests_1/vid_task.rs
+++ b/crates/testing/tests/tests_1/vid_task.rs
@@ -69,7 +69,7 @@ async fn test_vid_task() {
     let encoded_transactions = Arc::from(TestTransaction::encode(&transactions));
     let vid_disperse = vid.disperse(&encoded_transactions).unwrap();
     let (_, vid_precompute) = vid.commit_only_precompute(&encoded_transactions).unwrap();
-    let payload_commitment = vid_disperse.commit.clone();
+    let payload_commitment = vid_disperse.commit;
 
     let signature = <TestTypes as NodeType>::SignatureKey::sign(
         handle.private_key(),

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -38,7 +38,6 @@ time = { workspace = true }
 tracing = { workspace = true }
 typenum = { workspace = true }
 derivative = "2"
-derive_more = { workspace = true, features = ["display"] } # TODO promote display feature to workspace?
 jf-vid = { workspace = true }
 jf-pcs = { workspace = true }
 jf-signature = { workspace = true, features = ["schnorr"] }

--- a/crates/types/src/data.rs
+++ b/crates/types/src/data.rs
@@ -282,7 +282,7 @@ impl<TYPES: NodeType> VidDisperseShare<TYPES> {
                 recipient_key,
                 view_number: vid_disperse.view_number,
                 common: vid_disperse.common.clone(),
-                payload_commitment: vid_disperse.payload_commitment.clone(),
+                payload_commitment: vid_disperse.payload_commitment,
             })
             .collect()
     }
@@ -345,7 +345,7 @@ impl<TYPES: NodeType> VidDisperseShare<TYPES> {
                     recipient_key,
                     view_number: vid_disperse_proposal.data.view_number,
                     common: vid_disperse_proposal.data.common.clone(),
-                    payload_commitment: vid_disperse_proposal.data.payload_commitment.clone(),
+                    payload_commitment: vid_disperse_proposal.data.payload_commitment,
                 },
                 signature: vid_disperse_proposal.signature.clone(),
                 _pd: vid_disperse_proposal._pd,

--- a/crates/types/src/utils.rs
+++ b/crates/types/src/utils.rs
@@ -58,7 +58,7 @@ impl<TYPES: NodeType> Clone for ViewInner<TYPES> {
     fn clone(&self) -> Self {
         match self {
             Self::Da { payload_commitment } => Self::Da {
-                payload_commitment: payload_commitment.clone(),
+                payload_commitment: *payload_commitment,
             },
             Self::Leaf { leaf, state, delta } => Self::Leaf {
                 leaf: *leaf,
@@ -123,7 +123,7 @@ impl<TYPES: NodeType> ViewInner<TYPES> {
     #[must_use]
     pub fn payload_commitment(&self) -> Option<VidCommitment> {
         if let Self::Da { payload_commitment } = self {
-            Some(payload_commitment.clone())
+            Some(*payload_commitment)
         } else {
             None
         }


### PR DESCRIPTION
Closes #3812 
<!-- See here for keywords in Github -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

### This PR: 
completely revert all changes to `crates/types/src/vid.rs` introduced in 36ac48df17d8e90aa4085e87313b94f649ffbdba

### This PR does not: 
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->

### Key places to review: 
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
