### PR TITLE
fix broken link Cargo.toml

### DIFF
--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -7,7 +7,7 @@ name = "workspace-hack"
 version = "0.1.0"
 edition = "2021"
 description = "workspace-hack package, managed by hakari"
-# You can choose to publish this crate: see https://docs.rs/cargo-hakari/latest/cargo_hakari/publishing.
+# You can choose to publish this crate: see https://docs.rs/cargo-hakari/latest/cargo_hakari/publishing/index.html
 publish = false
 
 # The parts of the file between the BEGIN HAKARI SECTION and END HAKARI SECTION comments


### PR DESCRIPTION
Replaced the broken link with the correct one:
From: https://docs.rs/cargo-hakari/latest/cargo_hakari/publishing
To: https://docs.rs/cargo-hakari/latest/cargo_hakari/publishing/index.html