### PR TITLE
fix: Typo Correction aws_ecs_benchmarks_cdn_gpu.sh

### DIFF
--- a/scripts/benchmark_scripts/aws_ecs_benchmarks_cdn_gpu.sh
+++ b/scripts/benchmark_scripts/aws_ecs_benchmarks_cdn_gpu.sh
@@ -106,7 +106,7 @@ EOF
                                 sleep 30
 
                                 # start leaders need to run on GPU FIRST
-                                # and WAIT for enough time till it registerred at orchestrator
+                                # and WAIT for enough time till it registered at orchestrator
                                 # make sure you're able to access the remote nvidia gpu server
                                 echo -e "\e[35mGoing to start leaders on remote gpu server $REMOTE_GPU_HOST\e[0m"
                                 


### PR DESCRIPTION
This pull request fixes a typo in the `aws_ecs_benchmarks_cdn_gpu.sh` script. Specifically:
- Corrected `registerred` to `registered`.

### Changes
- **File Modified**: `scripts/benchmark_scripts/aws_ecs_benchmarks_cdn_gpu.sh`
- **Lines Changed**: 
  - Line 106: Fixed spelling mistake in the comment
 
![image](https://github.com/user-attachments/assets/4c41980e-2009-43f7-b98f-3ef8c7b29c54)
