### PR TITLE
Revert breaking view change evidence changes

### DIFF
--- a/crates/task-impls/src/helpers.rs
+++ b/crates/task-impls/src/helpers.rs
@@ -15,7 +15,7 @@ use committable::{Commitment, Committable};
 use hotshot_task::dependency::{Dependency, EventDependency};
 use hotshot_types::{
     consensus::OuterConsensus,
-    data::{Leaf2, QuorumProposal2, ViewChangeEvidence},
+    data::{Leaf2, QuorumProposal2, ViewChangeEvidence2},
     event::{Event, EventType, LeafInfo},
     message::{Proposal, UpgradeLock},
     request_response::ProposalRequestPayload,
@@ -752,7 +752,7 @@ pub(crate) async fn validate_proposal_view_and_certs<
         ))?;
 
         match received_proposal_cert {
-            ViewChangeEvidence::Timeout(timeout_cert) => {
+            ViewChangeEvidence2::Timeout(timeout_cert) => {
                 ensure!(
                     timeout_cert.data().view == view_number - 1,
                     "Timeout certificate for view {} was not for the immediately preceding view",
@@ -778,7 +778,7 @@ pub(crate) async fn validate_proposal_view_and_certs<
                     *view_number
                 );
             }
-            ViewChangeEvidence::ViewSync(view_sync_cert) => {
+            ViewChangeEvidence2::ViewSync(view_sync_cert) => {
                 ensure!(
                     view_sync_cert.view_number == view_number,
                     "View sync cert view number {:?} does not match proposal view number {:?}",

--- a/crates/task-impls/src/quorum_proposal/handlers.rs
+++ b/crates/task-impls/src/quorum_proposal/handlers.rs
@@ -24,7 +24,7 @@ use hotshot_task::{
 };
 use hotshot_types::{
     consensus::{CommitmentAndMetadata, OuterConsensus},
-    data::{Leaf2, QuorumProposal2, VidDisperse, ViewChangeEvidence},
+    data::{Leaf2, QuorumProposal2, VidDisperse, ViewChangeEvidence2},
     message::Proposal,
     simple_certificate::{NextEpochQuorumCertificate2, QuorumCertificate2, UpgradeCertificate},
     traits::{
@@ -265,7 +265,7 @@ impl<TYPES: NodeType, V: Versions> ProposalDependencyHandle<TYPES, V> {
         &self,
         commitment_and_metadata: CommitmentAndMetadata<TYPES>,
         vid_share: Proposal<TYPES, VidDisperse<TYPES>>,
-        view_change_evidence: Option<ViewChangeEvidence<TYPES>>,
+        view_change_evidence: Option<ViewChangeEvidence2<TYPES>>,
         formed_upgrade_certificate: Option<UpgradeCertificate<TYPES>>,
         decided_upgrade_certificate: Arc<RwLock<Option<UpgradeCertificate<TYPES>>>>,
         parent_qc: QuorumCertificate2<TYPES>,
@@ -530,9 +530,9 @@ impl<TYPES: NodeType, V: Versions> HandleDepOutput for ProposalDependencyHandle<
         }
 
         let proposal_cert = if let Some(view_sync_cert) = view_sync_finalize_cert {
-            Some(ViewChangeEvidence::ViewSync(view_sync_cert))
+            Some(ViewChangeEvidence2::ViewSync(view_sync_cert))
         } else {
-            timeout_certificate.map(ViewChangeEvidence::Timeout)
+            timeout_certificate.map(ViewChangeEvidence2::Timeout)
         };
 
         if let Err(e) = self

--- a/crates/task-impls/src/quorum_proposal_recv/mod.rs
+++ b/crates/task-impls/src/quorum_proposal_recv/mod.rs
@@ -16,7 +16,7 @@ use futures::future::{err, join_all};
 use hotshot_task::task::{Task, TaskState};
 use hotshot_types::{
     consensus::{Consensus, OuterConsensus},
-    data::{EpochNumber, Leaf, ViewChangeEvidence},
+    data::{EpochNumber, Leaf, ViewChangeEvidence2},
     event::Event,
     message::UpgradeLock,
     simple_certificate::UpgradeCertificate,

--- a/crates/testing/src/view_generator.rs
+++ b/crates/testing/src/view_generator.rs
@@ -24,7 +24,7 @@ use hotshot_example_types::{
 use hotshot_types::{
     data::{
         DaProposal2, EpochNumber, Leaf2, QuorumProposal2, VidDisperse, VidDisperseShare2,
-        ViewChangeEvidence, ViewNumber,
+        ViewChangeEvidence2, ViewNumber,
     },
     message::{Proposal, UpgradeLock},
     simple_certificate::{
@@ -352,9 +352,9 @@ impl TestView {
         };
 
         let view_change_evidence = if let Some(tc) = timeout_certificate {
-            Some(ViewChangeEvidence::Timeout(tc))
+            Some(ViewChangeEvidence2::Timeout(tc))
         } else {
-            view_sync_certificate.map(ViewChangeEvidence::ViewSync)
+            view_sync_certificate.map(ViewChangeEvidence2::ViewSync)
         };
 
         let random = thread_rng().gen_range(0..=u64::MAX);

--- a/crates/testing/tests/tests_1/quorum_proposal_task.rs
+++ b/crates/testing/tests/tests_1/quorum_proposal_task.rs
@@ -25,7 +25,7 @@ use hotshot_testing::{
     view_generator::TestViewGenerator,
 };
 use hotshot_types::{
-    data::{null_block, EpochNumber, Leaf2, ViewChangeEvidence, ViewNumber},
+    data::{null_block, EpochNumber, Leaf2, ViewChangeEvidence2, ViewNumber},
     simple_vote::{TimeoutData2, ViewSyncFinalizeData2},
     traits::{
         election::Membership,
@@ -353,7 +353,7 @@ async fn test_quorum_proposal_task_qc_timeout() {
 
     // Get the proposal cert out for the view sync input
     let cert = match proposals[1].data.view_change_evidence.clone().unwrap() {
-        ViewChangeEvidence::Timeout(tc) => tc,
+        ViewChangeEvidence2::Timeout(tc) => tc,
         _ => panic!("Found a View Sync Cert when there should have been a Timeout cert"),
     };
 
@@ -445,7 +445,7 @@ async fn test_quorum_proposal_task_view_sync() {
 
     // Get the proposal cert out for the view sync input
     let cert = match proposals[1].data.view_change_evidence.clone().unwrap() {
-        ViewChangeEvidence::ViewSync(vsc) => vsc,
+        ViewChangeEvidence2::ViewSync(vsc) => vsc,
         _ => panic!("Found a TC when there should have been a view sync cert"),
     };
 

--- a/crates/types/src/data.rs
+++ b/crates/types/src/data.rs
@@ -34,8 +34,9 @@ use crate::{
     impl_has_epoch,
     message::{Proposal, UpgradeLock},
     simple_certificate::{
-        NextEpochQuorumCertificate2, QuorumCertificate, QuorumCertificate2, TimeoutCertificate2,
-        UpgradeCertificate, ViewSyncFinalizeCertificate2,
+        NextEpochQuorumCertificate2, QuorumCertificate, QuorumCertificate2, TimeoutCertificate,
+        TimeoutCertificate2, UpgradeCertificate, ViewSyncFinalizeCertificate,
+        ViewSyncFinalizeCertificate2,
     },
     simple_vote::{HasEpoch, QuorumData, QuorumData2, UpgradeProposalData, VersionedVoteData},
     traits::{
@@ -313,9 +314,9 @@ impl<TYPES: NodeType> VidDisperse<TYPES> {
 #[serde(bound(deserialize = ""))]
 pub enum ViewChangeEvidence<TYPES: NodeType> {
     /// Holds a timeout certificate.
-    Timeout(TimeoutCertificate2<TYPES>),
+    Timeout(TimeoutCertificate<TYPES>),
     /// Holds a view sync finalized certificate.
-    ViewSync(ViewSyncFinalizeCertificate2<TYPES>),
+    ViewSync(ViewSyncFinalizeCertificate<TYPES>),
 }
 
 impl<TYPES: NodeType> ViewChangeEvidence<TYPES> {
@@ -324,6 +325,51 @@ impl<TYPES: NodeType> ViewChangeEvidence<TYPES> {
         match self {
             ViewChangeEvidence::Timeout(timeout_cert) => timeout_cert.data().view == *view - 1,
             ViewChangeEvidence::ViewSync(view_sync_cert) => view_sync_cert.view_number == *view,
+        }
+    }
+
+    /// Convert to ViewChangeEvidence2
+    pub fn to_evidence2(self) -> ViewChangeEvidence2<TYPES> {
+        match self {
+            ViewChangeEvidence::Timeout(timeout_cert) => {
+                ViewChangeEvidence2::Timeout(timeout_cert.to_tc2())
+            }
+            ViewChangeEvidence::ViewSync(view_sync_cert) => {
+                ViewChangeEvidence2::ViewSync(view_sync_cert.to_vsc2())
+            }
+        }
+    }
+}
+
+/// Helper type to encapsulate the various ways that proposal certificates can be captured and
+/// stored.
+#[derive(derive_more::Debug, Serialize, Deserialize, Clone, Eq, PartialEq, Hash)]
+#[serde(bound(deserialize = ""))]
+pub enum ViewChangeEvidence2<TYPES: NodeType> {
+    /// Holds a timeout certificate.
+    Timeout(TimeoutCertificate2<TYPES>),
+    /// Holds a view sync finalized certificate.
+    ViewSync(ViewSyncFinalizeCertificate2<TYPES>),
+}
+
+impl<TYPES: NodeType> ViewChangeEvidence2<TYPES> {
+    /// Check that the given ViewChangeEvidence2 is relevant to the current view.
+    pub fn is_valid_for_view(&self, view: &TYPES::View) -> bool {
+        match self {
+            ViewChangeEvidence2::Timeout(timeout_cert) => timeout_cert.data().view == *view - 1,
+            ViewChangeEvidence2::ViewSync(view_sync_cert) => view_sync_cert.view_number == *view,
+        }
+    }
+
+    /// Convert to ViewChangeEvidence
+    pub fn to_evidence(self) -> ViewChangeEvidence<TYPES> {
+        match self {
+            ViewChangeEvidence2::Timeout(timeout_cert) => {
+                ViewChangeEvidence::Timeout(timeout_cert.to_tc())
+            }
+            ViewChangeEvidence2::ViewSync(view_sync_cert) => {
+                ViewChangeEvidence::ViewSync(view_sync_cert.to_vsc())
+            }
         }
     }
 }
@@ -633,7 +679,7 @@ pub struct QuorumProposal2<TYPES: NodeType> {
     pub upgrade_certificate: Option<UpgradeCertificate<TYPES>>,
 
     /// Possible timeout or view sync certificate. If the `justify_qc` is not for a proposal in the immediately preceding view, then either a timeout or view sync certificate must be attached.
-    pub view_change_evidence: Option<ViewChangeEvidence<TYPES>>,
+    pub view_change_evidence: Option<ViewChangeEvidence2<TYPES>>,
 
     /// The DRB result for the next epoch.
     ///
@@ -651,7 +697,9 @@ impl<TYPES: NodeType> From<QuorumProposal<TYPES>> for QuorumProposal2<TYPES> {
             justify_qc: quorum_proposal.justify_qc.to_qc2(),
             next_epoch_justify_qc: None,
             upgrade_certificate: quorum_proposal.upgrade_certificate,
-            view_change_evidence: quorum_proposal.proposal_certificate,
+            view_change_evidence: quorum_proposal
+                .proposal_certificate
+                .map(ViewChangeEvidence::to_evidence2),
             next_drb_result: None,
         }
     }
@@ -664,7 +712,9 @@ impl<TYPES: NodeType> From<QuorumProposal2<TYPES>> for QuorumProposal<TYPES> {
             view_number: quorum_proposal2.view_number,
             justify_qc: quorum_proposal2.justify_qc.to_qc(),
             upgrade_certificate: quorum_proposal2.upgrade_certificate,
-            proposal_certificate: quorum_proposal2.view_change_evidence,
+            proposal_certificate: quorum_proposal2
+                .view_change_evidence
+                .map(ViewChangeEvidence2::to_evidence),
         }
     }
 }
@@ -823,7 +873,7 @@ pub struct Leaf2<TYPES: NodeType> {
     block_payload: Option<TYPES::BlockPayload>,
 
     /// Possible timeout or view sync certificate. If the `justify_qc` is not for a proposal in the immediately preceding view, then either a timeout or view sync certificate must be attached.
-    pub view_change_evidence: Option<ViewChangeEvidence<TYPES>>,
+    pub view_change_evidence: Option<ViewChangeEvidence2<TYPES>>,
 }
 
 impl<TYPES: NodeType> Leaf2<TYPES> {

--- a/crates/types/src/simple_certificate.rs
+++ b/crates/types/src/simple_certificate.rs
@@ -698,7 +698,7 @@ impl<TYPES: NodeType> ViewSyncFinalizeCertificate2<TYPES> {
 
 impl<TYPES: NodeType> TimeoutCertificate<TYPES> {
     /// Convert a `DaCertificate` into a `DaCertificate2`
-    pub fn to_vsc2(self) -> TimeoutCertificate2<TYPES> {
+    pub fn to_tc2(self) -> TimeoutCertificate2<TYPES> {
         let data = TimeoutData2 {
             view: self.data.view,
             epoch: TYPES::Epoch::new(0),
@@ -719,7 +719,7 @@ impl<TYPES: NodeType> TimeoutCertificate<TYPES> {
 
 impl<TYPES: NodeType> TimeoutCertificate2<TYPES> {
     /// Convert a `DaCertificate` into a `DaCertificate2`
-    pub fn to_vsc(self) -> TimeoutCertificate<TYPES> {
+    pub fn to_tc(self) -> TimeoutCertificate<TYPES> {
         let data = TimeoutData {
             view: self.data.view,
         };


### PR DESCRIPTION
### This PR: 
Reverts changes to `ViewChangeEvidence` that broke backwards compatibility

### This PR does not: 

### Key places to review: 
