### PR TITLE
CI: add typos job

### DIFF
--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -1,0 +1,23 @@
+name: Typos
+
+on:
+  push:
+    branches:
+      - main
+      - release-*
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  typos:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        name: Checkout Repository
+
+      - name: typos-action
+        uses: crate-ci/typos@v1.27.3

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,5 @@
+[files]
+extend-exclude = [
+  "*.drawio",
+  "crates/orchestrator/run-config.toml"
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1307,7 +1307,7 @@ dependencies = [
  "rcgen 0.13.1",
  "redis",
  "rkyv",
- "rustls 0.23.16",
+ "rustls 0.23.18",
  "rustls-pki-types",
  "sqlx",
  "thiserror 1.0.68",
@@ -2454,7 +2454,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f2f12607f92c69b12ed746fabf9ca4f5c482cba46679c1a75b874ed7c26adb"
 dependencies = [
  "futures-io",
- "rustls 0.23.16",
+ "rustls 0.23.18",
  "rustls-pki-types",
 ]
 
@@ -3351,7 +3351,7 @@ dependencies = [
  "http 1.1.0",
  "hyper 1.5.0",
  "hyper-util",
- "rustls 0.23.16",
+ "rustls 0.23.18",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -4425,7 +4425,7 @@ dependencies = [
  "quinn",
  "rand 0.8.5",
  "ring 0.17.8",
- "rustls 0.23.16",
+ "rustls 0.23.18",
  "socket2 0.5.7",
  "thiserror 1.0.68",
  "tokio",
@@ -4519,7 +4519,7 @@ dependencies = [
  "libp2p-identity",
  "rcgen 0.11.3",
  "ring 0.17.8",
- "rustls 0.23.16",
+ "rustls 0.23.18",
  "rustls-webpki 0.101.7",
  "thiserror 1.0.68",
  "x509-parser",
@@ -5735,7 +5735,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash 2.0.0",
- "rustls 0.23.16",
+ "rustls 0.23.18",
  "socket2 0.5.7",
  "thiserror 1.0.68",
  "tokio",
@@ -5752,7 +5752,7 @@ dependencies = [
  "rand 0.8.5",
  "ring 0.17.8",
  "rustc-hash 2.0.0",
- "rustls 0.23.16",
+ "rustls 0.23.18",
  "slab",
  "thiserror 1.0.68",
  "tinyvec",
@@ -5770,7 +5770,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.7",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6279,9 +6279,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.16"
+version = "0.23.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eee87ff5d9b36712a58574e12e9f0ea80f915a5b0ac518d322b24a465617925e"
+checksum = "9c9cc1d47e243d655ace55ed38201c19ae02c148ae56412ab8750e8f0166ab7f"
 dependencies = [
  "log",
  "once_cell",
@@ -7677,7 +7677,7 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
- "rustls 0.23.16",
+ "rustls 0.23.18",
  "rustls-pki-types",
  "tokio",
 ]
@@ -8073,7 +8073,7 @@ dependencies = [
  "flate2",
  "log",
  "once_cell",
- "rustls 0.23.16",
+ "rustls 0.23.18",
  "rustls-pki-types",
  "url",
  "webpki-roots 0.26.6",

--- a/README.md
+++ b/README.md
@@ -227,3 +227,5 @@ NOTE: Do NOT configure dap at all with rust-tools. Do it manually.
 ## Vscode
 
 Install the extension and load the `launch.json` file. Then run the desired test target.
+
+A typo: extenion

--- a/README.md
+++ b/README.md
@@ -227,5 +227,3 @@ NOTE: Do NOT configure dap at all with rust-tools. Do it manually.
 ## Vscode
 
 Install the extension and load the `launch.json` file. Then run the desired test target.
-
-A typo: extenion

--- a/crates/example-types/src/auction_results_provider_types.rs
+++ b/crates/example-types/src/auction_results_provider_types.rs
@@ -29,7 +29,7 @@ impl HasUrls for TestAuctionResult {
 /// The test auction results type is used to mimic the results from the Solver.
 #[derive(Clone, Debug, Default)]
 pub struct TestAuctionResultsProvider<TYPES: NodeType> {
-    /// We intentionally allow for the results to be pre-cooked for the unit test to gurantee a
+    /// We intentionally allow for the results to be pre-cooked for the unit test to guarantee a
     /// particular outcome is met.
     pub solver_results: TYPES::AuctionResult,
 

--- a/crates/example-types/src/block_types.rs
+++ b/crates/example-types/src/block_types.rs
@@ -262,7 +262,7 @@ pub struct TestBlockHeader {
     pub payload_commitment: VidCommitment,
     /// Fast commitment for builder verification
     pub builder_commitment: BuilderCommitment,
-    /// block metdata
+    /// block metadata
     pub metadata: TestMetadata,
     /// Timestamp when this header was created.
     pub timestamp: u64,

--- a/crates/example-types/src/storage_types.rs
+++ b/crates/example-types/src/storage_types.rs
@@ -226,7 +226,7 @@ impl<TYPES: NodeType> Storage<TYPES> for TestStorage<TYPES> {
     }
     async fn update_undecided_state(
         &self,
-        _leafs: CommitmentMap<Leaf<TYPES>>,
+        _leaves: CommitmentMap<Leaf<TYPES>>,
         _state: BTreeMap<TYPES::View, View<TYPES>>,
     ) -> Result<()> {
         if self.should_return_err {
@@ -237,7 +237,7 @@ impl<TYPES: NodeType> Storage<TYPES> for TestStorage<TYPES> {
     }
     async fn update_undecided_state2(
         &self,
-        _leafs: CommitmentMap<Leaf2<TYPES>>,
+        _leaves: CommitmentMap<Leaf2<TYPES>>,
         _state: BTreeMap<TYPES::View, View<TYPES>>,
     ) -> Result<()> {
         if self.should_return_err {

--- a/crates/examples/infra/mod.rs
+++ b/crates/examples/infra/mod.rs
@@ -556,7 +556,7 @@ pub trait RunDa<
         let total_time_elapsed = start.elapsed(); // in seconds
         println!("[{node_index}]: {rounds} rounds completed in {total_time_elapsed:?} - Total transactions sent: {total_transactions_sent} - Total transactions committed: {total_transactions_committed} - Total commitments: {num_successful_commits}");
         if total_transactions_committed != 0 {
-            // prevent devision by 0
+            // prevent division by 0
             let total_time_elapsed_sec = std::cmp::max(total_time_elapsed.as_secs(), 1u64);
             // extra 8 bytes for timestamp
             let throughput_bytes_per_sec = total_transactions_committed

--- a/crates/hotshot/src/lib.rs
+++ b/crates/hotshot/src/lib.rs
@@ -228,7 +228,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> SystemContext<T
             }
         }
 
-        let interal_chan = broadcast(EVENT_CHANNEL_SIZE);
+        let internal_chan = broadcast(EVENT_CHANNEL_SIZE);
         let external_chan = broadcast(EXTERNAL_EVENT_CHANNEL_SIZE);
 
         Self::new_from_channels(
@@ -242,7 +242,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> SystemContext<T
             metrics,
             storage,
             marketplace_config,
-            interal_chan,
+            internal_chan,
             external_chan,
         )
     }
@@ -252,7 +252,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> SystemContext<T
     /// To do a full initialization, use `fn init` instead, which will set up background tasks as
     /// well.
     ///
-    /// Use this function if you want to use some prexisting channels and to spin up the tasks
+    /// Use this function if you want to use some preexisting channels and to spin up the tasks
     /// and start consensus manually.  Mostly useful for tests
     #[allow(clippy::too_many_arguments, clippy::type_complexity)]
     pub fn new_from_channels(
@@ -320,7 +320,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> SystemContext<T
         let mut saved_payloads = BTreeMap::new();
         saved_leaves.insert(anchored_leaf.commit(), anchored_leaf.clone());
 
-        for leaf in initializer.undecided_leafs {
+        for leaf in initializer.undecided_leaves {
             saved_leaves.insert(leaf.commit(), leaf.clone());
         }
         if let Some(payload) = anchored_leaf.block_payload() {
@@ -990,9 +990,9 @@ pub struct HotShotInitializer<TYPES: NodeType> {
     /// If it's given, we'll use it to construct the `SystemContext`.
     state_delta: Option<Arc<<TYPES::ValidatedState as ValidatedState<TYPES>>::Delta>>,
 
-    /// Starting view number that should be equivelant to the view the node shut down with last.
+    /// Starting view number that should be equivalent to the view the node shut down with last.
     start_view: TYPES::View,
-    /// Starting epoch number that should be equivelant to the epoch the node shut down with last.
+    /// Starting epoch number that should be equivalent to the epoch the node shut down with last.
     start_epoch: TYPES::Epoch,
     /// The view we last performed an action in.  An action is Proposing or voting for
     /// Either the quorum or DA.
@@ -1003,9 +1003,9 @@ pub struct HotShotInitializer<TYPES: NodeType> {
     high_qc: QuorumCertificate2<TYPES>,
     /// Previously decided upgrade certificate; this is necessary if an upgrade has happened and we are not restarting with the new version
     decided_upgrade_certificate: Option<UpgradeCertificate<TYPES>>,
-    /// Undecided leafs that were seen, but not yet decided on.  These allow a restarting node
+    /// Undecided leaves that were seen, but not yet decided on.  These allow a restarting node
     /// to vote and propose right away if they didn't miss anything while down.
-    undecided_leafs: Vec<Leaf2<TYPES>>,
+    undecided_leaves: Vec<Leaf2<TYPES>>,
     /// Not yet decided state
     undecided_state: BTreeMap<TYPES::View, View<TYPES>>,
     /// Proposals we have sent out to provide to others for catchup
@@ -1036,7 +1036,7 @@ impl<TYPES: NodeType> HotShotInitializer<TYPES> {
             saved_proposals: BTreeMap::new(),
             high_qc,
             decided_upgrade_certificate: None,
-            undecided_leafs: Vec::new(),
+            undecided_leaves: Vec::new(),
             undecided_state: BTreeMap::new(),
             instance_state,
         })
@@ -1060,7 +1060,7 @@ impl<TYPES: NodeType> HotShotInitializer<TYPES> {
         saved_proposals: BTreeMap<TYPES::View, Proposal<TYPES, QuorumProposal2<TYPES>>>,
         high_qc: QuorumCertificate2<TYPES>,
         decided_upgrade_certificate: Option<UpgradeCertificate<TYPES>>,
-        undecided_leafs: Vec<Leaf2<TYPES>>,
+        undecided_leaves: Vec<Leaf2<TYPES>>,
         undecided_state: BTreeMap<TYPES::View, View<TYPES>>,
     ) -> Self {
         Self {
@@ -1074,7 +1074,7 @@ impl<TYPES: NodeType> HotShotInitializer<TYPES> {
             saved_proposals,
             high_qc,
             decided_upgrade_certificate,
-            undecided_leafs,
+            undecided_leaves,
             undecided_state,
         }
     }

--- a/crates/hotshot/src/traits/networking/libp2p_network.rs
+++ b/crates/hotshot/src/traits/networking/libp2p_network.rs
@@ -968,14 +968,14 @@ impl<T: NodeType> ConnectedNetwork<T::SignatureKey> for Libp2pNetwork<T> {
 
     /// The libp2p view update is a special operation intrinsic to its internal behavior.
     ///
-    /// Libp2p needs to do a lookup because a libp2p address is not releated to
+    /// Libp2p needs to do a lookup because a libp2p address is not related to
     /// hotshot keys. So in libp2p we store a mapping of HotShot key to libp2p address
     /// in a distributed hash table.
     ///
     /// This means to directly message someone on libp2p we need to lookup in the hash
     /// table what their libp2p address is, using their HotShot public key as the key.
     ///
-    /// So the logic with libp2p is to prefetch upcomming leaders libp2p address to
+    /// So the logic with libp2p is to prefetch upcoming leaders libp2p address to
     /// save time when we later need to direct message the leader our vote. Hence the
     /// use of the future view and leader to queue the lookups.
     async fn update_view<'a, TYPES>(&'a self, view: u64, epoch: u64, membership: &TYPES::Membership)

--- a/crates/hotshot/src/types/handle.rs
+++ b/crates/hotshot/src/types/handle.rs
@@ -94,7 +94,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static, V: Versions>
         self.output_event_stream.1.activate_cloned()
     }
 
-    /// Message other participents with a serialized message from the application
+    /// Message other participants with a serialized message from the application
     /// Receivers of this message will get an `Event::ExternalMessageReceived` via
     /// the event stream.
     ///
@@ -197,7 +197,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static, V: Versions>
                     if commit == leaf_commitment {
                         return Ok(quorum_proposal.clone());
                     }
-                    tracing::warn!("Proposal receied from request has different commitment than expected.\nExpected = {:?}\nReceived{:?}", leaf_commitment, commit);
+                    tracing::warn!("Proposal received from request has different commitment than expected.\nExpected = {:?}\nReceived{:?}", leaf_commitment, commit);
                 }
             }
         })

--- a/crates/libp2p-networking/src/network/behaviours/dht/mod.rs
+++ b/crates/libp2p-networking/src/network/behaviours/dht/mod.rs
@@ -394,7 +394,7 @@ impl<K: SignatureKey + 'static> DHTBehaviour<K> {
         }
     }
 
-    /// Send that the bootsrap suceeded
+    /// Send that the bootstrap succeeded
     fn finish_bootstrap(&mut self) {
         if let Some(mut tx) = self.bootstrap_tx.clone() {
             spawn(async move { tx.send(bootstrap::InputEvent::BootstrapFinished).await });

--- a/crates/libp2p-networking/src/network/def.rs
+++ b/crates/libp2p-networking/src/network/def.rs
@@ -47,7 +47,7 @@ pub struct NetworkDef<K: SignatureKey + 'static> {
     #[debug(skip)]
     pub direct_message: cbor::Behaviour<Vec<u8>, Vec<u8>>,
 
-    /// Auto NAT behaviour to determine if we are publically reachable and
+    /// Auto NAT behaviour to determine if we are publicly reachable and
     /// by which address
     #[debug(skip)]
     pub autonat: libp2p::autonat::Behaviour,

--- a/crates/libp2p-networking/src/network/node.rs
+++ b/crates/libp2p-networking/src/network/node.rs
@@ -355,7 +355,7 @@ impl<T: NodeType> NetworkNode<T> {
     }
 
     /// event handler for client events
-    /// currectly supported actions include
+    /// currently supported actions include
     /// - shutting down the swarm
     /// - gossipping a message to known peers on the `global` topic
     /// - returning the id of the current peer

--- a/crates/orchestrator/run-config.toml
+++ b/crates/orchestrator/run-config.toml
@@ -6,17 +6,17 @@ node_index = 0
 seed = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
 cdn_marshal_address = "127.0.0.1:8999"
 public_keys = [
-    { stake_table_key = "BLS_VER_KEY~bQszS-QKYvUij2g20VqS8asttGSb95NrTu2PUj0uMh1CBUxNy1FqyPDjZqB29M7ZbjWqj79QkEOWkpga84AmDYUeTuWmy-0P1AdKHD3ehc-dKvei78BDj5USwXPJiDUlCxvYs_9rWYhagaq-5_LXENr78xel17spftNd5MA1Mw5U", state_ver_key = "SCHNORR_VER_KEY~lJqDaVZyM0hWP2Br52IX5FeE-dCAIC-dPX7bL5-qUx-vjbunwe-ENOeZxj6FuOyvDCFzoGeP7yZ0fM995qF-CRE", stake = 1, da = true },
+    { stake_table_key = "BLS_VER_KEY~bQszS-QKYvUij2g20VqS8asttGSb95NrTu2PUj0uMh1CBUxNy1FqyPDjZqB29M7ZbjWqj79QkEOWkpga84AmDYUeTuWmy-0P1AdKHD3ehc-dKvei78BDj5USwXPJiDUlCxvYs_9rWYhagaq-5_LXENr78xel17spftAnd5MA1Mw5U", state_ver_key = "SCHNORR_VER_KEY~lJqDaVZyM0hWP2Br52IX5FeE-dCAIC-dPX7bL5-qUx-vjbunwe-ENOeZxj6FuOyvDCFzoGeP7yZ0fM995qF-CRE", stake = 1, da = true },
 
     { stake_table_key = "BLS_VER_KEY~IBRoz_Q1EXvcm1pNZcmVlyYZU8hZ7qmy337ePAjEMhz8Hl2q8vWPFOd3BaLwgRS1UzAPW3z4E-XIgRDGcRBTAMZX9b_0lKYjlyTlNF2EZfNnKmvv-xJ0yurkfjiveeYEsD2l5d8q_rJJbH1iZdXy-yPEbwI0SIvQfwdlcaKw9po4", state_ver_key = "SCHNORR_VER_KEY~tyuplKrHzvjODsjPKMHVFYfoMcgklQsMye-2aSCktBcbW_CIzLOq3wZXRIPBbw3FiV6_QoUXYAlpZ5up0zG_ANY", stake = 1, da = true },
 
-    { stake_table_key = "BLS_VER_KEY~4zQnaCOFJ7m95OjxeNls0QOOwWbz4rfxaL3NwmN2zSdnf8t5Nw_dfmMHq05ee8jCegw6Bn5T8inmrnGGAsQJMMWLv77nd7FJziz2ViAbXg-XGGF7o4HyzELCmypDOIYF3X2UWferFE_n72ZX0iQkUhOvYZZ7cfXToXxRTtb_mwRR", state_ver_key = "SCHNORR_VER_KEY~qQAC373HPv4s0mTTpdmSaynfUXC4SfPCuGD2fbeigSpexFB2ycCeXV9UAjuR86CC9udPhopgMsFLyD29VO2iJSg", stake = 1, da = true},
+    { stake_table_key = "BLS_VER_KEY~4zQnaCOFJ7m95OjxeNls0QOOwWbz4rfxaL3NwmN2zSdnf8t5Nw_dfmMHq05ee8jCegw6Bn5T8inmrnGGAsQJMMWLv77and7FJziz2ViAbXg-XGGF7o4HyzELCmypDOIYF3X2UWferFE_n72ZX0iQkUhOvYZZ7cfXToXxRTtb_mwRR", state_ver_key = "SCHNORR_VER_KEY~qQAC373HPv4s0mTTpdmSaynfUXC4SfPCuGD2fbeigSpexFB2ycCeXV9UAjuR86CC9udPhopgMsFLyD29VO2iJSg", stake = 1, da = true},
 
-    { stake_table_key = "BLS_VER_KEY~rO2PIjyY30HGfapFcloFe3mNDKMIFi6JlOLkH5ZWBSYoRm5fE2-Rm6Lp3EvmAcB5r7KFJ0c1Uor308x78r04EY_sfjcsDCWt7RSJdL4cJoD_4fSTCv_bisO8k98hs_8BtqQt8BHlPeJohpUXvcfnK8suXJETiJ6Er97pfxRbzgAL", state_ver_key = "SCHNORR_VER_KEY~le6RHdTasbBsTcbMqArt0XWFwfIJTY7RbUwaCvdxswL8LpXpO3eb86iyYUr63dtv4GGa5fIJaRH97nCd1lV9H8g", stake = 1, da = true },
+    { stake_table_key = "BLS_VER_KEY~rO2PIjyY30HGfapFcloFe3mNDKMIFi6JlOLkH5ZWBSYoRm5fE2-Rm6Lp3EvmAcB5r7KFJ0c1Uor308x78r04EY_sfjcsDCWt7RSJdL4cJoD_4fSTCv_bisO8k98hs_8BtqQt8BHlPeJohpUXvcfnK8suXJETiJ6Er97pfxRbzgAL", state_ver_key = "SCHNORR_VER_KEY~le6RHdTasbBsTcbMqArt0XWFwfIJTY7RbUwaCvdxswL8LpXpO3eb86itYUr63dtv4GGa5fIJaRH97nCd1lV9H8g", stake = 1, da = true },
 
-    { stake_table_key = "BLS_VER_KEY~r6b-Cwzp-b3czlt0MHmYPJIow5kMsXbrNmZsLSYg9RV49oCCO4WEeCRFR02x9bqLCa_sgNFMrIeNdEa11qNiBAohApYFIvrSa-zP5QGj3xbZaMOCrshxYit6E2TR-XsWvv6gjOrypmugjyTAth-iqQzTboSfmO9DD1-gjJIdCaD7", state_ver_key = "SCHNORR_VER_KEY~LfL6fFJQ8UZWR1Jro6LHtKm_y5-VQZBapO0XhcB8ABAmsVght9B8k7NntrgniffAMD8_OJ6Zjg8XUklhbb42CIw", stake = 1, da = true },
+    { stake_table_key = "BLS_VER_KEY~r6b-Cwzp-b3czlt0MHmYPJIow5kMsXbrNmZsLSYg9RV49oCCO4WEeCRFR02x9bqLCa_sgNFMrIeAndEa11qNiBAohApYFIvrSa-zP5QGj3xbZaMOCrshxYit6E2TR-XsWvv6gjOrypmugjyTAth-iqQzTboSfmO9DD1-gjJIdCaD7", state_ver_key = "SCHNORR_VER_KEY~LfL6fFJQ8UZWR1Jro6LHtKm_y5-VQZBapO0XhcB8ABAmsVght9B8k7NntrgniffAMD8_OJ6Zjg8XUklhbb42CIw", stake = 1, da = true },
 
-    { stake_table_key = "BLS_VER_KEY~kEUEUJFBtCXl68fM_2roQw856wQlu1ZoDmPn8uu4bQgeZwyb5oz5_kMl-oAJ_OtbYV1serjWE--eXB_qYIpQLZka42-cML6WjCQjNl1hGSejtoBDkExNeUNcweFQBbEsaDiIy3-sgHTrfYpFd1icKeAVihLRn5_RtSU_RUu1TQqR", state_ver_key = "SCHNORR_VER_KEY~qKOggsQMNIIvmiIPM3smiGk40kYGXCVupsmgIrf3RgMmua683F3vUwzWcx0s7mxdzLXJwPAB06LD96cxip7JLJM", stake = 1, da = true },
+    { stake_table_key = "BLS_VER_KEY~kEUEUJFBtCXl68fM_2roQw856wQlu1ZoDmOn8uu4bQgeZwyb5oz5_kMl-oAJ_OtbYV1serjWE--eXB_qYIpQLZka42-cML6WjCQjNl1hGSejtoBDkExNeUNcweFQBbEsaDiIt3-sgHTrfYpFd1icKeAVihLRn5_RtSU_RUu1TQqR", state_ver_key = "SCHNORR_VER_KEY~qKOggsQMNIIvmiIPM3smiGk40kYGXCVupsmgIrf3RgMmua683F3vUwzWcx0s7mxdzLXJwPAB06LD96cxip7JLJM", stake = 1, da = true },
 
     { stake_table_key = "BLS_VER_KEY~96hAcdFZxQT8CEHcyV8j2ILJRsXagquENPkc9AwLSx3u6AE_uMupIKGbNJRiM99oFneK2vI5g1u61HidWeuTLRPM2537xAXeaO8e-wJYx4FaPKw_xTcLPrIm0OZT7SsLAMwFuqfMbDdKM71-RyrLwhff5517xXBKEk5Tg9iT9Qrr", state_ver_key = "SCHNORR_VER_KEY~y0nltwKyKSpwO3ki9Czu5asjAt5g1Ya3XmAywcerOSUg__FuZOcYq6tKxMsnsjE7ylpWLZv8R5W4-6WkP0DWI94", stake = 1, da = true },
 

--- a/crates/orchestrator/run-config.toml
+++ b/crates/orchestrator/run-config.toml
@@ -6,17 +6,17 @@ node_index = 0
 seed = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
 cdn_marshal_address = "127.0.0.1:8999"
 public_keys = [
-    { stake_table_key = "BLS_VER_KEY~bQszS-QKYvUij2g20VqS8asttGSb95NrTu2PUj0uMh1CBUxNy1FqyPDjZqB29M7ZbjWqj79QkEOWkpga84AmDYUeTuWmy-0P1AdKHD3ehc-dKvei78BDj5USwXPJiDUlCxvYs_9rWYhagaq-5_LXENr78xel17spftAnd5MA1Mw5U", state_ver_key = "SCHNORR_VER_KEY~lJqDaVZyM0hWP2Br52IX5FeE-dCAIC-dPX7bL5-qUx-vjbunwe-ENOeZxj6FuOyvDCFzoGeP7yZ0fM995qF-CRE", stake = 1, da = true },
+    { stake_table_key = "BLS_VER_KEY~bQszS-QKYvUij2g20VqS8asttGSb95NrTu2PUj0uMh1CBUxNy1FqyPDjZqB29M7ZbjWqj79QkEOWkpga84AmDYUeTuWmy-0P1AdKHD3ehc-dKvei78BDj5USwXPJiDUlCxvYs_9rWYhagaq-5_LXENr78xel17spftNd5MA1Mw5U", state_ver_key = "SCHNORR_VER_KEY~lJqDaVZyM0hWP2Br52IX5FeE-dCAIC-dPX7bL5-qUx-vjbunwe-ENOeZxj6FuOyvDCFzoGeP7yZ0fM995qF-CRE", stake = 1, da = true },
 
     { stake_table_key = "BLS_VER_KEY~IBRoz_Q1EXvcm1pNZcmVlyYZU8hZ7qmy337ePAjEMhz8Hl2q8vWPFOd3BaLwgRS1UzAPW3z4E-XIgRDGcRBTAMZX9b_0lKYjlyTlNF2EZfNnKmvv-xJ0yurkfjiveeYEsD2l5d8q_rJJbH1iZdXy-yPEbwI0SIvQfwdlcaKw9po4", state_ver_key = "SCHNORR_VER_KEY~tyuplKrHzvjODsjPKMHVFYfoMcgklQsMye-2aSCktBcbW_CIzLOq3wZXRIPBbw3FiV6_QoUXYAlpZ5up0zG_ANY", stake = 1, da = true },
 
-    { stake_table_key = "BLS_VER_KEY~4zQnaCOFJ7m95OjxeNls0QOOwWbz4rfxaL3NwmN2zSdnf8t5Nw_dfmMHq05ee8jCegw6Bn5T8inmrnGGAsQJMMWLv77and7FJziz2ViAbXg-XGGF7o4HyzELCmypDOIYF3X2UWferFE_n72ZX0iQkUhOvYZZ7cfXToXxRTtb_mwRR", state_ver_key = "SCHNORR_VER_KEY~qQAC373HPv4s0mTTpdmSaynfUXC4SfPCuGD2fbeigSpexFB2ycCeXV9UAjuR86CC9udPhopgMsFLyD29VO2iJSg", stake = 1, da = true},
+    { stake_table_key = "BLS_VER_KEY~4zQnaCOFJ7m95OjxeNls0QOOwWbz4rfxaL3NwmN2zSdnf8t5Nw_dfmMHq05ee8jCegw6Bn5T8inmrnGGAsQJMMWLv77nd7FJziz2ViAbXg-XGGF7o4HyzELCmypDOIYF3X2UWferFE_n72ZX0iQkUhOvYZZ7cfXToXxRTtb_mwRR", state_ver_key = "SCHNORR_VER_KEY~qQAC373HPv4s0mTTpdmSaynfUXC4SfPCuGD2fbeigSpexFB2ycCeXV9UAjuR86CC9udPhopgMsFLyD29VO2iJSg", stake = 1, da = true},
 
-    { stake_table_key = "BLS_VER_KEY~rO2PIjyY30HGfapFcloFe3mNDKMIFi6JlOLkH5ZWBSYoRm5fE2-Rm6Lp3EvmAcB5r7KFJ0c1Uor308x78r04EY_sfjcsDCWt7RSJdL4cJoD_4fSTCv_bisO8k98hs_8BtqQt8BHlPeJohpUXvcfnK8suXJETiJ6Er97pfxRbzgAL", state_ver_key = "SCHNORR_VER_KEY~le6RHdTasbBsTcbMqArt0XWFwfIJTY7RbUwaCvdxswL8LpXpO3eb86itYUr63dtv4GGa5fIJaRH97nCd1lV9H8g", stake = 1, da = true },
+    { stake_table_key = "BLS_VER_KEY~rO2PIjyY30HGfapFcloFe3mNDKMIFi6JlOLkH5ZWBSYoRm5fE2-Rm6Lp3EvmAcB5r7KFJ0c1Uor308x78r04EY_sfjcsDCWt7RSJdL4cJoD_4fSTCv_bisO8k98hs_8BtqQt8BHlPeJohpUXvcfnK8suXJETiJ6Er97pfxRbzgAL", state_ver_key = "SCHNORR_VER_KEY~le6RHdTasbBsTcbMqArt0XWFwfIJTY7RbUwaCvdxswL8LpXpO3eb86iyYUr63dtv4GGa5fIJaRH97nCd1lV9H8g", stake = 1, da = true },
 
-    { stake_table_key = "BLS_VER_KEY~r6b-Cwzp-b3czlt0MHmYPJIow5kMsXbrNmZsLSYg9RV49oCCO4WEeCRFR02x9bqLCa_sgNFMrIeAndEa11qNiBAohApYFIvrSa-zP5QGj3xbZaMOCrshxYit6E2TR-XsWvv6gjOrypmugjyTAth-iqQzTboSfmO9DD1-gjJIdCaD7", state_ver_key = "SCHNORR_VER_KEY~LfL6fFJQ8UZWR1Jro6LHtKm_y5-VQZBapO0XhcB8ABAmsVght9B8k7NntrgniffAMD8_OJ6Zjg8XUklhbb42CIw", stake = 1, da = true },
+    { stake_table_key = "BLS_VER_KEY~r6b-Cwzp-b3czlt0MHmYPJIow5kMsXbrNmZsLSYg9RV49oCCO4WEeCRFR02x9bqLCa_sgNFMrIeNdEa11qNiBAohApYFIvrSa-zP5QGj3xbZaMOCrshxYit6E2TR-XsWvv6gjOrypmugjyTAth-iqQzTboSfmO9DD1-gjJIdCaD7", state_ver_key = "SCHNORR_VER_KEY~LfL6fFJQ8UZWR1Jro6LHtKm_y5-VQZBapO0XhcB8ABAmsVght9B8k7NntrgniffAMD8_OJ6Zjg8XUklhbb42CIw", stake = 1, da = true },
 
-    { stake_table_key = "BLS_VER_KEY~kEUEUJFBtCXl68fM_2roQw856wQlu1ZoDmOn8uu4bQgeZwyb5oz5_kMl-oAJ_OtbYV1serjWE--eXB_qYIpQLZka42-cML6WjCQjNl1hGSejtoBDkExNeUNcweFQBbEsaDiIt3-sgHTrfYpFd1icKeAVihLRn5_RtSU_RUu1TQqR", state_ver_key = "SCHNORR_VER_KEY~qKOggsQMNIIvmiIPM3smiGk40kYGXCVupsmgIrf3RgMmua683F3vUwzWcx0s7mxdzLXJwPAB06LD96cxip7JLJM", stake = 1, da = true },
+    { stake_table_key = "BLS_VER_KEY~kEUEUJFBtCXl68fM_2roQw856wQlu1ZoDmPn8uu4bQgeZwyb5oz5_kMl-oAJ_OtbYV1serjWE--eXB_qYIpQLZka42-cML6WjCQjNl1hGSejtoBDkExNeUNcweFQBbEsaDiIy3-sgHTrfYpFd1icKeAVihLRn5_RtSU_RUu1TQqR", state_ver_key = "SCHNORR_VER_KEY~qKOggsQMNIIvmiIPM3smiGk40kYGXCVupsmgIrf3RgMmua683F3vUwzWcx0s7mxdzLXJwPAB06LD96cxip7JLJM", stake = 1, da = true },
 
     { stake_table_key = "BLS_VER_KEY~96hAcdFZxQT8CEHcyV8j2ILJRsXagquENPkc9AwLSx3u6AE_uMupIKGbNJRiM99oFneK2vI5g1u61HidWeuTLRPM2537xAXeaO8e-wJYx4FaPKw_xTcLPrIm0OZT7SsLAMwFuqfMbDdKM71-RyrLwhff5517xXBKEk5Tg9iT9Qrr", state_ver_key = "SCHNORR_VER_KEY~y0nltwKyKSpwO3ki9Czu5asjAt5g1Ya3XmAywcerOSUg__FuZOcYq6tKxMsnsjE7ylpWLZv8R5W4-6WkP0DWI94", stake = 1, da = true },
 

--- a/crates/orchestrator/src/client.rs
+++ b/crates/orchestrator/src/client.rs
@@ -103,7 +103,7 @@ pub struct BenchResultsDownloadConfig {
     // Results starting here
     /// Whether the results are partially collected
     /// "One" when the results are collected for one node
-    /// "Half" when the results are collecte for half running nodes if not all nodes terminate successfully
+    /// "Half" when the results are collective for half running nodes if not all nodes terminate successfully
     /// "Full" if the results are successfully collected from all nodes
     pub partial_results: String,
     /// The average latency of the transactions

--- a/crates/task-impls/src/consensus/handlers.rs
+++ b/crates/task-impls/src/consensus/handlers.rs
@@ -127,7 +127,7 @@ pub async fn send_high_qc<TYPES: NodeType, V: Versions, I: NodeImplementation<TY
     let version = task_state.upgrade_lock.version(new_view_number).await?;
     ensure!(
         version >= V::Epochs::VERSION,
-        debug!("HotStuff 2 updgrade not yet in effect")
+        debug!("HotStuff 2 upgrade not yet in effect")
     );
     let high_qc = task_state.consensus.read().await.high_qc().clone();
     let leader = task_state

--- a/crates/task-impls/src/network.rs
+++ b/crates/task-impls/src/network.rs
@@ -332,7 +332,7 @@ impl<
                 return Err(());
             }
             // If the action was view sync record it as a vote, but we don't
-            // want to limit to 1 View sycn vote above so change the action here.
+            // want to limit to 1 View sync vote above so change the action here.
             if matches!(action, HotShotAction::ViewSyncVote) {
                 action = HotShotAction::Vote;
             }

--- a/crates/task-impls/src/quorum_proposal/handlers.rs
+++ b/crates/task-impls/src/quorum_proposal/handlers.rs
@@ -55,7 +55,7 @@ pub(crate) enum ProposalDependency {
     /// For the `Qc2Formed` event timeout branch.
     TimeoutCert,
 
-    /// For the `QuroumProposalRecv` event.
+    /// For the `QuorumProposalRecv` event.
     Proposal,
 
     /// For the `VidShareValidated` event.
@@ -110,7 +110,7 @@ pub struct ProposalDependencyHandle<TYPES: NodeType, V: Versions> {
     /// The time this view started
     pub view_start_time: Instant,
 
-    /// The higest_qc we've seen at the start of this task
+    /// The highest_qc we've seen at the start of this task
     pub highest_qc: QuorumCertificate2<TYPES>,
 }
 
@@ -137,7 +137,7 @@ impl<TYPES: NodeType, V: Versions> ProposalDependencyHandle<TYPES, V> {
         None
     }
     /// Waits for the ocnfigured timeout for nodes to send HighQc messages to us.  We'll
-    /// then propose with the higest QC from among these proposals.
+    /// then propose with the highest QC from among these proposals.
     async fn wait_for_highest_qc(&mut self) {
         tracing::error!("waiting for QC");
         // If we haven't upgraded to Hotstuff 2 just return the high qc right away

--- a/crates/task-impls/src/quorum_proposal/mod.rs
+++ b/crates/task-impls/src/quorum_proposal/mod.rs
@@ -82,7 +82,7 @@ pub struct QuorumProposalTaskState<TYPES: NodeType, I: NodeImplementation<TYPES>
     /// Number of blocks in an epoch, zero means there are no epochs
     pub epoch_height: u64,
 
-    /// The higest_qc we've seen at the start of this task
+    /// The highest_qc we've seen at the start of this task
     pub highest_qc: QuorumCertificate2<TYPES>,
 }
 

--- a/crates/task-impls/src/request.rs
+++ b/crates/task-impls/src/request.rs
@@ -242,7 +242,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> NetworkRequestState<TYPES, I
                 } else {
                     // This shouldnt be possible `recipients_it.next()` should clone original and start over if `None`
                     tracing::warn!(
-                        "Sent VID request to all available DA members and got no reponse for view: {:?}",
+                        "Sent VID request to all available DA members and got no response for view: {:?}",
                         view
                     );
                     return;

--- a/crates/task-impls/src/view_sync.rs
+++ b/crates/task-impls/src/view_sync.rs
@@ -742,7 +742,7 @@ impl<TYPES: NodeType, V: Versions> ViewSyncReplicaTaskState<TYPES, V> {
             HotShotEvent::ViewSyncTrigger(view_number) => {
                 let view_number = *view_number;
                 if self.next_view != TYPES::View::new(*view_number) {
-                    tracing::error!("Unexpected view number to triger view sync");
+                    tracing::error!("Unexpected view number to trigger view sync");
                     return None;
                 }
 

--- a/crates/task-impls/src/vote_collection.rs
+++ b/crates/task-impls/src/vote_collection.rs
@@ -186,7 +186,7 @@ pub struct AccumulatorInfo<TYPES: NodeType> {
 /// Generic function for spawning a vote task.  Returns the event stream id of the spawned task if created
 ///
 /// # Errors
-/// If we faile to create the accumulator
+/// If we failed to create the accumulator
 ///
 /// # Panics
 /// Calls unwrap but should never panic.

--- a/crates/task/src/dependency_task.rs
+++ b/crates/task/src/dependency_task.rs
@@ -20,7 +20,7 @@ pub trait HandleDepOutput: Send + Sized + Sync + 'static {
 
 /// A task that runs until it's dependency completes and it handles the result
 pub struct DependencyTask<D: Dependency<H::Output> + Send, H: HandleDepOutput + Send> {
-    /// Dependency this taks waits for
+    /// Dependency this tasks waits for
     pub(crate) dep: D,
     /// Handles the results returned from `self.dep.completed().await`
     pub(crate) handle: H,

--- a/crates/testing/src/block_builder/random.rs
+++ b/crates/testing/src/block_builder/random.rs
@@ -242,7 +242,7 @@ where
 {
     /// Create new [`RandomBuilderSource`]
     #[must_use]
-    #[allow(clippy::missing_panics_doc)] // ony panics if 256 == 0
+    #[allow(clippy::missing_panics_doc)] // only panics if 256 == 0
     pub fn new(pub_key: TYPES::BuilderSignatureKey, num_nodes: Arc<RwLock<usize>>) -> Self {
         Self {
             blocks: Arc::new(RwLock::new(LruCache::new(NonZeroUsize::new(256).unwrap()))),

--- a/crates/testing/src/byzantine/mod.rs
+++ b/crates/testing/src/byzantine/mod.rs
@@ -1,2 +1,2 @@
-/// Byzantine defintions and implementations of different behaviours
+/// Byzantine definitions and implementations of different behaviours
 pub mod byzantine_behaviour;

--- a/crates/testing/src/spinning_task.rs
+++ b/crates/testing/src/spinning_task.rs
@@ -43,7 +43,7 @@ use crate::{
     test_task::{TestResult, TestTaskState},
 };
 
-/// convience type for state and block
+/// convenience type for state and block
 pub type StateAndBlock<S, B> = (Vec<S>, Vec<B>);
 
 /// Spinning task state
@@ -225,7 +225,7 @@ where
                                     context: LateNodeContext::Restart,
                                 }) = self.late_start.get(&node_id)
                                 else {
-                                    panic!("Restarted Nodes must have an unitialized context");
+                                    panic!("Restarted Nodes must have an uninitialized context");
                                 };
 
                                 let storage = node.handle.storage().clone();
@@ -391,7 +391,7 @@ pub enum NodeAction {
     /// Take a node down to be restarted after a number of views
     RestartDown(u64),
     /// Start a node up again after it's been shutdown for restart.  This
-    /// should only be created following a `ResartDown`
+    /// should only be created following a `RestartDown`
     RestartUp,
 }
 

--- a/crates/testing/src/test_runner.rs
+++ b/crates/testing/src/test_runner.rs
@@ -660,7 +660,7 @@ pub struct Node<TYPES: NodeType, I: TestableNodeImplementation<TYPES>, V: Versio
     pub handle: SystemContextHandle<TYPES, I, V>,
 }
 
-/// This type combines all of the paramters needed to build the context for a node that started
+/// This type combines all of the parameters needed to build the context for a node that started
 /// late during a unit test or integration test.
 pub struct LateNodeContextParameters<TYPES: NodeType, I: TestableNodeImplementation<TYPES>> {
     /// The storage trait for Sequencer persistence.
@@ -669,7 +669,7 @@ pub struct LateNodeContextParameters<TYPES: NodeType, I: TestableNodeImplementat
     /// The memberships of this particular node.
     pub memberships: Memberships<TYPES>,
 
-    /// The config associted with this node.
+    /// The config associated with this node.
     pub config: HotShotConfig<TYPES::SignatureKey>,
 
     /// The marketplace config for this node.

--- a/crates/testing/src/view_generator.rs
+++ b/crates/testing/src/view_generator.rs
@@ -577,7 +577,7 @@ impl TestViewGenerator {
         }
     }
 
-    pub async fn next_from_anscestor_view(&mut self, ancestor: TestView) {
+    pub async fn next_from_ancestor_view(&mut self, ancestor: TestView) {
         if let Some(ref view) = self.current_view {
             self.current_view = Some(view.next_view_from_ancestor(ancestor).await)
         } else {

--- a/crates/testing/tests/tests_1/vote_dependency_handle.rs
+++ b/crates/testing/tests/tests_1/vote_dependency_handle.rs
@@ -30,7 +30,7 @@ async fn test_vote_dependency_handle() {
 
     hotshot::helpers::initialize_logging();
 
-    // We use a node ID of 2 here abitrarily. We just need it to build the system handle.
+    // We use a node ID of 2 here arbitrarily. We just need it to build the system handle.
     let node_id = 2;
     // Construct the system handle for the node ID to build all of the state objects.
     let handle = build_system_handle::<TestTypes, MemoryImpl, TestVersions>(node_id)

--- a/crates/types/src/consensus.rs
+++ b/crates/types/src/consensus.rs
@@ -556,7 +556,7 @@ impl<TYPES: NodeType> Consensus<TYPES> {
                 }
                 // TODO Add logic to prevent double voting.  For now the simple check if
                 // the last voted view is less than the view we are trying to vote doesn't work
-                // becuase the leader of view n + 1 may propose to the DA (and we would vote)
+                // because the leader of view n + 1 may propose to the DA (and we would vote)
                 // before the leader of view n.
                 return true;
             }
@@ -624,7 +624,7 @@ impl<TYPES: NodeType> Consensus<TYPES> {
     /// Update the validated state map with a new view_number/view combo.
     ///
     /// # Errors
-    /// Can return an error when the new view contains less information than the exisiting view
+    /// Can return an error when the new view contains less information than the existing view
     /// with the same view number.
     pub fn update_da_view(
         &mut self,
@@ -640,7 +640,7 @@ impl<TYPES: NodeType> Consensus<TYPES> {
     /// Update the validated state map with a new view_number/view combo.
     ///
     /// # Errors
-    /// Can return an error when the new view contains less information than the exisiting view
+    /// Can return an error when the new view contains less information than the existing view
     /// with the same view number.
     pub fn update_leaf(
         &mut self,
@@ -664,7 +664,7 @@ impl<TYPES: NodeType> Consensus<TYPES> {
     /// Update the validated state map with a new view_number/view combo.
     ///
     /// # Errors
-    /// Can return an error when the new view contains less information than the exisiting view
+    /// Can return an error when the new view contains less information than the existing view
     /// with the same view number.
     fn update_validated_state_map(
         &mut self,

--- a/crates/types/src/data.rs
+++ b/crates/types/src/data.rs
@@ -646,7 +646,7 @@ impl<TYPES: NodeType> Leaf2<TYPES> {
 
     /// Validate that a leaf has the right upgrade certificate to be the immediate child of another leaf
     ///
-    /// This may not be a complete function. Please double-check that it performs the checks you expect before subtituting validation logic with it.
+    /// This may not be a complete function. Please double-check that it performs the checks you expect before substituting validation logic with it.
     ///
     /// # Errors
     /// Returns an error if the certificates are not identical, or that when we no longer see a
@@ -946,7 +946,7 @@ impl<TYPES: NodeType> Leaf<TYPES> {
 
     /// Validate that a leaf has the right upgrade certificate to be the immediate child of another leaf
     ///
-    /// This may not be a complete function. Please double-check that it performs the checks you expect before subtituting validation logic with it.
+    /// This may not be a complete function. Please double-check that it performs the checks you expect before substituting validation logic with it.
     ///
     /// # Errors
     /// Returns an error if the certificates are not identical, or that when we no longer see a

--- a/crates/types/src/event.rs
+++ b/crates/types/src/event.rs
@@ -110,7 +110,7 @@ pub enum EventType<TYPES: NodeType> {
     },
     /// A new decision event was issued
     Decide {
-        /// The chain of Leafs that were committed by this decision
+        /// The chain of Leaves that were committed by this decision
         ///
         /// This list is sorted in reverse view number order, with the newest (highest view number)
         /// block first in the list.

--- a/crates/types/src/network.rs
+++ b/crates/types/src/network.rs
@@ -200,7 +200,7 @@ impl<K: SignatureKey> NetworkConfig<K> {
     /// // NOTE: broken due to staticelectionconfig not being importable
     /// // cannot import staticelectionconfig from hotshot without creating circular dependency
     /// // making this work probably involves the `types` crate implementing a dummy
-    /// // electionconfigtype just ot make this example work
+    /// // electionconfigtype just to make this example work
     /// let config = NetworkConfig::<BLSPubKey, StaticElectionConfig>::from_file(file).unwrap();
     /// ```
     pub fn from_file(file: String) -> Result<Self, NetworkConfigError> {

--- a/crates/types/src/request_response.rs
+++ b/crates/types/src/request_response.rs
@@ -18,7 +18,7 @@ pub struct ProposalRequestPayload<TYPES: NodeType> {
     /// The view number that we're requesting a proposal for.
     pub view_number: TYPES::View,
 
-    /// Our public key. The ensures that the receipient can reply to
+    /// Our public key. The ensures that the recipient can reply to
     /// us directly.
     pub key: TYPES::SignatureKey,
 }

--- a/crates/types/src/traits/metrics.rs
+++ b/crates/types/src/traits/metrics.rs
@@ -58,7 +58,7 @@ pub trait Metrics: Send + Sync + DynClone + Debug {
 /// A family of related metrics, partitioned by their label values.
 ///
 /// All metrics in a family have the same name. They are distinguished by a vector of strings
-/// called labels. Each label has a name and a value, and each distinct vector of lable values
+/// called labels. Each label has a name and a value, and each distinct vector of label values
 /// within a family acts like a distinct metric.
 ///
 /// The family object is used to instantiate individual metrics within the family via the
@@ -217,7 +217,7 @@ pub trait Gauge: Send + Sync + Debug + DynClone {
     /// Set the gauge value
     fn set(&self, amount: usize);
 
-    /// Update the guage value
+    /// Update the gage value
     fn update(&self, delts: i64);
 }
 

--- a/crates/types/src/traits/metrics.rs
+++ b/crates/types/src/traits/metrics.rs
@@ -217,7 +217,7 @@ pub trait Gauge: Send + Sync + Debug + DynClone {
     /// Set the gauge value
     fn set(&self, amount: usize);
 
-    /// Update the gage value
+    /// Update the gauge value
     fn update(&self, delts: i64);
 }
 

--- a/crates/types/src/traits/node_implementation.rs
+++ b/crates/types/src/traits/node_implementation.rs
@@ -45,7 +45,7 @@ use crate::{
 /// essentially ensures that the results returned by the [`AuctionResultsProvider`] trait includes a
 /// list of urls for the builders that HotShot must request from.
 pub trait HasUrls {
-    /// Returns the builer url associated with the datatype
+    /// Returns the builder url associated with the datatype
     fn urls(&self) -> Vec<Url>;
 }
 

--- a/crates/types/src/traits/storage.rs
+++ b/crates/types/src/traits/storage.rs
@@ -56,14 +56,14 @@ pub trait Storage<TYPES: NodeType>: Send + Sync + Clone {
     /// and the undecided state.
     async fn update_undecided_state(
         &self,
-        leafs: CommitmentMap<Leaf<TYPES>>,
+        leaves: CommitmentMap<Leaf<TYPES>>,
         state: BTreeMap<TYPES::View, View<TYPES>>,
     ) -> Result<()>;
     /// Update the currently undecided state of consensus.  This includes the undecided leaf chain,
     /// and the undecided state.
     async fn update_undecided_state2(
         &self,
-        leafs: CommitmentMap<Leaf2<TYPES>>,
+        leaves: CommitmentMap<Leaf2<TYPES>>,
         state: BTreeMap<TYPES::View, View<TYPES>>,
     ) -> Result<()>;
     /// Upgrade the current decided upgrade certificate in storage.

--- a/flake.nix
+++ b/flake.nix
@@ -173,6 +173,7 @@
             cargo-audit
             nixpkgs-fmt
             git-chglog
+            typos
             protobuf
             python3
             zlib.dev

--- a/scripts/benchmark_scripts/aws_ecs_benchmarks_cdn_gpu.sh
+++ b/scripts/benchmark_scripts/aws_ecs_benchmarks_cdn_gpu.sh
@@ -106,7 +106,7 @@ EOF
                                 sleep 30
 
                                 # start leaders need to run on GPU FIRST
-                                # and WAIT for enough time till it registerred at orchestrator
+                                # and WAIT for enough time till it registered at orchestrator
                                 # make sure you're able to access the remote nvidia gpu server
                                 echo -e "\e[35mGoing to start leaders on remote gpu server $REMOTE_GPU_HOST\e[0m"
                                 


### PR DESCRIPTION
- Add typos to flake.nix.
- Add typos config file: ignore files with false hits.

There are mostly fixes to comments but a few small changes to rust code
as well. Theres should be no functional changes or changes to public
interfaces.