### PR TITLE
Serialization fixes

### DIFF
--- a/crates/types/src/message.rs
+++ b/crates/types/src/message.rs
@@ -210,14 +210,14 @@ pub enum GeneralConsensusMessage<TYPES: NodeType> {
         <TYPES::SignatureKey as SignatureKey>::PureAssembledSignatureType,
     ),
 
+    /// A replica has responded with a valid proposal.
+    ProposalResponse(Proposal<TYPES, QuorumProposal<TYPES>>),
+
     /// Message with a quorum proposal.
     Proposal2(Proposal<TYPES, QuorumProposal2<TYPES>>),
 
     /// Message with a quorum vote.
     Vote2(QuorumVote2<TYPES>),
-
-    /// A replica has responded with a valid proposal.
-    ProposalResponse(Proposal<TYPES, QuorumProposal<TYPES>>),
 
     /// A replica has responded with a valid proposal.
     ProposalResponse2(Proposal<TYPES, QuorumProposal2<TYPES>>),

--- a/crates/types/src/message.rs
+++ b/crates/types/src/message.rs
@@ -204,17 +204,17 @@ pub enum GeneralConsensusMessage<TYPES: NodeType> {
     /// Message with an upgrade vote
     UpgradeVote(UpgradeVote<TYPES>),
 
-    /// Message with a quorum proposal.
-    Proposal2(Proposal<TYPES, QuorumProposal2<TYPES>>),
-
-    /// Message with a quorum vote.
-    Vote2(QuorumVote2<TYPES>),
-
     /// A peer node needs a proposal from the leader.
     ProposalRequested(
         ProposalRequestPayload<TYPES>,
         <TYPES::SignatureKey as SignatureKey>::PureAssembledSignatureType,
     ),
+
+    /// Message with a quorum proposal.
+    Proposal2(Proposal<TYPES, QuorumProposal2<TYPES>>),
+
+    /// Message with a quorum vote.
+    Vote2(QuorumVote2<TYPES>),
 
     /// A replica has responded with a valid proposal.
     ProposalResponse(Proposal<TYPES, QuorumProposal<TYPES>>),


### PR DESCRIPTION
`Proposal2` and `Vote2` were added above `ProposalRequested` and `LeaderProposalAvailable` (renamed to `ProposalResponse`) in this diff: https://github.com/EspressoSystems/HotShot/compare/4ed1df20f793b947d5c9f90a1cb10e4177f8521d..99929f7d717100e174c568ac7728bbf63e43ed8b

This PR moves `ProposalRequested` and `ProposalResponses` back to their original positions