### PR TITLE
Fix documentation typos and improve clarity

### DIFF
--- a/crates/hotshot/src/tasks/mod.rs
+++ b/crates/hotshot/src/tasks/mod.rs
@@ -93,7 +93,7 @@ pub fn add_response_task<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versi
     ));
 }
 
-/// Add a task which updates our queue lenght metric at a set interval
+/// Add a task which updates our queue length metric at a set interval
 pub fn add_queue_len_task<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions>(
     handle: &mut SystemContextHandle<TYPES, I, V>,
 ) {

--- a/crates/libp2p-networking/src/network/def.rs
+++ b/crates/libp2p-networking/src/network/def.rs
@@ -20,7 +20,7 @@ use tracing::{debug, error};
 use super::{behaviours::dht::store::ValidatedStore, cbor, NetworkEventInternal};
 
 /// Overarching network behaviour performing:
-/// - network topology discovoery
+/// - network topology discovery
 /// - direct messaging
 /// - p2p broadcast
 /// - connection management
@@ -78,7 +78,7 @@ impl<K: SignatureKey + 'static> NetworkDef<K> {
     /// Add an address
     pub fn add_address(&mut self, peer_id: &PeerId, address: Multiaddr) {
         // NOTE to get this address to play nice with the other
-        // behaviours using the DHT for ouring
+        // behaviours using the DHT for routing
         // we only need to add this address to the DHT since it
         // is always enabled. If it were not always enabled,
         // we would need to manually add the address to

--- a/crates/task-impls/src/quorum_vote/mod.rs
+++ b/crates/task-impls/src/quorum_vote/mod.rs
@@ -47,7 +47,7 @@ mod handlers;
 /// Vote dependency types.
 #[derive(Debug, PartialEq)]
 enum VoteDependency {
-    /// For the `QuroumProposalValidated` event after validating `QuorumProposalRecv`.
+    /// For the `QuorumProposalValidated` event after validating `QuorumProposalRecv`.
     QuorumProposal,
     /// For the `DaCertificateRecv` event.
     Dac,


### PR DESCRIPTION
Fixes typos in documentation and comments:
"lenght" -> "length" in queue metric comment
"discovoery" -> "discovery" in network topology comment
"ouring" -> "routing" in DHT behavior comment
"Quroum" -> "Quorum" in event validation comment