### PR TITLE
Better test misconfiguration reporting, dump offsets for randomized q…

### DIFF
--- a/crates/hotshot/src/traits/election/helpers.rs
+++ b/crates/hotshot/src/traits/election/helpers.rs
@@ -226,6 +226,10 @@ impl RandomOverlapQuorumIterator {
             count / 2 > overlap_max,
             "Overlap cannot be greater than the entire set size"
         );
+        assert!(
+            count / 2 >= members_max - overlap_min,
+            "members_max must be greater or equal to half of the count plus overlap_min"
+        );
 
         let (mut prev_rng, mut this_rng) = make_rngs(seed, round);
 


### PR DESCRIPTION
…uora at test start

Creates output at the start of the randomized quorum tests like this:
```
hotshot::traits::election::helpers::RandomOverlapQuorumFilterConfig<123, 4, 7, 0, 2> offsets for Quorum filter:
  epoch 1: {1, 3, 5, 7, 9, 11, 13}
  epoch 2: {0, 4, 6, 10}
  epoch 3: {1, 4, 5, 6, 9}
  epoch 4: {1, 4, 5, 10, 12}
  epoch 5: {1, 3, 5, 7, 9, 11, 12}
  epoch 6: {0, 2, 4, 12}
  epoch 7: {3, 5, 7, 11, 12, 13}
  epoch 8: {3, 4, 11, 12}
  epoch 9: {3, 4, 11, 12}
  epoch 10: {0, 4, 6, 8}
hotshot::traits::election::helpers::RandomOverlapQuorumFilterConfig<123, 4, 7, 0, 2> offsets for DA Quorum filter:
  epoch 1: {1, 3, 5, 7, 9, 11, 13}
  epoch 2: {0, 4, 6, 10}
  epoch 3: {1, 4, 5, 6, 9}
  epoch 4: {1, 4, 5, 10, 12}
  epoch 5: {1, 3, 5, 7, 9, 11, 12}
  epoch 6: {0, 2, 4, 12}
  epoch 7: {3, 5, 7, 11, 12, 13}
  epoch 8: {3, 4, 11, 12}
  epoch 9: {3, 4, 11, 12}
  epoch 10: {0, 4, 6, 8}
```

Uses a Once to avoid printing the output a bunch of times. I figure it's okay to do this since this struct is only used for testing anyway.