### PR TITLE
Add back external messages

### DIFF
--- a/crates/task-impls/src/network.rs
+++ b/crates/task-impls/src/network.rs
@@ -17,7 +17,7 @@ use hotshot_task::task::TaskState;
 use hotshot_types::{
     consensus::OuterConsensus,
     data::{VidDisperse, VidDisperseShare, VidDisperseShare2},
-    event::{Event, HotShotAction},
+    event::{Event, EventType, HotShotAction},
     message::{
         convert_proposal, DaConsensusMessage, DataMessage, GeneralConsensusMessage, Message,
         MessageKind, Proposal, SequencingMessage, UpgradeLock,
@@ -438,6 +438,22 @@ impl<TYPES: NodeType, V: Versions> NetworkMessageTaskState<TYPES, V> {
                     }
                 }
             },
+
+            // Handle external messages
+            MessageKind::External(data) => {
+                if sender == self.public_key {
+                    return;
+                }
+                // Send the external message to the external event stream so it can be processed
+                broadcast_event(
+                    Event {
+                        view_number: TYPES::View::new(1),
+                        event: EventType::ExternalMessageReceived { sender, data },
+                    },
+                    &self.external_event_stream,
+                )
+                .await;
+            }
         }
     }
 }

--- a/crates/testing/tests/tests_1/network_task.rs
+++ b/crates/testing/tests/tests_1/network_task.rs
@@ -122,11 +122,11 @@ async fn test_network_external_mnessages() {
     let builder: TestDescription<TestTypes, MemoryImpl, TestVersions> =
         TestDescription::default_multiple_rounds();
 
-    let launcher = builder.gen_launcher(0);
+    let launcher = builder.gen_launcher();
 
     let mut handles = vec![];
     let mut event_streams = vec![];
-    for i in 0..launcher.metadata.num_nodes_with_stake {
+    for i in 0..launcher.metadata.test_config.num_nodes_with_stake.into() {
         let handle = build_system_handle_from_launcher::<TestTypes, MemoryImpl, TestVersions>(
             i.try_into().unwrap(),
             &launcher,

--- a/crates/testing/tests/tests_1/network_task.rs
+++ b/crates/testing/tests/tests_1/network_task.rs
@@ -112,6 +112,98 @@ async fn test_network_task() {
 
 #[cfg(test)]
 #[tokio::test(flavor = "multi_thread")]
+async fn test_network_external_mnessages() {
+    use hotshot::types::EventType;
+    use hotshot_testing::helpers::build_system_handle_from_launcher;
+    use hotshot_types::message::RecipientList;
+
+    hotshot::helpers::initialize_logging();
+
+    let builder: TestDescription<TestTypes, MemoryImpl, TestVersions> =
+        TestDescription::default_multiple_rounds();
+
+    let launcher = builder.gen_launcher(0);
+
+    let mut handles = vec![];
+    let mut event_streams = vec![];
+    for i in 0..launcher.metadata.num_nodes_with_stake {
+        let handle = build_system_handle_from_launcher::<TestTypes, MemoryImpl, TestVersions>(
+            i.try_into().unwrap(),
+            &launcher,
+        )
+        .await
+        .0;
+        event_streams.push(handle.event_stream_known_impl());
+        handles.push(handle);
+    }
+
+    // Send a message from 1 -> 2
+    handles[1]
+        .send_external_message(vec![1, 2], RecipientList::Direct(handles[2].public_key()))
+        .await
+        .unwrap();
+    let event = tokio::time::timeout(Duration::from_millis(100), event_streams[2].recv())
+        .await
+        .unwrap()
+        .unwrap()
+        .event;
+
+    // check that 2 received the message
+    assert!(matches!(
+        event,
+        EventType::ExternalMessageReceived {
+            sender,
+            data,
+        } if sender == handles[1].public_key() && data == vec![1, 2]
+    ));
+
+    // Send a message from 2 -> 1
+    handles[2]
+        .send_external_message(vec![2, 1], RecipientList::Direct(handles[1].public_key()))
+        .await
+        .unwrap();
+    let event = tokio::time::timeout(Duration::from_millis(100), event_streams[1].recv())
+        .await
+        .unwrap()
+        .unwrap()
+        .event;
+
+    // check that 1 received the message
+    assert!(matches!(
+        event,
+        EventType::ExternalMessageReceived {
+            sender,
+            data,
+        } if sender == handles[2].public_key() && data == vec![2,1]
+    ));
+
+    // Check broadcast works
+    handles[0]
+        .send_external_message(vec![0, 0, 0], RecipientList::Broadcast)
+        .await
+        .unwrap();
+    // All other nodes get the broadcast
+    for stream in event_streams.iter_mut().skip(1) {
+        let event = tokio::time::timeout(Duration::from_millis(100), stream.recv())
+            .await
+            .unwrap()
+            .unwrap()
+            .event;
+        assert!(matches!(
+            event,
+            EventType::ExternalMessageReceived {
+                sender,
+                data,
+            } if sender == handles[0].public_key() && data == vec![0,0,0]
+        ));
+    }
+    // No event on 0 even after short sleep
+    tokio::time::sleep(Duration::from_millis(2)).await;
+    assert!(event_streams[0].is_empty());
+}
+
+#[cfg(test)]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_network_storage_fail() {
     use std::collections::BTreeMap;
 

--- a/crates/types/src/event.rs
+++ b/crates/types/src/event.rs
@@ -172,6 +172,14 @@ pub enum EventType<TYPES: NodeType> {
         /// Public key of the leader submitting the proposal
         sender: TYPES::SignatureKey,
     },
+
+    /// A message destined for external listeners was received
+    ExternalMessageReceived {
+        /// Public Key of the message sender
+        sender: TYPES::SignatureKey,
+        /// Serialized data of the message
+        data: Vec<u8>,
+    },
 }
 #[derive(Debug, Serialize, Deserialize, Clone, Copy)]
 /// A list of actions that we track for nodes

--- a/crates/types/src/message.rs
+++ b/crates/types/src/message.rs
@@ -123,6 +123,8 @@ pub enum MessageKind<TYPES: NodeType> {
     Consensus(SequencingMessage<TYPES>),
     /// Messages relating to sharing data between nodes
     Data(DataMessage<TYPES>),
+    /// A (still serialized) message to be passed through to external listeners
+    External(Vec<u8>),
 }
 
 /// List of keys to send a message to, or broadcast to all known keys
@@ -160,6 +162,7 @@ impl<TYPES: NodeType> ViewMessage<TYPES> for MessageKind<TYPES> {
                 ResponseMessage::Found(m) => m.view_number(),
                 ResponseMessage::NotFound | ResponseMessage::Denied => TYPES::View::new(1),
             },
+            MessageKind::External(_) => TYPES::View::new(1),
         }
     }
 }


### PR DESCRIPTION
I originally removed this because it was unused and causes some scary-looking sequencer errors on startup

But we are going to need this for the request/response protocol so I am bringing it back 