### PR TITLE
Remove unneeded bounds from `Memberships trait

### DIFF
--- a/crates/types/src/traits/election.rs
+++ b/crates/types/src/traits/election.rs
@@ -5,7 +5,7 @@
 // along with the HotShot repository. If not, see <https://mit-license.org/>.
 
 //! The election trait, used to decide which node is the leader and determine if a vote is valid.
-use std::{collections::BTreeSet, fmt::Debug, hash::Hash, num::NonZeroU64};
+use std::{collections::BTreeSet, fmt::Debug, num::NonZeroU64};
 
 use utils::anytrace::Result;
 
@@ -13,9 +13,7 @@ use super::{network::Topic, node_implementation::NodeType};
 use crate::{traits::signature_key::SignatureKey, PeerConfig};
 
 /// A protocol for determining membership in and participating in a committee.
-pub trait Membership<TYPES: NodeType>:
-    Clone + Debug + Eq + PartialEq + Send + Sync + Hash + 'static
-{
+pub trait Membership<TYPES: NodeType>: Clone + Debug + Send + Sync {
     /// The error type returned by methods like `lookup_leader`.
     type Error: std::fmt::Display;
 


### PR DESCRIPTION
Closes #<ISSUE_NUMBER>
<!-- See here for keywords in Github -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

### This PR: 
Removs `Hash`, `Eq`, `PartialEq` and `static` bounds from `Membership`. These restrictions prevented us from adding application layer's `L1Client` as a field to the concrete type implementing the trait. We need this in order to fetch stake table for PoS. 
