### PR TITLE
Propagate certificate errors

### DIFF
--- a/crates/request-response/src/lib.rs
+++ b/crates/request-response/src/lib.rs
@@ -1,10 +1,12 @@
 //! This crate contains a general request-response protocol. It is used to send requests to
 //! a set of recipients and wait for responses.
 
-use std::collections::HashMap;
-use std::sync::Weak;
-use std::time::Instant;
-use std::{marker::PhantomData, sync::Arc, time::Duration};
+use std::{
+    collections::HashMap,
+    marker::PhantomData,
+    sync::{Arc, Weak},
+    time::{Duration, Instant},
+};
 
 use anyhow::{anyhow, Context, Result};
 use data_source::DataSource;
@@ -17,8 +19,10 @@ use parking_lot::RwLock;
 use rand::seq::SliceRandom;
 use recipient_source::RecipientSource;
 use request::{Request, Response};
-use tokio::spawn;
-use tokio::time::{sleep, timeout};
+use tokio::{
+    spawn,
+    time::{sleep, timeout},
+};
 use tokio_util::task::AbortOnDropHandle;
 use tracing::{error, warn};
 use util::BoundedVecDeque;

--- a/crates/request-response/src/message.rs
+++ b/crates/request-response/src/message.rs
@@ -294,9 +294,8 @@ mod tests {
     use hotshot_types::signature_key::BLSPubKey;
     use rand::Rng;
 
-    use crate::request::Response;
-
     use super::*;
+    use crate::request::Response;
 
     // A testing implementation of the [`Serializable`] trait for [`Vec<u8>`]
     impl Serializable for Vec<u8> {

--- a/crates/task-impls/src/quorum_proposal/handlers.rs
+++ b/crates/task-impls/src/quorum_proposal/handlers.rs
@@ -143,6 +143,7 @@ impl<TYPES: NodeType, V: Versions> ProposalDependencyHandle<TYPES, V> {
                         &self.upgrade_lock,
                     )
                     .await
+                    .is_ok()
                 {
                     return Some(qc.clone());
                 }

--- a/crates/task-impls/src/quorum_proposal/mod.rs
+++ b/crates/task-impls/src/quorum_proposal/mod.rs
@@ -477,19 +477,20 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions>
                     membership_reader.success_threshold(epoch_number);
                 drop(membership_reader);
 
-                ensure!(
-                    certificate
-                        .is_valid_cert(
-                            membership_stake_table,
-                            membership_success_threshold,
-                            &self.upgrade_lock
-                        )
-                        .await,
-                    warn!(
-                        "View Sync Finalize certificate {:?} was invalid",
-                        certificate.data()
+                certificate
+                    .is_valid_cert(
+                        membership_stake_table,
+                        membership_success_threshold,
+                        &self.upgrade_lock,
                     )
-                );
+                    .await
+                    .context(|e| {
+                        warn!(
+                            "View Sync Finalize certificate {:?} was invalid: {}",
+                            certificate.data(),
+                            e
+                        )
+                    })?;
 
                 let view_number = certificate.view_number;
 
@@ -561,15 +562,14 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions>
                     membership_reader.success_threshold(cert_epoch_number);
                 drop(membership_reader);
 
-                ensure!(
-                    qc.is_valid_cert(
-                        membership_stake_table,
-                        membership_success_threshold,
-                        &self.upgrade_lock
-                    )
-                    .await,
-                    warn!("Quorum certificate {:?} was invalid", qc.data())
-                );
+                qc.is_valid_cert(
+                    membership_stake_table,
+                    membership_success_threshold,
+                    &self.upgrade_lock,
+                )
+                .await
+                .context(|e| warn!("Quorum certificate {:?} was invalid: {}", qc.data(), e))?;
+
                 self.highest_qc = qc.clone();
             }
             HotShotEvent::NextEpochQc2Formed(Either::Left(next_epoch_qc)) => {

--- a/crates/task-impls/src/quorum_proposal_recv/handlers.rs
+++ b/crates/task-impls/src/quorum_proposal_recv/handlers.rs
@@ -168,17 +168,20 @@ pub(crate) async fn handle_quorum_proposal_recv<
     let membership_success_threshold = membership_reader.success_threshold(justify_qc.data.epoch);
     drop(membership_reader);
 
-    if !justify_qc
-        .is_valid_cert(
-            membership_stake_table,
-            membership_success_threshold,
-            &validation_info.upgrade_lock,
-        )
-        .await
     {
         let consensus_reader = validation_info.consensus.read().await;
-        consensus_reader.metrics.invalid_qc.update(1);
-        bail!("Invalid justify_qc in proposal for view {}", *view_number);
+        justify_qc
+            .is_valid_cert(
+                membership_stake_table,
+                membership_success_threshold,
+                &validation_info.upgrade_lock,
+            )
+            .await
+            .context(|e| {
+                consensus_reader.metrics.invalid_qc.update(1);
+
+                warn!("Invalid certificate for view {}: {}", *view_number, e)
+            })?;
     }
 
     if let Some(ref next_epoch_justify_qc) = maybe_next_epoch_justify_qc {
@@ -198,19 +201,14 @@ pub(crate) async fn handle_quorum_proposal_recv<
         drop(membership_reader);
 
         // Validate the next epoch justify qc as well
-        if !next_epoch_justify_qc
+        next_epoch_justify_qc
             .is_valid_cert(
                 membership_next_stake_table,
                 membership_next_success_threshold,
                 &validation_info.upgrade_lock,
             )
             .await
-        {
-            bail!(
-                "Invalid next_epoch_justify_qc in proposal for view {}",
-                *view_number
-            );
-        }
+            .context(|e| warn!("Invalid certificate for view {}: {}", *view_number, e))?;
     }
 
     broadcast_event(

--- a/crates/task-impls/src/quorum_vote/mod.rs
+++ b/crates/task-impls/src/quorum_vote/mod.rs
@@ -531,15 +531,13 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> QuorumVoteTaskS
                 drop(membership_reader);
 
                 // Validate the DAC.
-                ensure!(
-                    cert.is_valid_cert(
-                        membership_da_stake_table,
-                        membership_da_success_threshold,
-                        &self.upgrade_lock
-                    )
-                    .await,
-                    warn!("Invalid DAC")
-                );
+                cert.is_valid_cert(
+                    membership_da_stake_table,
+                    membership_da_success_threshold,
+                    &self.upgrade_lock,
+                )
+                .await
+                .context(|e| warn!("Invalid DAC: {}", e))?;
 
                 // Add to the storage.
                 self.consensus

--- a/crates/task-impls/src/view_sync.rs
+++ b/crates/task-impls/src/view_sync.rs
@@ -555,7 +555,7 @@ impl<TYPES: NodeType, V: Versions> ViewSyncReplicaTaskState<TYPES, V> {
                 drop(membership_reader);
 
                 // If certificate is not valid, return current state
-                if !certificate
+                if let Err(e) = certificate
                     .is_valid_cert(
                         membership_stake_table,
                         membership_failure_threshold,
@@ -563,7 +563,11 @@ impl<TYPES: NodeType, V: Versions> ViewSyncReplicaTaskState<TYPES, V> {
                     )
                     .await
                 {
-                    tracing::error!("Not valid view sync cert! {:?}", certificate.data());
+                    tracing::error!(
+                        "Not valid view sync cert! data: {:?}, error: {}",
+                        certificate.data(),
+                        e
+                    );
 
                     return None;
                 }
@@ -645,7 +649,7 @@ impl<TYPES: NodeType, V: Versions> ViewSyncReplicaTaskState<TYPES, V> {
                 drop(membership_reader);
 
                 // If certificate is not valid, return current state
-                if !certificate
+                if let Err(e) = certificate
                     .is_valid_cert(
                         membership_stake_table,
                         membership_success_threshold,
@@ -653,7 +657,11 @@ impl<TYPES: NodeType, V: Versions> ViewSyncReplicaTaskState<TYPES, V> {
                     )
                     .await
                 {
-                    tracing::error!("Not valid view sync cert! {:?}", certificate.data());
+                    tracing::error!(
+                        "Not valid view sync cert! data: {:?}, error: {}",
+                        certificate.data(),
+                        e
+                    );
 
                     return None;
                 }
@@ -746,7 +754,7 @@ impl<TYPES: NodeType, V: Versions> ViewSyncReplicaTaskState<TYPES, V> {
                 drop(membership_reader);
 
                 // If certificate is not valid, return current state
-                if !certificate
+                if let Err(e) = certificate
                     .is_valid_cert(
                         membership_stake_table,
                         membership_success_threshold,
@@ -754,7 +762,11 @@ impl<TYPES: NodeType, V: Versions> ViewSyncReplicaTaskState<TYPES, V> {
                     )
                     .await
                 {
-                    tracing::error!("Not valid view sync cert! {:?}", certificate.data());
+                    tracing::error!(
+                        "Not valid view sync cert! data: {:?}, error: {}",
+                        certificate.data(),
+                        e
+                    );
 
                     return None;
                 }

--- a/crates/testing/tests/tests_1/message.rs
+++ b/crates/testing/tests/tests_1/message.rs
@@ -109,23 +109,23 @@ async fn test_certificate2_validity() {
     let membership_success_threshold = membership_reader.success_threshold(None);
     drop(membership_reader);
 
-    assert!(
-        qc.is_valid_cert(
+    assert!(qc
+        .is_valid_cert(
             membership_stake_table.clone(),
             membership_success_threshold,
             &handle.hotshot.upgrade_lock
         )
         .await
-    );
+        .is_ok());
 
-    assert!(
-        qc2.is_valid_cert(
+    assert!(qc2
+        .is_valid_cert(
             membership_stake_table,
             membership_success_threshold,
             &handle.hotshot.upgrade_lock
         )
         .await
-    );
+        .is_ok());
 
     // ensure that we don't break the leaf commitment chain
     let leaf2 = Leaf2::from_quorum_proposal(&proposal.data);

--- a/crates/types/src/data/vid_disperse.rs
+++ b/crates/types/src/data/vid_disperse.rs
@@ -6,6 +6,14 @@
 
 //! This module provides types for VID disperse related data structures.
 
+use std::{collections::BTreeMap, fmt::Debug, hash::Hash, marker::PhantomData, sync::Arc};
+
+use async_lock::RwLock;
+use jf_vid::{VidDisperse as JfVidDisperse, VidScheme};
+use serde::{Deserialize, Serialize};
+use tokio::task::spawn_blocking;
+use utils::anytrace::*;
+
 use crate::{
     impl_has_epoch,
     message::Proposal,
@@ -17,12 +25,6 @@ use crate::{
     vid::{advz_scheme, VidCommitment, VidCommon, VidSchemeType, VidShare},
     vote::HasViewNumber,
 };
-use async_lock::RwLock;
-use jf_vid::{VidDisperse as JfVidDisperse, VidScheme};
-use serde::{Deserialize, Serialize};
-use std::{collections::BTreeMap, fmt::Debug, hash::Hash, marker::PhantomData, sync::Arc};
-use tokio::task::spawn_blocking;
-use utils::anytrace::*;
 
 impl_has_epoch!(ADVZDisperse<TYPES>, VidDisperseShare2<TYPES>);
 

--- a/crates/types/src/signature_key.rs
+++ b/crates/types/src/signature_key.rs
@@ -122,9 +122,13 @@ impl SignatureKey for BLSPubKey {
         }
     }
 
-    fn check(real_qc_pp: &Self::QcParams, data: &[u8], qc: &Self::QcType) -> bool {
+    fn check(
+        real_qc_pp: &Self::QcParams,
+        data: &[u8],
+        qc: &Self::QcType,
+    ) -> Result<(), SignatureError> {
         let msg = GenericArray::from_slice(data);
-        BitVectorQc::<BLSOverBN254CurveSignatureScheme>::check(real_qc_pp, msg, qc).is_ok()
+        BitVectorQc::<BLSOverBN254CurveSignatureScheme>::check(real_qc_pp, msg, qc).map(|_| ())
     }
 
     fn sig_proof(signature: &Self::QcType) -> (Self::PureAssembledSignatureType, BitVec) {

--- a/crates/types/src/simple_certificate.rs
+++ b/crates/types/src/simple_certificate.rs
@@ -169,22 +169,23 @@ impl<TYPES: NodeType, THRESHOLD: Threshold<TYPES>> Certificate<TYPES, DaData>
         stake_table: Vec<<TYPES::SignatureKey as SignatureKey>::StakeTableEntry>,
         threshold: NonZeroU64,
         upgrade_lock: &UpgradeLock<TYPES, V>,
-    ) -> bool {
+    ) -> Result<()> {
         if self.view_number == TYPES::View::genesis() {
-            return true;
+            return Ok(());
         }
         let real_qc_pp = <TYPES::SignatureKey as SignatureKey>::public_parameter(
             stake_table,
             U256::from(u64::from(threshold)),
         );
-        let Ok(commit) = self.data_commitment(upgrade_lock).await else {
-            return false;
-        };
+        let commit = self.data_commitment(upgrade_lock).await?;
+
         <TYPES::SignatureKey as SignatureKey>::check(
             &real_qc_pp,
             commit.as_ref(),
             self.signatures.as_ref().unwrap(),
         )
+        .wrap()
+        .context(|e| warn!("Signature check failed: {}", e))
     }
     /// Proxy's to `Membership.stake`
     fn stake_table_entry<MEMBERSHIP: Membership<TYPES>>(
@@ -257,22 +258,23 @@ impl<TYPES: NodeType, THRESHOLD: Threshold<TYPES>> Certificate<TYPES, DaData2<TY
         stake_table: Vec<<TYPES::SignatureKey as SignatureKey>::StakeTableEntry>,
         threshold: NonZeroU64,
         upgrade_lock: &UpgradeLock<TYPES, V>,
-    ) -> bool {
+    ) -> Result<()> {
         if self.view_number == TYPES::View::genesis() {
-            return true;
+            return Ok(());
         }
         let real_qc_pp = <TYPES::SignatureKey as SignatureKey>::public_parameter(
             stake_table,
             U256::from(u64::from(threshold)),
         );
-        let Ok(commit) = self.data_commitment(upgrade_lock).await else {
-            return false;
-        };
+        let commit = self.data_commitment(upgrade_lock).await?;
+
         <TYPES::SignatureKey as SignatureKey>::check(
             &real_qc_pp,
             commit.as_ref(),
             self.signatures.as_ref().unwrap(),
         )
+        .wrap()
+        .context(|e| warn!("Signature check failed: {}", e))
     }
     /// Proxy's to `Membership.stake`
     fn stake_table_entry<MEMBERSHIP: Membership<TYPES>>(
@@ -348,22 +350,23 @@ impl<
         stake_table: Vec<<TYPES::SignatureKey as SignatureKey>::StakeTableEntry>,
         threshold: NonZeroU64,
         upgrade_lock: &UpgradeLock<TYPES, V>,
-    ) -> bool {
+    ) -> Result<()> {
         if self.view_number == TYPES::View::genesis() {
-            return true;
+            return Ok(());
         }
         let real_qc_pp = <TYPES::SignatureKey as SignatureKey>::public_parameter(
             stake_table,
             U256::from(u64::from(threshold)),
         );
-        let Ok(commit) = self.data_commitment(upgrade_lock).await else {
-            return false;
-        };
+        let commit = self.data_commitment(upgrade_lock).await?;
+
         <TYPES::SignatureKey as SignatureKey>::check(
             &real_qc_pp,
             commit.as_ref(),
             self.signatures.as_ref().unwrap(),
         )
+        .wrap()
+        .context(|e| warn!("Signature check failed: {}", e))
     }
     fn threshold<MEMBERSHIP: Membership<TYPES>>(
         membership: &MEMBERSHIP,
@@ -461,19 +464,16 @@ impl<TYPES: NodeType> UpgradeCertificate<TYPES> {
             let membership_upgrade_threshold = membership_reader.upgrade_threshold(epoch);
             drop(membership_reader);
 
-            ensure!(
-                cert.is_valid_cert(
-                    membership_stake_table,
-                    membership_upgrade_threshold,
-                    upgrade_lock
-                )
-                .await,
-                "Invalid upgrade certificate."
-            );
-            Ok(())
-        } else {
-            Ok(())
+            cert.is_valid_cert(
+                membership_stake_table,
+                membership_upgrade_threshold,
+                upgrade_lock,
+            )
+            .await
+            .context(|e| warn!("Invalid upgrade certificate: {}", e))?;
         }
+
+        Ok(())
     }
 
     /// Given an upgrade certificate and a view, tests whether the view is in the period

--- a/crates/types/src/traits/signature_key.rs
+++ b/crates/types/src/traits/signature_key.rs
@@ -17,6 +17,7 @@ use std::{
 use ark_serialize::SerializationError;
 use bitvec::prelude::*;
 use committable::Committable;
+use jf_signature::SignatureError;
 use jf_vid::VidScheme;
 use primitive_types::U256;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
@@ -154,8 +155,15 @@ pub trait SignatureKey:
         threshold: U256,
     ) -> Self::QcParams;
 
-    /// check the quorum certificate for the assembled signature
-    fn check(real_qc_pp: &Self::QcParams, data: &[u8], qc: &Self::QcType) -> bool;
+    /// check the quorum certificate for the assembled signature, returning `Ok(())` if it is valid.
+    ///
+    /// # Errors
+    /// Returns an error if the signature key fails to validate
+    fn check(
+        real_qc_pp: &Self::QcParams,
+        data: &[u8],
+        qc: &Self::QcType,
+    ) -> Result<(), SignatureError>;
 
     /// get the assembled signature and the `BitVec` separately from the assembled signature
     fn sig_proof(signature: &Self::QcType) -> (Self::PureAssembledSignatureType, BitVec);

--- a/crates/types/src/vote.rs
+++ b/crates/types/src/vote.rs
@@ -18,7 +18,7 @@ use bitvec::{bitvec, vec::BitVec};
 use committable::{Commitment, Committable};
 use primitive_types::U256;
 use tracing::error;
-use utils::anytrace::Result;
+use utils::anytrace::*;
 
 use crate::{
     message::UpgradeLock,
@@ -79,7 +79,7 @@ pub trait Certificate<TYPES: NodeType, T>: HasViewNumber<TYPES> {
         stake_table: Vec<<TYPES::SignatureKey as SignatureKey>::StakeTableEntry>,
         threshold: NonZeroU64,
         upgrade_lock: &UpgradeLock<TYPES, V>,
-    ) -> impl std::future::Future<Output = bool>;
+    ) -> impl std::future::Future<Output = Result<()>>;
     /// Returns the amount of stake needed to create this certificate
     // TODO: Make this a static ratio of the total stake of `Membership`
     fn threshold<MEMBERSHIP: Membership<TYPES>>(


### PR DESCRIPTION
Certificate validation can fail for a number of reasons, which we differentiate with different error types. However, we currently do not propagate the error. 

### This PR: 
Propagates the error in certificate validation, causing it be logged.

### This PR does not: 

### Key places to review: 
