### PR TITLE
Clarified instruction fix Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ This second window should now display task usage.
 
 To view distributed logs with just the centralized server and one client, first edit the `centralized_server/orchestrator` file to include have a threshold and num_nodes of 1.
 
-Then open 3 terminals.
+Then open three separate terminals.
 
 ```bash
 # Terminal 1


### PR DESCRIPTION
In the "Open Telemetry + Jaeger Integration" section, the instruction "Then open 3 terminals" has been updated to "**Then open three separate terminals**."

This change aims to clarify the instruction and ensure the user understands that they should open three distinct terminal windows, rather than implying a single terminal window with multiple tabs or sessions. 

This small clarification helps avoid confusion, especially for users who may not be familiar with how terminal sessions work, ensuring a smoother setup process.