### PR TITLE
Fix grammar issues in documentation and code comments

### DIFF
--- a/crates/examples/orchestrator.rs
+++ b/crates/examples/orchestrator.rs
@@ -4,7 +4,7 @@
 // You should have received a copy of the MIT License
 // along with the HotShot repository. If not, see <https://mit-license.org/>.
 
-//! A orchestrator
+//! An orchestrator
 
 use hotshot::helpers::initialize_logging;
 use hotshot_example_types::state_types::TestTypes;

--- a/crates/examples/push-cdn/all.rs
+++ b/crates/examples/push-cdn/all.rs
@@ -4,7 +4,7 @@
 // You should have received a copy of the MIT License
 // along with the HotShot repository. If not, see <https://mit-license.org/>.
 
-//! A example program using the Push CDN
+//! An example program using the Push CDN
 /// The types we're importing
 pub mod types;
 

--- a/crates/libp2p-networking/src/network/mod.rs
+++ b/crates/libp2p-networking/src/network/mod.rs
@@ -128,7 +128,7 @@ pub enum NetworkEvent {
 pub enum NetworkEventInternal {
     /// a DHT event
     DHTEvent(libp2p::kad::Event),
-    /// a identify event. Is boxed because this event is much larger than the other ones so we want
+    /// an identify event. Is boxed because this event is much larger than the other ones so we want
     /// to store it on the heap.
     IdentifyEvent(Box<IdentifyEvent>),
     /// a gossip  event

--- a/crates/libp2p-networking/src/network/mod.rs
+++ b/crates/libp2p-networking/src/network/mod.rs
@@ -135,7 +135,7 @@ pub enum NetworkEventInternal {
     GossipEvent(Box<GossipEvent>),
     /// a direct message event
     DMEvent(libp2p::request_response::Event<Vec<u8>, Vec<u8>>),
-    /// a autonat event
+    /// an autonat event
     AutonatEvent(libp2p::autonat::Event),
 }
 


### PR DESCRIPTION
This pull request addresses several grammar issues related to the use of the articles "a" and "an" in documentation and code comments across multiple files. The changes include:

- Replacing "A orchestrator" with "An orchestrator" in `orchestrator.rs`
- Replacing "A example program" with "An example program" in `all.rs`
- Replacing "a identify event" with "an identify event" and "a autonat event" with "an autonat event" in `mod.rs`

These changes improve the readability and correctness of the comments and documentation.

## This PR:
- Fixes grammar issues in comments by replacing incorrect usage of "a" with "an" where appropriate.