### PR TITLE
[Libp2p] File-backed Kademlia store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4404,9 +4404,9 @@ dependencies = [
  "pin-project",
  "rand 0.8.5",
  "serde",
- "serde_json",
  "tokio",
  "tracing",
+ "tracing-subscriber 0.3.18",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4404,6 +4404,7 @@ dependencies = [
  "pin-project",
  "rand 0.8.5",
  "serde",
+ "serde_json",
  "tokio",
  "tracing",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ rand_chacha = { version = "0.3", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde-inline-default = "0.2"
 serde_bytes = { version = "0.11" }
-serde_json = { version = "1.0" }
+serde_json = { version = "1" }
 sha2 = "0.10"
 thiserror = "2"
 surf-disco = "0.9"

--- a/crates/libp2p-networking/Cargo.toml
+++ b/crates/libp2p-networking/Cargo.toml
@@ -33,7 +33,7 @@ rand = { workspace = true }
 serde = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
-serde_json = { workspace = true }
+tracing-subscriber = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/libp2p-networking/Cargo.toml
+++ b/crates/libp2p-networking/Cargo.toml
@@ -33,6 +33,7 @@ rand = { workspace = true }
 serde = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
+serde_json = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/libp2p-networking/src/network/behaviours/dht/mod.rs
+++ b/crates/libp2p-networking/src/network/behaviours/dht/mod.rs
@@ -28,7 +28,7 @@ use libp2p::kad::{
     store::RecordStore, Behaviour as KademliaBehaviour, BootstrapError, Event as KademliaEvent,
 };
 use libp2p_identity::PeerId;
-use store::ValidatedStore;
+use store::{file_backed::FileBackedStore, validated::ValidatedStore};
 use tokio::{spawn, sync::mpsc::UnboundedSender, time::sleep};
 use tracing::{debug, error, warn};
 
@@ -143,7 +143,7 @@ impl<K: SignatureKey + 'static> DHTBehaviour<K> {
     /// print out the routing table to stderr
     pub fn print_routing_table(
         &mut self,
-        kadem: &mut KademliaBehaviour<ValidatedStore<MemoryStore, K>>,
+        kadem: &mut KademliaBehaviour<FileBackedStore<ValidatedStore<MemoryStore, K>>>,
     ) {
         let mut err = format!("KBUCKETS: PID: {:?}, ", self.peer_id);
         let v = kadem.kbuckets().collect::<Vec<_>>();
@@ -179,7 +179,7 @@ impl<K: SignatureKey + 'static> DHTBehaviour<K> {
         factor: NonZeroUsize,
         backoff: ExponentialBackoff,
         retry_count: u8,
-        kad: &mut KademliaBehaviour<ValidatedStore<MemoryStore, K>>,
+        kad: &mut KademliaBehaviour<FileBackedStore<ValidatedStore<MemoryStore, K>>>,
     ) {
         // noop
         if retry_count == 0 {
@@ -247,7 +247,7 @@ impl<K: SignatureKey + 'static> DHTBehaviour<K> {
     /// update state based on recv-ed get query
     fn handle_get_query(
         &mut self,
-        store: &mut ValidatedStore<MemoryStore, K>,
+        store: &mut FileBackedStore<ValidatedStore<MemoryStore, K>>,
         record_results: GetRecordResult,
         id: QueryId,
         mut last: bool,
@@ -405,7 +405,7 @@ impl<K: SignatureKey + 'static> DHTBehaviour<K> {
     pub fn dht_handle_event(
         &mut self,
         event: KademliaEvent,
-        store: &mut ValidatedStore<MemoryStore, K>,
+        store: &mut FileBackedStore<ValidatedStore<MemoryStore, K>>,
     ) -> Option<NetworkEvent> {
         match event {
             KademliaEvent::OutboundQueryProgressed {

--- a/crates/libp2p-networking/src/network/behaviours/dht/store/file_backed.rs
+++ b/crates/libp2p-networking/src/network/behaviours/dht/store/file_backed.rs
@@ -1,0 +1,196 @@
+//! This file contains the `FileBackedStore` struct, which is a wrapper around a `RecordStore`
+//! that occasionally saves the DHT to a file on disk.
+
+use std::collections::HashMap;
+
+use anyhow::Context;
+use delegate::delegate;
+use libp2p::kad::store::{RecordStore, Result};
+use tracing::{debug, warn};
+
+/// A `RecordStore` wrapper that occasionally saves the DHT to a file on disk.
+pub struct FileBackedStore<R: RecordStore> {
+    /// The underlying store
+    underlying_store: R,
+
+    /// The path to the file
+    path: String,
+
+    /// The running delta between the records in the file and the records in the underlying store
+    record_delta: u64,
+}
+
+impl<R: RecordStore> FileBackedStore<R> {
+    /// Create a new `FileBackedStore` with the given underlying store and path
+    pub fn new(underlying_store: R, path: String) -> Self {
+        // Create the new store
+        let mut store = FileBackedStore {
+            underlying_store,
+            path: path.clone(),
+            record_delta: 0,
+        };
+
+        // Try to restore the DHT from a file. If it fails, warn and start with an empty store
+        if let Err(err) = store.restore_from_file(path) {
+            warn!(
+                "Failed to restore DHT from file: {:?}. Starting with empty store",
+                err
+            );
+        }
+
+        // Return the new store
+        store
+    }
+
+    /// Attempt to restore the DHT to the underlying store from the file at the given path
+    pub fn restore_from_file(&mut self, path: String) -> anyhow::Result<()> {
+        // Read the contents of the file as a `HashMap` of `Key` to `Vec<u8>`
+        let contents = std::fs::read_to_string(path).with_context(|| "Failed to read DHT file")?;
+
+        // Convert the contents to a `HashMap` of `RecordKey` to `Vec<u8>`
+        let map: HashMap<libp2p::kad::RecordKey, Vec<u8>> =
+            serde_json::from_str(&contents).with_context(|| "Failed to parse DHT file")?;
+
+        // Get all records from the original store and put them in the new store
+        for (record_key, record_value) in map {
+            if let Err(err) = self
+                .underlying_store
+                .put(libp2p::kad::Record::new(record_key, record_value))
+            {
+                warn!("Failed to restore record: {:?}", err);
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Attempt to save the DHT to the file at the given path
+    pub fn save_to_file(&mut self) -> anyhow::Result<()> {
+        debug!("Saving DHT to file");
+
+        // Get all records from the underlying store
+        let records = self.underlying_store.records();
+
+        // Convert the records to a `HashMap` of `RecordKey` to `Vec<u8>`
+        let map: HashMap<libp2p::kad::RecordKey, Vec<u8>> =
+            records.map(|r| (r.key.clone(), r.value.clone())).collect();
+
+        // Serialize the map to a JSON string
+        let contents = serde_json::to_string(&map).with_context(|| "Failed to serialize DHT")?;
+
+        // Write the contents to the file
+        std::fs::write(self.path.clone(), contents)
+            .with_context(|| "Failed to write DHT to file")?;
+
+        debug!("Saved DHT to file");
+
+        Ok(())
+    }
+}
+
+/// Implement the `RecordStore` trait for `FileBackedStore`
+impl<R: RecordStore> RecordStore for FileBackedStore<R> {
+    type ProvidedIter<'a>
+        = R::ProvidedIter<'a>
+    where
+        R: 'a;
+    type RecordsIter<'a>
+        = R::RecordsIter<'a>
+    where
+        R: 'a;
+
+    // Delegate all `RecordStore` methods except `put` to the inner store
+    delegate! {
+        to self.underlying_store {
+            fn add_provider(&mut self, record: libp2p::kad::ProviderRecord) -> libp2p::kad::store::Result<()>;
+            fn get(&self, k: &libp2p::kad::RecordKey) -> Option<std::borrow::Cow<'_, libp2p::kad::Record>>;
+            fn provided(&self) -> Self::ProvidedIter<'_>;
+            fn providers(&self, key: &libp2p::kad::RecordKey) -> Vec<libp2p::kad::ProviderRecord>;
+            fn records(&self) -> Self::RecordsIter<'_>;
+            fn remove_provider(&mut self, k: &libp2p::kad::RecordKey, p: &libp2p::PeerId);
+        }
+    }
+
+    /// Overwrite the `put` method to potentially save the record to a file
+    fn put(&mut self, record: libp2p::kad::Record) -> Result<()> {
+        // Try to write to the underlying store
+        let result = self.underlying_store.put(record);
+
+        // If the record was successfully written, update the record delta
+        if result.is_ok() {
+            self.record_delta += 1;
+
+            // If the record delta is greater than 10, try to save the file
+            if self.record_delta > 10 {
+                if let Err(e) = self.save_to_file() {
+                    warn!("Failed to save DHT to file: {:?}", e);
+                }
+            }
+        }
+
+        result
+    }
+
+    /// Overwrite the `remove` method to potentially remove the record from a file
+    fn remove(&mut self, k: &libp2p::kad::RecordKey) {
+        // Remove the record from the underlying store
+        self.underlying_store.remove(k);
+
+        // Update the record delta
+        self.record_delta += 1;
+
+        // If the record delta is greater than 10, try to save the file
+        if self.record_delta > 10 {
+            if let Err(e) = self.save_to_file() {
+                warn!("Failed to save DHT to file: {:?}", e);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use libp2p::{
+        kad::{store::MemoryStore, RecordKey},
+        PeerId,
+    };
+
+    use super::*;
+
+    #[test]
+    fn test_save_and_restore() {
+        // Create a test store
+        let mut store = FileBackedStore::new(
+            MemoryStore::new(PeerId::random()),
+            "/tmp/test.dht".to_string(),
+        );
+
+        // The key is a string
+        let key = RecordKey::new(&b"test_key".to_vec());
+
+        // The value is a random 16-byte array
+        let random_value = rand::random::<[u8; 16]>();
+
+        // Put a record into the store
+        store
+            .put(libp2p::kad::Record::new(key.clone(), random_value.to_vec()))
+            .expect("Failed to put record into store");
+
+        // Save the store to a file
+        store.save_to_file().expect("Failed to save store to file");
+
+        // Create a new store from the file
+        let new_store = FileBackedStore::new(
+            MemoryStore::new(PeerId::random()),
+            "/tmp/test.dht".to_string(),
+        );
+
+        // Check that the new store has the record
+        let restored_record = new_store
+            .get(&key)
+            .expect("Failed to get record from store");
+
+        // Check that the restored record has the same value as the original record
+        assert_eq!(restored_record.value, random_value.to_vec());
+    }
+}

--- a/crates/libp2p-networking/src/network/behaviours/dht/store/mod.rs
+++ b/crates/libp2p-networking/src/network/behaviours/dht/store/mod.rs
@@ -1,0 +1,2 @@
+pub mod file_backed;
+pub mod validated;

--- a/crates/libp2p-networking/src/network/behaviours/dht/store/validated.rs
+++ b/crates/libp2p-networking/src/network/behaviours/dht/store/validated.rs
@@ -10,8 +10,7 @@ use hotshot_types::traits::signature_key::SignatureKey;
 use libp2p::kad::store::{Error, RecordStore, Result};
 use tracing::warn;
 
-use super::record::RecordValue;
-use crate::network::behaviours::dht::record::RecordKey;
+use crate::network::behaviours::dht::record::{RecordKey, RecordValue};
 
 /// A `RecordStore` wrapper that validates records before storing them.
 pub struct ValidatedStore<R: RecordStore, K: SignatureKey> {

--- a/crates/libp2p-networking/src/network/node.rs
+++ b/crates/libp2p-networking/src/network/node.rs
@@ -59,7 +59,7 @@ pub use self::{
 use super::{
     behaviours::dht::{
         bootstrap::{DHTBootstrapTask, InputEvent},
-        store::ValidatedStore,
+        store::{file_backed::FileBackedStore, validated::ValidatedStore},
     },
     cbor::Cbor,
     gen_transport, BoxedTransport, ClientRequest, NetworkDef, NetworkError, NetworkEvent,
@@ -253,9 +253,19 @@ impl<T: NodeType> NetworkNode<T> {
                 panic!("Replication factor not set");
             }
 
+            // Extract the DHT file path from the config, defaulting to `libp2p_dht.json`
+            let dht_file_path = config
+                .dht_file_path
+                .clone()
+                .unwrap_or_else(|| format!("libp2p_dht.json"));
+
+            // Create the DHT behaviour
             let mut kadem = Behaviour::with_config(
                 peer_id,
-                ValidatedStore::new(MemoryStore::new(peer_id)),
+                FileBackedStore::new(
+                    ValidatedStore::new(MemoryStore::new(peer_id)),
+                    dht_file_path,
+                ),
                 kconfig,
             );
             kadem.set_mode(Some(Mode::Server));

--- a/crates/libp2p-networking/src/network/node.rs
+++ b/crates/libp2p-networking/src/network/node.rs
@@ -257,7 +257,7 @@ impl<T: NodeType> NetworkNode<T> {
             let dht_file_path = config
                 .dht_file_path
                 .clone()
-                .unwrap_or_else(|| format!("libp2p_dht.json"));
+                .unwrap_or_else(|| "libp2p_dht.bin".into());
 
             // Create the DHT behaviour
             let mut kadem = Behaviour::with_config(
@@ -265,6 +265,7 @@ impl<T: NodeType> NetworkNode<T> {
                 FileBackedStore::new(
                     ValidatedStore::new(MemoryStore::new(peer_id)),
                     dht_file_path,
+                    10,
                 ),
                 kconfig,
             );

--- a/crates/libp2p-networking/src/network/node/config.rs
+++ b/crates/libp2p-networking/src/network/node/config.rs
@@ -51,6 +51,10 @@ pub struct NetworkNodeConfig<T: NodeType> {
     #[builder(default)]
     pub stake_table: Option<T::Membership>,
 
+    /// The path to the file to save the DHT to
+    #[builder(default)]
+    pub dht_file_path: Option<String>,
+
     /// The signed authentication message sent to the remote peer
     /// If not supplied we will not send an authentication message during the handshake
     #[builder(default)]


### PR DESCRIPTION
### This PR: 
<!-- Describe what this PR adds to HotSHot -->
<!-- E.g. -->
<!-- * Implements feature 1 -->
<!-- * Implements feature 2 -->
<!-- * Fixes bug 3 -->
Adds and utilizes a file-backed Kademlia store. This allows the Kademlia DHT to persist across restarts. 

### Key places to review: 
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->
`file_backed.rs`

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
