### PR TITLE
Documentation Improvements and Typo Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ just careful
 
 ## Testing on CI
 
-To test as if running on CI, one must limit the number of cores and ram to match github runners (2 core, 7 gig ram). To limit the ram, spin up a virtual machine or container with 7 gigs ram. To limit the core count when running tests:
+To test as if running on CI, one must limit the number of cores and ram to match github runners (2 cores, 7GB ram). To limit the ram, spin up a virtual machine or container with 7 gigs ram. To limit the core count when running tests:
 
 ```
 ASYNC_STD_THREAD_COUNT=1 RUST_LOG=$ERROR_LOG_LEVEL RUST_LOG_FORMAT=$ERROR_LOG_FORMAT just tokio test
@@ -177,7 +177,7 @@ heaptrack $(fd -I "counter*" -t x | rg release) --ignored -- test_stress_dht_man
 # palette provides memory statistics, omission will provide cpu cycle stats as colors
 # NOTE: must be run as root on macos
 flamegraph --palette=mem $(fd -I "counter*" -t x | rg release) --ignored -- test_stress_dht_one_round
-# code coveragte statistics
+# code coverage statistics
 cargo-llvm-cov llvm-cov --test=test_stress_dht_many_round --workspace --all-targets --release --html --output-path lcov.html
 ```
 

--- a/crates/examples/push-cdn/README.md
+++ b/crates/examples/push-cdn/README.md
@@ -1,7 +1,7 @@
 Steps
 ---------------
 
-KeyDB is the ephemeral database, it's like Redis but with extra features. The only thing we run it with is with `--requirepass` to set a password.
+KeyDB is the ephemeral database, it's like Redis but with extra features. The only thing we run it with `--requirepass` to set a password.
 
 **Marshals:**
 The marshal is the entry point of the push CDN, all users connect there first. It tells users which broker to connect to.


### PR DESCRIPTION
1. In README.md:
- To test as if running on CI, one must limit the number of cores and ram to match github runners (2 core, 7 gig ram)
+ To test as if running on CI, one must limit the number of cores and ram to match github runners (2 cores, 7GB RAM)
Reason: Improves technical accuracy by using proper pluralization and standard units (GB RAM instead of gig ram)

-  code coveragte statistics
+ code coverage statistics
Reason: Fixes typo in the word "coverage" to improve documentation readability

2. In crates/examples/push-cdn/README.md:
- The only thing we run it with is with `--requirepass` to set a password.
+ The only thing we run it with `--requirepass` to set a password.
Reason: Removes redundant "with" to improve sentence clarity
