### PR TITLE
Ignore ark dependencies in dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,10 @@ updates:
         - "*"
       exclude-patterns:
         - "cdn-*"
+        - "ark-*"
     cdn:
       patterns:
         - "cdn-*"
+    ark:
+      patterns:
+        - "ark-*"


### PR DESCRIPTION
### This PR: 
Makes dependabot ignore `ark-*` version updates, moving them to a separate group. These updates should happen as part of updating jellyfish anyway.

### This PR does not: 

### Key places to review: 
