### PR TITLE
[CLEANUP] Nuke VID precompute

### DIFF
--- a/crates/builder-api/src/v0_1/block_info.rs
+++ b/crates/builder-api/src/v0_1/block_info.rs
@@ -9,7 +9,7 @@ use std::marker::PhantomData;
 use hotshot_types::{
     traits::{node_implementation::NodeType, signature_key::BuilderSignatureKey, BlockPayload},
     utils::BuilderCommitment,
-    vid::{VidCommitment, VidPrecomputeData},
+    vid::VidCommitment,
 };
 use serde::{Deserialize, Serialize};
 
@@ -48,7 +48,6 @@ impl<TYPES: NodeType> AvailableBlockData<TYPES> {
 #[serde(bound = "")]
 pub struct AvailableBlockHeaderInput<TYPES: NodeType> {
     pub vid_commitment: VidCommitment,
-    pub vid_precompute_data: VidPrecomputeData,
     // signature over vid_commitment, BlockPayload::Metadata, and offered_fee
     pub fee_signature:
         <<TYPES as NodeType>::BuilderSignatureKey as BuilderSignatureKey>::BuilderSignature,

--- a/crates/testing/src/block_builder/mod.rs
+++ b/crates/testing/src/block_builder/mod.rs
@@ -22,8 +22,7 @@ use hotshot_builder_api::{
 use hotshot_types::{
     constants::{LEGACY_BUILDER_MODULE, MARKETPLACE_BUILDER_MODULE},
     traits::{
-        block_contents::{precompute_vid_commitment, EncodeBytes},
-        node_implementation::NodeType,
+        block_contents::EncodeBytes, node_implementation::NodeType,
         signature_key::BuilderSignatureKey,
     },
 };
@@ -186,8 +185,10 @@ where
 
     let commitment = block_payload.builder_commitment(&metadata);
 
-    let (vid_commitment, precompute_data) =
-        precompute_vid_commitment(&block_payload.encode(), *num_storage_nodes.read_arc().await);
+    let vid_commitment = hotshot_types::traits::block_contents::vid_commitment(
+        &block_payload.encode(),
+        *num_storage_nodes.read_arc().await,
+    );
 
     // Get block size from the encoded payload
     let block_size = block_payload.encode().len() as u64;
@@ -224,7 +225,6 @@ where
     };
     let header_input = AvailableBlockHeaderInput {
         vid_commitment,
-        vid_precompute_data: precompute_data,
         message_signature: signature_over_vid_commitment.clone(),
         fee_signature: signature_over_fee_info,
         sender: pub_key,

--- a/crates/testing/tests/tests_1/da_task.rs
+++ b/crates/testing/tests/tests_1/da_task.rs
@@ -25,7 +25,6 @@ use hotshot_types::{
     data::{null_block, PackedBundle, ViewNumber},
     simple_vote::DaData2,
     traits::{
-        block_contents::precompute_vid_commitment,
         election::Membership,
         node_implementation::{ConsensusTime, Versions},
     },
@@ -45,8 +44,8 @@ async fn test_da_task() {
     // Make some empty encoded transactions, we just care about having a commitment handy for the
     // later calls. We need the VID commitment to be able to propose later.
     let transactions = vec![TestTransaction::new(vec![0])];
-    let encoded_transactions = Arc::from(TestTransaction::encode(&transactions));
-    let (payload_commit, precompute) = precompute_vid_commitment(
+    let encoded_transactions: Arc<[u8]> = Arc::from(TestTransaction::encode(&transactions));
+    let payload_commit = hotshot_types::traits::block_contents::vid_commitment(
         &encoded_transactions,
         handle.hotshot.memberships.read().await.total_nodes(None),
     );
@@ -112,7 +111,6 @@ async fn test_da_task() {
                     *ViewNumber::new(2),
                 )
                 .unwrap()],
-                Some(precompute),
                 None,
             )),
         ],
@@ -153,8 +151,8 @@ async fn test_da_task_storage_failure() {
     // Make some empty encoded transactions, we just care about having a commitment handy for the
     // later calls. We need the VID commitment to be able to propose later.
     let transactions = vec![TestTransaction::new(vec![0])];
-    let encoded_transactions = Arc::from(TestTransaction::encode(&transactions));
-    let (payload_commit, precompute) = precompute_vid_commitment(
+    let encoded_transactions: Arc<[u8]> = Arc::from(TestTransaction::encode(&transactions));
+    let payload_commit = hotshot_types::traits::block_contents::vid_commitment(
         &encoded_transactions,
         handle.hotshot.memberships.read().await.total_nodes(None),
     );
@@ -220,7 +218,6 @@ async fn test_da_task_storage_failure() {
                     *ViewNumber::new(2),
                 )
                 .unwrap()],
-                Some(precompute),
                 None,
             ),)
         ],

--- a/crates/testing/tests/tests_1/transaction_task.rs
+++ b/crates/testing/tests/tests_1/transaction_task.rs
@@ -10,7 +10,6 @@ use hotshot_testing::helpers::build_system_handle;
 use hotshot_types::{
     data::{null_block, EpochNumber, PackedBundle, ViewNumber},
     traits::{
-        block_contents::precompute_vid_commitment,
         election::Membership,
         node_implementation::{ConsensusTime, Versions},
     },
@@ -43,16 +42,6 @@ async fn test_transaction_task_leader_two_views_in_a_row() {
     ));
     input.push(HotShotEvent::Shutdown);
 
-    let (_, precompute_data) = precompute_vid_commitment(
-        &[],
-        handle
-            .hotshot
-            .memberships
-            .read()
-            .await
-            .total_nodes(Some(EpochNumber::new(0))),
-    );
-
     // current view
     let mut exp_packed_bundle = PackedBundle::new(
         vec![].into(),
@@ -74,7 +63,6 @@ async fn test_transaction_task_leader_two_views_in_a_row() {
             )
             .unwrap()
         ],
-        Some(precompute_data.clone()),
         None,
     );
     output.push(HotShotEvent::BlockRecv(exp_packed_bundle.clone()));

--- a/crates/testing/tests/tests_1/vid_task.rs
+++ b/crates/testing/tests/tests_1/vid_task.rs
@@ -29,7 +29,7 @@ use hotshot_types::{
         BlockPayload,
     },
 };
-use jf_vid::{precomputable::Precomputable, VidScheme};
+use jf_vid::VidScheme;
 use vbs::version::StaticVersionType;
 use vec1::vec1;
 
@@ -62,7 +62,6 @@ async fn test_vid_task() {
         <TestBlockPayload as BlockPayload<TestTypes>>::builder_commitment(&payload, &metadata);
     let encoded_transactions = Arc::from(TestTransaction::encode(&transactions));
     let vid_disperse = vid.disperse(&encoded_transactions).unwrap();
-    let (_, vid_precompute) = vid.commit_only_precompute(&encoded_transactions).unwrap();
     let payload_commitment = vid_disperse.commit;
 
     let signature = <TestTypes as NodeType>::SignatureKey::sign(
@@ -115,7 +114,6 @@ async fn test_vid_task() {
                     *ViewNumber::new(2),
                 )
                 .unwrap()],
-                Some(vid_precompute),
                 None,
             )),
         ],

--- a/crates/types/src/data.rs
+++ b/crates/types/src/data.rs
@@ -50,7 +50,7 @@ use crate::{
         BlockPayload,
     },
     utils::{bincode_opts, genesis_epoch_from_version, option_epoch_from_block_number},
-    vid::{vid_scheme, VidCommitment, VidCommon, VidPrecomputeData, VidSchemeType, VidShare},
+    vid::{vid_scheme, VidCommitment, VidCommon, VidSchemeType, VidShare},
     vote::{Certificate, HasViewNumber},
 };
 
@@ -251,7 +251,6 @@ impl<TYPES: NodeType> VidDisperse<TYPES> {
     }
 
     /// Calculate the vid disperse information from the payload given a view, epoch and membership,
-    /// optionally using precompute data from builder.
     /// If the sender epoch is missing, it means it's the same as the target epoch.
     ///
     /// # Errors
@@ -1727,9 +1726,6 @@ pub struct PackedBundle<TYPES: NodeType> {
     /// The sequencing fee for submitting bundles.
     pub sequencing_fees: Vec1<BuilderFee<TYPES>>,
 
-    /// The Vid precompute for the block.
-    pub vid_precompute: Option<VidPrecomputeData>,
-
     /// The auction results for the block, if it was produced as the result of an auction
     pub auction_result: Option<TYPES::AuctionResult>,
 }
@@ -1742,7 +1738,6 @@ impl<TYPES: NodeType> PackedBundle<TYPES> {
         view_number: TYPES::View,
         epoch_number: Option<TYPES::Epoch>,
         sequencing_fees: Vec1<BuilderFee<TYPES>>,
-        vid_precompute: Option<VidPrecomputeData>,
         auction_result: Option<TYPES::AuctionResult>,
     ) -> Self {
         Self {
@@ -1751,7 +1746,6 @@ impl<TYPES: NodeType> PackedBundle<TYPES> {
             view_number,
             epoch_number,
             sequencing_fees,
-            vid_precompute,
             auction_result,
         }
     }

--- a/crates/types/src/traits/block_contents.rs
+++ b/crates/types/src/traits/block_contents.rs
@@ -19,7 +19,7 @@ use std::{
 
 use async_trait::async_trait;
 use committable::{Commitment, Committable};
-use jf_vid::{precomputable::Precomputable, VidScheme};
+use jf_vid::VidScheme;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use vbs::version::Version;
 
@@ -151,22 +151,6 @@ pub fn vid_commitment(
 ) -> <VidSchemeType as VidScheme>::Commit {
     let encoded_tx_len = encoded_transactions.len();
     vid_scheme(num_storage_nodes).commit_only(encoded_transactions).unwrap_or_else(|err| panic!("VidScheme::commit_only failure:(num_storage_nodes,payload_byte_len)=({num_storage_nodes},{encoded_tx_len}) error: {err}"))
-}
-
-/// Compute the VID payload commitment along with precompute data reducing time in VID Disperse
-/// # Panics
-/// If the VID computation fails.
-#[must_use]
-#[allow(clippy::panic)]
-pub fn precompute_vid_commitment(
-    encoded_transactions: &[u8],
-    num_storage_nodes: usize,
-) -> (
-    <VidSchemeType as VidScheme>::Commit,
-    <VidSchemeType as Precomputable>::PrecomputeData,
-) {
-    let encoded_tx_len = encoded_transactions.len();
-    vid_scheme(num_storage_nodes).commit_only_precompute(encoded_transactions).unwrap_or_else(|err| panic!("VidScheme::commit_only failure:(num_storage_nodes,payload_byte_len)=({num_storage_nodes},{encoded_tx_len}) error: {err}"))
 }
 
 /// The number of storage nodes to use when computing the genesis VID commitment.

--- a/crates/types/src/vid.rs
+++ b/crates/types/src/vid.rs
@@ -28,7 +28,6 @@ use jf_vid::{
         payload_prover::{LargeRangeProof, SmallRangeProof},
     },
     payload_prover::{PayloadProver, Statement},
-    precomputable::Precomputable,
     VidDisperse, VidResult, VidScheme,
 };
 use lazy_static::lazy_static;
@@ -109,8 +108,6 @@ pub type VidCommitment = <VidSchemeType as VidScheme>::Commit;
 pub type VidCommon = <VidSchemeType as VidScheme>::Common;
 /// VID share type
 pub type VidShare = <VidSchemeType as VidScheme>::Share;
-/// VID PrecomputeData type
-pub type VidPrecomputeData = <VidSchemeType as Precomputable>::PrecomputeData;
 /// VID proposal type
 pub type VidProposal<TYPES> = (
     Proposal<TYPES, HotShotVidDisperse<TYPES>>,
@@ -287,33 +284,6 @@ impl PayloadProver<SmallRangeProofType> for VidSchemeType {
         proof: &SmallRangeProofType,
     ) -> VidResult<Result<(), ()>> {
         self.0.payload_verify(stmt_conversion(stmt), &proof.0)
-    }
-}
-
-impl Precomputable for VidSchemeType {
-    type PrecomputeData = <Advz as Precomputable>::PrecomputeData;
-
-    fn commit_only_precompute<B>(
-        &self,
-        payload: B,
-    ) -> VidResult<(Self::Commit, Self::PrecomputeData)>
-    where
-        B: AsRef<[u8]>,
-    {
-        self.0.commit_only_precompute(payload)
-    }
-
-    fn disperse_precompute<B>(
-        &self,
-        payload: B,
-        data: &Self::PrecomputeData,
-    ) -> VidResult<VidDisperse<Self>>
-    where
-        B: AsRef<[u8]>,
-    {
-        self.0
-            .disperse_precompute(payload, data)
-            .map(vid_disperse_conversion)
     }
 }
 


### PR DESCRIPTION
Closes #<ISSUE_NUMBER>
<!-- See here for keywords in Github -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

### This PR: 
<!-- Describe what this PR adds to HotSHot -->
<!-- E.g. -->
<!-- * Implements feature 1 -->
<!-- * Implements feature 2 -->
<!-- * Fixes bug 3 -->
Nukes VID precompute since it's no longer in use.

### This PR does not: 
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->

### Key places to review: 
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
