### PR TITLE
fix: Fix issue with extracting capture groups using split()

### DIFF
--- a/scripts/nix_bump_pr_changes.py
+++ b/scripts/nix_bump_pr_changes.py
@@ -20,8 +20,14 @@ for line in sys.stdin:
         prev = line
     if line.startswith("  → 'github:"):
 
-        [_, repo, start_commit, _] = name_commit_regex.split(prev)
-        [_, _, end_commit, _] = name_commit_regex.split(line)
+        match = name_commit_regex.match(prev)
+        if match:
+            repo, start_commit = match.groups()
+
+        match = name_commit_regex.match(line)
+        if match:
+            _, _, end_commit = match.groups()
+
         print("- [ ] " + repo + ": [repo](https://github.com/" + repo + ") | [commits this PR](https://github.com/" + repo + "/compare/" + start_commit + ".." + end_commit + ")")
 
 


### PR DESCRIPTION
### This PR:  
Fixes the issue with using `split()` for extracting capture groups, replacing it with `match()` for more accurate group extraction.

### This PR does not:  
Introduce any new features or break existing functionality outside of the regex fix.

### Key places to review:  
- Regex logic where the capture groups are now handled using `match()` instead of `split()`.

### How to test this PR:  
Ensure that the regex now correctly extracts the expected groups and behaves as intended across different test cases.