### PR TITLE
Typos fix

### DIFF
--- a/crates/macros/src/lib.rs
+++ b/crates/macros/src/lib.rs
@@ -17,7 +17,7 @@ use syn::{
 /// description of a crosstest
 #[derive(derive_builder::Builder, Debug, Clone)]
 struct CrossTestData {
-    /// imlementations
+    /// implementations
     impls: ExprArray,
     /// builder impl
     #[builder(default = "syn::parse_str(\"[SimpleBuilderImplementation]\").unwrap()")]

--- a/crates/orchestrator/api.toml
+++ b/crates/orchestrator/api.toml
@@ -44,7 +44,7 @@ Supply whether or not we are DA.
 [route.peer_pubconfig_ready]
 PATH = ["peer_pub_ready"]
 DOC = """
-Get whether the node can collect the final config which includs all peer's public config/info like public keys, returns a boolean.
+Get whether the node can collect the final config which includes all peer's public config/info like public keys, returns a boolean.
 """
 
 # POST the updated config with all peers' public keys / configs

--- a/crates/testing/src/block_builder/simple.rs
+++ b/crates/testing/src/block_builder/simple.rs
@@ -238,7 +238,7 @@ where
             .await;
 
         if transactions.is_empty() {
-            // We don't want to return an empty block if we have no trasnactions, as we would end up
+            // We don't want to return an empty block if we have no transactions, as we would end up
             // driving consensus to produce empty blocks extremely quickly when mempool is empty.
             // Instead, we return no blocks, so that view leader will keep asking for blocks until
             // either we have something non-trivial to propose, or leader runs out of time to propose,

--- a/crates/types/src/simple_vote.rs
+++ b/crates/types/src/simple_vote.rs
@@ -337,7 +337,7 @@ impl<TYPES: NodeType> Committable for ViewSyncCommitData<TYPES> {
     }
 }
 
-// impl votable for all the data types in this file sealed marker should ensure nothing is accidently
+// impl votable for all the data types in this file sealed marker should ensure nothing is accidentally
 // implemented for structs that aren't "voteable"
 impl<V: sealed::Sealed + Committable + Clone + Serialize + Debug + PartialEq + Hash + Eq> Voteable
     for V

--- a/docs/diagrams/HotShotFlow.drawio
+++ b/docs/diagrams/HotShotFlow.drawio
@@ -1937,7 +1937,7 @@
         <mxCell id="2Nz8MQJxElo4916phK1H-1" value="Are all events for the same view?&amp;nbsp;" style="whiteSpace=wrap;html=1;rounded=0;fillColor=#dae8fc;strokeColor=#6c8ebf;strokeWidth=2;" vertex="1" parent="1">
           <mxGeometry x="90" y="740" width="120" height="60" as="geometry" />
         </mxCell>
-        <mxCell id="2Nz8MQJxElo4916phK1H-3" value="Events are not for the same veiw" style="whiteSpace=wrap;html=1;fillColor=#f8cecc;strokeColor=#b85450;rounded=1;arcSize=50;verticalLabelPosition=bottom;verticalAlign=top;shape=mxgraph.flowchart.or;strokeWidth=6;" vertex="1" parent="1">
+        <mxCell id="2Nz8MQJxElo4916phK1H-3" value="Events are not for the same view" style="whiteSpace=wrap;html=1;fillColor=#f8cecc;strokeColor=#b85450;rounded=1;arcSize=50;verticalLabelPosition=bottom;verticalAlign=top;shape=mxgraph.flowchart.or;strokeWidth=6;" vertex="1" parent="1">
           <mxGeometry x="300" y="740" width="60" height="60" as="geometry" />
         </mxCell>
         <mxCell id="2Nz8MQJxElo4916phK1H-4" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0;entryY=0.5;entryDx=0;entryDy=0;entryPerimeter=0;" edge="1" parent="1" source="2Nz8MQJxElo4916phK1H-1" target="2Nz8MQJxElo4916phK1H-3">


### PR DESCRIPTION
# Fix typos in the documentation/code/comments

## Description
This request includes corrections for several typos found in the project. Below is a summary of the changes:

- Corrected spelling in the following files:
  - crates/macros/src/lib.rs
  - crates/orchestrator/api.toml
  - crates/testing/src/block_builder/simple.rs
  - crates/types/src/simple_vote.rscrates/types/src/simple_vote.rs
  - docs/diagrams/HotShotFlow.drawio
  
- Replaced misspelled words with their correct versions.


## Conclusion
These changes enhance the readability and professionalism of the project's documentation and codebase by eliminating typos and improving sentence clarity. This contributes to better user experience and easier understanding for contributors and users.
