### PR TITLE
fix: multiple typos of different importance

### DIFF
--- a/.github/ISSUE_TEMPLATE/BASIC_ISSUE_FORM.yml
+++ b/.github/ISSUE_TEMPLATE/BASIC_ISSUE_FORM.yml
@@ -11,7 +11,7 @@ body:
   - type: textarea
     id: task_reason
     attributes:
-      label: What is this task and why do we need to work on it? 
+      label: What is this task and why must we work on it? 
       placeholder: |
         For MACRO tasks: The description should be written for someone unfamiliar with HotShot. 
         For regular tasks: The description should be written for someone familiar with HotShot but not with this particular issue.
@@ -23,10 +23,10 @@ body:
       label: What work will need to be done to complete this task? 
       description: 
       placeholder: | 
-        If this is unknown, describe what information is needed to determine this. 
+        If this is unknown, describe what information is required to determine this. 
         
         If this is a MACRO task link the sub-issues here.
-        If this is a regular task use check boxes to list the sub-tasks here.
+        If this is a regular task use checkboxes to list the sub-tasks here.
 
         E.g. 
         - [ ] Task 1

--- a/crates/builder-api/src/v0_1/builder.rs
+++ b/crates/builder-api/src/v0_1/builder.rs
@@ -50,7 +50,7 @@ pub enum BuildError {
     Error(String),
 }
 
-/// Enum to keep track on status of a transaction
+/// Enum to keep track of the status of a transaction
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 pub enum TransactionStatus {
     Pending,

--- a/crates/examples/combined/validator.rs
+++ b/crates/examples/combined/validator.rs
@@ -30,7 +30,7 @@ async fn main() {
 
     let mut args = ValidatorArgs::parse();
 
-    // If we did not set the advertise address, use our local IP and port 8000
+    // If we did not set the advertised address, use our local IP and port 8000
     let local_ip = local_ip().expect("failed to get local IP");
     args.advertise_address = Some(args.advertise_address.unwrap_or(format!("{local_ip}:8000")));
 

--- a/crates/hotshot-stake-table/src/mt_based/internal.rs
+++ b/crates/hotshot-stake-table/src/mt_based/internal.rs
@@ -264,7 +264,7 @@ impl<K: Key> PersistentMerkleNode<K> {
         }
     }
 
-    /// Returns the stakes withhelded by a public key, None if the key is not registered.
+    /// Returns the stakes withheld by a public key, None if the key is not registered.
     pub fn simple_lookup(&self, height: usize, path: &[usize]) -> Result<U256, StakeTableError> {
         match self {
             PersistentMerkleNode::Empty => Err(StakeTableError::KeyNotFound),
@@ -320,8 +320,8 @@ impl<K: Key> PersistentMerkleNode<K> {
         }
     }
 
-    /// Imagine that the keys in this subtree is sorted, returns the first key such that
-    /// the prefix sum of withholding stakes is greater or equal the given `stake_number`.
+    /// Imagine that the keys in this subtree are sorted, returns the first key such that
+    /// the prefix sum of withholding stakes is greater or equal to the given `stake_number`.
     /// Useful for key sampling weighted by withholding stakes
     pub fn key_by_stake(&self, mut stake_number: U256) -> Option<(&K, &U256)> {
         if stake_number >= self.total_stakes() {
@@ -571,7 +571,7 @@ impl<K: Key> Iterator for IntoIter<K> {
             return None;
         }
 
-        // This unwrap always succeed because `unvisited` is nonempty
+        // This unwrap always succeeds because `unvisited` is nonempty
         let visiting = (*self.unvisited.pop().unwrap()).clone();
         match visiting {
             PersistentMerkleNode::Empty => None,
@@ -656,7 +656,7 @@ mod tests {
                     .unwrap(),
             );
         }
-        // Check that if the insertion is perform correctly
+        // Check that the insertion is performed correctly
         for i in 0..10 {
             assert!(roots[i].simple_lookup(height, &path[i]).is_err());
             assert_eq!(i, roots[i].num_keys());

--- a/crates/hotshot-stake-table/src/vec_based.rs
+++ b/crates/hotshot-stake-table/src/vec_based.rs
@@ -43,7 +43,7 @@ impl<K1, K2> Default for StakeTableSnapshot<K1, K2> {
 }
 
 /// Locally maintained stake table, generic over public key type `K`.
-/// Whose commitment is a rescue hash of all key-value pairs over field `F`.
+/// Whose commitment is a rescue hash of all key-value pairs over the field `F`.
 /// NOTE: the commitment is only available for the finalized versions, and is
 /// computed only once when it's finalized.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -57,9 +57,9 @@ where
     capacity: usize,
     /// The most up-to-date stake table, where the incoming transactions shall be performed on.
     head: StakeTableSnapshot<K1, K2>,
-    /// The snapshot of stake table at the beginning of the current epoch
+    /// The snapshot of the stake table at the beginning of the current epoch
     epoch_start: StakeTableSnapshot<K1, K2>,
-    /// The stake table used for leader election.
+    /// The stake table is used for leader election.
     last_epoch_start: StakeTableSnapshot<K1, K2>,
 
     /// Total stakes in the most update-to-date stake table
@@ -295,7 +295,7 @@ where
     }
 
     /// Set the stake withheld by `key` to be `value`.
-    /// Return the previous stake if succeed.
+    /// Return the previous stake if succeeds.
     /// # Errors
     /// Errors if key is not in the stake table
     pub fn set_value(&mut self, key: &K1, value: U256) -> Result<U256, StakeTableError> {
@@ -313,7 +313,7 @@ where
 
     /// Helper function to recompute the stake table commitment for head version
     /// Commitment of a stake table is a triple `(bls_keys_comm, schnorr_keys_comm, stake_amount_comm)`
-    /// TODO(Chengyu): The BLS verification keys doesn't implement Default. Thus we directly pad with `F::default()`.
+    /// TODO(Chengyu): The BLS verification keys don't implement Default. Thus we directly pad with `F::default()`.
     fn compute_head_comm(&mut self) -> (F, F, F) {
         let padding_len = self.capacity - self.head.bls_keys.len();
         // Compute rescue hash for bls keys
@@ -351,7 +351,7 @@ where
     }
 
     /// Return the index of a given key.
-    /// Err if the key doesn't exists
+    /// Err if the key doesn't exist
     fn lookup_pos(&self, key: &K1) -> Result<usize, StakeTableError> {
         match self.bls_mapping.get(key) {
             Some(pos) => Ok(*pos),

--- a/crates/hotshot-stake-table/src/vec_based/config.rs
+++ b/crates/hotshot-stake-table/src/vec_based/config.rs
@@ -19,7 +19,7 @@ pub type FieldType = ark_ed_on_bn254::Fq;
 
 /// Hashable representation of a key
 /// NOTE: commitment is only used in light client contract.
-/// For this application, we needs only hash the Schnorr verification key.
+/// For this application, we need only hash the Schnorr verification key.
 impl ToFields<FieldType> for StateVerKey {
     const SIZE: usize = 2;
 

--- a/crates/hotshot/src/traits/networking/combined_network.rs
+++ b/crates/hotshot/src/traits/networking/combined_network.rs
@@ -79,7 +79,7 @@ pub struct CombinedNetworks<TYPES: NodeType> {
     /// Channels to the delayed tasks
     delayed_tasks_channels: DelayedTasksChannelsMap,
 
-    /// How many times messages were sent on secondary without delay because primary is down
+    /// How many times were messages sent on secondary without delay because the primary is down
     no_delay_counter: Arc<AtomicU64>,
 }
 

--- a/crates/hotshot/src/traits/networking/memory_network.rs
+++ b/crates/hotshot/src/traits/networking/memory_network.rs
@@ -76,7 +76,7 @@ struct MemoryNetworkInner<K: SignatureKey> {
     /// The master map
     master_map: Arc<MasterMap<K>>,
 
-    /// Count of messages that are in-flight (send but not processed yet)
+    /// Count of in-flight messages (sent but not processed yet)
     in_flight_message_count: AtomicUsize,
 
     /// config to introduce unreliability to the network

--- a/crates/hotshot/src/types/handle.rs
+++ b/crates/hotshot/src/types/handle.rs
@@ -131,7 +131,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static, V: Versions>
         Ok(())
     }
 
-    /// Request a proposal from the all other nodes.  Will block until some node
+    /// Request a proposal from all the other nodes.  Will block until some node
     /// returns a valid proposal with the requested commitment.  If nobody has the
     /// proposal this will block forever
     ///
@@ -286,7 +286,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static, V: Versions>
         self.hotshot.consensus()
     }
 
-    /// Shut down the the inner hotshot and wait until all background threads are closed.
+    /// Shut down the inner hotshot and wait until all background threads are closed.
     pub async fn shut_down(&mut self) {
         // this is required because `SystemContextHandle` holds an inactive receiver and
         // `broadcast_direct` below can wait indefinitely


### PR DESCRIPTION
## Overview

This pull request fixes multiple typos in comments and documentation across several files in the codebase. These changes improve the clarity, readability, and professionalism of the codebase without altering its functionality. 

### This PR:
- Fixes grammatical issues such as:
  - "withhelded" → "withheld"
  - "signalling" → "signaling"
  - "exists" → "exist"
  - "needs only hash" → "need only hash"
  - And others.
- Adjusts phrases for consistency and readability, like:
  - "Count of messages that are in-flight (send but not processed yet)" → "Count of in-flight messages (sent but not processed yet)".
  - "Shut down the the inner hotshot" → "Shut down the inner hotshot".

### Key places to review:
- `.github/ISSUE_TEMPLATE/BASIC_ISSUE_FORM.yml`: Adjusted wording for task descriptions and placeholders.
- `crates/builder-api/src/v0_1/builder.rs`: Corrected "on status of a transaction" → "of the status of a transaction".
- `crates/examples/combined/validator.rs`: Fixed "set the advertise address" → "set the advertised address".
- Various fixes in `hotshot-stake-table` and `hotshot` modules for typos and redundant wording.

### Out of scope:
- No functional or feature changes are included in this PR.

## Tests

No tests were added or modified as this PR only addresses comments and documentation. The codebase's functionality and existing tests remain unaffected.

## Metadata

Closes #<ISSUE_NUMBER> <!-- Replace with the relevant issue number if applicable. -->

---

Allow edits by maintainers: ✅
