### PR TITLE
Fix typos ahead of Monorepo

### DIFF
--- a/crates/types/src/utils.rs
+++ b/crates/types/src/utils.rs
@@ -141,7 +141,7 @@ impl<TYPES: NodeType> ViewInner<TYPES> {
         }
     }
 
-    /// return the underlying block paylod commitment if it exists
+    /// return the underlying block payload commitment if it exists
     #[must_use]
     pub fn payload_commitment(&self) -> Option<VidCommitment> {
         if let Self::Da {


### PR DESCRIPTION
Monorepo is coming and sequencer has a typo rule. I'll be running this over the next week while I get things ready for the merge to avoid breaking downstream changes for branch development.