### PR TITLE
[DRB] - Store DRB seed and epoch root with consistent block info

### DIFF
--- a/crates/task-impls/src/helpers.rs
+++ b/crates/task-impls/src/helpers.rs
@@ -329,14 +329,13 @@ pub async fn decide_from_proposal_2<TYPES: NodeType>(
         let epoch_height = consensus_reader.epoch_height;
         drop(consensus_reader);
 
-        // `leaf_views.last()` is never none if we've reached a new decide, so this is safe to
-        // unwrap.
-        decide_epoch_root(
-            &res.leaf_views.last().unwrap().leaf,
-            epoch_height,
-            membership,
-        )
-        .await;
+        if let Some(decided_leaf_info) = res.leaf_views.last() {
+            decide_epoch_root(&decided_leaf_info.leaf, epoch_height, membership).await;
+        } else {
+            tracing::warn!(
+                "No decided leaf while a view has been decided, which should be impossible."
+            );
+        }
     }
 
     res
@@ -490,14 +489,13 @@ pub async fn decide_from_proposal<TYPES: NodeType>(
         let epoch_height = consensus_reader.epoch_height;
         drop(consensus_reader);
 
-        // `leaf_views.last()` is never none if we've reached a new decide, so this is safe to
-        // unwrap.
-        decide_epoch_root(
-            &res.leaf_views.last().unwrap().leaf,
-            epoch_height,
-            membership,
-        )
-        .await;
+        if let Some(decided_leaf_info) = res.leaf_views.last() {
+            decide_epoch_root(&decided_leaf_info.leaf, epoch_height, membership).await;
+        } else {
+            tracing::warn!(
+                "No decided leaf while a view has been decided, which should be impossible."
+            );
+        }
     }
 
     res

--- a/crates/task-impls/src/helpers.rs
+++ b/crates/task-impls/src/helpers.rs
@@ -332,9 +332,7 @@ pub async fn decide_from_proposal_2<TYPES: NodeType>(
         if let Some(decided_leaf_info) = res.leaf_views.last() {
             decide_epoch_root(&decided_leaf_info.leaf, epoch_height, membership).await;
         } else {
-            tracing::warn!(
-                "No decided leaf while a view has been decided, which should be impossible."
-            );
+            tracing::info!("No decided leaf while a view has been decided.");
         }
     }
 
@@ -492,9 +490,7 @@ pub async fn decide_from_proposal<TYPES: NodeType>(
         if let Some(decided_leaf_info) = res.leaf_views.last() {
             decide_epoch_root(&decided_leaf_info.leaf, epoch_height, membership).await;
         } else {
-            tracing::warn!(
-                "No decided leaf while a view has been decided, which should be impossible."
-            );
+            tracing::info!("No decided leaf while a view has been decided.");
         }
     }
 

--- a/crates/task-impls/src/quorum_vote/handlers.rs
+++ b/crates/task-impls/src/quorum_vote/handlers.rs
@@ -140,7 +140,7 @@ async fn verify_drb_result<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Ver
 
 /// Start the DRB computation task for the next epoch.
 ///
-/// Uses the seed previously stored in `store_drb_seed_and_computed_result`.
+/// Uses the seed previously stored in `store_drb_seed_and_result`.
 async fn start_drb_task<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions>(
     proposal: &QuorumProposal2<TYPES>,
     task_state: &mut QuorumVoteTaskState<TYPES, I, V>,
@@ -229,11 +229,7 @@ async fn start_drb_task<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versio
 ///
 /// We don't need to handle the special cases explicitly here, because the first leaf with which
 /// we'll start the DRB computation is for epoch 3.
-async fn store_drb_seed_and_computed_result<
-    TYPES: NodeType,
-    I: NodeImplementation<TYPES>,
-    V: Versions,
->(
+async fn store_drb_seed_and_result<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions>(
     task_state: &mut QuorumVoteTaskState<TYPES, I, V>,
     decided_leaf: &Leaf2<TYPES>,
 ) -> Result<()> {
@@ -437,8 +433,7 @@ pub(crate) async fn handle_quorum_proposal_validated<
         if version >= V::Epochs::VERSION {
             // `leaf_views.last()` is never none if we've reached a new decide, so this is safe to
             // unwrap.
-            store_drb_seed_and_computed_result(task_state, &leaf_views.last().unwrap().leaf)
-                .await?;
+            store_drb_seed_and_result(task_state, &leaf_views.last().unwrap().leaf).await?;
         }
     }
 

--- a/crates/task-impls/src/quorum_vote/handlers.rs
+++ b/crates/task-impls/src/quorum_vote/handlers.rs
@@ -43,53 +43,6 @@ use crate::{
     quorum_vote::Versions,
 };
 
-/// Store the DRB result from the quorum proposal.
-///
-/// Returns an error if receiving an inconsistent result.
-async fn store_received_drb_result<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions>(
-    epoch_number: TYPES::Epoch,
-    drb_result: DrbResult,
-    task_state: &mut QuorumVoteTaskState<TYPES, I, V>,
-) -> Result<()> {
-    let mut exist = false;
-    if let Some(stored_result) = task_state
-        .consensus
-        .read()
-        .await
-        .drb_seeds_and_results
-        .results
-        .get(&epoch_number)
-    {
-        if drb_result == *stored_result {
-            return Ok(());
-        }
-        exist = true;
-    }
-
-    // If there exists an inconsistent result, remove it.
-    if exist {
-        task_state
-            .consensus
-            .write()
-            .await
-            .drb_seeds_and_results
-            .results
-            .remove(&epoch_number);
-        bail!("Inconsistent result with the storage.");
-    }
-    // Otherwise, store the result.
-    else {
-        task_state
-            .consensus
-            .write()
-            .await
-            .drb_seeds_and_results
-            .results
-            .insert(epoch_number, drb_result);
-        Ok(())
-    }
-}
-
 /// Store the DRB result from the computation task to the shared `results` table.
 ///
 /// Returns the result if it exists.
@@ -181,14 +134,6 @@ async fn verify_drb_result<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Ver
                 bail!("Inconsistent DRB result for the next epoch.");
             }
             return Ok(());
-        } else if task_state
-            .membership
-            .read()
-            .await
-            .has_stake(&task_state.public_key, current_epoch_number + 1)
-        {
-            store_received_drb_result(current_epoch_number + 1, proposal_result, task_state)
-                .await?;
         }
     }
     Ok(())
@@ -196,7 +141,7 @@ async fn verify_drb_result<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Ver
 
 /// Start the DRB computation task for the next epoch.
 ///
-/// Uses the seed previously stored in `store_drb_seed_and_result`.
+/// Uses the seed previously stored in `store_drb_seed_and_computed_result`.
 async fn start_drb_task<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions>(
     proposal: &QuorumProposal2<TYPES>,
     task_state: &mut QuorumVoteTaskState<TYPES, I, V>,
@@ -268,66 +213,101 @@ async fn start_drb_task<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versio
     }
 }
 
-/// Store the DRB seed two epochs in advance and the computed DRB result for next epoch.
+/// Store the DRB seed two epochs in advance and the computed or received DRB result for next
+/// epoch.
 ///
-/// We store the DRB seed and result of the decided block if it's the third from the last block in
-/// the current epoch and for the former, if we are in the quorum committee of the next epoch.
+/// We store a combination of the following data.
+/// * The DRB seed two epochs in advance, if the third from the last block, i.e., the epoch root,
+///     is decided and we are in the quorum committee of the next epoch.
+/// * The computed result for the next epoch, if the third from the last block is decided.
+/// * The received result for the next epoch, if the last block of the epoch is decided and we are
+///     in the quorum committee of the committee of the next epoch.
 ///
 /// Special cases:
 /// * Epoch 0: No DRB computation since we'll transition to epoch 1 immediately.
 /// * Epoch 1 and 2: No computed DRB result since when we first start the computation in epoch 1,
-///   the result is for epoch 3.
+///     the result is for epoch 3.
 ///
 /// We don't need to handle the special cases explicitly here, because the first leaf with which
 /// we'll start the DRB computation is for epoch 3.
-async fn store_drb_seed_and_result<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions>(
+async fn store_drb_seed_and_computed_result<
+    TYPES: NodeType,
+    I: NodeImplementation<TYPES>,
+    V: Versions,
+>(
     task_state: &mut QuorumVoteTaskState<TYPES, I, V>,
     decided_leaf: &Leaf2<TYPES>,
 ) -> Result<()> {
     let decided_block_number = decided_leaf.block_header().block_number();
 
-    // Skip if this is not the expected block.
-    if task_state.epoch_height != 0 && is_epoch_root(decided_block_number, task_state.epoch_height)
-    {
-        // Cancel old DRB computation tasks.
+    if task_state.epoch_height != 0 {
         let current_epoch_number = TYPES::Epoch::new(epoch_from_block_number(
             decided_block_number,
             task_state.epoch_height,
         ));
 
-        let mut consensus_writer = task_state.consensus.write().await;
-        consensus_writer
-            .drb_seeds_and_results
-            .garbage_collect(current_epoch_number);
-        drop(consensus_writer);
-
-        // Store the DRB result for the next epoch, which will be used by the proposal task to
-        // include in the proposal in the last block of this epoch.
-        store_and_get_computed_drb_result(current_epoch_number + 1, task_state).await?;
-
-        // Skip if we are not in the committee of the next epoch.
-        if task_state
-            .membership
-            .read()
-            .await
-            .has_stake(&task_state.public_key, current_epoch_number + 1)
-        {
-            let new_epoch_number = current_epoch_number + 2;
-            let Ok(drb_seed_input_vec) = bincode::serialize(&decided_leaf.justify_qc().signatures)
-            else {
-                bail!("Failed to serialize the QC signature.");
-            };
-            let Ok(drb_seed_input) = drb_seed_input_vec.try_into() else {
-                bail!("Failed to convert the serialized QC signature into a DRB seed input.");
-            };
-
-            // Store the DRB seed input for the epoch after the next one.
-            task_state
-                .consensus
-                .write()
-                .await
+        // Skip storing the seed and computed result if this is not the epoch root.
+        if is_epoch_root(decided_block_number, task_state.epoch_height) {
+            // Cancel old DRB computation tasks.
+            let mut consensus_writer = task_state.consensus.write().await;
+            consensus_writer
                 .drb_seeds_and_results
-                .store_seed(new_epoch_number, drb_seed_input);
+                .garbage_collect(current_epoch_number);
+            drop(consensus_writer);
+
+            // Store the DRB result for the next epoch, which will be used by the proposal task to
+            // include in the proposal in the last block of this epoch.
+            store_and_get_computed_drb_result(current_epoch_number + 1, task_state).await?;
+
+            // Skip storing the seed if we are not in the committee of the next epoch.
+            if task_state
+                .membership
+                .read()
+                .await
+                .has_stake(&task_state.public_key, current_epoch_number + 1)
+            {
+                let Ok(drb_seed_input_vec) =
+                    bincode::serialize(&decided_leaf.justify_qc().signatures)
+                else {
+                    bail!("Failed to serialize the QC signature.");
+                };
+                let Ok(drb_seed_input) = drb_seed_input_vec.try_into() else {
+                    bail!("Failed to convert the serialized QC signature into a DRB seed input.");
+                };
+
+                // Store the DRB seed input for the epoch after the next one.
+                task_state
+                    .consensus
+                    .write()
+                    .await
+                    .drb_seeds_and_results
+                    .store_seed(current_epoch_number + 2, drb_seed_input);
+            }
+        }
+        // Skip storing the received result if this is not the last block.
+        else if is_last_block_in_epoch(decided_block_number, task_state.epoch_height) {
+            // Skip if we are not in the committee of the next epoch.
+            if !task_state
+                .membership
+                .read()
+                .await
+                .has_stake(&task_state.public_key, current_epoch_number + 1)
+            {
+                return Ok(());
+            }
+            if let Some(result) = decided_leaf.next_drb_result {
+                // We don't need to check value existance and consistency because it should be
+                // impossible to decide on a block with different DRB results.
+                task_state
+                    .consensus
+                    .write()
+                    .await
+                    .drb_seeds_and_results
+                    .results
+                    .insert(current_epoch_number + 1, result);
+            } else {
+                bail!("The last block of the epoch is decided but doesn't contain a DRB result.");
+            }
         }
     }
     Ok(())
@@ -458,7 +438,8 @@ pub(crate) async fn handle_quorum_proposal_validated<
         if version >= V::Epochs::VERSION {
             // `leaf_views.last()` is never none if we've reached a new decide, so this is safe to
             // unwrap.
-            store_drb_seed_and_result(task_state, &leaf_views.last().unwrap().leaf).await?;
+            store_drb_seed_and_computed_result(task_state, &leaf_views.last().unwrap().leaf)
+                .await?;
         }
     }
 

--- a/crates/task-impls/src/quorum_vote/handlers.rs
+++ b/crates/task-impls/src/quorum_vote/handlers.rs
@@ -291,7 +291,7 @@ async fn store_drb_seed_and_result<TYPES: NodeType, I: NodeImplementation<TYPES>
                 return Ok(());
             }
             if let Some(result) = decided_leaf.next_drb_result {
-                // We don't need to check value existance and consistency because it should be
+                // We don't need to check value existence and consistency because it should be
                 // impossible to decide on a block with different DRB results.
                 task_state
                     .consensus

--- a/crates/task-impls/src/quorum_vote/handlers.rs
+++ b/crates/task-impls/src/quorum_vote/handlers.rs
@@ -274,15 +274,6 @@ async fn store_drb_seed_and_result<TYPES: NodeType, I: NodeImplementation<TYPES>
     }
     // Skip storing the received result if this is not the last block.
     else if is_last_block_in_epoch(decided_block_number, task_state.epoch_height) {
-        // Skip if we are not in the committee of the next epoch.
-        if !task_state
-            .membership
-            .read()
-            .await
-            .has_stake(&task_state.public_key, current_epoch_number + 1)
-        {
-            return Ok(());
-        }
         if let Some(result) = decided_leaf.next_drb_result {
             // We don't need to check value existence and consistency because it should be
             // impossible to decide on a block with different DRB results.

--- a/crates/types/src/data.rs
+++ b/crates/types/src/data.rs
@@ -682,6 +682,7 @@ impl<TYPES: NodeType> From<Leaf<TYPES>> for Leaf2<TYPES> {
             upgrade_certificate: leaf.upgrade_certificate,
             block_payload: leaf.block_payload,
             view_change_evidence: None,
+            next_drb_result: None,
         }
     }
 }
@@ -824,6 +825,13 @@ pub struct Leaf2<TYPES: NodeType> {
 
     /// Possible timeout or view sync certificate. If the `justify_qc` is not for a proposal in the immediately preceding view, then either a timeout or view sync certificate must be attached.
     pub view_change_evidence: Option<ViewChangeEvidence<TYPES>>,
+
+    /// The DRB result for the next epoch.
+    ///
+    /// This is required only for the last block of the epoch. Nodes will verify that it's
+    /// consistent with the result from their computations.
+    #[serde(with = "serde_bytes")]
+    pub next_drb_result: Option<DrbResult>,
 }
 
 impl<TYPES: NodeType> Leaf2<TYPES> {
@@ -876,6 +884,7 @@ impl<TYPES: NodeType> Leaf2<TYPES> {
             block_header: block_header.clone(),
             block_payload: Some(payload),
             view_change_evidence: None,
+            next_drb_result: None,
         }
     }
     /// Time when this leaf was created.
@@ -1043,6 +1052,7 @@ impl<TYPES: NodeType> PartialEq for Leaf2<TYPES> {
             upgrade_certificate,
             block_payload: _,
             view_change_evidence,
+            next_drb_result,
         } = self;
 
         *view_number == other.view_number
@@ -1052,6 +1062,7 @@ impl<TYPES: NodeType> PartialEq for Leaf2<TYPES> {
             && *block_header == other.block_header
             && *upgrade_certificate == other.upgrade_certificate
             && *view_change_evidence == other.view_change_evidence
+            && *next_drb_result == other.next_drb_result
     }
 }
 
@@ -1415,7 +1426,7 @@ impl<TYPES: NodeType> Leaf2<TYPES> {
             block_header,
             upgrade_certificate,
             view_change_evidence,
-            next_drb_result: _,
+            next_drb_result,
         } = quorum_proposal;
 
         Self {
@@ -1427,6 +1438,7 @@ impl<TYPES: NodeType> Leaf2<TYPES> {
             upgrade_certificate: upgrade_certificate.clone(),
             block_payload: None,
             view_change_evidence: view_change_evidence.clone(),
+            next_drb_result: *next_drb_result,
         }
     }
 }


### PR DESCRIPTION
Closes #3998. Closes #4008.

### This PR: 
* Moves `store_received_drb_result` inside `store_drb_seed_and_result` to handle storing the seed, the received result, and the computed result together.
* Fixes the logic in `store_drb_seed_and_result` to use the decided block rather than the newly proposed block for storing the DRB seed.
* Removes the condition to block voting if failed to store the received result.
* Rename `decide_from_proposal_add_epoch_root` to `decide_epoch_root`.
* Fixes the logic in `decide_epoch_root` for adding epoch root.
