### PR TITLE
Fix spelling error in Documentation and Improve Readability in HotShot Networking Code

### DIFF
--- a/crates/hotshot/src/lib.rs
+++ b/crates/hotshot/src/lib.rs
@@ -110,7 +110,7 @@ pub struct SystemContext<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versi
     /// Memberships used by consensus
     pub memberships: Arc<RwLock<TYPES::Membership>>,
 
-    /// the metrics that the implementor is using.
+    /// the metrics that the implementer is using.
     metrics: Arc<ConsensusMetricsValue>,
 
     /// The hotstuff implementation

--- a/crates/hotshot/src/traits/networking/libp2p_network.rs
+++ b/crates/hotshot/src/traits/networking/libp2p_network.rs
@@ -584,7 +584,7 @@ impl<T: NodeType> Libp2pNetwork<T> {
         Ok(result)
     }
 
-    /// Spawns task for looking up nodes pre-emptively
+    /// Spawns task for looking up nodes preemptively
     #[allow(clippy::cast_sign_loss, clippy::cast_precision_loss)]
     fn spawn_node_lookup(
         &self,

--- a/crates/libp2p-networking/src/network/node.rs
+++ b/crates/libp2p-networking/src/network/node.rs
@@ -257,7 +257,7 @@ impl<T: NodeType, D: DhtPersistentStorage> NetworkNode<T, D> {
                 .set_publication_interval(Some(record_republication_interval))
                 .set_record_ttl(ttl);
 
-            // allowing panic here because something is very wrong if this fales
+            // allowing panic here because something is very wrong if this fails
             #[allow(clippy::panic)]
             if let Some(factor) = config.replication_factor {
                 kconfig.set_replication_factor(factor);


### PR DESCRIPTION
- **Updated terminology for better clarity:**  

  - `"the implementor"` → `"the implementer"` in `lib.rs`  
  - `"pre-emptively"` → `"preemptively"` in `libp2p_network.rs`  
  - `"if this fales"` → `"if this fails"` in `node.rs`  

### Key Files to Review:  
- `crates/hotshot/src/lib.rs`  
- `crates/hotshot/src/traits/networking/libp2p_network.rs`  
- `crates/libp2p-networking/src/network/node.rs`  