### PR TITLE
Reorganize tests and add epoch upgrade test

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -3,3 +3,9 @@ retries = 2
 slow-timeout = { period = "1m", terminate-after = 3 }
 final-status-level = "flaky"
 threads-required = "num-test-threads"
+
+[profile.local]
+retries = 0
+slow-timeout = { period = "1m", terminate-after = 3 }
+final-status-level = "slow"
+threads-required = "num-test-threads"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -24,6 +24,7 @@ jobs:
           - test-ci-3
           - test-ci-4
           - test-ci-5
+          - test-ci-6
           - test-ci-rest
       fail-fast: false
     runs-on: ubuntu-latest

--- a/crates/example-types/src/node_types.rs
+++ b/crates/example-types/src/node_types.rs
@@ -295,7 +295,23 @@ impl Versions for EpochsTestVersions {
         0, 0,
     ];
 
-    type Marketplace = StaticVersion<0, 3>;
+    type Marketplace = StaticVersion<0, 5>;
+
+    type Epochs = StaticVersion<0, 4>;
+}
+
+#[derive(Clone, Debug, Copy)]
+pub struct EpochUpgradeTestVersions {}
+
+impl Versions for EpochUpgradeTestVersions {
+    type Base = StaticVersion<0, 3>;
+    type Upgrade = StaticVersion<0, 4>;
+    const UPGRADE_HASH: [u8; 32] = [
+        1, 0, 1, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0,
+        0, 0,
+    ];
+
+    type Marketplace = StaticVersion<0, 5>;
 
     type Epochs = StaticVersion<0, 4>;
 }

--- a/crates/task-impls/src/vid.rs
+++ b/crates/task-impls/src/vid.rs
@@ -76,7 +76,6 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> VidTaskState<TYPES, I> {
                     metadata,
                     view_number,
                     sequencing_fees,
-                    vid_precompute,
                     auction_result,
                     ..
                 } = packed_bundle;
@@ -103,9 +102,9 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> VidTaskState<TYPES, I> {
                     *view_number,
                     epoch,
                     epoch,
-                    vid_precompute.clone(),
                 )
-                .await;
+                .await
+                .ok()?;
                 let payload_commitment = vid_disperse.payload_commitment;
                 let shares = VidDisperseShare2::from_vid_disperse(vid_disperse.clone());
                 let mut consensus_writer = self.consensus.write().await;
@@ -209,9 +208,9 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> VidTaskState<TYPES, I> {
                     proposal_view_number,
                     target_epoch,
                     sender_epoch,
-                    None,
                 )
-                .await;
+                .await
+                .ok()?;
                 let Ok(next_epoch_signature) = TYPES::SignatureKey::sign(
                     &self.private_key,
                     next_epoch_vid_disperse.payload_commitment.as_ref(),

--- a/crates/testing/tests/tests_1/test_success.rs
+++ b/crates/testing/tests/tests_1/test_success.rs
@@ -8,9 +8,8 @@ use std::time::Duration;
 
 use hotshot_example_types::{
     node_types::{
-        CombinedImpl, EpochsTestVersions, Libp2pImpl, MemoryImpl, PushCdnImpl,
-        TestConsecutiveLeaderTypes, TestTwoStakeTablesTypes, TestTypes, TestTypesRandomizedLeader,
-        TestVersions,
+        Libp2pImpl, MemoryImpl, PushCdnImpl, TestConsecutiveLeaderTypes, TestTypes,
+        TestTypesRandomizedLeader, TestVersions,
     },
     testable_delay::{DelayConfig, DelayOptions, DelaySettings, SupportedTraitTypesForAsyncDelay},
 };
@@ -18,7 +17,6 @@ use hotshot_macros::cross_tests;
 use hotshot_testing::{
     block_builder::SimpleBuilderImplementation,
     completion_task::{CompletionTaskDescription, TimeBasedCompletionTaskDescription},
-    spinning_task::{ChangeNode, NodeAction, SpinningTaskDescription},
     test_builder::TestDescription,
     view_sync_task::ViewSyncTaskDescription,
 };

--- a/crates/testing/tests/tests_6.rs
+++ b/crates/testing/tests/tests_6.rs
@@ -1,0 +1,9 @@
+// Copyright (c) 2021-2024 Espresso Systems (espressosys.com)
+// This file is part of the HotShot repository.
+
+// You should have received a copy of the MIT License
+// along with the HotShot repository. If not, see <https://mit-license.org/>.
+
+mod tests_6 {
+    automod::dir!("tests/tests_6");
+}

--- a/crates/testing/tests/tests_6/test_epochs.rs
+++ b/crates/testing/tests/tests_6/test_epochs.rs
@@ -8,9 +8,9 @@ use std::time::Duration;
 
 use hotshot_example_types::{
     node_types::{
-        CombinedImpl, EpochsTestVersions, Libp2pImpl, MemoryImpl, PushCdnImpl,
-        TestConsecutiveLeaderTypes, TestTwoStakeTablesTypes, TestTypes, TestTypesRandomizedLeader,
-        TestVersions,
+        CombinedImpl, EpochUpgradeTestVersions, EpochsTestVersions, Libp2pImpl, MemoryImpl,
+        PushCdnImpl, TestConsecutiveLeaderTypes, TestTwoStakeTablesTypes, TestTypes,
+        TestTypesRandomizedLeader,
     },
     testable_delay::{DelayConfig, DelayOptions, DelaySettings, SupportedTraitTypesForAsyncDelay},
 };
@@ -215,5 +215,26 @@ cross_tests!(
         metadata.overall_safety_properties.num_successful_views = 1;
         metadata.overall_safety_properties.num_failed_views = 0;
         metadata
+    },
+);
+
+cross_tests!(
+    TestName: test_epoch_upgrade,
+    Impls: [MemoryImpl],
+    Types: [TestTypes, TestTypesRandomizedLeader, TestTwoStakeTablesTypes],
+    Versions: [EpochUpgradeTestVersions],
+    Ignore: true,
+    Metadata: {
+        TestDescription {
+            // allow more time to pass in CI
+            completion_task_description: CompletionTaskDescription::TimeBasedCompletionTaskBuilder(
+                                             TimeBasedCompletionTaskDescription {
+                                                 duration: Duration::from_secs(60),
+                                             },
+                                         ),
+            epoch_height: 50,
+            upgrade_view: Some(5),
+            ..TestDescription::default()
+        }
     },
 );

--- a/crates/types/src/consensus.rs
+++ b/crates/types/src/consensus.rs
@@ -954,8 +954,9 @@ impl<TYPES: NodeType> Consensus<TYPES> {
             .get(&view)?
             .view_inner
             .epoch()?;
-        let vid =
-            VidDisperse::calculate_vid_disperse(txns, &membership, view, epoch, epoch, None).await;
+        let vid = VidDisperse::calculate_vid_disperse(txns, &membership, view, epoch, epoch)
+            .await
+            .ok()?;
         let shares = VidDisperseShare2::from_vid_disperse(vid);
         let mut consensus_writer = consensus.write().await;
         for share in shares {

--- a/crates/types/src/data.rs
+++ b/crates/types/src/data.rs
@@ -258,8 +258,8 @@ impl<TYPES: NodeType> VidDisperse<TYPES> {
     /// optionally using precompute data from builder.
     /// If the sender epoch is missing, it means it's the same as the target epoch.
     ///
-    /// # Panics
-    /// Panics if the VID calculation fails, this should not happen.
+    /// # Errors
+    /// Returns an error if the disperse or commitment calculation fails
     #[allow(clippy::panic)]
     pub async fn calculate_vid_disperse(
         txns: Arc<[u8]>,

--- a/crates/types/src/data.rs
+++ b/crates/types/src/data.rs
@@ -20,12 +20,11 @@ use std::{
 use async_lock::RwLock;
 use bincode::Options;
 use committable::{Commitment, CommitmentBoundsArkless, Committable, RawCommitmentBuilder};
-use jf_vid::{precomputable::Precomputable, VidDisperse as JfVidDisperse, VidScheme};
+use jf_vid::{VidDisperse as JfVidDisperse, VidScheme};
 use rand::Rng;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tokio::task::spawn_blocking;
-use tracing::error;
 use utils::anytrace::*;
 use vec1::Vec1;
 
@@ -268,42 +267,42 @@ impl<TYPES: NodeType> VidDisperse<TYPES> {
         view: TYPES::View,
         target_epoch: TYPES::Epoch,
         data_epoch: TYPES::Epoch,
-        precompute_data: Option<VidPrecomputeData>,
-    ) -> Self {
+    ) -> Result<Self> {
         let num_nodes = membership.read().await.total_nodes(target_epoch);
+        let num_txns = txns.len();
 
         let txns_clone = Arc::clone(&txns);
-        let vid_disperse = spawn_blocking(move || {
-            precompute_data
-                .map_or_else(
-                    || vid_scheme(num_nodes).disperse(&txns_clone),
-                    |data| vid_scheme(num_nodes).disperse_precompute(&txns_clone, &data)
-                )
-                .unwrap_or_else(|err| panic!("VID disperse failure:(num_storage nodes,payload_byte_len)=({num_nodes},{}) error: {err}", txns_clone.len()))
-        }).await;
-        let data_epoch_payload_commitment = if target_epoch == data_epoch {
+        let vid_disperse = spawn_blocking(move || vid_scheme(num_nodes).disperse(&txns_clone))
+            .await
+            .wrap()
+            .context(error!("Join error"))?
+            .wrap()
+            .context(|err| error!("Failed to calculate VID disperse. Error: {}", err))?;
+
+        let payload_commitment = if target_epoch == data_epoch {
             None
         } else {
-            let data_epoch_num_nodes = membership.read().await.total_nodes(data_epoch);
-            Some(spawn_blocking(move || {
-                vid_scheme(data_epoch_num_nodes).commit_only(&txns)
-                    .unwrap_or_else(|err| panic!("VID commit_only failure:(num_storage nodes,payload_byte_len)=({num_nodes},{}) error: {err}", txns.len()))
-            }).await)
-        };
-        // Unwrap here will just propagate any panic from the spawned task, it's not a new place we can panic.
-        let vid_disperse = vid_disperse.unwrap();
-        let data_epoch_payload_commitment =
-            data_epoch_payload_commitment.map(|result| result.unwrap());
+            let num_nodes = membership.read().await.total_nodes(data_epoch);
 
-        Self::from_membership(
+            Some(
+              spawn_blocking(move || vid_scheme(num_nodes).commit_only(&txns))
+                .await
+                .wrap()
+                .context(error!("Join error"))?
+                .wrap()
+                .context(|err| error!("Failed to calculate VID commitment with (num_storage_nodes, payload_byte_len) = ({}, {}). Error: {}", num_nodes, num_txns, err))?
+            )
+        };
+
+        Ok(Self::from_membership(
             view,
             vid_disperse,
             membership,
             target_epoch,
             data_epoch,
-            data_epoch_payload_commitment,
+            payload_commitment,
         )
-        .await
+        .await)
     }
 }
 
@@ -367,7 +366,7 @@ impl<TYPES: NodeType> VidDisperseShare<TYPES> {
         let Ok(signature) =
             TYPES::SignatureKey::sign(private_key, self.payload_commitment.as_ref())
         else {
-            error!("VID: failed to sign dispersal share payload");
+            tracing::error!("VID: failed to sign dispersal share payload");
             return None;
         };
         Some(Proposal {
@@ -523,7 +522,7 @@ impl<TYPES: NodeType> VidDisperseShare2<TYPES> {
         let Ok(signature) =
             TYPES::SignatureKey::sign(private_key, self.payload_commitment.as_ref())
         else {
-            error!("VID: failed to sign dispersal share payload");
+            tracing::error!("VID: failed to sign dispersal share payload");
             return None;
         };
         Some(Proposal {

--- a/flake.nix
+++ b/flake.nix
@@ -171,6 +171,7 @@
             cargo-expand
             cargo-workspaces
             cargo-audit
+            cargo-nextest
             nixpkgs-fmt
             git-chglog
             typos

--- a/justfile
+++ b/justfile
@@ -56,7 +56,7 @@ test-ci-6:
 #   just test memoryimpl_::test_success --nocapture
 test *ARGS:
   echo Running test {{ARGS}}
-  RUST_LOG=warn,hotshot_task_impls=debug cargo nextest run --profile local {{ARGS}} --lib --bins --tests --benches --workspace
+  cargo nextest run --profile local {{ARGS}} --lib --bins --tests --benches --workspace
 
 check:
   echo Checking

--- a/justfile
+++ b/justfile
@@ -19,120 +19,44 @@ example_fixed_leader *ARGS:
 example_gpuvid_leader *ARGS:
   cargo run --features "fixed-leader-election, gpu-vid" --profile=release-lto --example {{ARGS}}
 
-test *ARGS:
-  echo Testing {{ARGS}}
-  cargo test --lib --bins --tests --benches --workspace --no-fail-fast {{ARGS}} -- --test-threads=1 --nocapture --skip crypto_test
-
-test-ci *ARGS:
-  echo Testing {{ARGS}}
-  RUST_LOG=info cargo nextest run --profile ci tests_1 --lib --bins --tests --benches --workspace --no-fail-fast {{ARGS}}
-
 test-ci-rest *ARGS:
-  echo Testing {{ARGS}}
-  RUST_LOG=info cargo nextest run -E 'not (test(tests_1) | test(tests_2) | test(tests_3) | test(tests_4) | test(tests_5))' --profile ci --lib --bins --tests --benches --workspace --no-fail-fast {{ARGS}}
+  echo Running unit tests
+  RUST_LOG=info cargo nextest run -E 'not (test(tests_1) | test(tests_2) | test(tests_3) | test(tests_4) | test(tests_5) | test(tests_6))' --profile ci --lib --bins --tests --benches --workspace --no-fail-fast {{ARGS}}
 
-test-ci-1 *ARGS:
-  echo Testing {{ARGS}}
-  RUST_LOG=info cargo nextest run --profile ci tests_1 --lib --bins --tests --benches --workspace --no-fail-fast {{ARGS}}
+test-ci-1:
+  echo Running integration test group 1
+  RUST_LOG=info cargo nextest run --profile ci tests_1 --lib --bins --tests --benches --workspace --no-fail-fast
 
-test-ci-2 *ARGS:
-  echo Testing {{ARGS}}
-  RUST_LOG=info cargo nextest run --profile ci tests_2 --lib --bins --tests --benches --workspace --no-fail-fast {{ARGS}}
+test-ci-2:
+  echo Running integration test group 2
+  RUST_LOG=info cargo nextest run --profile ci tests_2 --lib --bins --tests --benches --workspace --no-fail-fast
 
-test-ci-3 *ARGS:
-  echo Testing {{ARGS}}
-  RUST_LOG=info cargo nextest run --profile ci tests_3 --lib --bins --tests --benches --workspace --no-fail-fast {{ARGS}}
+test-ci-3:
+  echo Running integration test group 3
+  RUST_LOG=info cargo nextest run --profile ci tests_3 --lib --bins --tests --benches --workspace --no-fail-fast
 
-test-ci-4 *ARGS:
-  echo Testing {{ARGS}}
-  RUST_LOG=info cargo nextest run --profile ci tests_4 --lib --bins --tests --benches --workspace --no-fail-fast {{ARGS}}
+test-ci-4:
+  echo Running integration test group 4
+  RUST_LOG=info cargo nextest run --profile ci tests_4 --lib --bins --tests --benches --workspace --no-fail-fast
 
-test-ci-5 *ARGS:
-  echo Testing {{ARGS}}
-  RUST_LOG=info cargo nextest run --profile ci tests_5 --lib --bins --tests --benches --workspace --no-fail-fast {{ARGS}}
+test-ci-5:
+  echo Running integration test group 5
+  RUST_LOG=info cargo nextest run --profile ci tests_5 --lib --bins --tests --benches --workspace --no-fail-fast
 
-test_basic: test_success test_with_failures test_network_task test_da_task test_vid_task test_view_sync_task
+test-ci-6:
+  echo Running integration test group 6
+  RUST_LOG=info cargo nextest run --profile ci tests_6 --lib --bins --tests --benches --workspace --no-fail-fast
 
-test_catchup:
-  echo Testing catchup
-  cargo test --lib --bins --tests --benches --workspace --no-fail-fast test_catchup -- --test-threads=1 --nocapture
-
-test_crypto:
-  cargo test --lib --bins --tests --benches --workspace --no-fail-fast crypto_test -- --test-threads=1 --nocapture
-
-test_success:
-  echo Testing success test
-  cargo test --lib --bins --tests --benches --workspace --no-fail-fast test_success -- --test-threads=1 --nocapture
-
-test_timeout:
-  echo Testing timeout test
-  cargo test --lib --bins --tests --benches --workspace --no-fail-fast test_timeout -- --test-threads=1 --nocapture
-
-test_combined_network:
-  echo Testing combined network
-  cargo test  --lib --bins --tests --benches --workspace --no-fail-fast test_combined_network -- --test-threads=1 --nocapture
-
-test_web_server:
-  echo Testing web server
-  cargo test  --lib --bins --tests --benches --workspace --no-fail-fast web_server_network -- --test-threads=1 --nocapture
-
-test_with_failures:
-  echo Testing nodes leaving the network
-  cargo test  --lib --bins --tests --benches --workspace --no-fail-fast test_with_failures -- --test-threads=1 --nocapture
-
-test_network_task:
-  echo Testing the DA task
-  cargo test --lib --bins --tests --benches --workspace --no-fail-fast test_network_task -- --test-threads=1 --nocapture
-
-test_memory_network:
-  echo Testing the DA task
-  cargo test --lib --bins --tests --benches --workspace --no-fail-fast memory_network -- --test-threads=1 --nocapture
-
-test_quorum_vote_task:
-  echo Testing the quorum vote task
-  cargo test  --lib --bins --tests --benches --workspace --no-fail-fast test_quorum_vote_task -- --test-threads=1 --nocapture
-
-test_quorum_proposal_task:
-  echo Testing the quorum proposal task
-  cargo test  --lib --bins --tests --benches --workspace --no-fail-fast test_quorum_proposal_task -- --test-threads=1 --nocapture
-
-test_da_task:
-  echo Testing the DA task
-  cargo test --lib --bins --tests --benches --workspace --no-fail-fast test_da_task -- --test-threads=1 --nocapture
-
-test_vid_task:
-  echo Testing the VID task
-  cargo test --lib --bins --tests --benches --workspace --no-fail-fast test_vid_task -- --test-threads=1 --nocapture
-
-test_view_sync_task:
-  echo Testing the view sync task
-  cargo test --lib --bins --tests --benches --workspace --no-fail-fast test_view_sync_task -- --test-threads=1 --nocapture
-
-test_quorum_proposal_recv_task:
-  echo Testing the quorum proposal recv task
-  cargo test --lib --bins --tests --benches --workspace --no-fail-fast test_quorum_proposal_recv_task -- --test-threads=1 --nocapture
-
-test_upgrade_task:
-  echo Testing the upgrade task
-  cargo test --lib --bins --tests --benches --workspace --no-fail-fast test_upgrade_task -- --test-threads=1 --nocapture
-
-test_pkg := "hotshot"
-
-default_test := ""
-
-test_name := "sequencing_libp2p_test"
-
-run_test test=default_test:
-  cargo test --lib --bins --tests --benches {{test}} --no-fail-fast -- --test-threads=1 --nocapture
-
-test_pkg_all pkg=test_pkg:
-  cargo test --lib --bins --tests --benches --package={{pkg}} --no-fail-fast -- --test-threads=1 --nocapture
-
-list_tests_json package=test_pkg:
-  RUST_LOG=none cargo test --lib --bins --tests --benches --package={{package}} --no-fail-fast -- --test-threads=1 -Zunstable-options --format json
-
-list_examples package=test_pkg:
-  cargo metadata | jq '.packages[] | select(.name == "{{package}}") | .targets[] | select(.kind  == ["example"] ) | .name'
+# Usage:
+#
+#   just test memoryimpl_::test_success
+#
+# To display logs from a test run:
+#
+#   just test memoryimpl_::test_success --nocapture
+test *ARGS:
+  echo Running test {{ARGS}}
+  RUST_LOG=warn,hotshot_task_impls=debug cargo nextest run --profile local {{ARGS}} --lib --bins --tests --benches --workspace
 
 check:
   echo Checking


### PR DESCRIPTION
### This PR: 
- Reorganizes tests, creating a new CI test group for epoch tests (`tests_6`)
- Cleans up some `justfile` commands, removing a bunch that were too specific. Local testing can now be done with `just test <testname>` (optionally `--nocapture`).
- Adds a test for an upgrade to a version enabling epochs, but the test is currently disabled because it fails
- Adjusts the marketplace version in `EpochsTestVersions`, since we expect to deploy epochs well before the marketplace.

### This PR does not: 

### Key places to review: 
