### PR TITLE
Remove "testing implementations" warning

### DIFF
--- a/crates/testing/src/lib.rs
+++ b/crates/testing/src/lib.rs
@@ -6,12 +6,6 @@
 
 //! Testing infrastructure for `HotShot`
 
-#![cfg_attr(
-    // hotshot_example option is set manually in justfile when running examples
-    not(any(test, debug_assertions)),
-    deprecated = "suspicious usage of testing/demo implementations in non-test/non-debug build"
-)]
-
 /// Helpers for initializing system context handle and building tasks.
 pub mod helpers;
 


### PR DESCRIPTION
Closes #0000
<!-- See here for keywords in Github -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

### This PR: 
As per title. This warning ends up triggering in many legitimate situations, such as running tests in release mode in downstream repositories, and has to my knowledge never been triggered in a situation where it would be actually useful.

### This PR does not: 
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->

### Key places to review: 
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
