### PR TITLE
make membership functions async

### DIFF
--- a/crates/examples/infra/mod.rs
+++ b/crates/examples/infra/mod.rs
@@ -532,6 +532,7 @@ pub trait RunDa<
             .hotshot
             .memberships
             .committee_leaders(TYPES::View::genesis(), TYPES::Epoch::genesis())
+            .await
             .len();
         let total_num_views = usize::try_from(consensus.locked_view().u64()).unwrap();
         // `failed_num_views` could include uncommitted views

--- a/crates/hotshot/src/lib.rs
+++ b/crates/hotshot/src/lib.rs
@@ -509,7 +509,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> SystemContext<T
                 api
                     .network.da_broadcast_message(
                         serialized_message,
-                        api.memberships.da_committee_members(view_number, TYPES::Epoch::new(1)).iter().cloned().collect(),
+                        api.memberships.da_committee_members(view_number, TYPES::Epoch::new(1)).await.iter().cloned().collect(),
                         BroadcastDelay::None,
                     ),
                 api

--- a/crates/hotshot/src/traits/election/randomized_committee.rs
+++ b/crates/hotshot/src/traits/election/randomized_committee.rs
@@ -102,7 +102,7 @@ impl<TYPES: NodeType> Membership<TYPES> for RandomizedCommittee<TYPES> {
     }
 
     /// Get the stake table for the current view
-    fn stake_table(
+    async fn stake_table(
         &self,
         _epoch: <TYPES as NodeType>::Epoch,
     ) -> Vec<<<TYPES as NodeType>::SignatureKey as SignatureKey>::StakeTableEntry> {
@@ -110,7 +110,7 @@ impl<TYPES: NodeType> Membership<TYPES> for RandomizedCommittee<TYPES> {
     }
 
     /// Get the stake table for the current view
-    fn da_stake_table(
+    async fn da_stake_table(
         &self,
         _epoch: <TYPES as NodeType>::Epoch,
     ) -> Vec<<<TYPES as NodeType>::SignatureKey as SignatureKey>::StakeTableEntry> {
@@ -118,7 +118,7 @@ impl<TYPES: NodeType> Membership<TYPES> for RandomizedCommittee<TYPES> {
     }
 
     /// Get all members of the committee for the current view
-    fn committee_members(
+    async fn committee_members(
         &self,
         _view_number: <TYPES as NodeType>::View,
         _epoch: <TYPES as NodeType>::Epoch,
@@ -130,7 +130,7 @@ impl<TYPES: NodeType> Membership<TYPES> for RandomizedCommittee<TYPES> {
     }
 
     /// Get all members of the committee for the current view
-    fn da_committee_members(
+    async fn da_committee_members(
         &self,
         _view_number: <TYPES as NodeType>::View,
         _epoch: <TYPES as NodeType>::Epoch,
@@ -142,7 +142,7 @@ impl<TYPES: NodeType> Membership<TYPES> for RandomizedCommittee<TYPES> {
     }
 
     /// Get all eligible leaders of the committee for the current view
-    fn committee_leaders(
+    async fn committee_leaders(
         &self,
         _view_number: <TYPES as NodeType>::View,
         _epoch: <TYPES as NodeType>::Epoch,
@@ -154,7 +154,7 @@ impl<TYPES: NodeType> Membership<TYPES> for RandomizedCommittee<TYPES> {
     }
 
     /// Get the stake table entry for a public key
-    fn stake(
+    async fn stake(
         &self,
         pub_key: &<TYPES as NodeType>::SignatureKey,
         _epoch: <TYPES as NodeType>::Epoch,
@@ -164,7 +164,7 @@ impl<TYPES: NodeType> Membership<TYPES> for RandomizedCommittee<TYPES> {
     }
 
     /// Get the stake table entry for a public key
-    fn da_stake(
+    async fn da_stake(
         &self,
         pub_key: &<TYPES as NodeType>::SignatureKey,
         _epoch: <TYPES as NodeType>::Epoch,
@@ -174,7 +174,7 @@ impl<TYPES: NodeType> Membership<TYPES> for RandomizedCommittee<TYPES> {
     }
 
     /// Check if a node has stake in the committee
-    fn has_stake(
+    async fn has_stake(
         &self,
         pub_key: &<TYPES as NodeType>::SignatureKey,
         _epoch: <TYPES as NodeType>::Epoch,
@@ -185,7 +185,7 @@ impl<TYPES: NodeType> Membership<TYPES> for RandomizedCommittee<TYPES> {
     }
 
     /// Check if a node has stake in the committee
-    fn has_da_stake(
+    async fn has_da_stake(
         &self,
         pub_key: &<TYPES as NodeType>::SignatureKey,
         _epoch: <TYPES as NodeType>::Epoch,
@@ -201,7 +201,7 @@ impl<TYPES: NodeType> Membership<TYPES> for RandomizedCommittee<TYPES> {
     // }
 
     /// Index the vector of public keys with the current view number
-    fn lookup_leader(
+    async fn lookup_leader(
         &self,
         view_number: TYPES::View,
         _epoch: <TYPES as NodeType>::Epoch,
@@ -218,30 +218,30 @@ impl<TYPES: NodeType> Membership<TYPES> for RandomizedCommittee<TYPES> {
     }
 
     /// Get the total number of nodes in the committee
-    fn total_nodes(&self, _epoch: <TYPES as NodeType>::Epoch) -> usize {
+    async fn total_nodes(&self, _epoch: <TYPES as NodeType>::Epoch) -> usize {
         self.stake_table.len()
     }
     /// Get the total number of nodes in the committee
-    fn da_total_nodes(&self, _epoch: <TYPES as NodeType>::Epoch) -> usize {
+    async fn da_total_nodes(&self, _epoch: <TYPES as NodeType>::Epoch) -> usize {
         self.da_stake_table.len()
     }
     /// Get the voting success threshold for the committee
-    fn success_threshold(&self, _epoch: <TYPES as NodeType>::Epoch) -> NonZeroU64 {
+    async fn success_threshold(&self, _epoch: <TYPES as NodeType>::Epoch) -> NonZeroU64 {
         NonZeroU64::new(((self.stake_table.len() as u64 * 2) / 3) + 1).unwrap()
     }
 
     /// Get the voting success threshold for the committee
-    fn da_success_threshold(&self, _epoch: <TYPES as NodeType>::Epoch) -> NonZeroU64 {
+    async fn da_success_threshold(&self, _epoch: <TYPES as NodeType>::Epoch) -> NonZeroU64 {
         NonZeroU64::new(((self.da_stake_table.len() as u64 * 2) / 3) + 1).unwrap()
     }
 
     /// Get the voting failure threshold for the committee
-    fn failure_threshold(&self, _epoch: <TYPES as NodeType>::Epoch) -> NonZeroU64 {
+    async fn failure_threshold(&self, _epoch: <TYPES as NodeType>::Epoch) -> NonZeroU64 {
         NonZeroU64::new(((self.stake_table.len() as u64) / 3) + 1).unwrap()
     }
 
     /// Get the voting upgrade threshold for the committee
-    fn upgrade_threshold(&self, _epoch: <TYPES as NodeType>::Epoch) -> NonZeroU64 {
+    async fn upgrade_threshold(&self, _epoch: <TYPES as NodeType>::Epoch) -> NonZeroU64 {
         NonZeroU64::new(max(
             (self.stake_table.len() as u64 * 9) / 10,
             ((self.stake_table.len() as u64 * 2) / 3) + 1,

--- a/crates/hotshot/src/traits/election/randomized_committee_members.rs
+++ b/crates/hotshot/src/traits/election/randomized_committee_members.rs
@@ -125,7 +125,7 @@ impl<TYPES: NodeType, CONFIG: QuorumFilterConfig> Membership<TYPES>
     }
 
     /// Get the stake table for the current view
-    fn stake_table(
+    async fn stake_table(
         &self,
         epoch: <TYPES as NodeType>::Epoch,
     ) -> Vec<<<TYPES as NodeType>::SignatureKey as SignatureKey>::StakeTableEntry> {
@@ -140,7 +140,7 @@ impl<TYPES: NodeType, CONFIG: QuorumFilterConfig> Membership<TYPES>
     }
 
     /// Get the da stake table for the current view
-    fn da_stake_table(
+    async fn da_stake_table(
         &self,
         epoch: <TYPES as NodeType>::Epoch,
     ) -> Vec<<<TYPES as NodeType>::SignatureKey as SignatureKey>::StakeTableEntry> {
@@ -155,11 +155,11 @@ impl<TYPES: NodeType, CONFIG: QuorumFilterConfig> Membership<TYPES>
     }
 
     /// Get all members of the committee for the current view
-    fn committee_members(
+    async fn committee_members(
         &self,
         _view_number: <TYPES as NodeType>::View,
         epoch: <TYPES as NodeType>::Epoch,
-    ) -> BTreeSet<<TYPES as NodeType>::SignatureKey> {
+    ) -> BTreeSet<TYPES::SignatureKey> {
         let filter = self.make_quorum_filter(epoch);
         self.stake_table
             .iter()
@@ -170,7 +170,7 @@ impl<TYPES: NodeType, CONFIG: QuorumFilterConfig> Membership<TYPES>
     }
 
     /// Get all members of the committee for the current view
-    fn da_committee_members(
+    async fn da_committee_members(
         &self,
         _view_number: <TYPES as NodeType>::View,
         epoch: <TYPES as NodeType>::Epoch,
@@ -189,12 +189,12 @@ impl<TYPES: NodeType, CONFIG: QuorumFilterConfig> Membership<TYPES>
         &self,
         view_number: <TYPES as NodeType>::View,
         epoch: <TYPES as NodeType>::Epoch,
-    ) -> BTreeSet<<TYPES as NodeType>::SignatureKey> {
+    ) -> impl futures::Future<Output = BTreeSet<TYPES::SignatureKey>> + Send {
         self.committee_members(view_number, epoch)
     }
 
     /// Get the stake table entry for a public key
-    fn stake(
+    async fn stake(
         &self,
         pub_key: &<TYPES as NodeType>::SignatureKey,
         epoch: <TYPES as NodeType>::Epoch,
@@ -218,7 +218,7 @@ impl<TYPES: NodeType, CONFIG: QuorumFilterConfig> Membership<TYPES>
     }
 
     /// Get the da stake table entry for a public key
-    fn da_stake(
+    async fn da_stake(
         &self,
         pub_key: &<TYPES as NodeType>::SignatureKey,
         epoch: <TYPES as NodeType>::Epoch,
@@ -242,7 +242,7 @@ impl<TYPES: NodeType, CONFIG: QuorumFilterConfig> Membership<TYPES>
     }
 
     /// Check if a node has stake in the committee
-    fn has_stake(
+    async fn has_stake(
         &self,
         pub_key: &<TYPES as NodeType>::SignatureKey,
         epoch: <TYPES as NodeType>::Epoch,
@@ -267,7 +267,7 @@ impl<TYPES: NodeType, CONFIG: QuorumFilterConfig> Membership<TYPES>
     }
 
     /// Check if a node has stake in the committee
-    fn has_da_stake(
+    async fn has_da_stake(
         &self,
         pub_key: &<TYPES as NodeType>::SignatureKey,
         epoch: <TYPES as NodeType>::Epoch,
@@ -292,7 +292,7 @@ impl<TYPES: NodeType, CONFIG: QuorumFilterConfig> Membership<TYPES>
     }
 
     /// Index the vector of public keys with the current view number
-    fn lookup_leader(
+    async fn lookup_leader(
         &self,
         view_number: TYPES::View,
         epoch: <TYPES as NodeType>::Epoch,
@@ -318,36 +318,36 @@ impl<TYPES: NodeType, CONFIG: QuorumFilterConfig> Membership<TYPES>
     }
 
     /// Get the total number of nodes in the committee
-    fn total_nodes(&self, epoch: <TYPES as NodeType>::Epoch) -> usize {
+    async fn total_nodes(&self, epoch: <TYPES as NodeType>::Epoch) -> usize {
         self.make_quorum_filter(epoch).len()
     }
 
     /// Get the total number of nodes in the committee
-    fn da_total_nodes(&self, epoch: <TYPES as NodeType>::Epoch) -> usize {
+    async fn da_total_nodes(&self, epoch: <TYPES as NodeType>::Epoch) -> usize {
         self.make_da_quorum_filter(epoch).len()
     }
 
     /// Get the voting success threshold for the committee
-    fn success_threshold(&self, epoch: <TYPES as NodeType>::Epoch) -> NonZeroU64 {
-        let len = self.total_nodes(epoch);
+    async fn success_threshold(&self, epoch: <TYPES as NodeType>::Epoch) -> NonZeroU64 {
+        let len = self.total_nodes(epoch).await;
         NonZeroU64::new(((len as u64 * 2) / 3) + 1).unwrap()
     }
 
     /// Get the voting success threshold for the committee
-    fn da_success_threshold(&self, epoch: <TYPES as NodeType>::Epoch) -> NonZeroU64 {
-        let len = self.da_total_nodes(epoch);
+    async fn da_success_threshold(&self, epoch: <TYPES as NodeType>::Epoch) -> NonZeroU64 {
+        let len = self.da_total_nodes(epoch).await;
         NonZeroU64::new(((len as u64 * 2) / 3) + 1).unwrap()
     }
 
     /// Get the voting failure threshold for the committee
-    fn failure_threshold(&self, epoch: <TYPES as NodeType>::Epoch) -> NonZeroU64 {
-        let len = self.total_nodes(epoch);
+    async fn failure_threshold(&self, epoch: <TYPES as NodeType>::Epoch) -> NonZeroU64 {
+        let len = self.total_nodes(epoch).await;
         NonZeroU64::new(((len as u64) / 3) + 1).unwrap()
     }
 
     /// Get the voting upgrade threshold for the committee
-    fn upgrade_threshold(&self, epoch: <TYPES as NodeType>::Epoch) -> NonZeroU64 {
-        let len = self.total_nodes(epoch);
+    async fn upgrade_threshold(&self, epoch: <TYPES as NodeType>::Epoch) -> NonZeroU64 {
+        let len = self.total_nodes(epoch).await;
         NonZeroU64::new(max((len as u64 * 9) / 10, ((len as u64 * 2) / 3) + 1)).unwrap()
     }
 }

--- a/crates/hotshot/src/traits/election/static_committee.rs
+++ b/crates/hotshot/src/traits/election/static_committee.rs
@@ -99,7 +99,7 @@ impl<TYPES: NodeType> Membership<TYPES> for StaticCommittee<TYPES> {
     }
 
     /// Get the stake table for the current view
-    fn stake_table(
+    async fn stake_table(
         &self,
         _epoch: <TYPES as NodeType>::Epoch,
     ) -> Vec<<<TYPES as NodeType>::SignatureKey as SignatureKey>::StakeTableEntry> {
@@ -107,7 +107,7 @@ impl<TYPES: NodeType> Membership<TYPES> for StaticCommittee<TYPES> {
     }
 
     /// Get the stake table for the current view
-    fn da_stake_table(
+    async fn da_stake_table(
         &self,
         _epoch: <TYPES as NodeType>::Epoch,
     ) -> Vec<<<TYPES as NodeType>::SignatureKey as SignatureKey>::StakeTableEntry> {
@@ -115,7 +115,7 @@ impl<TYPES: NodeType> Membership<TYPES> for StaticCommittee<TYPES> {
     }
 
     /// Get all members of the committee for the current view
-    fn committee_members(
+    async fn committee_members(
         &self,
         _view_number: <TYPES as NodeType>::View,
         _epoch: <TYPES as NodeType>::Epoch,
@@ -127,7 +127,7 @@ impl<TYPES: NodeType> Membership<TYPES> for StaticCommittee<TYPES> {
     }
 
     /// Get all members of the committee for the current view
-    fn da_committee_members(
+    async fn da_committee_members(
         &self,
         _view_number: <TYPES as NodeType>::View,
         _epoch: <TYPES as NodeType>::Epoch,
@@ -139,7 +139,7 @@ impl<TYPES: NodeType> Membership<TYPES> for StaticCommittee<TYPES> {
     }
 
     /// Get all eligible leaders of the committee for the current view
-    fn committee_leaders(
+    async fn committee_leaders(
         &self,
         _view_number: <TYPES as NodeType>::View,
         _epoch: <TYPES as NodeType>::Epoch,
@@ -151,7 +151,7 @@ impl<TYPES: NodeType> Membership<TYPES> for StaticCommittee<TYPES> {
     }
 
     /// Get the stake table entry for a public key
-    fn stake(
+    async fn stake(
         &self,
         pub_key: &<TYPES as NodeType>::SignatureKey,
         _epoch: <TYPES as NodeType>::Epoch,
@@ -161,7 +161,7 @@ impl<TYPES: NodeType> Membership<TYPES> for StaticCommittee<TYPES> {
     }
 
     /// Get the DA stake table entry for a public key
-    fn da_stake(
+    async fn da_stake(
         &self,
         pub_key: &<TYPES as NodeType>::SignatureKey,
         _epoch: <TYPES as NodeType>::Epoch,
@@ -171,7 +171,7 @@ impl<TYPES: NodeType> Membership<TYPES> for StaticCommittee<TYPES> {
     }
 
     /// Check if a node has stake in the committee
-    fn has_stake(
+    async fn has_stake(
         &self,
         pub_key: &<TYPES as NodeType>::SignatureKey,
         _epoch: <TYPES as NodeType>::Epoch,
@@ -182,7 +182,7 @@ impl<TYPES: NodeType> Membership<TYPES> for StaticCommittee<TYPES> {
     }
 
     /// Check if a node has stake in the committee
-    fn has_da_stake(
+    async fn has_da_stake(
         &self,
         pub_key: &<TYPES as NodeType>::SignatureKey,
         _epoch: <TYPES as NodeType>::Epoch,
@@ -193,7 +193,7 @@ impl<TYPES: NodeType> Membership<TYPES> for StaticCommittee<TYPES> {
     }
 
     /// Index the vector of public keys with the current view number
-    fn lookup_leader(
+    async fn lookup_leader(
         &self,
         view_number: TYPES::View,
         _epoch: <TYPES as NodeType>::Epoch,
@@ -205,32 +205,32 @@ impl<TYPES: NodeType> Membership<TYPES> for StaticCommittee<TYPES> {
     }
 
     /// Get the total number of nodes in the committee
-    fn total_nodes(&self, _epoch: <TYPES as NodeType>::Epoch) -> usize {
+    async fn total_nodes(&self, _epoch: <TYPES as NodeType>::Epoch) -> usize {
         self.stake_table.len()
     }
 
     /// Get the total number of DA nodes in the committee
-    fn da_total_nodes(&self, _epoch: <TYPES as NodeType>::Epoch) -> usize {
+    async fn da_total_nodes(&self, _epoch: <TYPES as NodeType>::Epoch) -> usize {
         self.da_stake_table.len()
     }
 
     /// Get the voting success threshold for the committee
-    fn success_threshold(&self, _epoch: <TYPES as NodeType>::Epoch) -> NonZeroU64 {
+    async fn success_threshold(&self, _epoch: <TYPES as NodeType>::Epoch) -> NonZeroU64 {
         NonZeroU64::new(((self.stake_table.len() as u64 * 2) / 3) + 1).unwrap()
     }
 
     /// Get the voting success threshold for the committee
-    fn da_success_threshold(&self, _epoch: <TYPES as NodeType>::Epoch) -> NonZeroU64 {
+    async fn da_success_threshold(&self, _epoch: <TYPES as NodeType>::Epoch) -> NonZeroU64 {
         NonZeroU64::new(((self.da_stake_table.len() as u64 * 2) / 3) + 1).unwrap()
     }
 
     /// Get the voting failure threshold for the committee
-    fn failure_threshold(&self, _epoch: <TYPES as NodeType>::Epoch) -> NonZeroU64 {
+    async fn failure_threshold(&self, _epoch: <TYPES as NodeType>::Epoch) -> NonZeroU64 {
         NonZeroU64::new(((self.stake_table.len() as u64) / 3) + 1).unwrap()
     }
 
     /// Get the voting upgrade threshold for the committee
-    fn upgrade_threshold(&self, _epoch: <TYPES as NodeType>::Epoch) -> NonZeroU64 {
+    async fn upgrade_threshold(&self, _epoch: <TYPES as NodeType>::Epoch) -> NonZeroU64 {
         let len = self.stake_table.len();
         NonZeroU64::new(max((len as u64 * 9) / 10, ((len as u64 * 2) / 3) + 1)).unwrap()
     }

--- a/crates/hotshot/src/traits/election/static_committee_leader_two_views.rs
+++ b/crates/hotshot/src/traits/election/static_committee_leader_two_views.rs
@@ -100,7 +100,7 @@ impl<TYPES: NodeType> Membership<TYPES> for StaticCommitteeLeaderForTwoViews<TYP
     }
 
     /// Get the stake table for the current view
-    fn stake_table(
+    async fn stake_table(
         &self,
         _epoch: <TYPES as NodeType>::Epoch,
     ) -> Vec<<<TYPES as NodeType>::SignatureKey as SignatureKey>::StakeTableEntry> {
@@ -108,7 +108,7 @@ impl<TYPES: NodeType> Membership<TYPES> for StaticCommitteeLeaderForTwoViews<TYP
     }
 
     /// Get the stake table for the current view
-    fn da_stake_table(
+    async fn da_stake_table(
         &self,
         _epoch: <TYPES as NodeType>::Epoch,
     ) -> Vec<<<TYPES as NodeType>::SignatureKey as SignatureKey>::StakeTableEntry> {
@@ -116,7 +116,7 @@ impl<TYPES: NodeType> Membership<TYPES> for StaticCommitteeLeaderForTwoViews<TYP
     }
 
     /// Get all members of the committee for the current view
-    fn committee_members(
+    async fn committee_members(
         &self,
         _view_number: <TYPES as NodeType>::View,
         _epoch: <TYPES as NodeType>::Epoch,
@@ -128,7 +128,7 @@ impl<TYPES: NodeType> Membership<TYPES> for StaticCommitteeLeaderForTwoViews<TYP
     }
 
     /// Get all members of the committee for the current view
-    fn da_committee_members(
+    async fn da_committee_members(
         &self,
         _view_number: <TYPES as NodeType>::View,
         _epoch: <TYPES as NodeType>::Epoch,
@@ -140,7 +140,7 @@ impl<TYPES: NodeType> Membership<TYPES> for StaticCommitteeLeaderForTwoViews<TYP
     }
 
     /// Get all eligible leaders of the committee for the current view
-    fn committee_leaders(
+    async fn committee_leaders(
         &self,
         _view_number: <TYPES as NodeType>::View,
         _epoch: <TYPES as NodeType>::Epoch,
@@ -152,7 +152,7 @@ impl<TYPES: NodeType> Membership<TYPES> for StaticCommitteeLeaderForTwoViews<TYP
     }
 
     /// Get the stake table entry for a public key
-    fn stake(
+    async fn stake(
         &self,
         pub_key: &<TYPES as NodeType>::SignatureKey,
         _epoch: <TYPES as NodeType>::Epoch,
@@ -162,7 +162,7 @@ impl<TYPES: NodeType> Membership<TYPES> for StaticCommitteeLeaderForTwoViews<TYP
     }
 
     /// Get DA the stake table entry for a public key
-    fn da_stake(
+    async fn da_stake(
         &self,
         pub_key: &<TYPES as NodeType>::SignatureKey,
         _epoch: <TYPES as NodeType>::Epoch,
@@ -172,7 +172,7 @@ impl<TYPES: NodeType> Membership<TYPES> for StaticCommitteeLeaderForTwoViews<TYP
     }
 
     /// Check if a node has stake in the committee
-    fn has_stake(
+    async fn has_stake(
         &self,
         pub_key: &<TYPES as NodeType>::SignatureKey,
         _epoch: <TYPES as NodeType>::Epoch,
@@ -183,7 +183,7 @@ impl<TYPES: NodeType> Membership<TYPES> for StaticCommitteeLeaderForTwoViews<TYP
     }
 
     /// Check if a node has stake in the committee
-    fn has_da_stake(
+    async fn has_da_stake(
         &self,
         pub_key: &<TYPES as NodeType>::SignatureKey,
         _epoch: <TYPES as NodeType>::Epoch,
@@ -194,7 +194,7 @@ impl<TYPES: NodeType> Membership<TYPES> for StaticCommitteeLeaderForTwoViews<TYP
     }
 
     /// Index the vector of public keys with the current view number
-    fn lookup_leader(
+    async fn lookup_leader(
         &self,
         view_number: TYPES::View,
         _epoch: <TYPES as NodeType>::Epoch,
@@ -207,32 +207,32 @@ impl<TYPES: NodeType> Membership<TYPES> for StaticCommitteeLeaderForTwoViews<TYP
     }
 
     /// Get the total number of nodes in the committee
-    fn total_nodes(&self, _epoch: <TYPES as NodeType>::Epoch) -> usize {
+    async fn total_nodes(&self, _epoch: <TYPES as NodeType>::Epoch) -> usize {
         self.stake_table.len()
     }
 
     /// Get the total number of DA nodes in the committee
-    fn da_total_nodes(&self, _epoch: <TYPES as NodeType>::Epoch) -> usize {
+    async fn da_total_nodes(&self, _epoch: <TYPES as NodeType>::Epoch) -> usize {
         self.da_stake_table.len()
     }
 
     /// Get the voting success threshold for the committee
-    fn success_threshold(&self, _epoch: <TYPES as NodeType>::Epoch) -> NonZeroU64 {
+    async fn success_threshold(&self, _epoch: <TYPES as NodeType>::Epoch) -> NonZeroU64 {
         NonZeroU64::new(((self.stake_table.len() as u64 * 2) / 3) + 1).unwrap()
     }
 
     /// Get the voting success threshold for the committee
-    fn da_success_threshold(&self, _epoch: <TYPES as NodeType>::Epoch) -> NonZeroU64 {
+    async fn da_success_threshold(&self, _epoch: <TYPES as NodeType>::Epoch) -> NonZeroU64 {
         NonZeroU64::new(((self.da_stake_table.len() as u64 * 2) / 3) + 1).unwrap()
     }
 
     /// Get the voting failure threshold for the committee
-    fn failure_threshold(&self, _epoch: <TYPES as NodeType>::Epoch) -> NonZeroU64 {
+    async fn failure_threshold(&self, _epoch: <TYPES as NodeType>::Epoch) -> NonZeroU64 {
         NonZeroU64::new(((self.stake_table.len() as u64) / 3) + 1).unwrap()
     }
 
     /// Get the voting upgrade threshold for the committee
-    fn upgrade_threshold(&self, _epoch: <TYPES as NodeType>::Epoch) -> NonZeroU64 {
+    async fn upgrade_threshold(&self, _epoch: <TYPES as NodeType>::Epoch) -> NonZeroU64 {
         NonZeroU64::new(((self.stake_table.len() as u64 * 9) / 10) + 1).unwrap()
     }
 }

--- a/crates/hotshot/src/traits/networking/libp2p_network.rs
+++ b/crates/hotshot/src/traits/networking/libp2p_network.rs
@@ -984,7 +984,7 @@ impl<T: NodeType> ConnectedNetwork<T::SignatureKey> for Libp2pNetwork<T> {
     {
         let future_view = <TYPES as NodeType>::View::new(view) + LOOK_AHEAD;
         let epoch = <TYPES as NodeType>::Epoch::new(epoch);
-        let future_leader = match membership.leader(future_view, epoch) {
+        let future_leader = match membership.leader(future_view, epoch).await {
             Ok(l) => l,
             Err(e) => {
                 return tracing::info!(

--- a/crates/hotshot/src/types/handle.rs
+++ b/crates/hotshot/src/types/handle.rs
@@ -187,7 +187,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static, V: Versions>
                 if let HotShotEvent::QuorumProposalResponseRecv(quorum_proposal) = hs_event.as_ref()
                 {
                     // Make sure that the quorum_proposal is valid
-                    if let Err(err) = quorum_proposal.validate_signature(&mem, epoch) {
+                    if let Err(err) = quorum_proposal.validate_signature(&mem, epoch).await {
                         tracing::warn!("Invalid Proposal Received after Request.  Err {:?}", err);
                         continue;
                     }
@@ -327,6 +327,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static, V: Versions>
         self.hotshot
             .memberships
             .leader(view_number, epoch_number)
+            .await
             .context("Failed to lookup leader")
     }
 

--- a/crates/libp2p-networking/src/network/transport.rs
+++ b/crates/libp2p-networking/src/network/transport.rs
@@ -136,7 +136,10 @@ impl<T: Transport, Types: NodeType, C: StreamMuxer + Unpin> StakeTableAuthentica
             }
 
             // Check if the public key is in the stake table
-            if !stake_table.has_stake(&public_key, Types::Epoch::new(0)) {
+            if !stake_table
+                .has_stake(&public_key, Types::Epoch::new(0))
+                .await
+            {
                 return Err(anyhow::anyhow!("Peer not in stake table"));
             }
         }

--- a/crates/task-impls/src/consensus/handlers.rs
+++ b/crates/task-impls/src/consensus/handlers.rs
@@ -46,7 +46,8 @@ pub(crate) async fn handle_quorum_vote_recv<
         .is_leaf_extended(vote.data.leaf_commit);
     let we_are_leader = task_state
         .membership
-        .leader(vote.view_number() + 1, task_state.cur_epoch)?
+        .leader(vote.view_number() + 1, task_state.cur_epoch)
+        .await?
         == task_state.public_key;
     ensure!(
         is_vote_leaf_extended || we_are_leader,
@@ -88,7 +89,8 @@ pub(crate) async fn handle_timeout_vote_recv<
     ensure!(
         task_state
             .membership
-            .leader(vote.view_number() + 1, task_state.cur_epoch)?
+            .leader(vote.view_number() + 1, task_state.cur_epoch)
+            .await?
             == task_state.public_key,
         info!(
             "We are not the leader for view {:?}",
@@ -132,7 +134,8 @@ pub async fn send_high_qc<TYPES: NodeType, V: Versions, I: NodeImplementation<TY
     let high_qc = task_state.consensus.read().await.high_qc().clone();
     let leader = task_state
         .membership
-        .leader(new_view_number, TYPES::Epoch::new(0))?;
+        .leader(new_view_number, TYPES::Epoch::new(0))
+        .await?;
     broadcast_event(
         Arc::new(HotShotEvent::HighQcSend(
             high_qc,
@@ -232,7 +235,8 @@ pub(crate) async fn handle_view_change<
     let cur_view_time = Utc::now().timestamp();
     if task_state
         .membership
-        .leader(old_view_number, task_state.cur_epoch)?
+        .leader(old_view_number, task_state.cur_epoch)
+        .await?
         == task_state.public_key
     {
         #[allow(clippy::cast_precision_loss)]
@@ -285,7 +289,8 @@ pub(crate) async fn handle_timeout<TYPES: NodeType, I: NodeImplementation<TYPES>
     ensure!(
         task_state
             .membership
-            .has_stake(&task_state.public_key, task_state.cur_epoch),
+            .has_stake(&task_state.public_key, task_state.cur_epoch)
+            .await,
         debug!(
             "We were not chosen for the consensus committee for view {:?}",
             view_number
@@ -336,7 +341,8 @@ pub(crate) async fn handle_timeout<TYPES: NodeType, I: NodeImplementation<TYPES>
         .add(1);
     if task_state
         .membership
-        .leader(view_number, task_state.cur_epoch)?
+        .leader(view_number, task_state.cur_epoch)
+        .await?
         == task_state.public_key
     {
         task_state

--- a/crates/task-impls/src/da.rs
+++ b/crates/task-impls/src/da.rs
@@ -120,7 +120,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> DaTaskState<TYP
                 );
 
                 let encoded_transactions_hash = Sha256::digest(&proposal.data.encoded_transactions);
-                let view_leader_key = self.membership.leader(view, self.cur_epoch)?;
+                let view_leader_key = self.membership.leader(view, self.cur_epoch).await?;
                 ensure!(
                     view_leader_key == sender,
                     warn!(
@@ -169,7 +169,9 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> DaTaskState<TYP
                 .await;
 
                 ensure!(
-                    self.membership.has_da_stake(&self.public_key, epoch_number),
+                    self.membership
+                        .has_da_stake(&self.public_key, epoch_number)
+                        .await,
                     debug!(
                         "We were not chosen for consensus committee for view {:?} in epoch {:?}",
                         view_number, epoch_number
@@ -177,7 +179,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> DaTaskState<TYP
                 );
 
                 let txns = Arc::clone(&proposal.data.encoded_transactions);
-                let num_nodes = self.membership.total_nodes(epoch_number);
+                let num_nodes = self.membership.total_nodes(epoch_number).await;
                 let payload_commitment =
                     spawn_blocking(move || vid_commitment(&txns, num_nodes)).await;
                 let payload_commitment = payload_commitment.unwrap();
@@ -262,11 +264,11 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> DaTaskState<TYP
                 let view = vote.view_number();
 
                 ensure!(
-                    self.membership.leader(view, self.cur_epoch)? == self.public_key,
+                    self.membership.leader(view, self.cur_epoch).await? == self.public_key,
                     debug!(
                       "We are not the DA committee leader for view {} are we leader for next view? {}",
                       *view,
-                      self.membership.leader(view + 1, self.cur_epoch)? == self.public_key
+                      self.membership.leader(view + 1, self.cur_epoch).await? == self.public_key
                     )
                 );
 

--- a/crates/task-impls/src/quorum_proposal/handlers.rs
+++ b/crates/task-impls/src/quorum_proposal/handlers.rs
@@ -128,9 +128,12 @@ impl<TYPES: NodeType, V: Versions> ProposalDependencyHandle<TYPES, V> {
                     .is_valid_cert(
                         // TODO take epoch from `qc`
                         // https://github.com/EspressoSystems/HotShot/issues/3917
-                        self.quorum_membership.stake_table(TYPES::Epoch::new(0)),
                         self.quorum_membership
-                            .success_threshold(TYPES::Epoch::new(0)),
+                            .stake_table(TYPES::Epoch::new(0))
+                            .await,
+                        self.quorum_membership
+                            .success_threshold(TYPES::Epoch::new(0))
+                            .await,
                         &self.upgrade_lock,
                     )
                     .await

--- a/crates/task-impls/src/quorum_proposal_recv/handlers.rs
+++ b/crates/task-impls/src/quorum_proposal_recv/handlers.rs
@@ -156,10 +156,12 @@ pub(crate) async fn handle_quorum_proposal_recv<
         .is_valid_cert(
             validation_info
                 .quorum_membership
-                .stake_table(justify_qc.data.epoch),
+                .stake_table(justify_qc.data.epoch)
+                .await,
             validation_info
                 .quorum_membership
-                .success_threshold(justify_qc.data.epoch),
+                .success_threshold(justify_qc.data.epoch)
+                .await,
             &validation_info.upgrade_lock,
         )
         .await

--- a/crates/task-impls/src/quorum_vote/handlers.rs
+++ b/crates/task-impls/src/quorum_vote/handlers.rs
@@ -60,6 +60,7 @@ async fn handle_quorum_proposal_validated_drb_calculation_start<
     if task_state
         .membership
         .has_stake(&task_state.public_key, current_epoch_number)
+        .await
     {
         task_state
             .drb_computations
@@ -80,7 +81,7 @@ async fn handle_quorum_proposal_validated_drb_calculation_start<
 ///
 /// We don't need to handle the special cases explicitly here, because the first proposal
 /// with which we'll start the DRB computation is for epoch 3.
-fn handle_quorum_proposal_validated_drb_calculation_seed<
+async fn handle_quorum_proposal_validated_drb_calculation_seed<
     TYPES: NodeType,
     I: NodeImplementation<TYPES>,
     V: Versions,
@@ -113,6 +114,7 @@ fn handle_quorum_proposal_validated_drb_calculation_seed<
         if task_state
             .membership
             .has_stake(&task_state.public_key, current_epoch_number + 1)
+            .await
         {
             let new_epoch_number = current_epoch_number + 2;
             let Ok(drb_seed_input_vec) = bincode::serialize(&proposal.justify_qc.signatures) else {
@@ -252,7 +254,8 @@ pub(crate) async fn handle_quorum_proposal_validated<
                 proposal,
                 task_state,
                 &leaf_views,
-            )?;
+            )
+            .await?;
         }
     }
 
@@ -411,7 +414,7 @@ pub(crate) async fn submit_vote<TYPES: NodeType, I: NodeImplementation<TYPES>, V
     ));
 
     ensure!(
-        quorum_membership.has_stake(&public_key, epoch_number),
+        quorum_membership.has_stake(&public_key, epoch_number).await,
         info!(
             "We were not chosen for quorum committee on {:?}",
             view_number

--- a/crates/task-impls/src/quorum_vote/mod.rs
+++ b/crates/task-impls/src/quorum_vote/mod.rs
@@ -500,8 +500,8 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> QuorumVoteTaskS
                 // Validate the DAC.
                 ensure!(
                     cert.is_valid_cert(
-                        self.membership.da_stake_table(cur_epoch),
-                        self.membership.da_success_threshold(cur_epoch),
+                        self.membership.da_stake_table(cur_epoch).await,
+                        self.membership.da_success_threshold(cur_epoch).await,
                         &self.upgrade_lock
                     )
                     .await,
@@ -544,14 +544,15 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> QuorumVoteTaskS
                 ensure!(
                     self.membership
                         .da_committee_members(view, cur_epoch)
+                        .await
                         .contains(sender)
-                        || *sender == self.membership.leader(view, cur_epoch)?,
+                        || *sender == self.membership.leader(view, cur_epoch).await?,
                     "VID share was not sent by a DA member or the view leader."
                 );
 
                 // NOTE: `verify_share` returns a nested `Result`, so we must check both the inner
                 // and outer results
-                match vid_scheme(self.membership.total_nodes(cur_epoch)).verify_share(
+                match vid_scheme(self.membership.total_nodes(cur_epoch).await).verify_share(
                     &disperse.data.share,
                     &disperse.data.common,
                     payload_commitment,

--- a/crates/task-impls/src/request.rs
+++ b/crates/task-impls/src/request.rs
@@ -113,7 +113,8 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> TaskState for NetworkRequest
                         .vid_shares()
                         .contains_key(&prop_view)
                 {
-                    self.spawn_requests(prop_view, prop_epoch, sender, receiver).await;
+                    self.spawn_requests(prop_view, prop_epoch, sender, receiver)
+                        .await;
                 }
                 Ok(())
             }

--- a/crates/task-impls/src/response.rs
+++ b/crates/task-impls/src/response.rs
@@ -72,7 +72,9 @@ impl<TYPES: NodeType> NetworkResponseState<TYPES> {
                     match event.as_ref() {
                         HotShotEvent::VidRequestRecv(request, sender) => {
                             // Verify request is valid
-                            if !self.valid_sender(sender, self.consensus.read().await.cur_epoch())
+                            if !self
+                                .valid_sender(sender, self.consensus.read().await.cur_epoch())
+                                .await
                                 || !valid_signature::<TYPES>(request, sender)
                             {
                                 continue;
@@ -181,8 +183,8 @@ impl<TYPES: NodeType> NetworkResponseState<TYPES> {
     }
 
     /// Makes sure the sender is allowed to send a request in the given epoch.
-    fn valid_sender(&self, sender: &TYPES::SignatureKey, epoch: TYPES::Epoch) -> bool {
-        self.quorum.has_stake(sender, epoch)
+    async fn valid_sender(&self, sender: &TYPES::SignatureKey, epoch: TYPES::Epoch) -> bool {
+        self.quorum.has_stake(sender, epoch).await
     }
 }
 

--- a/crates/task-impls/src/view_sync.rs
+++ b/crates/task-impls/src/view_sync.rs
@@ -309,7 +309,10 @@ impl<TYPES: NodeType, V: Versions> ViewSyncTaskState<TYPES, V> {
 
                 // We do not have a relay task already running, so start one
                 ensure!(
-                    self.membership.leader(vote_view + relay, self.cur_epoch)? == self.public_key,
+                    self.membership
+                        .leader(vote_view + relay, self.cur_epoch)
+                        .await?
+                        == self.public_key,
                     "View sync vote sent to wrong leader"
                 );
 
@@ -354,7 +357,10 @@ impl<TYPES: NodeType, V: Versions> ViewSyncTaskState<TYPES, V> {
 
                 // We do not have a relay task already running, so start one
                 ensure!(
-                    self.membership.leader(vote_view + relay, self.cur_epoch)? == self.public_key,
+                    self.membership
+                        .leader(vote_view + relay, self.cur_epoch)
+                        .await?
+                        == self.public_key,
                     debug!("View sync vote sent to wrong leader")
                 );
 
@@ -399,7 +405,10 @@ impl<TYPES: NodeType, V: Versions> ViewSyncTaskState<TYPES, V> {
 
                 // We do not have a relay task already running, so start one
                 ensure!(
-                    self.membership.leader(vote_view + relay, self.cur_epoch)? == self.public_key,
+                    self.membership
+                        .leader(vote_view + relay, self.cur_epoch)
+                        .await?
+                        == self.public_key,
                     debug!("View sync vote sent to wrong leader")
                 );
 
@@ -472,7 +481,7 @@ impl<TYPES: NodeType, V: Versions> ViewSyncTaskState<TYPES, V> {
                 );
 
                 self.num_timeouts_tracked += 1;
-                let leader = self.membership.leader(view_number, self.cur_epoch)?;
+                let leader = self.membership.leader(view_number, self.cur_epoch).await?;
                 tracing::warn!(
                     %leader,
                     leader_mnemonic = hotshot_types::utils::mnemonic(&leader),
@@ -533,8 +542,8 @@ impl<TYPES: NodeType, V: Versions> ViewSyncReplicaTaskState<TYPES, V> {
                 // If certificate is not valid, return current state
                 if !certificate
                     .is_valid_cert(
-                        self.membership.stake_table(self.cur_epoch),
-                        self.membership.failure_threshold(self.cur_epoch),
+                        self.membership.stake_table(self.cur_epoch).await,
+                        self.membership.failure_threshold(self.cur_epoch).await,
                         &self.upgrade_lock,
                     )
                     .await
@@ -619,8 +628,8 @@ impl<TYPES: NodeType, V: Versions> ViewSyncReplicaTaskState<TYPES, V> {
                 // If certificate is not valid, return current state
                 if !certificate
                     .is_valid_cert(
-                        self.membership.stake_table(self.cur_epoch),
-                        self.membership.success_threshold(self.cur_epoch),
+                        self.membership.stake_table(self.cur_epoch).await,
+                        self.membership.success_threshold(self.cur_epoch).await,
                         &self.upgrade_lock,
                     )
                     .await
@@ -716,8 +725,8 @@ impl<TYPES: NodeType, V: Versions> ViewSyncReplicaTaskState<TYPES, V> {
                 // If certificate is not valid, return current state
                 if !certificate
                     .is_valid_cert(
-                        self.membership.stake_table(self.cur_epoch),
-                        self.membership.success_threshold(self.cur_epoch),
+                        self.membership.stake_table(self.cur_epoch).await,
+                        self.membership.success_threshold(self.cur_epoch).await,
                         &self.upgrade_lock,
                     )
                     .await

--- a/crates/task-impls/src/vote_collection.rs
+++ b/crates/task-impls/src/vote_collection.rs
@@ -83,7 +83,7 @@ pub trait AggregatableVote<
         &self,
         membership: &TYPES::Membership,
         epoch: TYPES::Epoch,
-    ) -> Result<TYPES::SignatureKey>;
+    ) -> impl std::future::Future<Output = Result<TYPES::SignatureKey>> + Send;
 
     /// return the Hotshot event for the completion of this CERT
     fn make_cert_event(certificate: CERT, key: &TYPES::SignatureKey) -> HotShotEvent<TYPES>;
@@ -109,7 +109,7 @@ impl<
     ) -> Result<Option<CERT>> {
         if self.check_if_leader {
             ensure!(
-                vote.leader(&self.membership, self.epoch)? == self.public_key,
+                vote.leader(&self.membership, self.epoch).await? == self.public_key,
                 info!("Received vote for a view in which we were not the leader.")
             );
         }
@@ -336,12 +336,12 @@ type ViewSyncFinalizeVoteState<TYPES, V> = VoteCollectionTaskState<
 impl<TYPES: NodeType> AggregatableVote<TYPES, QuorumVote<TYPES>, QuorumCertificate<TYPES>>
     for QuorumVote<TYPES>
 {
-    fn leader(
+    async fn leader(
         &self,
         membership: &TYPES::Membership,
         epoch: TYPES::Epoch,
     ) -> Result<TYPES::SignatureKey> {
-        membership.leader(self.view_number() + 1, epoch)
+        membership.leader(self.view_number() + 1, epoch).await
     }
     fn make_cert_event(
         certificate: QuorumCertificate<TYPES>,
@@ -354,12 +354,12 @@ impl<TYPES: NodeType> AggregatableVote<TYPES, QuorumVote<TYPES>, QuorumCertifica
 impl<TYPES: NodeType> AggregatableVote<TYPES, QuorumVote2<TYPES>, QuorumCertificate2<TYPES>>
     for QuorumVote2<TYPES>
 {
-    fn leader(
+    async fn leader(
         &self,
         membership: &TYPES::Membership,
         epoch: TYPES::Epoch,
     ) -> Result<TYPES::SignatureKey> {
-        membership.leader(self.view_number() + 1, epoch)
+        membership.leader(self.view_number() + 1, epoch).await
     }
     fn make_cert_event(
         certificate: QuorumCertificate2<TYPES>,
@@ -372,12 +372,12 @@ impl<TYPES: NodeType> AggregatableVote<TYPES, QuorumVote2<TYPES>, QuorumCertific
 impl<TYPES: NodeType> AggregatableVote<TYPES, UpgradeVote<TYPES>, UpgradeCertificate<TYPES>>
     for UpgradeVote<TYPES>
 {
-    fn leader(
+    async fn leader(
         &self,
         membership: &TYPES::Membership,
         epoch: TYPES::Epoch,
     ) -> Result<TYPES::SignatureKey> {
-        membership.leader(self.view_number(), epoch)
+        membership.leader(self.view_number(), epoch).await
     }
     fn make_cert_event(
         certificate: UpgradeCertificate<TYPES>,
@@ -390,12 +390,12 @@ impl<TYPES: NodeType> AggregatableVote<TYPES, UpgradeVote<TYPES>, UpgradeCertifi
 impl<TYPES: NodeType> AggregatableVote<TYPES, DaVote2<TYPES>, DaCertificate2<TYPES>>
     for DaVote2<TYPES>
 {
-    fn leader(
+    async fn leader(
         &self,
         membership: &TYPES::Membership,
         epoch: TYPES::Epoch,
     ) -> Result<TYPES::SignatureKey> {
-        membership.leader(self.view_number(), epoch)
+        membership.leader(self.view_number(), epoch).await
     }
     fn make_cert_event(
         certificate: DaCertificate2<TYPES>,
@@ -408,12 +408,12 @@ impl<TYPES: NodeType> AggregatableVote<TYPES, DaVote2<TYPES>, DaCertificate2<TYP
 impl<TYPES: NodeType> AggregatableVote<TYPES, TimeoutVote<TYPES>, TimeoutCertificate<TYPES>>
     for TimeoutVote<TYPES>
 {
-    fn leader(
+    async fn leader(
         &self,
         membership: &TYPES::Membership,
         epoch: TYPES::Epoch,
     ) -> Result<TYPES::SignatureKey> {
-        membership.leader(self.view_number() + 1, epoch)
+        membership.leader(self.view_number() + 1, epoch).await
     }
     fn make_cert_event(
         certificate: TimeoutCertificate<TYPES>,
@@ -427,12 +427,14 @@ impl<TYPES: NodeType>
     AggregatableVote<TYPES, ViewSyncCommitVote<TYPES>, ViewSyncCommitCertificate<TYPES>>
     for ViewSyncCommitVote<TYPES>
 {
-    fn leader(
+    async fn leader(
         &self,
         membership: &TYPES::Membership,
         epoch: TYPES::Epoch,
     ) -> Result<TYPES::SignatureKey> {
-        membership.leader(self.date().round + self.date().relay, epoch)
+        membership
+            .leader(self.date().round + self.date().relay, epoch)
+            .await
     }
     fn make_cert_event(
         certificate: ViewSyncCommitCertificate<TYPES>,
@@ -446,12 +448,14 @@ impl<TYPES: NodeType>
     AggregatableVote<TYPES, ViewSyncPreCommitVote<TYPES>, ViewSyncPreCommitCertificate<TYPES>>
     for ViewSyncPreCommitVote<TYPES>
 {
-    fn leader(
+    async fn leader(
         &self,
         membership: &TYPES::Membership,
         epoch: TYPES::Epoch,
     ) -> Result<TYPES::SignatureKey> {
-        membership.leader(self.date().round + self.date().relay, epoch)
+        membership
+            .leader(self.date().round + self.date().relay, epoch)
+            .await
     }
     fn make_cert_event(
         certificate: ViewSyncPreCommitCertificate<TYPES>,
@@ -465,12 +469,14 @@ impl<TYPES: NodeType>
     AggregatableVote<TYPES, ViewSyncFinalizeVote<TYPES>, ViewSyncFinalizeCertificate<TYPES>>
     for ViewSyncFinalizeVote<TYPES>
 {
-    fn leader(
+    async fn leader(
         &self,
         membership: &TYPES::Membership,
         epoch: TYPES::Epoch,
     ) -> Result<TYPES::SignatureKey> {
-        membership.leader(self.date().round + self.date().relay, epoch)
+        membership
+            .leader(self.date().round + self.date().relay, epoch)
+            .await
     }
     fn make_cert_event(
         certificate: ViewSyncFinalizeCertificate<TYPES>,

--- a/crates/testing/src/helpers.rs
+++ b/crates/testing/src/helpers.rs
@@ -211,11 +211,11 @@ pub async fn build_assembled_sig<
     epoch: TYPES::Epoch,
     upgrade_lock: &UpgradeLock<TYPES, V>,
 ) -> <TYPES::SignatureKey as SignatureKey>::QcType {
-    let stake_table = CERT::stake_table(membership, epoch);
+    let stake_table = CERT::stake_table(membership, epoch).await;
     let real_qc_pp: <TYPES::SignatureKey as SignatureKey>::QcParams =
         <TYPES::SignatureKey as SignatureKey>::public_parameter(
             stake_table.clone(),
-            U256::from(CERT::threshold(membership, epoch)),
+            U256::from(CERT::threshold(membership, epoch).await),
         );
     let total_nodes = stake_table.len();
     let signers = bitvec![1; total_nodes];
@@ -264,32 +264,33 @@ pub fn key_pair_for_id<TYPES: NodeType>(
 /// # Panics
 /// if unable to create a [`VidSchemeType`]
 #[must_use]
-pub fn vid_scheme_from_view_number<TYPES: NodeType>(
+pub async fn vid_scheme_from_view_number<TYPES: NodeType>(
     membership: &TYPES::Membership,
     view_number: TYPES::View,
     epoch_number: TYPES::Epoch,
 ) -> VidSchemeType {
     let num_storage_nodes = membership
         .committee_members(view_number, epoch_number)
+        .await
         .len();
     vid_scheme(num_storage_nodes)
 }
 
-pub fn vid_payload_commitment<TYPES: NodeType>(
+pub async fn vid_payload_commitment<TYPES: NodeType>(
     quorum_membership: &<TYPES as NodeType>::Membership,
     view_number: TYPES::View,
     epoch_number: TYPES::Epoch,
     transactions: Vec<TestTransaction>,
 ) -> VidCommitment {
     let mut vid =
-        vid_scheme_from_view_number::<TYPES>(quorum_membership, view_number, epoch_number);
+        vid_scheme_from_view_number::<TYPES>(quorum_membership, view_number, epoch_number).await;
     let encoded_transactions = TestTransaction::encode(&transactions);
     let vid_disperse = vid.disperse(&encoded_transactions).unwrap();
 
     vid_disperse.commit
 }
 
-pub fn da_payload_commitment<TYPES: NodeType>(
+pub async fn da_payload_commitment<TYPES: NodeType>(
     quorum_membership: &<TYPES as NodeType>::Membership,
     transactions: Vec<TestTransaction>,
     epoch_number: TYPES::Epoch,
@@ -298,24 +299,24 @@ pub fn da_payload_commitment<TYPES: NodeType>(
 
     vid_commitment(
         &encoded_transactions,
-        quorum_membership.total_nodes(epoch_number),
+        quorum_membership.total_nodes(epoch_number).await,
     )
 }
 
-pub fn build_payload_commitment<TYPES: NodeType>(
+pub async fn build_payload_commitment<TYPES: NodeType>(
     membership: &<TYPES as NodeType>::Membership,
     view: TYPES::View,
     epoch: TYPES::Epoch,
 ) -> <VidSchemeType as VidScheme>::Commit {
     // Make some empty encoded transactions, we just care about having a commitment handy for the
     // later calls. We need the VID commitment to be able to propose later.
-    let mut vid = vid_scheme_from_view_number::<TYPES>(membership, view, epoch);
+    let mut vid = vid_scheme_from_view_number::<TYPES>(membership, view, epoch).await;
     let encoded_transactions = Vec::new();
     vid.commit_only(&encoded_transactions).unwrap()
 }
 
 /// TODO: <https://github.com/EspressoSystems/HotShot/issues/2821>
-pub fn build_vid_proposal<TYPES: NodeType>(
+pub async fn build_vid_proposal<TYPES: NodeType>(
     quorum_membership: &<TYPES as NodeType>::Membership,
     view_number: TYPES::View,
     epoch_number: TYPES::Epoch,
@@ -323,7 +324,7 @@ pub fn build_vid_proposal<TYPES: NodeType>(
     private_key: &<TYPES::SignatureKey as SignatureKey>::PrivateKey,
 ) -> VidProposal<TYPES> {
     let mut vid =
-        vid_scheme_from_view_number::<TYPES>(quorum_membership, view_number, epoch_number);
+        vid_scheme_from_view_number::<TYPES>(quorum_membership, view_number, epoch_number).await;
     let encoded_transactions = TestTransaction::encode(&transactions);
 
     let vid_disperse = VidDisperse::from_membership(
@@ -331,7 +332,8 @@ pub fn build_vid_proposal<TYPES: NodeType>(
         vid.disperse(&encoded_transactions).unwrap(),
         quorum_membership,
         epoch_number,
-    );
+    )
+    .await;
 
     let signature =
         TYPES::SignatureKey::sign(private_key, vid_disperse.payload_commitment.as_ref())
@@ -367,8 +369,10 @@ pub async fn build_da_certificate<TYPES: NodeType, V: Versions>(
 ) -> DaCertificate2<TYPES> {
     let encoded_transactions = TestTransaction::encode(&transactions);
 
-    let da_payload_commitment =
-        vid_commitment(&encoded_transactions, membership.total_nodes(epoch_number));
+    let da_payload_commitment = vid_commitment(
+        &encoded_transactions,
+        membership.total_nodes(epoch_number).await,
+    );
 
     let da_data = DaData2 {
         payload_commit: da_payload_commitment,

--- a/crates/testing/src/view_generator.rs
+++ b/crates/testing/src/view_generator.rs
@@ -99,7 +99,8 @@ impl TestView {
         let leader_public_key = public_key;
 
         let payload_commitment =
-            da_payload_commitment::<TestTypes>(membership, transactions.clone(), genesis_epoch);
+            da_payload_commitment::<TestTypes>(membership, transactions.clone(), genesis_epoch)
+                .await;
 
         let (vid_disperse, vid_proposal) = build_vid_proposal(
             membership,
@@ -107,7 +108,8 @@ impl TestView {
             genesis_epoch,
             transactions.clone(),
             &private_key,
-        );
+        )
+        .await;
 
         let da_certificate = build_da_certificate(
             membership,
@@ -242,7 +244,8 @@ impl TestView {
         );
 
         let payload_commitment =
-            da_payload_commitment::<TestTypes>(membership, transactions.clone(), self.epoch_number);
+            da_payload_commitment::<TestTypes>(membership, transactions.clone(), self.epoch_number)
+                .await;
 
         let (vid_disperse, vid_proposal) = build_vid_proposal(
             membership,
@@ -250,7 +253,8 @@ impl TestView {
             self.epoch_number,
             transactions.clone(),
             &private_key,
-        );
+        )
+        .await;
 
         let da_certificate = build_da_certificate::<TestTypes, TestVersions>(
             membership,

--- a/crates/testing/tests/tests_1/da_task.rs
+++ b/crates/testing/tests/tests_1/da_task.rs
@@ -48,7 +48,7 @@ async fn test_da_task() {
     let encoded_transactions = Arc::from(TestTransaction::encode(&transactions));
     let (payload_commit, precompute) = precompute_vid_commitment(
         &encoded_transactions,
-        handle.hotshot.memberships.total_nodes(EpochNumber::new(0)),
+        handle.hotshot.memberships.total_nodes(EpochNumber::new(0)).await,
     );
 
     let mut generator = TestViewGenerator::generate(membership.clone());
@@ -107,7 +107,7 @@ async fn test_da_task() {
                 ViewNumber::new(2),
                 EpochNumber::new(0),
                 vec1::vec1![null_block::builder_fee::<TestTypes, TestVersions>(
-                    membership.total_nodes(EpochNumber::new(0)),
+                    membership.total_nodes(EpochNumber::new(0)).await,
                     <TestVersions as Versions>::Base::VERSION,
                     *ViewNumber::new(2),
                 )
@@ -156,7 +156,7 @@ async fn test_da_task_storage_failure() {
     let encoded_transactions = Arc::from(TestTransaction::encode(&transactions));
     let (payload_commit, precompute) = precompute_vid_commitment(
         &encoded_transactions,
-        handle.hotshot.memberships.total_nodes(EpochNumber::new(0)),
+        handle.hotshot.memberships.total_nodes(EpochNumber::new(0)).await,
     );
 
     let mut generator = TestViewGenerator::generate(membership.clone());
@@ -215,7 +215,7 @@ async fn test_da_task_storage_failure() {
                 ViewNumber::new(2),
                 EpochNumber::new(0),
                 vec1::vec1![null_block::builder_fee::<TestTypes, TestVersions>(
-                    membership.total_nodes(EpochNumber::new(0)),
+                    membership.total_nodes(EpochNumber::new(0)).await,
                     <TestVersions as Versions>::Base::VERSION,
                     *ViewNumber::new(2),
                 )

--- a/crates/testing/tests/tests_1/da_task.rs
+++ b/crates/testing/tests/tests_1/da_task.rs
@@ -48,7 +48,11 @@ async fn test_da_task() {
     let encoded_transactions = Arc::from(TestTransaction::encode(&transactions));
     let (payload_commit, precompute) = precompute_vid_commitment(
         &encoded_transactions,
-        handle.hotshot.memberships.total_nodes(EpochNumber::new(0)).await,
+        handle
+            .hotshot
+            .memberships
+            .total_nodes(EpochNumber::new(0))
+            .await,
     );
 
     let mut generator = TestViewGenerator::generate(membership.clone());
@@ -156,7 +160,11 @@ async fn test_da_task_storage_failure() {
     let encoded_transactions = Arc::from(TestTransaction::encode(&transactions));
     let (payload_commit, precompute) = precompute_vid_commitment(
         &encoded_transactions,
-        handle.hotshot.memberships.total_nodes(EpochNumber::new(0)).await,
+        handle
+            .hotshot
+            .memberships
+            .total_nodes(EpochNumber::new(0))
+            .await,
     );
 
     let mut generator = TestViewGenerator::generate(membership.clone());

--- a/crates/testing/tests/tests_1/message.rs
+++ b/crates/testing/tests/tests_1/message.rs
@@ -103,8 +103,8 @@ async fn test_certificate2_validity() {
 
     assert!(
         qc.is_valid_cert(
-            membership.stake_table(EpochNumber::new(0)),
-            membership.success_threshold(EpochNumber::new(0)),
+            membership.stake_table(EpochNumber::new(0)).await,
+            membership.success_threshold(EpochNumber::new(0)).await,
             &handle.hotshot.upgrade_lock
         )
         .await
@@ -112,8 +112,8 @@ async fn test_certificate2_validity() {
 
     assert!(
         qc2.is_valid_cert(
-            membership.stake_table(EpochNumber::new(0)),
-            membership.success_threshold(EpochNumber::new(0)),
+            membership.stake_table(EpochNumber::new(0)).await,
+            membership.success_threshold(EpochNumber::new(0)).await,
             &handle.hotshot.upgrade_lock
         )
         .await

--- a/crates/testing/tests/tests_1/quorum_proposal_task.rs
+++ b/crates/testing/tests/tests_1/quorum_proposal_task.rs
@@ -57,7 +57,7 @@ async fn test_quorum_proposal_task_quorum_proposal_view_1() {
         &membership,
         ViewNumber::new(node_id),
         EpochNumber::new(1),
-    );
+    ).await;
 
     let mut generator = TestViewGenerator::generate(membership.clone());
 
@@ -90,7 +90,7 @@ async fn test_quorum_proposal_task_quorum_proposal_view_1() {
     let genesis_cert = proposals[0].data.justify_qc.clone();
     let builder_commitment = BuilderCommitment::from_raw_digest(sha2::Sha256::new().finalize());
     let builder_fee = null_block::builder_fee::<TestTypes, TestVersions>(
-        membership.total_nodes(EpochNumber::new(1)),
+        membership.total_nodes(EpochNumber::new(1)).await,
         <TestVersions as Versions>::Base::VERSION,
         *ViewNumber::new(1),
     )
@@ -182,7 +182,7 @@ async fn test_quorum_proposal_task_quorum_proposal_view_gt_1() {
 
     let builder_commitment = BuilderCommitment::from_raw_digest(sha2::Sha256::new().finalize());
     let builder_fee = null_block::builder_fee::<TestTypes, TestVersions>(
-        membership.total_nodes(EpochNumber::new(1)),
+        membership.total_nodes(EpochNumber::new(1)).await,
         <TestVersions as Versions>::Base::VERSION,
         *ViewNumber::new(1),
     )
@@ -196,7 +196,7 @@ async fn test_quorum_proposal_task_quorum_proposal_view_gt_1() {
                     &membership,
                     ViewNumber::new(1),
                     EpochNumber::new(1)
-                ),
+                ).await,
                 builder_commitment.clone(),
                 TestMetadata {
                     num_transactions: 0
@@ -215,7 +215,7 @@ async fn test_quorum_proposal_task_quorum_proposal_view_gt_1() {
                     &membership,
                     ViewNumber::new(2),
                     EpochNumber::new(1)
-                ),
+                ).await,
                 builder_commitment.clone(),
                 proposals[0].data.block_header.metadata,
                 ViewNumber::new(2),
@@ -232,7 +232,7 @@ async fn test_quorum_proposal_task_quorum_proposal_view_gt_1() {
                     &membership,
                     ViewNumber::new(3),
                     EpochNumber::new(1)
-                ),
+                ).await,
                 builder_commitment.clone(),
                 proposals[1].data.block_header.metadata,
                 ViewNumber::new(3),
@@ -249,7 +249,7 @@ async fn test_quorum_proposal_task_quorum_proposal_view_gt_1() {
                     &membership,
                     ViewNumber::new(4),
                     EpochNumber::new(1)
-                ),
+                ).await,
                 builder_commitment.clone(),
                 proposals[2].data.block_header.metadata,
                 ViewNumber::new(4),
@@ -266,7 +266,7 @@ async fn test_quorum_proposal_task_quorum_proposal_view_gt_1() {
                     &membership,
                     ViewNumber::new(5),
                     EpochNumber::new(1)
-                ),
+                ).await,
                 builder_commitment,
                 proposals[3].data.block_header.metadata,
                 ViewNumber::new(5),
@@ -314,7 +314,7 @@ async fn test_quorum_proposal_task_qc_timeout() {
         &membership,
         ViewNumber::new(node_id),
         EpochNumber::new(1),
-    );
+    ).await;
     let builder_commitment = BuilderCommitment::from_raw_digest(sha2::Sha256::new().finalize());
 
     let mut generator = TestViewGenerator::generate(membership.clone());
@@ -359,7 +359,7 @@ async fn test_quorum_proposal_task_qc_timeout() {
             },
             ViewNumber::new(3),
             vec1![null_block::builder_fee::<TestTypes, TestVersions>(
-                membership.total_nodes(EpochNumber::new(1)),
+                membership.total_nodes(EpochNumber::new(1)).await,
                 <TestVersions as Versions>::Base::VERSION,
                 *ViewNumber::new(3),
             )
@@ -402,7 +402,7 @@ async fn test_quorum_proposal_task_view_sync() {
         &membership,
         ViewNumber::new(node_id),
         EpochNumber::new(1),
-    );
+    ).await;
     let builder_commitment = BuilderCommitment::from_raw_digest(sha2::Sha256::new().finalize());
 
     let mut generator = TestViewGenerator::generate(membership.clone());
@@ -449,7 +449,7 @@ async fn test_quorum_proposal_task_view_sync() {
             },
             ViewNumber::new(2),
             vec1![null_block::builder_fee::<TestTypes, TestVersions>(
-                membership.total_nodes(EpochNumber::new(1)),
+                membership.total_nodes(EpochNumber::new(1)).await,
                 <TestVersions as Versions>::Base::VERSION,
                 *ViewNumber::new(2),
             )
@@ -516,7 +516,7 @@ async fn test_quorum_proposal_task_liveness_check() {
 
     let builder_commitment = BuilderCommitment::from_raw_digest(sha2::Sha256::new().finalize());
     let builder_fee = null_block::builder_fee::<TestTypes, TestVersions>(
-        membership.total_nodes(EpochNumber::new(1)),
+        membership.total_nodes(EpochNumber::new(1)).await,
         <TestVersions as Versions>::Base::VERSION,
         *ViewNumber::new(1),
     )
@@ -534,7 +534,7 @@ async fn test_quorum_proposal_task_liveness_check() {
                     &membership,
                     ViewNumber::new(1),
                     EpochNumber::new(1)
-                ),
+                ).await,
                 builder_commitment.clone(),
                 TestMetadata {
                     num_transactions: 0
@@ -553,7 +553,7 @@ async fn test_quorum_proposal_task_liveness_check() {
                     &membership,
                     ViewNumber::new(2),
                     EpochNumber::new(1)
-                ),
+                ).await,
                 builder_commitment.clone(),
                 proposals[0].data.block_header.metadata,
                 ViewNumber::new(2),
@@ -570,7 +570,7 @@ async fn test_quorum_proposal_task_liveness_check() {
                     &membership,
                     ViewNumber::new(3),
                     EpochNumber::new(1)
-                ),
+                ).await,
                 builder_commitment.clone(),
                 proposals[1].data.block_header.metadata,
                 ViewNumber::new(3),
@@ -587,7 +587,7 @@ async fn test_quorum_proposal_task_liveness_check() {
                     &membership,
                     ViewNumber::new(4),
                     EpochNumber::new(1)
-                ),
+                ).await,
                 builder_commitment.clone(),
                 proposals[2].data.block_header.metadata,
                 ViewNumber::new(4),
@@ -604,7 +604,7 @@ async fn test_quorum_proposal_task_liveness_check() {
                     &membership,
                     ViewNumber::new(5),
                     EpochNumber::new(1)
-                ),
+                ).await,
                 builder_commitment,
                 proposals[3].data.block_header.metadata,
                 ViewNumber::new(5),

--- a/crates/testing/tests/tests_1/quorum_proposal_task.rs
+++ b/crates/testing/tests/tests_1/quorum_proposal_task.rs
@@ -57,7 +57,8 @@ async fn test_quorum_proposal_task_quorum_proposal_view_1() {
         &membership,
         ViewNumber::new(node_id),
         EpochNumber::new(1),
-    ).await;
+    )
+    .await;
 
     let mut generator = TestViewGenerator::generate(membership.clone());
 
@@ -196,7 +197,8 @@ async fn test_quorum_proposal_task_quorum_proposal_view_gt_1() {
                     &membership,
                     ViewNumber::new(1),
                     EpochNumber::new(1)
-                ).await,
+                )
+                .await,
                 builder_commitment.clone(),
                 TestMetadata {
                     num_transactions: 0
@@ -215,7 +217,8 @@ async fn test_quorum_proposal_task_quorum_proposal_view_gt_1() {
                     &membership,
                     ViewNumber::new(2),
                     EpochNumber::new(1)
-                ).await,
+                )
+                .await,
                 builder_commitment.clone(),
                 proposals[0].data.block_header.metadata,
                 ViewNumber::new(2),
@@ -232,7 +235,8 @@ async fn test_quorum_proposal_task_quorum_proposal_view_gt_1() {
                     &membership,
                     ViewNumber::new(3),
                     EpochNumber::new(1)
-                ).await,
+                )
+                .await,
                 builder_commitment.clone(),
                 proposals[1].data.block_header.metadata,
                 ViewNumber::new(3),
@@ -249,7 +253,8 @@ async fn test_quorum_proposal_task_quorum_proposal_view_gt_1() {
                     &membership,
                     ViewNumber::new(4),
                     EpochNumber::new(1)
-                ).await,
+                )
+                .await,
                 builder_commitment.clone(),
                 proposals[2].data.block_header.metadata,
                 ViewNumber::new(4),
@@ -266,7 +271,8 @@ async fn test_quorum_proposal_task_quorum_proposal_view_gt_1() {
                     &membership,
                     ViewNumber::new(5),
                     EpochNumber::new(1)
-                ).await,
+                )
+                .await,
                 builder_commitment,
                 proposals[3].data.block_header.metadata,
                 ViewNumber::new(5),
@@ -314,7 +320,8 @@ async fn test_quorum_proposal_task_qc_timeout() {
         &membership,
         ViewNumber::new(node_id),
         EpochNumber::new(1),
-    ).await;
+    )
+    .await;
     let builder_commitment = BuilderCommitment::from_raw_digest(sha2::Sha256::new().finalize());
 
     let mut generator = TestViewGenerator::generate(membership.clone());
@@ -403,7 +410,8 @@ async fn test_quorum_proposal_task_view_sync() {
         &membership,
         ViewNumber::new(node_id),
         EpochNumber::new(1),
-    ).await;
+    )
+    .await;
     let builder_commitment = BuilderCommitment::from_raw_digest(sha2::Sha256::new().finalize());
 
     let mut generator = TestViewGenerator::generate(membership.clone());
@@ -536,7 +544,8 @@ async fn test_quorum_proposal_task_liveness_check() {
                     &membership,
                     ViewNumber::new(1),
                     EpochNumber::new(1)
-                ).await,
+                )
+                .await,
                 builder_commitment.clone(),
                 TestMetadata {
                     num_transactions: 0
@@ -555,7 +564,8 @@ async fn test_quorum_proposal_task_liveness_check() {
                     &membership,
                     ViewNumber::new(2),
                     EpochNumber::new(1)
-                ).await,
+                )
+                .await,
                 builder_commitment.clone(),
                 proposals[0].data.block_header.metadata,
                 ViewNumber::new(2),
@@ -572,7 +582,8 @@ async fn test_quorum_proposal_task_liveness_check() {
                     &membership,
                     ViewNumber::new(3),
                     EpochNumber::new(1)
-                ).await,
+                )
+                .await,
                 builder_commitment.clone(),
                 proposals[1].data.block_header.metadata,
                 ViewNumber::new(3),
@@ -589,7 +600,8 @@ async fn test_quorum_proposal_task_liveness_check() {
                     &membership,
                     ViewNumber::new(4),
                     EpochNumber::new(1)
-                ).await,
+                )
+                .await,
                 builder_commitment.clone(),
                 proposals[2].data.block_header.metadata,
                 ViewNumber::new(4),
@@ -606,7 +618,8 @@ async fn test_quorum_proposal_task_liveness_check() {
                     &membership,
                     ViewNumber::new(5),
                     EpochNumber::new(1)
-                ).await,
+                )
+                .await,
                 builder_commitment,
                 proposals[3].data.block_header.metadata,
                 ViewNumber::new(5),

--- a/crates/testing/tests/tests_1/transaction_task.rs
+++ b/crates/testing/tests/tests_1/transaction_task.rs
@@ -42,7 +42,11 @@ async fn test_transaction_task_leader_two_views_in_a_row() {
 
     let (_, precompute_data) = precompute_vid_commitment(
         &[],
-        handle.hotshot.memberships.total_nodes(EpochNumber::new(0)).await,
+        handle
+            .hotshot
+            .memberships
+            .total_nodes(EpochNumber::new(0))
+            .await,
     );
 
     // current view
@@ -55,7 +59,11 @@ async fn test_transaction_task_leader_two_views_in_a_row() {
         EpochNumber::new(1),
         vec1::vec1![
             null_block::builder_fee::<TestConsecutiveLeaderTypes, TestVersions>(
-                handle.hotshot.memberships.total_nodes(EpochNumber::new(0)).await,
+                handle
+                    .hotshot
+                    .memberships
+                    .total_nodes(EpochNumber::new(0))
+                    .await,
                 <TestVersions as Versions>::Base::VERSION,
                 *ViewNumber::new(4),
             )

--- a/crates/testing/tests/tests_1/transaction_task.rs
+++ b/crates/testing/tests/tests_1/transaction_task.rs
@@ -42,7 +42,7 @@ async fn test_transaction_task_leader_two_views_in_a_row() {
 
     let (_, precompute_data) = precompute_vid_commitment(
         &[],
-        handle.hotshot.memberships.total_nodes(EpochNumber::new(0)),
+        handle.hotshot.memberships.total_nodes(EpochNumber::new(0)).await,
     );
 
     // current view
@@ -55,7 +55,7 @@ async fn test_transaction_task_leader_two_views_in_a_row() {
         EpochNumber::new(1),
         vec1::vec1![
             null_block::builder_fee::<TestConsecutiveLeaderTypes, TestVersions>(
-                handle.hotshot.memberships.total_nodes(EpochNumber::new(0)),
+                handle.hotshot.memberships.total_nodes(EpochNumber::new(0)).await,
                 <TestVersions as Versions>::Base::VERSION,
                 *ViewNumber::new(4),
             )

--- a/crates/testing/tests/tests_1/upgrade_task_with_proposal.rs
+++ b/crates/testing/tests/tests_1/upgrade_task_with_proposal.rs
@@ -126,7 +126,7 @@ async fn test_upgrade_task_with_proposal() {
     let genesis_cert = proposals[0].data.justify_qc.clone();
     let builder_commitment = BuilderCommitment::from_raw_digest(sha2::Sha256::new().finalize());
     let builder_fee = null_block::builder_fee::<TestTypes, TestVersions>(
-        membership.total_nodes(EpochNumber::new(1)),
+        membership.total_nodes(EpochNumber::new(1)).await,
         <TestVersions as Versions>::Base::VERSION,
         *ViewNumber::new(1),
     )
@@ -156,7 +156,7 @@ async fn test_upgrade_task_with_proposal() {
                     &membership,
                     ViewNumber::new(1),
                     EpochNumber::new(1)
-                ),
+                ).await,
                 builder_commitment.clone(),
                 TestMetadata {
                     num_transactions: 0
@@ -175,7 +175,7 @@ async fn test_upgrade_task_with_proposal() {
                     &membership,
                     ViewNumber::new(2),
                     EpochNumber::new(1)
-                ),
+                ).await,
                 builder_commitment.clone(),
                 proposals[0].data.block_header.metadata,
                 ViewNumber::new(2),
@@ -193,7 +193,7 @@ async fn test_upgrade_task_with_proposal() {
                     &membership,
                     ViewNumber::new(3),
                     EpochNumber::new(1)
-                ),
+                ).await,
                 builder_commitment.clone(),
                 proposals[1].data.block_header.metadata,
                 ViewNumber::new(3),

--- a/crates/testing/tests/tests_1/upgrade_task_with_proposal.rs
+++ b/crates/testing/tests/tests_1/upgrade_task_with_proposal.rs
@@ -156,7 +156,8 @@ async fn test_upgrade_task_with_proposal() {
                     &membership,
                     ViewNumber::new(1),
                     EpochNumber::new(1)
-                ).await,
+                )
+                .await,
                 builder_commitment.clone(),
                 TestMetadata {
                     num_transactions: 0
@@ -175,7 +176,8 @@ async fn test_upgrade_task_with_proposal() {
                     &membership,
                     ViewNumber::new(2),
                     EpochNumber::new(1)
-                ).await,
+                )
+                .await,
                 builder_commitment.clone(),
                 proposals[0].data.block_header.metadata,
                 ViewNumber::new(2),
@@ -193,7 +195,8 @@ async fn test_upgrade_task_with_proposal() {
                     &membership,
                     ViewNumber::new(3),
                     EpochNumber::new(1)
-                ).await,
+                )
+                .await,
                 builder_commitment.clone(),
                 proposals[1].data.block_header.metadata,
                 ViewNumber::new(3),

--- a/crates/testing/tests/tests_1/vid_task.rs
+++ b/crates/testing/tests/tests_1/vid_task.rs
@@ -51,7 +51,8 @@ async fn test_vid_task() {
         &membership,
         ViewNumber::new(0),
         EpochNumber::new(0),
-    ).await;
+    )
+    .await;
     let transactions = vec![TestTransaction::new(vec![0])];
 
     let (payload, metadata) = <TestBlockPayload as BlockPayload<TestTypes>>::from_transactions(
@@ -91,7 +92,8 @@ async fn test_vid_task() {
         vid_disperse,
         &membership,
         EpochNumber::new(0),
-    ).await;
+    )
+    .await;
 
     let vid_proposal = Proposal {
         data: vid_disperse.clone(),

--- a/crates/testing/tests/tests_1/vid_task.rs
+++ b/crates/testing/tests/tests_1/vid_task.rs
@@ -51,7 +51,7 @@ async fn test_vid_task() {
         &membership,
         ViewNumber::new(0),
         EpochNumber::new(0),
-    );
+    ).await;
     let transactions = vec![TestTransaction::new(vec![0])];
 
     let (payload, metadata) = <TestBlockPayload as BlockPayload<TestTypes>>::from_transactions(
@@ -91,7 +91,7 @@ async fn test_vid_task() {
         vid_disperse,
         &membership,
         EpochNumber::new(0),
-    );
+    ).await;
 
     let vid_proposal = Proposal {
         data: vid_disperse.clone(),
@@ -110,7 +110,7 @@ async fn test_vid_task() {
                 ViewNumber::new(2),
                 EpochNumber::new(0),
                 vec1::vec1![null_block::builder_fee::<TestTypes, TestVersions>(
-                    membership.total_nodes(EpochNumber::new(0)),
+                    membership.total_nodes(EpochNumber::new(0)).await,
                     <TestVersions as Versions>::Base::VERSION,
                     *ViewNumber::new(2),
                 )
@@ -132,7 +132,7 @@ async fn test_vid_task() {
                 },
                 ViewNumber::new(2),
                 vec1![null_block::builder_fee::<TestTypes, TestVersions>(
-                    membership.total_nodes(EpochNumber::new(0)),
+                    membership.total_nodes(EpochNumber::new(0)).await,
                     <TestVersions as Versions>::Base::VERSION,
                     *ViewNumber::new(2),
                 )

--- a/crates/testing/tests/tests_3/byzantine_tests.rs
+++ b/crates/testing/tests/tests_3/byzantine_tests.rs
@@ -171,12 +171,12 @@ cross_tests!(
     Ignore: false,
     Metadata: {
         let nodes_count: usize = 10;
-        let behaviour = Rc::new(move |node_id| {
+        let behaviour = Rc::new(  move |node_id|   {
             let dishonest_voting = DishonestVoting {
                 view_increment: nodes_count as u64,
-                modifier: Arc::new(move |_pk, message_kind, transmit_type: &mut TransmitType<TestTypes>, membership: &<TestTypes as NodeType>::Membership| {
+                modifier: Arc::new(  move   |_pk, message_kind, transmit_type: &mut TransmitType<TestTypes>, membership: &<TestTypes as NodeType>::Membership|     {
                     if let MessageKind::Consensus(SequencingMessage::General(GeneralConsensusMessage::Vote(vote))) = message_kind {
-                        *transmit_type = TransmitType::Direct(membership.leader(vote.view_number() + 1 - nodes_count as u64, EpochNumber::new(0)).unwrap());
+                        *transmit_type = TransmitType::Direct(tokio::runtime::Runtime::new().unwrap().block_on(membership.leader(vote.view_number() + 1 - nodes_count as u64, EpochNumber::new(0))).unwrap());
                     } else {
                         {}
                     }

--- a/crates/types/src/data.rs
+++ b/crates/types/src/data.rs
@@ -216,7 +216,7 @@ impl<TYPES: NodeType> VidDisperse<TYPES> {
     /// Create VID dispersal from a specified membership for a given epoch.
     /// Uses the specified function to calculate share dispersal
     /// Allows for more complex stake table functionality
-    pub fn from_membership(
+    pub async fn from_membership(
         view_number: TYPES::View,
         mut vid_disperse: JfVidDisperse<VidSchemeType>,
         membership: &TYPES::Membership,
@@ -224,6 +224,7 @@ impl<TYPES: NodeType> VidDisperse<TYPES> {
     ) -> Self {
         let shares = membership
             .committee_members(view_number, epoch)
+            .await
             .iter()
             .map(|node| (node.clone(), vid_disperse.shares.remove(0)))
             .collect();
@@ -249,7 +250,7 @@ impl<TYPES: NodeType> VidDisperse<TYPES> {
         epoch: TYPES::Epoch,
         precompute_data: Option<VidPrecomputeData>,
     ) -> Self {
-        let num_nodes = membership.total_nodes(epoch);
+        let num_nodes = membership.total_nodes(epoch).await;
 
         let vid_disperse = spawn_blocking(move || {
             precompute_data
@@ -262,7 +263,7 @@ impl<TYPES: NodeType> VidDisperse<TYPES> {
         // Unwrap here will just propagate any panic from the spawned task, it's not a new place we can panic.
         let vid_disperse = vid_disperse.unwrap();
 
-        Self::from_membership(view, vid_disperse, membership.as_ref(), epoch)
+        Self::from_membership(view, vid_disperse, membership.as_ref(), epoch).await
     }
 }
 

--- a/crates/types/src/message.rs
+++ b/crates/types/src/message.rs
@@ -390,7 +390,7 @@ where
         upgrade_lock: &UpgradeLock<TYPES, V>,
     ) -> Result<()> {
         let view_number = self.data.view_number();
-        let view_leader_key = quorum_membership.leader(view_number, epoch)?;
+        let view_leader_key = quorum_membership.leader(view_number, epoch).await?;
         let proposed_leaf = Leaf::from_quorum_proposal(&self.data);
 
         ensure!(
@@ -412,13 +412,13 @@ where
     /// Checks that the signature of the quorum proposal is valid.
     /// # Errors
     /// Returns an error when the proposal signature is invalid.
-    pub fn validate_signature(
+    pub async fn validate_signature(
         &self,
         quorum_membership: &TYPES::Membership,
         epoch: TYPES::Epoch,
     ) -> Result<()> {
         let view_number = self.data.view_number();
-        let view_leader_key = quorum_membership.leader(view_number, epoch)?;
+        let view_leader_key = quorum_membership.leader(view_number, epoch).await?;
         let proposed_leaf = Leaf2::from_quorum_proposal(&self.data);
 
         ensure!(

--- a/crates/types/src/traits/election.rs
+++ b/crates/types/src/traits/election.rs
@@ -29,34 +29,34 @@ pub trait Membership<TYPES: NodeType>: Clone + Debug + Send + Sync {
     fn stake_table(
         &self,
         epoch: TYPES::Epoch,
-    ) -> Vec<<TYPES::SignatureKey as SignatureKey>::StakeTableEntry>;
+    ) -> impl futures::Future<Output = Vec<<TYPES::SignatureKey as SignatureKey>::StakeTableEntry>> + Send;
 
     /// Get all participants in the committee (including their stake) for a specific epoch
     fn da_stake_table(
         &self,
         epoch: TYPES::Epoch,
-    ) -> Vec<<TYPES::SignatureKey as SignatureKey>::StakeTableEntry>;
+    ) -> impl futures::Future<Output = Vec<<TYPES::SignatureKey as SignatureKey>::StakeTableEntry>> + Send;
 
     /// Get all participants in the committee for a specific view for a specific epoch
     fn committee_members(
         &self,
         view_number: TYPES::View,
         epoch: TYPES::Epoch,
-    ) -> BTreeSet<TYPES::SignatureKey>;
+    ) -> impl futures::Future<Output = BTreeSet<TYPES::SignatureKey>> + Send;
 
     /// Get all participants in the committee for a specific view for a specific epoch
     fn da_committee_members(
         &self,
         view_number: TYPES::View,
         epoch: TYPES::Epoch,
-    ) -> BTreeSet<TYPES::SignatureKey>;
+    ) -> impl futures::Future<Output = BTreeSet<TYPES::SignatureKey>> + Send;
 
     /// Get all leaders in the committee for a specific view for a specific epoch
     fn committee_leaders(
         &self,
         view_number: TYPES::View,
         epoch: TYPES::Epoch,
-    ) -> BTreeSet<TYPES::SignatureKey>;
+    ) -> impl futures::Future<Output = BTreeSet<TYPES::SignatureKey>> + Send;
 
     /// Get the stake table entry for a public key, returns `None` if the
     /// key is not in the table for a specific epoch
@@ -64,7 +64,8 @@ pub trait Membership<TYPES: NodeType>: Clone + Debug + Send + Sync {
         &self,
         pub_key: &TYPES::SignatureKey,
         epoch: TYPES::Epoch,
-    ) -> Option<<TYPES::SignatureKey as SignatureKey>::StakeTableEntry>;
+    ) -> impl futures::Future<Output = Option<<TYPES::SignatureKey as SignatureKey>::StakeTableEntry>>
+           + Send;
 
     /// Get the DA stake table entry for a public key, returns `None` if the
     /// key is not in the table for a specific epoch
@@ -72,13 +73,22 @@ pub trait Membership<TYPES: NodeType>: Clone + Debug + Send + Sync {
         &self,
         pub_key: &TYPES::SignatureKey,
         epoch: TYPES::Epoch,
-    ) -> Option<<TYPES::SignatureKey as SignatureKey>::StakeTableEntry>;
+    ) -> impl futures::Future<Output = Option<<TYPES::SignatureKey as SignatureKey>::StakeTableEntry>>
+           + Send;
 
     /// See if a node has stake in the committee in a specific epoch
-    fn has_stake(&self, pub_key: &TYPES::SignatureKey, epoch: TYPES::Epoch) -> bool;
+    fn has_stake(
+        &self,
+        pub_key: &TYPES::SignatureKey,
+        epoch: TYPES::Epoch,
+    ) -> impl futures::Future<Output = bool> + Send;
 
     /// See if a node has stake in the committee in a specific epoch
-    fn has_da_stake(&self, pub_key: &TYPES::SignatureKey, epoch: TYPES::Epoch) -> bool;
+    fn has_da_stake(
+        &self,
+        pub_key: &TYPES::SignatureKey,
+        epoch: TYPES::Epoch,
+    ) -> impl futures::Future<Output = bool> + Send;
 
     /// The leader of the committee for view `view_number` in `epoch`.
     ///
@@ -87,12 +97,18 @@ pub trait Membership<TYPES: NodeType>: Clone + Debug + Send + Sync {
     ///
     /// # Errors
     /// Returns an error if the leader cannot be calculated.
-    fn leader(&self, view: TYPES::View, epoch: TYPES::Epoch) -> Result<TYPES::SignatureKey> {
+    fn leader(
+        &self,
+        view: TYPES::View,
+        epoch: TYPES::Epoch,
+    ) -> impl futures::Future<Output = Result<TYPES::SignatureKey>> + Send {
         use utils::anytrace::*;
 
-        self.lookup_leader(view, epoch).wrap().context(info!(
-            "Failed to get leader for view {view} in epoch {epoch}"
-        ))
+        async move {
+            self.lookup_leader(view, epoch).await.wrap().context(info!(
+                "Failed to get leader for view {view} in epoch {epoch}"
+            ))
+        }
     }
 
     /// The leader of the committee for view `view_number` in `epoch`.
@@ -106,23 +122,35 @@ pub trait Membership<TYPES: NodeType>: Clone + Debug + Send + Sync {
         &self,
         view: TYPES::View,
         epoch: TYPES::Epoch,
-    ) -> std::result::Result<TYPES::SignatureKey, Self::Error>;
+    ) -> impl futures::Future<Output = std::result::Result<TYPES::SignatureKey, Self::Error>> + Send;
 
     /// Returns the number of total nodes in the committee in an epoch `epoch`
-    fn total_nodes(&self, epoch: TYPES::Epoch) -> usize;
+    fn total_nodes(&self, epoch: TYPES::Epoch) -> impl futures::Future<Output = usize> + Send;
 
     /// Returns the number of total DA nodes in the committee in an epoch `epoch`
-    fn da_total_nodes(&self, epoch: TYPES::Epoch) -> usize;
+    fn da_total_nodes(&self, epoch: TYPES::Epoch) -> impl futures::Future<Output = usize> + Send;
 
     /// Returns the threshold for a specific `Membership` implementation
-    fn success_threshold(&self, epoch: TYPES::Epoch) -> NonZeroU64;
+    fn success_threshold(
+        &self,
+        epoch: TYPES::Epoch,
+    ) -> impl futures::Future<Output = NonZeroU64> + Send;
 
     /// Returns the DA threshold for a specific `Membership` implementation
-    fn da_success_threshold(&self, epoch: TYPES::Epoch) -> NonZeroU64;
+    fn da_success_threshold(
+        &self,
+        epoch: TYPES::Epoch,
+    ) -> impl futures::Future<Output = NonZeroU64> + Send;
 
     /// Returns the threshold for a specific `Membership` implementation
-    fn failure_threshold(&self, epoch: TYPES::Epoch) -> NonZeroU64;
+    fn failure_threshold(
+        &self,
+        epoch: TYPES::Epoch,
+    ) -> impl futures::Future<Output = NonZeroU64> + Send;
 
     /// Returns the threshold required to upgrade the network protocol
-    fn upgrade_threshold(&self, epoch: TYPES::Epoch) -> NonZeroU64;
+    fn upgrade_threshold(
+        &self,
+        epoch: TYPES::Epoch,
+    ) -> impl futures::Future<Output = NonZeroU64> + Send;
 }


### PR DESCRIPTION
With the introduction of epochs, the Membership type is no longer static. We need to update the Membership on each epoch. This requires wrapping Membership in Arc<RwLock<..>>. Hence, all Membership methods would need to acquire a read lock, which requires making the membership functions async.

Since the current functions are not async, they block the thread to acquire the lock, which is dangerous. Some sequencer tests also return the following error:
`Cannot block the current thread from within a runtime. This happens because a function attempted to block the current thread while the thread is being used to drive asynchronous tasks.`

So, to make things work , we should make these functions async and this  PR implements these changes.

There has also been a discussion about Hotshot managing the locks on the Membership type and  handle the call to the update() function on Membership at every new epoch. This approach is  much better IMO, and I believe it would also require making these functions async.