### PR TITLE
Fix Typos in Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ RUST_LOG=$ERROR_LOG_LEVEL RUST_LOG_FORMAT=$ERROR_LOG_FORMAT just run_test test_s
 
 ## Careful
 
-To double check for UB:
+To double-check for UB:
 
 ```bash
 nix develop .#correctnessShell

--- a/crates/examples/push-cdn/README.md
+++ b/crates/examples/push-cdn/README.md
@@ -51,7 +51,7 @@ sleep 1m
 just example_fixed_leader multi-validator-push-cdn -- 9 http://127.0.0.1:4444
 ```
 
-Where ones using `example_gpuvid_leader` could be the leader and should be running on a nvidia GPU, and other validators using `example_fixed_leader` will never be a leader. In practice, these url should be changed to the corresponding ip and port.
+Where ones using `example_gpuvid_leader` could be the leader and should be running on an nvidia GPU, and other validators using `example_fixed_leader` will never be a leader. In practice, these url should be changed to the corresponding ip and port.
 
 
 If you don't have a gpu but want to test out fixed leader, you can run:


### PR DESCRIPTION
This PR addresses minor typographical errors in the documentation to enhance readability and maintain grammatical accuracy:  

1. **README.md**  
   - Corrected "double check" to "double-check".  

2. **crates/examples/push-cdn/README.md**  
   - Updated "a nvidia GPU" to "an nvidia GPU".  

### Key Places to Review  
- `README.md`: Ensure clarity and proper use of "double-check".  
- `crates/examples/push-cdn/README.md`: Verify appropriate grammatical correction.  
