### PR TITLE
feat: adding metadata input for `calculate_vid_disperse`

### DIFF
--- a/crates/hotshot/src/lib.rs
+++ b/crates/hotshot/src/lib.rs
@@ -61,7 +61,6 @@ use hotshot_types::{
         signature_key::SignatureKey,
         states::ValidatedState,
         storage::Storage,
-        EncodeBytes,
     },
     utils::epoch_from_block_number,
     HotShotConfig,
@@ -321,9 +320,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> SystemContext<T
             saved_leaves.insert(leaf.commit(), leaf.clone());
         }
         if let Some(payload) = anchored_leaf.block_payload() {
-            let encoded_txns = payload.encode();
-
-            saved_payloads.insert(anchored_leaf.view_number(), Arc::clone(&encoded_txns));
+            saved_payloads.insert(anchored_leaf.view_number(), Arc::new(payload));
         }
 
         let anchored_epoch = if config.epoch_height == 0 {

--- a/crates/task-impls/src/helpers.rs
+++ b/crates/task-impls/src/helpers.rs
@@ -313,14 +313,12 @@ pub async fn decide_from_proposal_2<TYPES: NodeType>(
         res.leaf_views.push(info.clone());
         // If the block payload is available for this leaf, include it in
         // the leaf chain that we send to the client.
-        if let Some(encoded_txns) = consensus_reader
+        if let Some(payload) = consensus_reader
             .saved_payloads()
             .get(&info.leaf.view_number())
         {
-            let payload =
-                BlockPayload::from_bytes(encoded_txns, info.leaf.block_header().metadata());
-
-            info.leaf.fill_block_payload_unchecked(payload);
+            info.leaf
+                .fill_block_payload_unchecked(payload.as_ref().clone());
         }
 
         if let Some(ref payload) = info.leaf.block_payload() {
@@ -451,13 +449,8 @@ pub async fn decide_from_proposal<TYPES: NodeType>(
                 }
                 // If the block payload is available for this leaf, include it in
                 // the leaf chain that we send to the client.
-                if let Some(encoded_txns) =
-                    consensus_reader.saved_payloads().get(&leaf.view_number())
-                {
-                    let payload =
-                        BlockPayload::from_bytes(encoded_txns, leaf.block_header().metadata());
-
-                    leaf.fill_block_payload_unchecked(payload);
+                if let Some(payload) = consensus_reader.saved_payloads().get(&leaf.view_number()) {
+                    leaf.fill_block_payload_unchecked(payload.as_ref().clone());
                 }
 
                 // Get the VID share at the leaf's view number, corresponding to our key

--- a/crates/task-impls/src/vid.rs
+++ b/crates/task-impls/src/vid.rs
@@ -98,7 +98,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> VidTaskState<TYPES, I> {
                     return None;
                 }
                 let vid_disperse = VidDisperse::calculate_vid_disperse(
-                    Arc::clone(encoded_transactions),
+                    &payload,
                     &Arc::clone(&self.membership),
                     *view_number,
                     epoch,
@@ -192,7 +192,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> VidTaskState<TYPES, I> {
                 );
 
                 let consensus_reader = self.consensus.read().await;
-                let Some(txns) = consensus_reader.saved_payloads().get(&proposal_view_number)
+                let Some(payload) = consensus_reader.saved_payloads().get(&proposal_view_number)
                 else {
                     tracing::warn!(
                         "We need to calculate VID for the nodes in the next epoch \
@@ -200,11 +200,11 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> VidTaskState<TYPES, I> {
                     );
                     return None;
                 };
-                let txns = Arc::clone(txns);
+                let payload = Arc::clone(payload);
                 drop(consensus_reader);
 
                 let next_epoch_vid_disperse = VidDisperse::calculate_vid_disperse(
-                    txns,
+                    payload.as_ref(),
                     &Arc::clone(&self.membership),
                     proposal_view_number,
                     target_epoch,

--- a/crates/types/src/data.rs
+++ b/crates/types/src/data.rs
@@ -258,7 +258,7 @@ impl<TYPES: NodeType> VidDisperse<TYPES> {
     /// Panics if the VID calculation fails, this should not happen.
     #[allow(clippy::panic)]
     pub async fn calculate_vid_disperse(
-        txns: Arc<[u8]>,
+        payload: &TYPES::BlockPayload,
         membership: &Arc<RwLock<TYPES::Membership>>,
         view: TYPES::View,
         target_epoch: TYPES::Epoch,
@@ -267,6 +267,7 @@ impl<TYPES: NodeType> VidDisperse<TYPES> {
     ) -> Self {
         let num_nodes = membership.read().await.total_nodes(target_epoch);
 
+        let txns = payload.encode();
         let txns_clone = Arc::clone(&txns);
         let vid_disperse = spawn_blocking(move || {
             precompute_data


### PR DESCRIPTION
Closes #3973 
<!-- See here for keywords in Github -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

### This PR: 
<!-- Describe what this PR adds to HotSHot -->
<!-- E.g. -->
<!-- * Implements feature 1 -->
<!-- * Implements feature 2 -->
<!-- * Fixes bug 3 -->

Use `BlockPayload` instead of encoded bytes as input for `calculate_vid_disperse`.

The metadata in `BlockPayload` seems to be for the namespace table: https://github.com/EspressoSystems/espresso-sequencer/blob/fa44122b66b49ca070eab64e59965290f9c0eecf/sequencer/src/block/full_payload/payload.rs#L141
Now VID can take it as input for efficient nsproof generation/verification.

### This PR does not: 
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->

### Key places to review: 
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
