### PR TITLE
chore: Expose request-response protocol to application layer

### DIFF
--- a/crates/hotshot/src/traits/networking/mod.rs
+++ b/crates/hotshot/src/traits/networking/mod.rs
@@ -1,0 +1,12 @@
+//! Networking module for HotShot consensus protocol
+
+pub mod request_response;
+
+// Re-exporting the main types for convenience.
+pub use request_response::{
+    NetworkRequest,
+    NetworkResponse,
+    RequestHandler,
+    RequestType,
+    ResponseStatus,
+};

--- a/crates/hotshot/src/traits/networking/request_response.rs
+++ b/crates/hotshot/src/traits/networking/request_response.rs
@@ -1,0 +1,36 @@
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub enum RequestType {
+    LeafByHeight(u64),
+    PayloadByVidCommitment(Vec<u8>),
+    VidCommonByCommitment(Vec<u8>), 
+    FeeAccountStates,
+    BlocksFrontier,
+    Config,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct NetworkRequest {
+    pub request_type: RequestType,
+    pub requester_id: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct NetworkResponse {
+    pub data: Vec<u8>,
+    pub status: ResponseStatus,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub enum ResponseStatus {
+    Success,
+    NotFound,
+    Error(String),
+}
+
+#[async_trait]
+pub trait RequestHandler {
+    async fn handle_request(&self, request: NetworkRequest) -> NetworkResponse;
+}


### PR DESCRIPTION
Closes #3871

### This PR:
* Implements request-response protocol for network layer
* Adds new types for network requests and responses
* Exposes network functionality to application layer through RequestHandler trait
* Implements basic request types (LeafByHeight, PayloadByVidCommitment, etc.)

### This PR does not:
* Implement specific request handlers for all request types (will be added based on application needs)
* Add comprehensive error handling (will be addressed in follow-up PRs)

### Key places to review:
* `crates/hotshot/src/networking/request_response.rs` - New protocol implementation
* `crates/hotshot/src/networking/mod.rs` - Module exports and organization

### How to test this PR:
* Currently includes only type definitions and traits
* Unit tests will be added in follow-up commits